### PR TITLE
[WIP] Test clang-tidy with selected checks

### DIFF
--- a/include/awkward/Slice.h
+++ b/include/awkward/Slice.h
@@ -139,7 +139,7 @@ namespace awkward {
     }
     virtual const std::string tostring() const;
     virtual bool preserves_type(const std::shared_ptr<Type>& type, const Index64& advanced) const {
-      return type.get() != nullptr  &&  type.get()->numfields() != -1  &&  util::subset(keys_, type.get()->keys());
+      return type != nullptr  &&  type.get()->numfields() != -1  &&  util::subset(keys_, type.get()->keys());
     }
   private:
     const std::vector<std::string> keys_;

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -18,40 +18,40 @@ namespace awkward {
     EmptyArray(const std::shared_ptr<Identity> id, const std::shared_ptr<Type> type)
         : Content(id, type) { }
 
-    virtual const std::string classname() const;
-    virtual void setid();
-    virtual void setid(const std::shared_ptr<Identity> id);
-    virtual const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const;
-    virtual void tojson_part(ToJson& builder) const;
-    virtual const std::shared_ptr<Type> innertype(bool bare) const;
-    virtual void settype_part(const std::shared_ptr<Type> type);
-    virtual bool accepts(const std::shared_ptr<Type> type);
-    virtual int64_t length() const;
-    virtual const std::shared_ptr<Content> shallow_copy() const;
-    virtual void check_for_iteration() const;
-    virtual const std::shared_ptr<Content> getitem_nothing() const;
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const;
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const;
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const;
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    const std::string classname() const override;
+    void setid() override;
+    void setid(const std::shared_ptr<Identity> id) override;
+    const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const override;
+    void tojson_part(ToJson& builder) const override;
+    const std::shared_ptr<Type> innertype(bool bare) const override;
+    void settype_part(const std::shared_ptr<Type> type) override;
+    bool accepts(const std::shared_ptr<Type> type) override;
+    int64_t length() const override;
+    const std::shared_ptr<Content> shallow_copy() const override;
+    void check_for_iteration() const override;
+    const std::shared_ptr<Content> getitem_nothing() const override;
+    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
+    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
+    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    const std::pair<int64_t, int64_t> minmax_depth() const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
   protected:
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const;
+    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
   };
 }
 

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -24,38 +24,38 @@ namespace awkward {
     const IndexOf<T> stops() const { return stops_; }
     const std::shared_ptr<Content> content() const { return content_; }
 
-    virtual const std::string classname() const;
-    virtual void setid();
-    virtual void setid(const std::shared_ptr<Identity> id);
-    virtual const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const;
-    virtual void tojson_part(ToJson& builder) const;
-    virtual const std::shared_ptr<Type> innertype(bool bare) const;
-    virtual void settype_part(const std::shared_ptr<Type> type);
-    virtual bool accepts(const std::shared_ptr<Type> type);
-    virtual int64_t length() const;
-    virtual const std::shared_ptr<Content> shallow_copy() const;
-    virtual void check_for_iteration() const;
-    virtual const std::shared_ptr<Content> getitem_nothing() const;
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const;
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const;
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const;
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    const std::string classname() const override;
+    void setid() override;
+    void setid(const std::shared_ptr<Identity> id) override;
+    const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const override;
+    void tojson_part(ToJson& builder) const override;
+    const std::shared_ptr<Type> innertype(bool bare) const override;
+    void settype_part(const std::shared_ptr<Type> type) override;
+    bool accepts(const std::shared_ptr<Type> type) override;
+    int64_t length() const override;
+    const std::shared_ptr<Content> shallow_copy() const override;
+    void check_for_iteration() const override;
+    const std::shared_ptr<Content> getitem_nothing() const override;
+    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
+    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
+    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    const std::pair<int64_t, int64_t> minmax_depth() const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
   protected:
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const;
+    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
 
   private:
     const IndexOf<T> starts_;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -22,38 +22,38 @@ namespace awkward {
     const IndexOf<T> offsets() const { return offsets_; }
     const std::shared_ptr<Content> content() const { return content_; }
 
-    virtual const std::string classname() const;
-    virtual void setid();
-    virtual void setid(const std::shared_ptr<Identity> id);
-    virtual const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const;
-    virtual void tojson_part(ToJson& builder) const;
-    virtual const std::shared_ptr<Type> innertype(bool bare) const;
-    virtual void settype_part(const std::shared_ptr<Type> type);
-    virtual bool accepts(const std::shared_ptr<Type> type);
-    virtual int64_t length() const;
-    virtual const std::shared_ptr<Content> shallow_copy() const;
-    virtual void check_for_iteration() const;
-    virtual const std::shared_ptr<Content> getitem_nothing() const;
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const;
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const;
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const;
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    const std::string classname() const override;
+    void setid() override;
+    void setid(const std::shared_ptr<Identity> id) override;
+    const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const override;
+    void tojson_part(ToJson& builder) const override;
+    const std::shared_ptr<Type> innertype(bool bare) const override;
+    void settype_part(const std::shared_ptr<Type> type) override;
+    bool accepts(const std::shared_ptr<Type> type) override;
+    int64_t length() const override;
+    const std::shared_ptr<Content> shallow_copy() const override;
+    void check_for_iteration() const override;
+    const std::shared_ptr<Content> getitem_nothing() const override;
+    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
+    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
+    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    const std::pair<int64_t, int64_t> minmax_depth() const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
   protected:
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const;
+    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
 
   private:
     const IndexOf<T> offsets_;

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -40,56 +40,56 @@ namespace awkward {
     ssize_t bytelength() const;
     uint8_t getbyte(ssize_t at) const;
 
-    virtual bool isscalar() const;
-    virtual const std::string classname() const;
-    virtual void setid();
-    virtual void setid(const std::shared_ptr<Identity> id);
-    virtual const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const;
-    virtual void tojson_part(ToJson& builder) const;
-    virtual const std::shared_ptr<Type> innertype(bool bare) const;
-    virtual const std::shared_ptr<Type> type() const;
-    virtual void settype_part(const std::shared_ptr<Type> type);
-    virtual bool accepts(const std::shared_ptr<Type> type);
-    virtual int64_t length() const;
-    virtual const std::shared_ptr<Content> shallow_copy() const;
-    virtual void check_for_iteration() const;
-    virtual const std::shared_ptr<Content> getitem_nothing() const;
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const;
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const;
-    virtual const std::shared_ptr<Content> getitem(const Slice& where) const;
-    virtual const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem> head, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const;
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    bool isscalar() const override;
+    const std::string classname() const override;
+    void setid() override;
+    void setid(const std::shared_ptr<Identity> id) override;
+    const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const override;
+    void tojson_part(ToJson& builder) const override;
+    const std::shared_ptr<Type> innertype(bool bare) const override;
+    const std::shared_ptr<Type> type() const override;
+    void settype_part(const std::shared_ptr<Type> type) override;
+    bool accepts(const std::shared_ptr<Type> type) override;
+    int64_t length() const override;
+    const std::shared_ptr<Content> shallow_copy() const override;
+    void check_for_iteration() const override;
+    const std::shared_ptr<Content> getitem_nothing() const override;
+    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
+    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
+    const std::shared_ptr<Content> getitem(const Slice& where) const override;
+    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem> head, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    const std::pair<int64_t, int64_t> minmax_depth() const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
     bool iscontiguous() const;
     void become_contiguous();
     const NumpyArray contiguous() const;
 
   protected:
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override {
       throw std::runtime_error("NumpyArray has its own getitem_next system");
     }
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override {
       throw std::runtime_error("NumpyArray has its own getitem_next system");
     }
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override {
       throw std::runtime_error("NumpyArray has its own getitem_next system");
     }
-    virtual const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override {
       throw std::runtime_error("NumpyArray has its own getitem_next system");
     }
-    virtual const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override {
       throw std::runtime_error("NumpyArray has its own getitem_next system");
     }
 

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -96,7 +96,7 @@ namespace awkward {
       }
     }
     void setid(const std::shared_ptr<Identity> id) override {
-      if (id.get() != nullptr  &&  length() != id.get()->length()) {
+      if (id != nullptr  &&  length() != id.get()->length()) {
         throw std::invalid_argument("content and its id must have the same length");
       }
       id_ = id;
@@ -409,8 +409,8 @@ namespace awkward {
         }
         awkward_regularize_rangeslice(&start, &stop, step > 0, range.hasstart(), range.hasstop(), length_);
 
-        int64_t numer = abs(start - stop);
-        int64_t denom = abs(step);
+        int64_t numer = std::abs(start - stop);
+        int64_t denom = std::abs(step);
         int64_t d = numer / denom;
         int64_t m = numer % denom;
         int64_t lenhead = d + (m != 0 ? 1 : 0);

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -79,9 +79,9 @@ namespace awkward {
 
     T* borrow(int64_t at) const { return reinterpret_cast<T*>(reinterpret_cast<ssize_t>(ptr_.get()) + (ssize_t)itemsize_*(ssize_t)(offset_ + at)); }
 
-    virtual const std::string classname() const { return std::string("RawArrayOf<") + std::string(typeid(T).name()) + std::string(">"); }
+    const std::string classname() const override { return std::string("RawArrayOf<") + std::string(typeid(T).name()) + std::string(">"); }
 
-    virtual void setid() {
+    void setid() override {
       if (length() <= kMaxInt32) {
         Identity32* rawid = new Identity32(Identity::newref(), Identity::FieldLoc(), 1, length());
         std::shared_ptr<Identity> newid(rawid);
@@ -95,7 +95,7 @@ namespace awkward {
         setid(newid);
       }
     }
-    virtual void setid(const std::shared_ptr<Identity> id) {
+    void setid(const std::shared_ptr<Identity> id) override {
       if (id.get() != nullptr  &&  length() != id.get()->length()) {
         throw std::invalid_argument("content and its id must have the same length");
       }
@@ -103,7 +103,7 @@ namespace awkward {
     }
 
     const std::string tostring() { return tostring_part("", "", ""); }
-    virtual const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const {
+    const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const override {
       std::stringstream out;
       out << indent << pre << "<RawArray of=\"" << typeid(T).name() << "\" length=\"" << length_ << "\" itemsize=\"" << itemsize_ << "\" data=\"";
       ssize_t len = bytelength();
@@ -143,7 +143,7 @@ namespace awkward {
       return out.str();
     }
 
-    virtual void tojson_part(ToJson& builder) const {
+    void tojson_part(ToJson& builder) const override {
       if (std::is_same<T, double>::value) {
         tojson_real(builder, reinterpret_cast<double*>(byteptr()), length());
       }
@@ -182,7 +182,7 @@ namespace awkward {
       }
     }
 
-    virtual const std::shared_ptr<Type> innertype(bool bare) const {
+    const std::shared_ptr<Type> innertype(bool bare) const override {
       if (std::is_same<T, double>::value) {
         return std::shared_ptr<Type>(new PrimitiveType(Type::Parameters(), PrimitiveType::float64));
       }
@@ -221,7 +221,7 @@ namespace awkward {
       }
     }
 
-    virtual void settype_part(const std::shared_ptr<Type> type) {
+    void settype_part(const std::shared_ptr<Type> type) override {
       if (accepts(type)) {
         type_ = type;
       }
@@ -230,7 +230,7 @@ namespace awkward {
       }
     }
 
-    virtual bool accepts(const std::shared_ptr<Type> type) {
+    bool accepts(const std::shared_ptr<Type> type) override {
       std::shared_ptr<Type> check = type.get()->level();
       if (std::is_same<T, double>::value) {
         return check.get()->equal(std::shared_ptr<Type>(new PrimitiveType(Type::Parameters(), PrimitiveType::float64)), false);
@@ -270,21 +270,21 @@ namespace awkward {
       }
     }
 
-    virtual int64_t length() const { return length_; }
+    int64_t length() const override { return length_; }
 
-    virtual const std::shared_ptr<Content> shallow_copy() const { return std::shared_ptr<Content>(new RawArrayOf<T>(id_, type_, ptr_, offset_, length_, itemsize_)); }
+    const std::shared_ptr<Content> shallow_copy() const override { return std::shared_ptr<Content>(new RawArrayOf<T>(id_, type_, ptr_, offset_, length_, itemsize_)); }
 
-    virtual void check_for_iteration() const {
+    void check_for_iteration() const override {
       if (id_.get() != nullptr  &&  id_.get()->length() < length_) {
         util::handle_error(failure("len(id) < len(array)", kSliceNone, kSliceNone), id_.get()->classname(), nullptr);
       }
     }
 
-    virtual const std::shared_ptr<Content> getitem_nothing() const {
+    const std::shared_ptr<Content> getitem_nothing() const override {
       return getitem_range_nowrap(0, 0);
     }
 
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const {
+    const std::shared_ptr<Content> getitem_at(int64_t at) const override {
       int64_t regular_at = at;
       if (regular_at < 0) {
         regular_at += length_;
@@ -295,11 +295,11 @@ namespace awkward {
       return getitem_at_nowrap(regular_at);
     }
 
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const {
+    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override {
       return getitem_range_nowrap(at, at + 1);
     }
 
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const {
+    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override {
       int64_t regular_start = start;
       int64_t regular_stop = stop;
       awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
@@ -309,7 +309,7 @@ namespace awkward {
       return getitem_range_nowrap(regular_start, regular_stop);
     }
 
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const {
+    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override {
       std::shared_ptr<Identity> id(nullptr);
       if (id_.get() != nullptr) {
         id = id_.get()->getitem_range_nowrap(start, stop);
@@ -317,29 +317,29 @@ namespace awkward {
       return std::shared_ptr<Content>(new RawArrayOf<T>(id, type_, ptr_, offset_ + start, stop - start, itemsize_));
     }
 
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const {
+    const std::shared_ptr<Content> getitem_field(const std::string& key) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
     }
 
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const {
+    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
     }
 
-    virtual const std::shared_ptr<Content> getitem(const Slice& where) const {
+    const std::shared_ptr<Content> getitem(const Slice& where) const override {
       std::shared_ptr<SliceItem> nexthead = where.head();
       Slice nexttail = where.tail();
       Index64 nextadvanced(0);
       return getitem_next(nexthead, nexttail, nextadvanced);
     }
 
-    virtual const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem> head, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem> head, const Slice& tail, const Index64& advanced) const override {
       if (tail.length() != 0) {
         throw std::invalid_argument("too many indexes for array");
       }
       return Content::getitem_next(head, tail, advanced);
     }
 
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const {
+    const std::shared_ptr<Content> carry(const Index64& carry) const override {
       std::shared_ptr<T> ptr(new T[(size_t)carry.length()], awkward::util::array_deleter<T>());
       struct Error err = awkward_numpyarray_getitem_next_null_64(
         reinterpret_cast<uint8_t*>(ptr.get()),
@@ -358,42 +358,42 @@ namespace awkward {
       return std::shared_ptr<Content>(new RawArrayOf<T>(id, type_, ptr, 0, carry.length(), itemsize_));
     }
 
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const {
+    const std::pair<int64_t, int64_t> minmax_depth() const override {
       return std::pair<int64_t, int64_t>(1, 1);
     }
 
-    virtual int64_t numfields() const { return -1; }
+    int64_t numfields() const override { return -1; }
 
-    virtual int64_t fieldindex(const std::string& key) const {
+    int64_t fieldindex(const std::string& key) const override {
       throw std::invalid_argument("array contains no Records");
     }
 
-    virtual const std::string key(int64_t fieldindex) const {
+    const std::string key(int64_t fieldindex) const override {
       throw std::invalid_argument("array contains no Records");
     }
 
-    virtual bool haskey(const std::string& key) const {
+    bool haskey(const std::string& key) const override {
       throw std::invalid_argument("array contains no Records");
     }
 
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const {
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override {
       throw std::invalid_argument("array contains no Records");
     }
 
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const {
+    const std::vector<std::string> keyaliases(const std::string& key) const override {
       throw std::invalid_argument("array contains no Records");
     }
 
-    virtual const std::vector<std::string> keys() const {
+    const std::vector<std::string> keys() const override {
       throw std::invalid_argument("array contains no Records");
     }
 
   protected:
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override {
       return getitem_at(at.at());
     }
 
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override {
       if (range.step() == Slice::none()  ||  range.step() == 1) {
         return getitem_range(range.start(), range.stop());
       }
@@ -425,7 +425,7 @@ namespace awkward {
       }
     }
 
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override {
       assert(advanced.length() == 0);
       if (array.shape().size() != 1) {
         throw std::runtime_error("array.ndim != 1");
@@ -439,11 +439,11 @@ namespace awkward {
       return carry(flathead);
     }
 
-    virtual const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override {
       throw std::invalid_argument(field.tostring() + std::string(" is not a valid slice type for ") + classname());
     }
 
-    virtual const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override {
       throw std::invalid_argument(fields.tostring() + std::string(" is not a valid slice type for ") + classname());
     }
 

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -24,7 +24,7 @@ namespace awkward {
     }
     const std::shared_ptr<RecordArray::Lookup> lookup() const { return array_.lookup(); }
     const std::shared_ptr<RecordArray::ReverseLookup> reverselookup() const { return array_.reverselookup(); }
-    bool istuple() const { return lookup().get() == nullptr; }
+    bool istuple() const { return lookup() == nullptr; }
 
     bool isscalar() const override;
     const std::string classname() const override;

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -26,37 +26,37 @@ namespace awkward {
     const std::shared_ptr<RecordArray::ReverseLookup> reverselookup() const { return array_.reverselookup(); }
     bool istuple() const { return lookup().get() == nullptr; }
 
-    virtual bool isscalar() const;
-    virtual const std::string classname() const;
-    virtual const std::shared_ptr<Identity> id() const;
-    virtual void setid();
-    virtual void setid(const std::shared_ptr<Identity> id);
-    virtual const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const;
-    virtual void tojson_part(ToJson& builder) const;
-    virtual const std::shared_ptr<Type> innertype(bool bare) const;
-    virtual const std::shared_ptr<Type> type() const;
-    virtual void settype(const std::shared_ptr<Type> type);
-    virtual void settype_part(const std::shared_ptr<Type> type);
-    virtual bool accepts(const std::shared_ptr<Type> type);
-    virtual int64_t length() const;
-    virtual const std::shared_ptr<Content> shallow_copy() const;
-    virtual void check_for_iteration() const;
-    virtual const std::shared_ptr<Content> getitem_nothing() const;
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const;
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const;
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const;
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    bool isscalar() const override;
+    const std::string classname() const override;
+    const std::shared_ptr<Identity> id() const override;
+    void setid() override;
+    void setid(const std::shared_ptr<Identity> id) override;
+    const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const override;
+    void tojson_part(ToJson& builder) const override;
+    const std::shared_ptr<Type> innertype(bool bare) const override;
+    const std::shared_ptr<Type> type() const override;
+    void settype(const std::shared_ptr<Type> type) override;
+    void settype_part(const std::shared_ptr<Type> type) override;
+    bool accepts(const std::shared_ptr<Type> type) override;
+    int64_t length() const override;
+    const std::shared_ptr<Content> shallow_copy() const override;
+    void check_for_iteration() const override;
+    const std::shared_ptr<Content> getitem_nothing() const override;
+    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
+    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
+    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    const std::pair<int64_t, int64_t> minmax_depth() const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
     const std::shared_ptr<Content> field(int64_t fieldindex) const;
     const std::shared_ptr<Content> field(const std::string& key) const;
@@ -65,11 +65,11 @@ namespace awkward {
     const Record astuple() const;
 
   protected:
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const;
+    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
 
   private:
     RecordArray array_;

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -23,7 +23,7 @@ namespace awkward {
         , lookup_(lookup)
         , reverselookup_(reverselookup)
         , length_(0) {
-      assert(contents.size() != 0);
+      assert(!contents.empty());
     }
     RecordArray(const std::shared_ptr<Identity> id, const std::shared_ptr<Type> type, const std::vector<std::shared_ptr<Content>>& contents)
         : Content(id, type)
@@ -31,7 +31,7 @@ namespace awkward {
         , lookup_(nullptr)
         , reverselookup_(nullptr)
         , length_(0) {
-      assert(contents.size() != 0);
+      assert(!contents.empty());
     }
     RecordArray(const std::shared_ptr<Identity> id, const std::shared_ptr<Type> type, int64_t length, bool istuple)
         : Content(id, type)
@@ -45,34 +45,34 @@ namespace awkward {
     const std::shared_ptr<ReverseLookup> reverselookup() const { return reverselookup_; }
     bool istuple() const { return lookup_.get() == nullptr; }
 
-    virtual const std::string classname() const;
-    virtual void setid();
-    virtual void setid(const std::shared_ptr<Identity> id);
-    virtual const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const;
-    virtual void tojson_part(ToJson& builder) const;
-    virtual const std::shared_ptr<Type> innertype(bool bare) const;
-    virtual void settype_part(const std::shared_ptr<Type> type);
-    virtual bool accepts(const std::shared_ptr<Type> type);
-    virtual int64_t length() const;
-    virtual const std::shared_ptr<Content> shallow_copy() const;
-    virtual void check_for_iteration() const;
-    virtual const std::shared_ptr<Content> getitem_nothing() const;
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const;
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const;
-    virtual const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem> head, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const;
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    const std::string classname() const override;
+    void setid() override;
+    void setid(const std::shared_ptr<Identity> id) override;
+    const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const override;
+    void tojson_part(ToJson& builder) const override;
+    const std::shared_ptr<Type> innertype(bool bare) const override;
+    void settype_part(const std::shared_ptr<Type> type) override;
+    bool accepts(const std::shared_ptr<Type> type) override;
+    int64_t length() const override;
+    const std::shared_ptr<Content> shallow_copy() const override;
+    void check_for_iteration() const override;
+    const std::shared_ptr<Content> getitem_nothing() const override;
+    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
+    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
+    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem> head, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    const std::pair<int64_t, int64_t> minmax_depth() const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
     const std::shared_ptr<Content> field(int64_t fieldindex) const;
     const std::shared_ptr<Content> field(const std::string& key) const;
@@ -85,11 +85,11 @@ namespace awkward {
     void setkey(int64_t fieldindex, const std::string& key);
 
   protected:
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const;
+    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
 
   private:
     std::vector<std::shared_ptr<Content>> contents_;

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -43,7 +43,7 @@ namespace awkward {
     const std::vector<std::shared_ptr<Content>> contents() const { return contents_; }
     const std::shared_ptr<Lookup> lookup() const { return lookup_; }
     const std::shared_ptr<ReverseLookup> reverselookup() const { return reverselookup_; }
-    bool istuple() const { return lookup_.get() == nullptr; }
+    bool istuple() const { return lookup_ == nullptr; }
 
     const std::string classname() const override;
     void setid() override;

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -23,38 +23,38 @@ namespace awkward {
     const std::shared_ptr<Content> content() const { return content_; }
     int64_t size() const { return size_; }
 
-    virtual const std::string classname() const;
-    virtual void setid();
-    virtual void setid(const std::shared_ptr<Identity> id);
-    virtual const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const;
-    virtual void tojson_part(ToJson& builder) const;
-    virtual const std::shared_ptr<Type> innertype(bool bare) const;
-    virtual void settype_part(const std::shared_ptr<Type> type);
-    virtual bool accepts(const std::shared_ptr<Type> type);
-    virtual int64_t length() const;
-    virtual const std::shared_ptr<Content> shallow_copy() const;
-    virtual void check_for_iteration() const;
-    virtual const std::shared_ptr<Content> getitem_nothing() const;
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const;
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const;
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const;
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const;
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const;
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    const std::string classname() const override;
+    void setid() override;
+    void setid(const std::shared_ptr<Identity> id) override;
+    const std::string tostring_part(const std::string indent, const std::string pre, const std::string post) const override;
+    void tojson_part(ToJson& builder) const override;
+    const std::shared_ptr<Type> innertype(bool bare) const override;
+    void settype_part(const std::shared_ptr<Type> type) override;
+    bool accepts(const std::shared_ptr<Type> type) override;
+    int64_t length() const override;
+    const std::shared_ptr<Content> shallow_copy() const override;
+    void check_for_iteration() const override;
+    const std::shared_ptr<Content> getitem_nothing() const override;
+    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
+    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
+    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
+    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    const std::pair<int64_t, int64_t> minmax_depth() const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
   protected:
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const;
+    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
 
   private:
     const std::shared_ptr<Content> content_;

--- a/include/awkward/fillable/BoolFillable.h
+++ b/include/awkward/fillable/BoolFillable.h
@@ -15,26 +15,26 @@ namespace awkward {
 
     static const std::shared_ptr<Fillable> fromempty(const FillableOptions& options);
 
-    virtual const std::string classname() const { return "BoolFillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "BoolFillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
   private:
     const FillableOptions options_;

--- a/include/awkward/fillable/Float64Fillable.h
+++ b/include/awkward/fillable/Float64Fillable.h
@@ -16,26 +16,26 @@ namespace awkward {
     static const std::shared_ptr<Fillable> fromempty(const FillableOptions& options);
     static const std::shared_ptr<Fillable> fromint64(const FillableOptions& options, GrowableBuffer<int64_t> old);
 
-    virtual const std::string classname() const { return "Float64Fillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "Float64Fillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
   private:
     const FillableOptions options_;

--- a/include/awkward/fillable/Int64Fillable.h
+++ b/include/awkward/fillable/Int64Fillable.h
@@ -15,26 +15,26 @@ namespace awkward {
 
     static const std::shared_ptr<Fillable> fromempty(const FillableOptions& options);
 
-    virtual const std::string classname() const { return "Int64Fillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "Int64Fillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
     const GrowableBuffer<int64_t> buffer() const { return buffer_; }
 

--- a/include/awkward/fillable/ListFillable.h
+++ b/include/awkward/fillable/ListFillable.h
@@ -18,26 +18,26 @@ namespace awkward {
 
     static const std::shared_ptr<Fillable> fromempty(const FillableOptions& options);
 
-    virtual const std::string classname() const { return "ListFillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "ListFillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
   private:
     const FillableOptions options_;

--- a/include/awkward/fillable/OptionFillable.h
+++ b/include/awkward/fillable/OptionFillable.h
@@ -18,26 +18,26 @@ namespace awkward {
     static const std::shared_ptr<Fillable> fromnulls(const FillableOptions& options, int64_t nullcount, std::shared_ptr<Fillable> content);
     static const std::shared_ptr<Fillable> fromvalids(const FillableOptions& options, std::shared_ptr<Fillable> content);
 
-    virtual const std::string classname() const { return "OptionFillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "OptionFillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
   private:
     const FillableOptions options_;

--- a/include/awkward/fillable/RecordFillable.h
+++ b/include/awkward/fillable/RecordFillable.h
@@ -28,26 +28,26 @@ namespace awkward {
 
     static const std::shared_ptr<Fillable> fromempty(const FillableOptions& options);
 
-    virtual const std::string classname() const { return "RecordFillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "RecordFillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
     const std::string name() const { return name_; }
     const char* nameptr() const { return nameptr_; }

--- a/include/awkward/fillable/StringFillable.h
+++ b/include/awkward/fillable/StringFillable.h
@@ -15,26 +15,26 @@ namespace awkward {
 
     static const std::shared_ptr<Fillable> fromempty(const FillableOptions& options, const char* encoding);
 
-    virtual const std::string classname() const { return "StringFillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "StringFillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
     const char* encoding() const { return encoding_; }
 

--- a/include/awkward/fillable/TupleFillable.h
+++ b/include/awkward/fillable/TupleFillable.h
@@ -23,26 +23,26 @@ namespace awkward {
 
     static const std::shared_ptr<Fillable> fromempty(const FillableOptions& options);
 
-    virtual const std::string classname() const { return "TupleFillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "TupleFillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
     int64_t numfields() const { return (int64_t)contents_.size(); }
 

--- a/include/awkward/fillable/UnionFillable.h
+++ b/include/awkward/fillable/UnionFillable.h
@@ -20,26 +20,26 @@ namespace awkward {
 
     static const std::shared_ptr<Fillable> fromsingle(const FillableOptions& options, const std::shared_ptr<Fillable> firstcontent);
 
-    virtual const std::string classname() const { return "UnionFillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "UnionFillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
   private:
     const FillableOptions options_;

--- a/include/awkward/fillable/UnknownFillable.h
+++ b/include/awkward/fillable/UnknownFillable.h
@@ -16,26 +16,26 @@ namespace awkward {
 
     static const std::shared_ptr<Fillable> fromempty(const FillableOptions& options);
 
-    virtual const std::string classname() const { return "UnknownFillable"; };
-    virtual int64_t length() const;
-    virtual void clear();
-    virtual const std::shared_ptr<Type> type() const;
-    virtual const std::shared_ptr<Content> snapshot() const;
+    const std::string classname() const override { return "UnknownFillable"; };
+    int64_t length() const override;
+    void clear() override;
+    const std::shared_ptr<Type> type() const override;
+    const std::shared_ptr<Content> snapshot() const override;
 
-    virtual bool active() const;
-    virtual const std::shared_ptr<Fillable> null();
-    virtual const std::shared_ptr<Fillable> boolean(bool x);
-    virtual const std::shared_ptr<Fillable> integer(int64_t x);
-    virtual const std::shared_ptr<Fillable> real(double x);
-    virtual const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding);
-    virtual const std::shared_ptr<Fillable> beginlist();
-    virtual const std::shared_ptr<Fillable> endlist();
-    virtual const std::shared_ptr<Fillable> begintuple(int64_t numfields);
-    virtual const std::shared_ptr<Fillable> index(int64_t index);
-    virtual const std::shared_ptr<Fillable> endtuple();
-    virtual const std::shared_ptr<Fillable> beginrecord(const char* name, bool check);
-    virtual const std::shared_ptr<Fillable> field(const char* key, bool check);
-    virtual const std::shared_ptr<Fillable> endrecord();
+    bool active() const override;
+    const std::shared_ptr<Fillable> null() override;
+    const std::shared_ptr<Fillable> boolean(bool x) override;
+    const std::shared_ptr<Fillable> integer(int64_t x) override;
+    const std::shared_ptr<Fillable> real(double x) override;
+    const std::shared_ptr<Fillable> string(const char* x, int64_t length, const char* encoding) override;
+    const std::shared_ptr<Fillable> beginlist() override;
+    const std::shared_ptr<Fillable> endlist() override;
+    const std::shared_ptr<Fillable> begintuple(int64_t numfields) override;
+    const std::shared_ptr<Fillable> index(int64_t index) override;
+    const std::shared_ptr<Fillable> endtuple() override;
+    const std::shared_ptr<Fillable> beginrecord(const char* name, bool check) override;
+    const std::shared_ptr<Fillable> field(const char* key, bool check) override;
+    const std::shared_ptr<Fillable> endrecord() override;
 
   private:
     const FillableOptions options_;

--- a/include/awkward/io/json.h
+++ b/include/awkward/io/json.h
@@ -48,16 +48,16 @@ namespace awkward {
       }
     }
 
-    virtual void null() { writer_.Null(); }
-    virtual void boolean(bool x) { writer_.Bool(x); }
-    virtual void integer(int64_t x) { writer_.Int64(x); }
-    virtual void real(double x) { writer_.Double(x); }
-    virtual void string(const char* x, int64_t length) { writer_.String(x, (rj::SizeType)length); }
-    virtual void beginlist() { writer_.StartArray(); }
-    virtual void endlist() { writer_.EndArray(); }
-    virtual void beginrecord() { writer_.StartObject(); }
-    virtual void field(const char* x) { writer_.Key(x); }
-    virtual void endrecord() { writer_.EndObject(); }
+    void null() override { writer_.Null(); }
+    void boolean(bool x) override { writer_.Bool(x); }
+    void integer(int64_t x) override { writer_.Int64(x); }
+    void real(double x) override { writer_.Double(x); }
+    void string(const char* x, int64_t length) override { writer_.String(x, (rj::SizeType)length); }
+    void beginlist() override { writer_.StartArray(); }
+    void endlist() override { writer_.EndArray(); }
+    void beginrecord() override { writer_.StartObject(); }
+    void field(const char* x) override { writer_.Key(x); }
+    void endrecord() override { writer_.EndObject(); }
 
     std::string tostring() {
       return std::string(buffer_.GetString());
@@ -76,16 +76,16 @@ namespace awkward {
       }
     }
 
-    virtual void null() { writer_.Null(); }
-    virtual void boolean(bool x) { writer_.Bool(x); }
-    virtual void integer(int64_t x) { writer_.Int64(x); }
-    virtual void real(double x) { writer_.Double(x); }
-    virtual void string(const char* x, int64_t length) { writer_.String(x, (rj::SizeType)length); }
-    virtual void beginlist() { writer_.StartArray(); }
-    virtual void endlist() { writer_.EndArray(); }
-    virtual void beginrecord() { writer_.StartObject(); }
-    virtual void field(const char* x) { writer_.Key(x); }
-    virtual void endrecord() { writer_.EndObject(); }
+    void null() override { writer_.Null(); }
+    void boolean(bool x) override { writer_.Bool(x); }
+    void integer(int64_t x) override { writer_.Int64(x); }
+    void real(double x) override { writer_.Double(x); }
+    void string(const char* x, int64_t length) override { writer_.String(x, (rj::SizeType)length); }
+    void beginlist() override { writer_.StartArray(); }
+    void endlist() override { writer_.EndArray(); }
+    void beginrecord() override { writer_.StartObject(); }
+    void field(const char* x) override { writer_.Key(x); }
+    void endrecord() override { writer_.EndObject(); }
 
     std::string tostring() {
       return std::string(buffer_.GetString());
@@ -104,16 +104,16 @@ namespace awkward {
       }
     }
 
-    virtual void null() { writer_.Null(); }
-    virtual void boolean(bool x) { writer_.Bool(x); }
-    virtual void integer(int64_t x) { writer_.Int64(x); }
-    virtual void real(double x) { writer_.Double(x); }
-    virtual void string(const char* x, int64_t length) { writer_.String(x, (rj::SizeType)length); }
-    virtual void beginlist() { writer_.StartArray(); }
-    virtual void endlist() { writer_.EndArray(); }
-    virtual void beginrecord() { writer_.StartObject(); }
-    virtual void field(const char* x) { writer_.Key(x); }
-    virtual void endrecord() { writer_.EndObject(); }
+    void null() override { writer_.Null(); }
+    void boolean(bool x) override { writer_.Bool(x); }
+    void integer(int64_t x) override { writer_.Int64(x); }
+    void real(double x) override { writer_.Double(x); }
+    void string(const char* x, int64_t length) override { writer_.String(x, (rj::SizeType)length); }
+    void beginlist() override { writer_.StartArray(); }
+    void endlist() override { writer_.EndArray(); }
+    void beginrecord() override { writer_.StartObject(); }
+    void field(const char* x) override { writer_.Key(x); }
+    void endrecord() override { writer_.EndObject(); }
 
   private:
     std::shared_ptr<char> buffer_;
@@ -129,16 +129,16 @@ namespace awkward {
       }
     }
 
-    virtual void null() { writer_.Null(); }
-    virtual void boolean(bool x) { writer_.Bool(x); }
-    virtual void integer(int64_t x) { writer_.Int64(x); }
-    virtual void real(double x) { writer_.Double(x); }
-    virtual void string(const char* x, int64_t length) { writer_.String(x, (rj::SizeType)length); }
-    virtual void beginlist() { writer_.StartArray(); }
-    virtual void endlist() { writer_.EndArray(); }
-    virtual void beginrecord() { writer_.StartObject(); }
-    virtual void field(const char* x) { writer_.Key(x); }
-    virtual void endrecord() { writer_.EndObject(); }
+    void null() override { writer_.Null(); }
+    void boolean(bool x) override { writer_.Bool(x); }
+    void integer(int64_t x) override { writer_.Int64(x); }
+    void real(double x) override { writer_.Double(x); }
+    void string(const char* x, int64_t length) override { writer_.String(x, (rj::SizeType)length); }
+    void beginlist() override { writer_.StartArray(); }
+    void endlist() override { writer_.EndArray(); }
+    void beginrecord() override { writer_.StartObject(); }
+    void field(const char* x) override { writer_.Key(x); }
+    void endrecord() override { writer_.EndObject(); }
 
   private:
     std::shared_ptr<char> buffer_;

--- a/include/awkward/type/ArrayType.h
+++ b/include/awkward/type/ArrayType.h
@@ -13,20 +13,20 @@ namespace awkward {
         , type_(type)
         , length_(length) { }
 
-    virtual std::string tostring_part(std::string indent, std::string pre, std::string post) const;
-    virtual const std::shared_ptr<Type> shallow_copy() const;
-    virtual bool equal(const std::shared_ptr<Type> other, bool check_parameters) const;
-    virtual std::shared_ptr<Type> nolength() const;
-    virtual std::shared_ptr<Type> level() const;
-    virtual std::shared_ptr<Type> inner() const;
-    virtual std::shared_ptr<Type> inner(const std::string& key) const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    std::string tostring_part(std::string indent, std::string pre, std::string post) const override;
+    const std::shared_ptr<Type> shallow_copy() const override;
+    bool equal(const std::shared_ptr<Type> other, bool check_parameters) const override;
+    std::shared_ptr<Type> nolength() const override;
+    std::shared_ptr<Type> level() const override;
+    std::shared_ptr<Type> inner() const override;
+    std::shared_ptr<Type> inner(const std::string& key) const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
     const std::shared_ptr<Type> type() const;
     int64_t length() const;

--- a/include/awkward/type/ListType.h
+++ b/include/awkward/type/ListType.h
@@ -12,19 +12,19 @@ namespace awkward {
         : Type(parameters)
         , type_(type) { }
 
-    virtual std::string tostring_part(std::string indent, std::string pre, std::string post) const;
-    virtual const std::shared_ptr<Type> shallow_copy() const;
-    virtual bool equal(const std::shared_ptr<Type> other, bool check_parameters) const;
-    virtual std::shared_ptr<Type> level() const;
-    virtual std::shared_ptr<Type> inner() const;
-    virtual std::shared_ptr<Type> inner(const std::string& key) const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    std::string tostring_part(std::string indent, std::string pre, std::string post) const override;
+    const std::shared_ptr<Type> shallow_copy() const override;
+    bool equal(const std::shared_ptr<Type> other, bool check_parameters) const override;
+    std::shared_ptr<Type> level() const override;
+    std::shared_ptr<Type> inner() const override;
+    std::shared_ptr<Type> inner(const std::string& key) const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
   const std::shared_ptr<Type> type() const;
 

--- a/include/awkward/type/OptionType.h
+++ b/include/awkward/type/OptionType.h
@@ -12,19 +12,19 @@ namespace awkward {
         : Type(parameters)
         , type_(type) { }
 
-    virtual std::string tostring_part(std::string indent, std::string pre, std::string post) const;
-    virtual const std::shared_ptr<Type> shallow_copy() const;
-    virtual bool equal(const std::shared_ptr<Type> other, bool check_parameters) const;
-    virtual std::shared_ptr<Type> level() const;
-    virtual std::shared_ptr<Type> inner() const;
-    virtual std::shared_ptr<Type> inner(const std::string& key) const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    std::string tostring_part(std::string indent, std::string pre, std::string post) const override;
+    const std::shared_ptr<Type> shallow_copy() const override;
+    bool equal(const std::shared_ptr<Type> other, bool check_parameters) const override;
+    std::shared_ptr<Type> level() const override;
+    std::shared_ptr<Type> inner() const override;
+    std::shared_ptr<Type> inner(const std::string& key) const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
   const std::shared_ptr<Type> type() const;
 

--- a/include/awkward/type/PrimitiveType.h
+++ b/include/awkward/type/PrimitiveType.h
@@ -27,19 +27,19 @@ namespace awkward {
         : Type(parameters)
         , dtype_(dtype) { }
 
-    virtual std::string tostring_part(std::string indent, std::string pre, std::string post) const;
-    virtual const std::shared_ptr<Type> shallow_copy() const;
-    virtual bool equal(const std::shared_ptr<Type> other, bool check_parameters) const;
-    virtual std::shared_ptr<Type> level() const;
-    virtual std::shared_ptr<Type> inner() const;
-    virtual std::shared_ptr<Type> inner(const std::string& key) const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    std::string tostring_part(std::string indent, std::string pre, std::string post) const override;
+    const std::shared_ptr<Type> shallow_copy() const override;
+    bool equal(const std::shared_ptr<Type> other, bool check_parameters) const override;
+    std::shared_ptr<Type> level() const override;
+    std::shared_ptr<Type> inner() const override;
+    std::shared_ptr<Type> inner(const std::string& key) const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
   const DType dtype() const;
 

--- a/include/awkward/type/RecordType.h
+++ b/include/awkward/type/RecordType.h
@@ -30,19 +30,19 @@ namespace awkward {
     const std::shared_ptr<Lookup> lookup() const { return lookup_; }
     const std::shared_ptr<ReverseLookup> reverselookup() const { return reverselookup_; }
 
-    virtual std::string tostring_part(std::string indent, std::string pre, std::string post) const;
-    virtual const std::shared_ptr<Type> shallow_copy() const;
-    virtual bool equal(const std::shared_ptr<Type> other, bool check_parameters) const;
-    virtual std::shared_ptr<Type> level() const;
-    virtual std::shared_ptr<Type> inner() const;
-    virtual std::shared_ptr<Type> inner(const std::string& key) const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    std::string tostring_part(std::string indent, std::string pre, std::string post) const override;
+    const std::shared_ptr<Type> shallow_copy() const override;
+    bool equal(const std::shared_ptr<Type> other, bool check_parameters) const override;
+    std::shared_ptr<Type> level() const override;
+    std::shared_ptr<Type> inner() const override;
+    std::shared_ptr<Type> inner(const std::string& key) const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
     const std::shared_ptr<Type> field(int64_t fieldindex) const;
     const std::shared_ptr<Type> field(const std::string& key) const;

--- a/include/awkward/type/RegularType.h
+++ b/include/awkward/type/RegularType.h
@@ -15,19 +15,19 @@ namespace awkward {
         , type_(type)
         , size_(size) { }
 
-    virtual std::string tostring_part(std::string indent, std::string pre, std::string post) const;
-    virtual const std::shared_ptr<Type> shallow_copy() const;
-    virtual bool equal(const std::shared_ptr<Type> other, bool check_parameters) const;
-    virtual std::shared_ptr<Type> level() const;
-    virtual std::shared_ptr<Type> inner() const;
-    virtual std::shared_ptr<Type> inner(const std::string& key) const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    std::string tostring_part(std::string indent, std::string pre, std::string post) const override;
+    const std::shared_ptr<Type> shallow_copy() const override;
+    bool equal(const std::shared_ptr<Type> other, bool check_parameters) const override;
+    std::shared_ptr<Type> level() const override;
+    std::shared_ptr<Type> inner() const override;
+    std::shared_ptr<Type> inner(const std::string& key) const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
     const std::shared_ptr<Type> type() const;
     int64_t size() const;

--- a/include/awkward/type/UnionType.h
+++ b/include/awkward/type/UnionType.h
@@ -12,19 +12,19 @@ namespace awkward {
   public:
     UnionType(const Parameters& parameters, const std::vector<std::shared_ptr<Type>>& types): Type(parameters), types_(types) { }
 
-    virtual std::string tostring_part(std::string indent, std::string pre, std::string post) const;
-    virtual const std::shared_ptr<Type> shallow_copy() const;
-    virtual bool equal(const std::shared_ptr<Type> other, bool check_parameters) const;
-    virtual std::shared_ptr<Type> level() const;
-    virtual std::shared_ptr<Type> inner() const;
-    virtual std::shared_ptr<Type> inner(const std::string& key) const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    std::string tostring_part(std::string indent, std::string pre, std::string post) const override;
+    const std::shared_ptr<Type> shallow_copy() const override;
+    bool equal(const std::shared_ptr<Type> other, bool check_parameters) const override;
+    std::shared_ptr<Type> level() const override;
+    std::shared_ptr<Type> inner() const override;
+    std::shared_ptr<Type> inner(const std::string& key) const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
     int64_t numtypes() const;
     const std::vector<std::shared_ptr<Type>> types() const;

--- a/include/awkward/type/UnknownType.h
+++ b/include/awkward/type/UnknownType.h
@@ -10,19 +10,19 @@ namespace awkward {
   public:
     UnknownType(const Parameters& parameters): Type(parameters) { }
 
-    virtual std::string tostring_part(std::string indent, std::string pre, std::string post) const;
-    virtual const std::shared_ptr<Type> shallow_copy() const;
-    virtual bool equal(const std::shared_ptr<Type> other, bool check_parameters) const;
-    virtual std::shared_ptr<Type> level() const;
-    virtual std::shared_ptr<Type> inner() const;
-    virtual std::shared_ptr<Type> inner(const std::string& key) const;
-    virtual int64_t numfields() const;
-    virtual int64_t fieldindex(const std::string& key) const;
-    virtual const std::string key(int64_t fieldindex) const;
-    virtual bool haskey(const std::string& key) const;
-    virtual const std::vector<std::string> keyaliases(int64_t fieldindex) const;
-    virtual const std::vector<std::string> keyaliases(const std::string& key) const;
-    virtual const std::vector<std::string> keys() const;
+    std::string tostring_part(std::string indent, std::string pre, std::string post) const override;
+    const std::shared_ptr<Type> shallow_copy() const override;
+    bool equal(const std::shared_ptr<Type> other, bool check_parameters) const override;
+    std::shared_ptr<Type> level() const override;
+    std::shared_ptr<Type> inner() const override;
+    std::shared_ptr<Type> inner(const std::string& key) const override;
+    int64_t numfields() const override;
+    int64_t fieldindex(const std::string& key) const override;
+    const std::string key(int64_t fieldindex) const override;
+    bool haskey(const std::string& key) const override;
+    const std::vector<std::string> keyaliases(int64_t fieldindex) const override;
+    const std::vector<std::string> keyaliases(const std::string& key) const override;
+    const std::vector<std::string> keys() const override;
 
   private:
   };

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -17,7 +17,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<Type> Content::type() const {
-    if (type_.get() == nullptr) {
+    if (type_ == nullptr) {
       if (isscalar()) {
         return innertype(false);
       }
@@ -42,7 +42,7 @@ namespace awkward {
   }
 
   bool Content::isbare() const {
-    return type_.get() == nullptr;
+    return type_ == nullptr;
   }
 
   const std::shared_ptr<Type> Content::baretype() const {
@@ -103,7 +103,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<Content> Content::getitem_next(const std::shared_ptr<SliceItem> head, const Slice& tail, const Index64& advanced) const {
-    if (head.get() == nullptr) {
+    if (head == nullptr) {
       return shallow_copy();
     }
     else if (SliceAt* at = dynamic_cast<SliceAt*>(head.get())) {

--- a/src/libawkward/Slice.cpp
+++ b/src/libawkward/Slice.cpp
@@ -163,7 +163,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<SliceItem> Slice::head() const {
-    if (items_.size() != 0) {
+    if (!items_.empty()) {
       return items_[0];
     }
     else {
@@ -173,7 +173,7 @@ namespace awkward {
 
   const Slice Slice::tail() const {
     std::vector<std::shared_ptr<SliceItem>> items;
-    if (items_.size() != 0) {
+    if (!items_.empty()) {
       items.insert(items.end(), items_.begin() + 1, items_.end());
     }
     return Slice(items, true);
@@ -224,7 +224,7 @@ namespace awkward {
     std::vector<int64_t> shape;
     for (size_t i = 0;  i < items_.size();  i++) {
       if (SliceArray64* array = dynamic_cast<SliceArray64*>(items_[i].get())) {
-        if (shape.size() == 0) {
+        if (shape.empty()) {
           shape = array->shape();
         }
         else if (shape.size() != array->ndim()) {
@@ -244,7 +244,7 @@ namespace awkward {
       }
     }
 
-    if (shape.size() != 0) {
+    if (!shape.empty()) {
       for (size_t i = 0;  i < items_.size();  i++) {
         if (SliceAt* at = dynamic_cast<SliceAt*>(items_[i].get())) {
           Index64 index(1);

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -15,7 +15,7 @@ namespace awkward {
   }
 
   void EmptyArray::setid(const std::shared_ptr<Identity> id) {
-    if (id.get() != nullptr  &&  length() != id.get()->length()) {
+    if (id != nullptr  &&  length() != id.get()->length()) {
       util::handle_error(failure("content and its id must have the same length", kSliceNone, kSliceNone), classname(), id_.get());
     }
     id_ = id;
@@ -26,14 +26,14 @@ namespace awkward {
   const std::string EmptyArray::tostring_part(const std::string indent, const std::string pre, const std::string post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname();
-    if (id_.get() == nullptr  &&  type_.get() == nullptr) {
+    if (id_ == nullptr  &&  type_ == nullptr) {
       out << "/>" << post;
     }
     else {
-      if (id_.get() != nullptr) {
+      if (id_ != nullptr) {
         out << ">\n" << id_.get()->tostring_part(indent + std::string("    "), "", "\n") << indent << "</" << classname() << ">" << post;
       }
-      if (type_.get() != nullptr) {
+      if (type_ != nullptr) {
         out << indent << "    <type>" + type().get()->tostring() + "</type>\n";
       }
     }

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -33,7 +33,7 @@ namespace awkward {
 
   template <>
   void ListArrayOf<int32_t>::setid(const std::shared_ptr<Identity> id) {
-    if (id.get() == nullptr) {
+    if (id == nullptr) {
       content_.get()->setid(id);
     }
     else {
@@ -87,7 +87,7 @@ namespace awkward {
 
   template <typename T>
   void ListArrayOf<T>::setid(const std::shared_ptr<Identity> id) {
-    if (id.get() == nullptr) {
+    if (id == nullptr) {
       content_.get()->setid(id);
     }
     else {
@@ -141,10 +141,10 @@ namespace awkward {
   const std::string ListArrayOf<T>::tostring_part(const std::string indent, const std::string pre, const std::string post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << ">\n";
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       out << id_.get()->tostring_part(indent + std::string("    "), "", "\n");
     }
-    if (type_.get() != nullptr) {
+    if (type_ != nullptr) {
       out << indent << "    <type>" + type().get()->tostring() + "</type>\n";
     }
     out << starts_.tostring_part(indent + std::string("    "), "<starts>", "</starts>\n");
@@ -205,7 +205,7 @@ namespace awkward {
     if (stops_.length() < starts_.length()) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), id_.get());
     }
-    if (id_.get() != nullptr  &&  id_.get()->length() < starts_.length()) {
+    if (id_ != nullptr  &&  id_.get()->length() < starts_.length()) {
       util::handle_error(failure("len(id) < len(array)", kSliceNone, kSliceNone), id_.get()->classname(), nullptr);
     }
   }
@@ -258,7 +258,7 @@ namespace awkward {
     if (regular_stop > stops_.length()) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), id_.get());
     }
-    if (id_.get() != nullptr  &&  regular_stop > id_.get()->length()) {
+    if (id_ != nullptr  &&  regular_stop > id_.get()->length()) {
       util::handle_error(failure("index out of range", kSliceNone, stop), id_.get()->classname(), nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
@@ -267,7 +267,7 @@ namespace awkward {
   template <typename T>
   const std::shared_ptr<Content> ListArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identity> id(nullptr);
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       id = id_.get()->getitem_range_nowrap(start, stop);
     }
     return std::shared_ptr<Content>(new ListArrayOf<T>(id, type_, starts_.getitem_range_nowrap(start, stop), stops_.getitem_range_nowrap(start, stop), content_));
@@ -307,7 +307,7 @@ namespace awkward {
       carry.length());
     util::handle_error(err, classname(), id_.get());
     std::shared_ptr<Identity> id(nullptr);
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       id = id_.get()->getitem_carry_64(carry);
     }
     return std::shared_ptr<Content>(new ListArrayOf<T>(id, type_, nextstarts, nextstops, content_));

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -43,7 +43,7 @@ namespace awkward {
 
   template <>
   void ListOffsetArrayOf<int32_t>::setid(const std::shared_ptr<Identity> id) {
-    if (id.get() == nullptr) {
+    if (id == nullptr) {
       content_.get()->setid(id);
     }
     else {
@@ -93,7 +93,7 @@ namespace awkward {
 
   template <typename T>
   void ListOffsetArrayOf<T>::setid(const std::shared_ptr<Identity> id) {
-    if (id.get() == nullptr) {
+    if (id == nullptr) {
       content_.get()->setid(id);
     }
     else {
@@ -145,10 +145,10 @@ namespace awkward {
   const std::string ListOffsetArrayOf<T>::tostring_part(const std::string indent, const std::string pre, const std::string post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << ">\n";
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       out << id_.get()->tostring_part(indent + std::string("    "), "", "\n");
     }
-    if (type_.get() != nullptr) {
+    if (type_ != nullptr) {
       out << indent << "    <type>" + type().get()->tostring() + "</type>\n";
     }
     out << offsets_.tostring_part(indent + std::string("    "), "<offsets>", "</offsets>\n");
@@ -205,7 +205,7 @@ namespace awkward {
 
   template <typename T>
   void ListOffsetArrayOf<T>::check_for_iteration() const {
-    if (id_.get() != nullptr  &&  id_.get()->length() < offsets_.length() - 1) {
+    if (id_ != nullptr  &&  id_.get()->length() < offsets_.length() - 1) {
       util::handle_error(failure("len(id) < len(array)", kSliceNone, kSliceNone), id_.get()->classname(), nullptr);
     }
   }
@@ -252,7 +252,7 @@ namespace awkward {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), offsets_.length() - 1);
-    if (id_.get() != nullptr  &&  regular_stop > id_.get()->length()) {
+    if (id_ != nullptr  &&  regular_stop > id_.get()->length()) {
       util::handle_error(failure("index out of range", kSliceNone, stop), id_.get()->classname(), nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
@@ -261,7 +261,7 @@ namespace awkward {
   template <typename T>
   const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identity> id(nullptr);
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       id = id_.get()->getitem_range_nowrap(start, stop);
     }
     return std::shared_ptr<Content>(new ListOffsetArrayOf<T>(id, type_, offsets_.getitem_range_nowrap(start, stop + 1), content_));
@@ -299,7 +299,7 @@ namespace awkward {
       carry.length());
     util::handle_error(err, classname(), id_.get());
     std::shared_ptr<Identity> id(nullptr);
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       id = id_.get()->getitem_carry_64(carry);
     }
     return std::shared_ptr<Content>(new ListArrayOf<T>(id, type_, nextstarts, nextstops, content_));

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -57,7 +57,7 @@ namespace awkward {
   }
 
   void NumpyArray::setid(const std::shared_ptr<Identity> id) {
-    if (id.get() != nullptr  &&  length() != id.get()->length()) {
+    if (id != nullptr  &&  length() != id.get()->length()) {
       util::handle_error(failure("content and its id must have the same length", kSliceNone, kSliceNone), classname(), id_.get());
     }
     id_ = id;
@@ -197,15 +197,15 @@ namespace awkward {
     }
     out << "\" at=\"0x";
     out << std::hex << std::setw(12) << std::setfill('0') << reinterpret_cast<ssize_t>(ptr_.get());
-    if (id_.get() == nullptr  &&  type_.get() == nullptr) {
+    if (id_ == nullptr  &&  type_ == nullptr) {
       out << "\"/>" << post;
     }
     else {
       out << "\">\n";
-      if (id_.get() != nullptr) {
+      if (id_ != nullptr) {
         out << id_.get()->tostring_part(indent + std::string("    "), "", "\n");
       }
-      if (type_.get() != nullptr) {
+      if (type_ != nullptr) {
         out << indent << "    <type>" + type().get()->tostring() + "</type>\n";
       }
       out << indent << "</" << classname() << ">" << post;
@@ -214,7 +214,7 @@ namespace awkward {
   }
 
   void NumpyArray::tojson_part(ToJson& builder) const {
-    if (type_.get() != nullptr  &&  type_.get()->parameter_equals("__class__", "\"char\"")) {
+    if (type_ != nullptr  &&  type_.get()->parameter_equals("__class__", "\"char\"")) {
       tojson_string(builder);
     }
     else if (format_.compare("d") == 0) {
@@ -337,7 +337,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<Type> NumpyArray::type() const {
-    if (type_.get() == nullptr) {
+    if (type_ == nullptr) {
       if (isscalar()) {
         return innertype(false);
       }
@@ -455,7 +455,7 @@ namespace awkward {
   }
 
   void NumpyArray::check_for_iteration() const {
-    if (id_.get() != nullptr  &&  id_.get()->length() < shape_[0]) {
+    if (id_ != nullptr  &&  id_.get()->length() < shape_[0]) {
       util::handle_error(failure("len(id) < len(array)", kSliceNone, kSliceNone), id_.get()->classname(), nullptr);
     }
   }
@@ -464,7 +464,7 @@ namespace awkward {
     const std::vector<ssize_t> shape({ 0 });
     const std::vector<ssize_t> strides({ itemsize_ });
     std::shared_ptr<Identity> id;
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       id = id_.get()->getitem_range_nowrap(0, 0);
     }
     return std::shared_ptr<Content>(new NumpyArray(id, type_, ptr_, shape, strides, byteoffset_, itemsize_, format_));
@@ -487,7 +487,7 @@ namespace awkward {
     const std::vector<ssize_t> shape(shape_.begin() + 1, shape_.end());
     const std::vector<ssize_t> strides(strides_.begin() + 1, strides_.end());
     std::shared_ptr<Identity> id;
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       if (at >= id_.get()->length()) {
         util::handle_error(failure("index out of range", kSliceNone, at), id_.get()->classname(), nullptr);
       }
@@ -510,7 +510,7 @@ namespace awkward {
     shape.push_back((ssize_t)(stop - start));
     shape.insert(shape.end(), shape_.begin() + 1, shape_.end());
     std::shared_ptr<Identity> id;
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       if (stop > id_.get()->length()) {
         util::handle_error(failure("index out of range", kSliceNone, stop), id_.get()->classname(), nullptr);
       }
@@ -530,7 +530,7 @@ namespace awkward {
   const std::shared_ptr<Content> NumpyArray::getitem(const Slice& where) const {
     assert(!isscalar());
 
-    if (!where.isadvanced()  &&  id_.get() == nullptr) {
+    if (!where.isadvanced()  &&  id_ == nullptr) {
       std::vector<ssize_t> nextshape = { 1 };
       nextshape.insert(nextshape.end(), shape_.begin(), shape_.end());
       std::vector<ssize_t> nextstrides = { shape_[0]*strides_[0] };
@@ -590,7 +590,7 @@ namespace awkward {
     util::handle_error(err, classname(), id_.get());
 
     std::shared_ptr<Identity> id(nullptr);
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       id = id_.get()->getitem_carry_64(carry);
     }
 
@@ -729,7 +729,7 @@ namespace awkward {
   }
 
   const NumpyArray NumpyArray::getitem_bystrides(const std::shared_ptr<SliceItem>& head, const Slice& tail, int64_t length) const {
-    if (head.get() == nullptr) {
+    if (head == nullptr) {
       return NumpyArray(id_, type_, ptr_, shape_, strides_, byteoffset_, itemsize_, format_);
     }
     else if (SliceAt* at = dynamic_cast<SliceAt*>(head.get())) {
@@ -791,8 +791,8 @@ namespace awkward {
     }
     awkward_regularize_rangeslice(&start, &stop, step > 0, range.hasstart(), range.hasstop(), (int64_t)shape_[1]);
 
-    int64_t numer = abs(start - stop);
-    int64_t denom = abs(step);
+    int64_t numer = std::abs(start - stop);
+    int64_t denom = std::abs(step);
     int64_t d = numer / denom;
     int64_t m = numer % denom;
     int64_t lenhead = d + (m != 0 ? 1 : 0);
@@ -845,7 +845,7 @@ namespace awkward {
   }
 
   const NumpyArray NumpyArray::getitem_next(const std::shared_ptr<SliceItem> head, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const {
-    if (head.get() == nullptr) {
+    if (head == nullptr) {
       std::shared_ptr<void> ptr(new uint8_t[(size_t)(carry.length()*stride)], awkward::util::array_deleter<uint8_t>());
       struct Error err = awkward_numpyarray_getitem_next_null_64(
         reinterpret_cast<uint8_t*>(ptr.get()),
@@ -857,7 +857,7 @@ namespace awkward {
       util::handle_error(err, classname(), id_.get());
 
       std::shared_ptr<Identity> id(nullptr);
-      if (id_.get() != nullptr) {
+      if (id_ != nullptr) {
         id = id_.get()->getitem_carry_64(carry);
       }
 
@@ -943,8 +943,8 @@ namespace awkward {
     }
     awkward_regularize_rangeslice(&start, &stop, step > 0, range.hasstart(), range.hasstop(), (int64_t)shape_[1]);
 
-    int64_t numer = abs(start - stop);
-    int64_t denom = abs(step);
+    int64_t numer = std::abs(start - stop);
+    int64_t denom = std::abs(step);
     int64_t d = numer / denom;
     int64_t m = numer % denom;
     int64_t lenhead = d + (m != 0 ? 1 : 0);

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -21,7 +21,7 @@ namespace awkward {
 
   const std::shared_ptr<Identity> Record::id() const {
     std::shared_ptr<Identity> recid = array_.id();
-    if (recid.get() == nullptr) {
+    if (recid == nullptr) {
       return recid;
     }
     else {
@@ -95,7 +95,7 @@ namespace awkward {
   }
 
   void Record::check_for_iteration() const {
-    if (array_.id().get() != nullptr  &&  array_.id().get()->length() != 1) {
+    if (array_.id() != nullptr  &&  array_.id().get()->length() != 1) {
       util::handle_error(failure("len(id) != 1 for scalar Record", kSliceNone, kSliceNone), array_.id().get()->classname(), nullptr);
     }
   }
@@ -126,7 +126,7 @@ namespace awkward {
 
   const std::shared_ptr<Content> Record::getitem_fields(const std::vector<std::string>& keys) const {
     std::shared_ptr<Type> type = Type::none();
-    if (type_.get() != nullptr  &&  type_.get()->numfields() != -1  &&  util::subset(keys, type_.get()->keys())) {
+    if (type_ != nullptr  &&  type_.get()->numfields() != -1  &&  util::subset(keys, type_.get()->keys())) {
       type = type_;
     }
     RecordArray out(array_.id(), type, length(), istuple());

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -1,5 +1,6 @@
 // BSD 3-Clause License; see https://github.com/jpivarski/awkward-1.0/blob/master/LICENSE
 
+#include <memory>
 #include <sstream>
 
 #include "awkward/cpu-kernels/identity.h"
@@ -52,7 +53,7 @@ namespace awkward {
     size_t cols = (size_t)numfields();
     std::shared_ptr<RecordArray::ReverseLookup> keys = array_.reverselookup();
     if (istuple()) {
-      keys = std::shared_ptr<RecordArray::ReverseLookup>(new RecordArray::ReverseLookup);
+      keys = std::make_shared<RecordArray::ReverseLookup>();
       for (size_t j = 0;  j < cols;  j++) {
         keys.get()->push_back(std::to_string(j));
       }

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -35,7 +35,7 @@ namespace awkward {
   }
 
   void RecordArray::setid(const std::shared_ptr<Identity> id) {
-    if (id.get() == nullptr) {
+    if (id == nullptr) {
       for (auto content : contents_) {
         content.get()->setid(id);
       }
@@ -70,10 +70,10 @@ namespace awkward {
       out << " length=\"" << length_ << "\"";
     }
     out << ">\n";
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       out << id_.get()->tostring_part(indent + std::string("    "), "", "\n");
     }
-    if (type_.get() != nullptr) {
+    if (type_ != nullptr) {
       out << indent << "    <type>" + type().get()->tostring() + "</type>\n";
     }
     for (size_t j = 0;  j < contents_.size();  j++) {
@@ -131,7 +131,7 @@ namespace awkward {
     if (accepts(type)) {
       std::shared_ptr<Type> level = type.get()->level();
       RecordType* raw = dynamic_cast<RecordType*>(level.get());
-      if (reverselookup_.get() == nullptr) {
+      if (reverselookup_ == nullptr) {
         for (int64_t i = 0;  i < numfields();  i++) {
           field(i).get()->settype_part(raw->field(i));
         }
@@ -151,14 +151,14 @@ namespace awkward {
   bool RecordArray::accepts(const std::shared_ptr<Type> type) {
     std::shared_ptr<Type> check = type.get()->level();
     if (RecordType* raw = dynamic_cast<RecordType*>(check.get())) {
-      if (reverselookup_.get() == nullptr) {
-        if (raw->reverselookup().get() != nullptr) {
+      if (reverselookup_ == nullptr) {
+        if (raw->reverselookup() != nullptr) {
           return false;
         }
         return numfields() == raw->numfields();
       }
       else {
-        if (raw->reverselookup().get() == nullptr) {
+        if (raw->reverselookup() == nullptr) {
           return false;
         }
         for (auto key : raw->keys()) {
@@ -200,7 +200,7 @@ namespace awkward {
   }
 
   void RecordArray::check_for_iteration() const {
-    if (id_.get() != nullptr  &&  id_.get()->length() < length()) {
+    if (id_ != nullptr  &&  id_.get()->length() < length()) {
       util::handle_error(failure("len(id) < len(array)", kSliceNone, kSliceNone), id_.get()->classname(), nullptr);
     }
   }
@@ -260,7 +260,7 @@ namespace awkward {
 
   const std::shared_ptr<Content> RecordArray::getitem_fields(const std::vector<std::string>& keys) const {
     std::shared_ptr<Type> type = Type::none();
-    if (type_.get() != nullptr  &&  type_.get()->numfields() != -1  &&  util::subset(keys, type_.get()->keys())) {
+    if (type_ != nullptr  &&  type_.get()->numfields() != -1  &&  util::subset(keys, type_.get()->keys())) {
       type = type_;
     }
     RecordArray out(id_, type, length(), istuple());
@@ -280,7 +280,7 @@ namespace awkward {
   const std::shared_ptr<Content> RecordArray::carry(const Index64& carry) const {
     if (contents_.empty()) {
       std::shared_ptr<Identity> id(nullptr);
-      if (id_.get() != nullptr) {
+      if (id_ != nullptr) {
         id = id_.get()->getitem_carry_64(carry);
       }
       return std::shared_ptr<Content>(new RecordArray(id, type_, carry.length(), istuple()));
@@ -291,7 +291,7 @@ namespace awkward {
         contents.push_back(content.get()->carry(carry));
       }
       std::shared_ptr<Identity> id(nullptr);
-      if (id_.get() != nullptr) {
+      if (id_ != nullptr) {
         id = id_.get()->getitem_carry_64(carry);
       }
       return std::shared_ptr<Content>(new RecordArray(id, type_, contents, lookup_, reverselookup_));
@@ -439,7 +439,7 @@ namespace awkward {
 
   const RecordArray RecordArray::astuple() const {
     RecordArray out(id_, Type::none(), contents_);
-    if (type_.get() != nullptr  &&  type_.get()->numfields() != -1  &&  util::subset(out.keys(), type_.get()->keys())) {
+    if (type_ != nullptr  &&  type_.get()->numfields() != -1  &&  util::subset(out.keys(), type_.get()->keys())) {
       out.type_ = type_;
     }
     return out;
@@ -476,7 +476,7 @@ namespace awkward {
     Slice emptytail;
     emptytail.become_sealed();
 
-    if (head.get() == nullptr) {
+    if (head == nullptr) {
       return shallow_copy();
     }
     else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -1,5 +1,6 @@
 // BSD 3-Clause License; see https://github.com/jpivarski/awkward-1.0/blob/master/LICENSE
 
+#include <memory>
 #include <sstream>
 
 #include "awkward/cpu-kernels/identity.h"
@@ -65,7 +66,7 @@ namespace awkward {
   const std::string RecordArray::tostring_part(const std::string indent, const std::string pre, const std::string post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname();
-    if (contents_.size() == 0) {
+    if (contents_.empty()) {
       out << " length=\"" << length_ << "\"";
     }
     out << ">\n";
@@ -101,7 +102,7 @@ namespace awkward {
     size_t cols = contents_.size();
     std::shared_ptr<ReverseLookup> keys = reverselookup_;
     if (istuple()) {
-      keys = std::shared_ptr<ReverseLookup>(new ReverseLookup);
+      keys = std::make_shared<ReverseLookup>();
       for (size_t j = 0;  j < cols;  j++) {
         keys.get()->push_back(std::to_string(j));
       }
@@ -174,7 +175,7 @@ namespace awkward {
   }
 
   int64_t RecordArray::length() const {
-    if (contents_.size() == 0) {
+    if (contents_.empty()) {
       return length_;
     }
     else {
@@ -190,7 +191,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<Content> RecordArray::shallow_copy() const {
-    if (contents_.size() == 0) {
+    if (contents_.empty()) {
       return std::shared_ptr<Content>(new RecordArray(id_, type_, length(), istuple()));
     }
     else {
@@ -225,7 +226,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<Content> RecordArray::getitem_range(int64_t start, int64_t stop) const {
-    if (contents_.size() == 0) {
+    if (contents_.empty()) {
       int64_t regular_start = start;
       int64_t regular_stop = stop;
       awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
@@ -241,7 +242,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<Content> RecordArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    if (contents_.size() == 0) {
+    if (contents_.empty()) {
       return std::shared_ptr<Content>(new RecordArray(id_, type_, stop - start, istuple()));
     }
     else {
@@ -277,7 +278,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<Content> RecordArray::carry(const Index64& carry) const {
-    if (contents_.size() == 0) {
+    if (contents_.empty()) {
       std::shared_ptr<Identity> id(nullptr);
       if (id_.get() != nullptr) {
         id = id_.get()->getitem_carry_64(carry);
@@ -298,7 +299,7 @@ namespace awkward {
   }
 
   const std::pair<int64_t, int64_t> RecordArray::minmax_depth() const {
-    if (contents_.size() == 0) {
+    if (contents_.empty()) {
       return std::pair<int64_t, int64_t>(0, 0);
     }
     int64_t min = kMaxInt64;
@@ -459,8 +460,8 @@ namespace awkward {
 
   void RecordArray::setkey(int64_t fieldindex, const std::string& fieldname) {
     if (istuple()) {
-      lookup_ = std::shared_ptr<Lookup>(new Lookup);
-      reverselookup_ = std::shared_ptr<ReverseLookup>(new ReverseLookup);
+      lookup_ = std::make_shared<Lookup>();
+      reverselookup_ = std::make_shared<ReverseLookup>();
       for (size_t j = 0;  j < contents_.size();  j++) {
         reverselookup_.get()->push_back(std::to_string(j));
       }
@@ -486,7 +487,7 @@ namespace awkward {
       std::shared_ptr<Content> out = getitem_next(*fields, emptytail, advanced);
       return out.get()->getitem_next(nexthead, nexttail, advanced);
     }
-    else if (contents_.size() == 0) {
+    else if (contents_.empty()) {
       RecordArray out(Identity::none(), type_, length(), istuple());
       return out.getitem_next(nexthead, nexttail, advanced);
     }

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -18,7 +18,7 @@ namespace awkward {
   }
 
   void RegularArray::setid(const std::shared_ptr<Identity> id) {
-    if (id.get() == nullptr) {
+    if (id == nullptr) {
       content_.get()->setid(id);
     }
     else {
@@ -84,10 +84,10 @@ namespace awkward {
   const std::string RegularArray::tostring_part(const std::string indent, const std::string pre, const std::string post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << " size=\"" << size_ << "\">\n";
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       out << id_.get()->tostring_part(indent + std::string("    "), "", "\n");
     }
-    if (type_.get() != nullptr) {
+    if (type_ != nullptr) {
       out << indent << "    <type>" + type().get()->tostring() + "</type>\n";
     }
     out << content_.get()->tostring_part(indent + std::string("    "), "<content>", "</content>\n");
@@ -141,7 +141,7 @@ namespace awkward {
   }
 
   void RegularArray::check_for_iteration() const {
-    if (id_.get() != nullptr  && id_.get()->length() < length()) {
+    if (id_ != nullptr  && id_.get()->length() < length()) {
       util::handle_error(failure("len(id) < len(array)", kSliceNone, kSliceNone), id_.get()->classname(), nullptr);
     }
   }
@@ -170,7 +170,7 @@ namespace awkward {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
-    if (id_.get() != nullptr  &&  regular_stop > id_.get()->length()) {
+    if (id_ != nullptr  &&  regular_stop > id_.get()->length()) {
       util::handle_error(failure("index out of range", kSliceNone, stop), id_.get()->classname(), nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
@@ -178,7 +178,7 @@ namespace awkward {
 
   const std::shared_ptr<Content> RegularArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identity> id(nullptr);
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       id = id_.get()->getitem_range_nowrap(start, stop);
     }
     return std::shared_ptr<Content>(new RegularArray(id_, type_, content_.get()->getitem_range_nowrap(start*size_, stop*size_), size_));
@@ -207,7 +207,7 @@ namespace awkward {
     util::handle_error(err, classname(), id_.get());
 
     std::shared_ptr<Identity> id(nullptr);
-    if (id_.get() != nullptr) {
+    if (id_ != nullptr) {
       id = id_.get()->getitem_carry_64(carry);
     }
     return std::shared_ptr<Content>(new RegularArray(id, type_, content_.get()->carry(nextcarry), size_));
@@ -273,7 +273,7 @@ namespace awkward {
     assert(range.step() != 0);
     int64_t regular_start = range.start();
     int64_t regular_stop = range.stop();
-    int64_t regular_step = abs(range.step());
+    int64_t regular_step = std::abs(range.step());
     awkward_regularize_rangeslice(&regular_start, &regular_stop, range.step() > 0, range.start() != Slice::none(), range.stop() != Slice::none(), size_);
     int64_t nextsize = 0;
     if (range.step() > 0  &&  regular_stop - regular_start > 0) {
@@ -305,7 +305,7 @@ namespace awkward {
     std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
 
     std::shared_ptr<Type> outtype = Type::none();
-    if (type_.get() != nullptr) {
+    if (type_ != nullptr) {
       RegularType* raw = dynamic_cast<RegularType*>(type_.get());
       outtype = std::shared_ptr<Type>(new RegularType(Type::Parameters(), raw->type(), nextsize));
     }

--- a/src/libawkward/fillable/FillableArray.cpp
+++ b/src/libawkward/fillable/FillableArray.cpp
@@ -87,7 +87,7 @@ namespace awkward {
 
   void FillableArray::endlist() {
     std::shared_ptr<Fillable> tmp = fillable_.get()->endlist();
-    if (tmp.get() == nullptr) {
+    if (tmp == nullptr) {
       throw std::invalid_argument("endlist doesn't match a corresponding beginlist");
     }
     maybeupdate(tmp);

--- a/src/libawkward/fillable/RecordFillable.cpp
+++ b/src/libawkward/fillable/RecordFillable.cpp
@@ -67,7 +67,7 @@ namespace awkward {
     if (length_ == -1) {
       return std::shared_ptr<Content>(new EmptyArray(Identity::none(), Type::none()));
     }
-    else if (contents_.size() == 0) {
+    else if (contents_.empty()) {
       std::shared_ptr<Content> out(new RecordArray(Identity::none(), Type::none(), length_, false));
       if (nameptr_ != nullptr) {
         std::shared_ptr<Type> type = out.get()->type();

--- a/src/libawkward/fillable/TupleFillable.cpp
+++ b/src/libawkward/fillable/TupleFillable.cpp
@@ -50,7 +50,7 @@ namespace awkward {
     if (length_ == -1) {
       return std::shared_ptr<Content>(new EmptyArray(Identity::none(), Type::none()));
     }
-    else if (contents_.size() == 0) {
+    else if (contents_.empty()) {
       return std::shared_ptr<Content>(new RecordArray(Identity::none(), Type::none(), length_, true));
     }
     else {

--- a/src/libawkward/fillable/UnionFillable.cpp
+++ b/src/libawkward/fillable/UnionFillable.cpp
@@ -79,7 +79,7 @@ namespace awkward {
         }
         i++;
       }
-      if (tofill.get() == nullptr) {
+      if (tofill == nullptr) {
         tofill = BoolFillable::fromempty(options_);
         contents_.push_back(tofill);
       }
@@ -105,7 +105,7 @@ namespace awkward {
         }
         i++;
       }
-      if (tofill.get() == nullptr) {
+      if (tofill == nullptr) {
         tofill = Int64Fillable::fromempty(options_);
         contents_.push_back(tofill);
       }
@@ -131,7 +131,7 @@ namespace awkward {
         }
         i++;
       }
-      if (tofill.get() == nullptr) {
+      if (tofill == nullptr) {
         i = 0;
         for (auto content : contents_) {
           if (dynamic_cast<Int64Fillable*>(content.get()) != nullptr) {
@@ -140,7 +140,7 @@ namespace awkward {
           }
           i++;
         }
-        if (tofill.get() != nullptr) {
+        if (tofill != nullptr) {
           tofill = Float64Fillable::fromint64(options_, dynamic_cast<Int64Fillable*>(tofill.get())->buffer());
           contents_[(size_t)i] = tofill;
         }
@@ -173,7 +173,7 @@ namespace awkward {
         }
         i++;
       }
-      if (tofill.get() == nullptr) {
+      if (tofill == nullptr) {
         tofill = StringFillable::fromempty(options_, encoding);
         contents_.push_back(tofill);
       }
@@ -199,7 +199,7 @@ namespace awkward {
         }
         i++;
       }
-      if (tofill.get() == nullptr) {
+      if (tofill == nullptr) {
         tofill = ListFillable::fromempty(options_);
         contents_.push_back(tofill);
       }
@@ -240,7 +240,7 @@ namespace awkward {
         }
         i++;
       }
-      if (tofill.get() == nullptr) {
+      if (tofill == nullptr) {
         tofill = TupleFillable::fromempty(options_);
         contents_.push_back(tofill);
       }
@@ -292,7 +292,7 @@ namespace awkward {
         }
         i++;
       }
-      if (tofill.get() == nullptr) {
+      if (tofill == nullptr) {
         tofill = RecordFillable::fromempty(options_);
         contents_.push_back(tofill);
       }

--- a/src/libawkward/type/ListType.cpp
+++ b/src/libawkward/type/ListType.cpp
@@ -16,7 +16,7 @@ namespace awkward {
     }
 
     std::stringstream out;
-    if (parameters_.size() == 0) {
+    if (parameters_.empty()) {
       out << indent << pre << "var * " << type_.get()->tostring_part(indent, "", "") << post;
     }
     else {

--- a/src/libawkward/type/OptionType.cpp
+++ b/src/libawkward/type/OptionType.cpp
@@ -17,7 +17,7 @@ namespace awkward {
     }
 
     std::stringstream out;
-    if (parameters_.size() == 0) {
+    if (parameters_.empty()) {
       if (dynamic_cast<ListType*>(type_.get()) != nullptr  ||
           dynamic_cast<RegularType*>(type_.get()) != nullptr) {
         out << indent << pre << "option[" << type_.get()->tostring_part(indent, "", "") << "]" << post;

--- a/src/libawkward/type/PrimitiveType.cpp
+++ b/src/libawkward/type/PrimitiveType.cpp
@@ -31,7 +31,7 @@ namespace awkward {
       case float64: s = "float64"; break;
       default:      assert(dtype_ < numtypes);
     }
-    if (parameters_.size() == 0) {
+    if (parameters_.empty()) {
       out << indent << pre << s << post;
     }
     else {

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -18,7 +18,7 @@ namespace awkward {
 
     std::stringstream out;
     if (parameters_.empty()) {
-      if (reverselookup_.get() == nullptr) {
+      if (reverselookup_ == nullptr) {
         out << "(";
         for (size_t j = 0;  j < types_.size();  j++) {
           if (j != 0) {
@@ -41,7 +41,7 @@ namespace awkward {
       }
     }
     else {
-      if (reverselookup_.get() == nullptr) {
+      if (reverselookup_ == nullptr) {
         out << "tuple[[";
         for (size_t j = 0;  j < types_.size();  j++) {
           if (j != 0) {
@@ -83,8 +83,8 @@ namespace awkward {
       if (numfields() != t->numfields()) {
         return false;
       }
-      if (reverselookup_.get() == nullptr) {
-        if (t->reverselookup().get() != nullptr) {
+      if (reverselookup_ == nullptr) {
+        if (t->reverselookup() != nullptr) {
           return false;
         }
         for (int64_t j = 0;  j < numfields();  j++) {
@@ -95,7 +95,7 @@ namespace awkward {
         return true;
       }
       else {
-        if (t->reverselookup().get() == nullptr) {
+        if (t->reverselookup() == nullptr) {
           return false;
         }
         if (lookup_.get()->size() != t->lookup().get()->size()) {
@@ -139,7 +139,7 @@ namespace awkward {
 
   int64_t RecordType::fieldindex(const std::string& key) const {
     int64_t out = -1;
-    if (lookup_.get() != nullptr) {
+    if (lookup_ != nullptr) {
       try {
         out = (int64_t)lookup_.get()->at(key);
       }
@@ -166,7 +166,7 @@ namespace awkward {
     if (fieldindex >= numfields()) {
       throw std::invalid_argument(std::string("fieldindex ") + std::to_string(fieldindex) + std::string(" for RecordType with only " + std::to_string(numfields()) + std::string(" fields")));
     }
-    if (reverselookup_.get() != nullptr) {
+    if (reverselookup_ != nullptr) {
       return reverselookup_.get()->at((size_t)fieldindex);
     }
     else {
@@ -188,7 +188,7 @@ namespace awkward {
     std::vector<std::string> out;
     std::string _default = std::to_string(fieldindex);
     bool has_default = false;
-    if (lookup_.get() != nullptr) {
+    if (lookup_ != nullptr) {
       for (auto pair : *lookup_.get()) {
         if (pair.second == fieldindex) {
           out.push_back(pair.first);
@@ -210,7 +210,7 @@ namespace awkward {
 
   const std::vector<std::string> RecordType::keys() const {
     std::vector<std::string> out;
-    if (reverselookup_.get() == nullptr) {
+    if (reverselookup_ == nullptr) {
       int64_t cols = numfields();
       for (int64_t j = 0;  j < cols;  j++) {
         out.push_back(std::to_string(j));
@@ -239,7 +239,7 @@ namespace awkward {
 
   const std::vector<std::pair<std::string, std::shared_ptr<Type>>> RecordType::fielditems() const {
     std::vector<std::pair<std::string, std::shared_ptr<Type>>> out;
-    if (reverselookup_.get() == nullptr) {
+    if (reverselookup_ == nullptr) {
       size_t cols = types_.size();
       for (size_t j = 0;  j < cols;  j++) {
         out.push_back(std::pair<std::string, std::shared_ptr<Type>>(std::to_string(j), types_[j]));

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -17,7 +17,7 @@ namespace awkward {
     }
 
     std::stringstream out;
-    if (parameters_.size() == 0) {
+    if (parameters_.empty()) {
       if (reverselookup_.get() == nullptr) {
         out << "(";
         for (size_t j = 0;  j < types_.size();  j++) {

--- a/src/libawkward/type/RegularType.cpp
+++ b/src/libawkward/type/RegularType.cpp
@@ -16,7 +16,7 @@ namespace awkward {
     }
 
     std::stringstream out;
-    if (parameters_.size() == 0) {
+    if (parameters_.empty()) {
       out << indent << pre << size_ << " * " << type_.get()->tostring_part(indent, "", "") << post;
     }
     else {

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -23,7 +23,7 @@ namespace awkward {
       }
       out << type(i).get()->tostring_part(indent, "", "");
     }
-    if (parameters_.size() != 0) {
+    if (!parameters_.empty()) {
       out << ", " << string_parameters();
     }
     out << "]" << post;

--- a/src/libawkward/type/UnknownType.cpp
+++ b/src/libawkward/type/UnknownType.cpp
@@ -13,7 +13,7 @@ namespace awkward {
     }
 
     std::stringstream out;
-    if (parameters_.size() == 0) {
+    if (parameters_.empty()) {
       out << indent << pre << "unknown" << post;
     }
     else {


### PR DESCRIPTION
Apply fixes from **clang-tidy** with **-checks**='-*,
   boost-use-to-string,
   misc-string-compare,
   misc-uniqueptr-reset-release,
   modernize-deprecated-headers,
   modernize-make-shared,
   modernize-use-bool-literals,
   modernize-use-equals-delete,
   modernize-use-nullptr,
   modernize-use-override,
   performance-unnecessary-copy-initialization,
   readability-container-size-empty,
   readability-redundant-string-cstr,
   readability-static-definition-in-anonymous-namespace,
   readability-uniqueptr-delete-release'

https://clang.llvm.org/extra/clang-tidy/

@jpivarski - please, review and comment