### PR TITLE
ak.Array and ak.Record constructors. Maybe the `ak.zip` function.

### DIFF
--- a/src/awkward1/_connect/_autograd.py
+++ b/src/awkward1/_connect/_autograd.py
@@ -46,9 +46,9 @@ def elementwise_grad(fun, argnum=0, *nary_op_args, **nary_op_kwargs):
     def broadcast(*args, **kwargs):
         nextargs = [awkward1.operations.convert.tolayout(x, allowrecord=True, allowother=True) for x in args]
 
-        def getfunction(inputs):
+        def getfunction(inputs, depth):
             if all(isinstance(x, awkward1.layout.NumpyArray) or not isinstance(x, awkward1.layout.Content) for x in inputs):
-                return lambda depth: (awkward1.layout.NumpyArray(gradfun(*inputs)),)
+                return lambda: (awkward1.layout.NumpyArray(gradfun(*inputs)),)
             else:
                 return None
 

--- a/src/awkward1/_connect/_numexpr.py
+++ b/src/awkward1/_connect/_numexpr.py
@@ -21,7 +21,7 @@ def getArguments(names, local_dict=None, global_dict=None):
         if global_dict is None:
             global_dict = frame_globals
 
-        # If `call_frame` is the top frame of the interpreter we can't clear its 
+        # If `call_frame` is the top frame of the interpreter we can't clear its
         # `local_dict`, because it is actually the `global_dict`.
         clear_local_dict = clear_local_dict and not frame_globals is local_dict
 
