### PR TITLE
Guard against inspecting __main__ module

### DIFF
--- a/awkward1/_util.py
+++ b/awkward1/_util.py
@@ -55,8 +55,8 @@ def wrap(content, classes, functions):
 def called_by_module(modulename):
     frame = inspect.currentframe()
     while frame is not None:
-        name = inspect.getmodule(frame).__name__
-        if name == modulename or name.startswith(modulename + "."):
+        name = getattr(inspect.getmodule(frame), '__name__', None)
+        if name is not None and (name == modulename or name.startswith(modulename + ".")):
             return True
         frame = frame.f_back
     return True


### PR DESCRIPTION
If in an interactive terminal, the `name` attribute of the top frame module is None, so guard against it.

Incidentally, `awkward1/signatures/Identities_8cpp.xml` was modified.  It appears machine-generated, is it something that should be in version control? Should I add it?