### PR TITLE
EmptyArrays have float64 type (like NumPy), but are integer arrays when used as a slice (fixing scikit-hep/awkward-array#236).

### DIFF
--- a/src/python/layout/content.cpp
+++ b/src/python/layout/content.cpp
@@ -914,6 +914,9 @@ py::class_<ak::EmptyArray, std::shared_ptr<ak::EmptyArray>, ak::Content> make_Em
       .def(py::init([](const py::object& identities, const py::object& parameters) -> ak::EmptyArray {
         return ak::EmptyArray(unbox_identities_none(identities), dict2parameters(parameters));
       }), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+      .def("toNumpyArray", [](const ak::EmptyArray& self) -> py::object {
+        return box(self.toNumpyArray("d", sizeof(double)));
+      })
   );
 }
 

--- a/tests/test_0138-emptyarray-type.py
+++ b/tests/test_0138-emptyarray-type.py
@@ -1,0 +1,22 @@
+# BSD 3-Clause License; see https://github.com/jpivarski/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+
+import pytest
+import numpy
+
+import awkward1
+
+def test():
+    empty1 = awkward1.Array(awkward1.layout.EmptyArray())
+    empty2 = awkward1.Array(awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 0, 0, 0], dtype=numpy.int64)), awkward1.layout.EmptyArray()))
+    array = awkward1.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
+
+    awkward1.tonumpy(empty1).dtype.type is numpy.float64
+
+    awkward1.tolist(array[empty1]) == []
+    awkward1.tolist(array[empty1,]) == []
+    awkward1.tolist(array[empty2]) == [[], [], []]
+    awkward1.tolist(array[empty2,]) == [[], [], []]


### PR DESCRIPTION
Fixes #138, and does one better: the type of an EmptyArray depends on how it's used.