@@ -53,9 +53,9 @@ def evaluate(expression, local_dict=None, global_dict=None, order="K", casting="
 
     arrays = [awkward1.operations.convert.tolayout(x, allowrecord=True, allowother=True) for x in arguments]
 
-    def getfunction(inputs):
+    def getfunction(inputs, depth):
         if all(isinstance(x, awkward1.layout.NumpyArray) or not isinstance(x, awkward1.layout.Content) for x in inputs):
-            return lambda depth: (awkward1.layout.NumpyArray(numexpr.evaluate(expression, dict(zip(names, inputs)), {}, order=order, casting=casting, **kwargs)),)
+            return lambda: (awkward1.layout.NumpyArray(numexpr.evaluate(expression, dict(zip(names, inputs)), {}, order=order, casting=casting, **kwargs)),)
         else:
             return None
 
@@ -77,12 +77,11 @@ def re_evaluate(local_dict=None):
 
     arrays = [awkward1.operations.convert.tolayout(x, allowrecord=True, allowother=True) for x in arguments]
 
-    def getfunction(inputs):
+    def getfunction(inputs, depth):
         if all(isinstance(x, awkward1.layout.NumpyArray) or not isinstance(x, awkward1.layout.Content) for x in inputs):
-
-            return lambda depth: (awkward1.layout.NumpyArray(numexpr.re_evaluate(dict(zip(names, inputs)))),)
-
-        return None
+            return lambda: (awkward1.layout.NumpyArray(numexpr.re_evaluate(dict(zip(names, inputs)))),)
+        else:
+            return None
 
     out = awkward1._util.broadcast_and_apply(arrays, getfunction)
     assert isinstance(out, tuple) and len(out) == 1

--- a/src/awkward1/_connect/_numpy.py
+++ b/src/awkward1/_connect/_numpy.py
@@ -51,19 +51,19 @@ def array_ufunc(ufunc, method, inputs, kwargs, behavior):
         else:
             return tmp
 
-    def getfunction(inputs):
+    def getfunction(inputs, depth):
         signature = (ufunc,) + tuple(x.parameters.get("__record__") if isinstance(x, awkward1.layout.Content) else type(x) for x in inputs)
         custom = awkward1._util.overload(behavior, signature)
         if custom is not None:
-            return lambda depth: adjust(custom, inputs, kwargs)
+            return lambda: adjust(custom, inputs, kwargs)
 
         signature = (ufunc,) + tuple(x.parameters.get("__array__") if isinstance(x, awkward1.layout.Content) else type(x) for x in inputs)
         custom = awkward1._util.overload(behavior, signature)
         if custom is not None:
-            return lambda depth: adjust(custom, inputs, kwargs)
+            return lambda: adjust(custom, inputs, kwargs)
 
         if all(isinstance(x, awkward1.layout.NumpyArray) or not isinstance(x, awkward1.layout.Content) for x in inputs):
-            return lambda depth: (awkward1.layout.NumpyArray(getattr(ufunc, method)(*inputs, **kwargs)),)
+            return lambda: (awkward1.layout.NumpyArray(getattr(ufunc, method)(*inputs, **kwargs)),)
 
         return None
 

--- a/src/awkward1/_util.py
+++ b/src/awkward1/_util.py
@@ -188,11 +188,11 @@ def numba_methods(layouttype, behavior):
 
 def numba_unaryops(unaryop, left, behavior):
     import awkward1
-    import awkward1._numba.layout
+    import awkward1._connect._numba.layout
     behavior = Behavior(awkward1.behavior, behavior)
     done = False
 
-    if isinstance(left, awkward1._numba.layout.ContentType):
+    if isinstance(left, awkward1._connect._numba.layout.ContentType):
         left = left.parameters.get("__record__")
         if not (isinstance(left, str) or (py27 and isinstance(left, unicode))):
             done = True
@@ -205,16 +205,16 @@ def numba_unaryops(unaryop, left, behavior):
 
 def numba_binops(binop, left, right, behavior):
     import awkward1
-    import awkward1._numba.layout
+    import awkward1._connect._numba.layout
     behavior = Behavior(awkward1.behavior, behavior)
     done = False
 
-    if isinstance(left, awkward1._numba.layout.ContentType):
+    if isinstance(left, awkward1._connect._numba.layout.ContentType):
         left = left.parameters.get("__record__")
         if not (isinstance(left, str) or (py27 and isinstance(left, unicode))):
             done = True
 
-    if isinstance(right, awkward1._numba.layout.ContentType):
+    if isinstance(right, awkward1._connect._numba.layout.ContentType):
         right = right.parameters.get("__record__")
         if not (isinstance(right, str) or (py27 and isinstance(right, unicode))):
             done = True
@@ -344,11 +344,11 @@ def broadcast_and_apply(inputs, getfunction):
         # now all lengths must agree
         checklength([x for x in inputs if isinstance(x, awkward1.layout.Content)])
 
-        function = getfunction(inputs)
+        function = getfunction(inputs, depth)
 
         # the rest of this is one switch statement
         if function is not None:
-            return function(depth)
+            return function()
 
         elif any(isinstance(x, unknowntypes) for x in inputs):
             return apply([x if not isinstance(x, unknowntypes) else awkward1.layout.NumpyArray(numpy.array([], dtype=numpy.bool_)) for x in inputs], depth)

--- a/src/awkward1/highlevel.py
+++ b/src/awkward1/highlevel.py
@@ -6,8 +6,10 @@ import re
 import keyword
 try:
     from collections.abc import Sequence
+    from collections.abc import Iterable
 except:
     from collections import Sequence
+    from collections import Iterable
 
 import numpy
 
@@ -25,11 +27,13 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
         elif isinstance(data, Array):
             layout = data.layout
         elif isinstance(data, numpy.ndarray):
-            layout = awkward1.operations.convert.fromnumpy(data).layout
+            layout = awkward1.operations.convert.fromnumpy(data, highlevel=False)
         elif isinstance(data, str):
-            layout = awkward1.operations.convert.fromjson(data).layout
+            layout = awkward1.operations.convert.fromjson(data, highlevel=False)
+        elif isinstance(data, dict):
+            raise TypeError("could not convert dict into an awkward1.Array; try awkward1.Record")
         else:
-            layout = awkward1.operations.convert.fromiter(data).layout
+            layout = awkward1.operations.convert.fromiter(data, highlevel=False, allowrecord=False)
         if not isinstance(layout, awkward1.layout.Content):
             raise TypeError("could not convert data into an awkward1.Array")
 
@@ -172,8 +176,18 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
 
 class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
     def __init__(self, data, behavior=None, checkvalid=False):
-        # FIXME: more checks here
-        layout = data
+        if isinstance(data, awkward1.layout.Record):
+            layout = data
+        elif isinstance(data, Record):
+            layout = data.layout
+        elif isinstance(data, str):
+            layout = awkward1.operations.convert.fromjson(data, highlevel=False)
+        elif isinstance(data, dict):
+            layout = awkward1.operations.convert.fromiter([data], highlevel=False)[0]
+        elif isinstance(data, Iterable):
+            raise TypeError("could not convert non-dict into an awkward1.Record; try awkward1.Array")
+        else:
+            layout = None
         if not isinstance(layout, awkward1.layout.Record):
             raise TypeError("could not convert data into an awkward1.Record")
 

--- a/src/awkward1/highlevel.py
+++ b/src/awkward1/highlevel.py
@@ -300,7 +300,7 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
     @property
     def numbatype(self):
         import numba
-        import awkward1._numba
+        import awkward1._connect._numba
         awkward1._connect._numba.register()
         if self._numbaview is None:
             self._numbaview = awkward1._connect._numba.arrayview.RecordView.fromrecord(self)

--- a/src/awkward1/operations/convert.py
+++ b/src/awkward1/operations/convert.py
@@ -49,7 +49,12 @@ def fromnumpy(array, regulararray=False, highlevel=True, behavior=None):
     else:
         return layout
 
-def fromiter(iterable, highlevel=True, behavior=None, initial=1024, resize=2.0):
+def fromiter(iterable, highlevel=True, behavior=None, allowrecord=True, initial=1024, resize=2.0):
+    if isinstance(iterable, dict):
+        if allowrecord:
+            return fromiter([iterable], highlevel=highlevel, behavior=behavior, initial=initial, resize=resize)[0]
+        else:
+            raise ValueError("cannot produce an array from a dict")
     out = awkward1.layout.ArrayBuilder(initial=initial, resize=resize)
     for x in iterable:
         out.fromiter(x)

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -13,12 +13,12 @@ def withfield(base, what, where=None):
     base = awkward1.operations.convert.tolayout(base, allowrecord=True, allowother=False)
     what = awkward1.operations.convert.tolayout(what, allowrecord=True, allowother=True)
 
-    def getfunction(inputs):
+    def getfunction(inputs, depth):
         base, what = inputs
         if isinstance(base, awkward1.layout.RecordArray):
             if not isinstance(what, awkward1.layout.Content):
                 what = awkward1.layout.NumpyArray(numpy.lib.stride_tricks.as_strided([what], shape=(len(base),), strides=(0,)))
-            return lambda depth: (base.setitem_field(where, what),)
+            return lambda: (base.setitem_field(where, what),)
         else:
             return None
 
@@ -161,9 +161,9 @@ def concatenate(arrays, axis=0, mergebool=True):
 def broadcast_arrays(*arrays):
     inputs = [awkward1.operations.convert.tolayout(x, allowrecord=True, allowother=False) for x in arrays]
 
-    def getfunction(inputs):
+    def getfunction(inputs, depth):
         if all(isinstance(x, awkward1.layout.NumpyArray) for x in inputs):
-            return lambda depth: tuple(inputs)
+            return lambda: tuple(inputs)
         else:
             return None
 

--- a/src/python/layout/content.cpp
+++ b/src/python/layout/content.cpp
@@ -510,23 +510,23 @@ py::object getitem(const T& self, const py::object& obj) {
 /////////////////////////////////////////////////////////////// ArrayBuilder
 
 void builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
-  if (obj.is(py::none())) {
-    self.null();
-  }
-  else if (py::isinstance<py::bool_>(obj)) {
-    self.boolean(obj.cast<bool>());
+  if (py::isinstance<py::float_>(obj)) {
+    self.real(obj.cast<double>());
   }
   else if (py::isinstance<py::int_>(obj)) {
     self.integer(obj.cast<int64_t>());
   }
-  else if (py::isinstance<py::float_>(obj)) {
-    self.real(obj.cast<double>());
+  else if (py::isinstance<py::bool_>(obj)) {
+    self.boolean(obj.cast<bool>());
   }
-  else if (py::isinstance<py::bytes>(obj)) {
-    self.bytestring(obj.cast<std::string>());
+  else if (obj.is(py::none())) {
+    self.null();
   }
   else if (py::isinstance<py::str>(obj)) {
     self.string(obj.cast<std::string>());
+  }
+  else if (py::isinstance<py::bytes>(obj)) {
+    self.bytestring(obj.cast<std::string>());
   }
   else if (py::isinstance<py::tuple>(obj)) {
     py::tuple tup = obj.cast<py::tuple>();
@@ -558,8 +558,25 @@ void builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
     }
     self.endlist();
   }
+  else if (py::isinstance<py::array>(obj)) {
+    py::iterable seq = obj.attr("tolist")().cast<py::iterable>();
+    self.beginlist();
+    for (auto x : seq) {
+      builder_fromiter(self, x);
+    }
+    self.endlist();
+  }
+  else if (py::isinstance(obj, py::module::import("numpy").attr("floating"))) {
+    self.real(obj.cast<double>());
+  }
+  else if (py::isinstance(obj, py::module::import("numpy").attr("integer"))) {
+    self.integer(obj.cast<int64_t>());
+  }
+  else if (py::isinstance(obj, py::module::import("numpy").attr("bool_"))) {
+    self.boolean(obj.cast<bool>());
+  }
   else {
-    throw std::invalid_argument(std::string("cannot convert ") + obj.attr("__repr__")().cast<std::string>() + std::string(" to an array element"));
+    throw std::invalid_argument(std::string("cannot convert ") + obj.attr("__repr__")().cast<std::string>() + std::string(" (type ") + obj.attr("__class__").attr("__name__").cast<std::string>() + std::string(") to an array element"));
   }
 }
 

--- a/src/python/layout/content.cpp
+++ b/src/python/layout/content.cpp
@@ -510,23 +510,23 @@ py::object getitem(const T& self, const py::object& obj) {
 /////////////////////////////////////////////////////////////// ArrayBuilder
 
 void builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
-  if (py::isinstance<py::float_>(obj)) {
-    self.real(obj.cast<double>());
-  }
-  else if (py::isinstance<py::int_>(obj)) {
-    self.integer(obj.cast<int64_t>());
+  if (obj.is(py::none())) {
+    self.null();
   }
   else if (py::isinstance<py::bool_>(obj)) {
     self.boolean(obj.cast<bool>());
   }
-  else if (obj.is(py::none())) {
-    self.null();
+  else if (py::isinstance<py::int_>(obj)) {
+    self.integer(obj.cast<int64_t>());
   }
-  else if (py::isinstance<py::str>(obj)) {
-    self.string(obj.cast<std::string>());
+  else if (py::isinstance<py::float_>(obj)) {
+    self.real(obj.cast<double>());
   }
   else if (py::isinstance<py::bytes>(obj)) {
     self.bytestring(obj.cast<std::string>());
+  }
+  else if (py::isinstance<py::str>(obj)) {
+    self.string(obj.cast<std::string>());
   }
   else if (py::isinstance<py::tuple>(obj)) {
     py::tuple tup = obj.cast<py::tuple>();
@@ -566,14 +566,14 @@ void builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
     }
     self.endlist();
   }
-  else if (py::isinstance(obj, py::module::import("numpy").attr("floating"))) {
-    self.real(obj.cast<double>());
+  else if (py::isinstance(obj, py::module::import("numpy").attr("bool_"))) {
+    self.boolean(obj.cast<bool>());
   }
   else if (py::isinstance(obj, py::module::import("numpy").attr("integer"))) {
     self.integer(obj.cast<int64_t>());
   }
-  else if (py::isinstance(obj, py::module::import("numpy").attr("bool_"))) {
-    self.boolean(obj.cast<bool>());
+  else if (py::isinstance(obj, py::module::import("numpy").attr("floating"))) {
+    self.real(obj.cast<double>());
   }
   else {
     throw std::invalid_argument(std::string("cannot convert ") + obj.attr("__repr__")().cast<std::string>() + std::string(" (type ") + obj.attr("__class__").attr("__name__").cast<std::string>() + std::string(") to an array element"));

--- a/tests/test_0118-numba-cpointers.py
+++ b/tests/test_0118-numba-cpointers.py
@@ -12,7 +12,7 @@ import awkward1
 
 numba = pytest.importorskip("numba")
 
-awkward1_numba_arrayview = pytest.importorskip("awkward1._numba.arrayview")
+awkward1_numba_arrayview = pytest.importorskip("awkward1._connect._numba.arrayview")
 
 def test_ArrayBuilder_append():
     array = awkward1.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]], checkvalid=True)

--- a/tests/test_0156-array-and-record-constructors.py
+++ b/tests/test_0156-array-and-record-constructors.py
@@ -9,5 +9,11 @@ import numpy
 
 import awkward1
 
-def test():
+def test_record():
     assert awkward1.tolist(awkward1.Record({"x": 1, "y": 2.2})) == {"x": 1, "y": 2.2}
+
+def test_fromiter():
+    array = awkward1.Array([numpy.array([1, 2, 3]), numpy.array([4, 5, 6, 7])])
+
+    assert str(awkward1.typeof(array)) == "2 * var * int64"
+    assert awkward1.tolist(awkward1.tolist(array)) == [[1, 2, 3], [4, 5, 6, 7]]

--- a/tests/test_0156-array-and-record-constructors.py
+++ b/tests/test_0156-array-and-record-constructors.py
@@ -1,0 +1,13 @@
+# BSD 3-Clause License; see https://github.com/jpivarski/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+
+import pytest
+import numpy
+
+import awkward1
+
+def test():
+    assert awkward1.tolist(awkward1.Record({"x": 1, "y": 2.2})) == {"x": 1, "y": 2.2}


### PR DESCRIPTION
Copied from https://github.com/scikit-hep/awkward-1.0/issues/156#issuecomment-597366071

   * [X] The `ak.Array` and `ak.Record` constructor bugs (iterating over the dict keys and implementing that FIXME)
   * [x] Make `fromiter` iterate over `py::array` (mentioned in #146)
   * [ ] ~~Possibly, but not necessarily, `ak.zip` (described in #77).~~

I'm going to do `ak.zip` in a separate PR because this one has some bug-fixes.