### PR TITLE
Issues #166, #167, #170 in one PR.

### DIFF
--- a/include/awkward/cpu-kernels/reducers.h
+++ b/include/awkward/cpu-kernels/reducers.h
@@ -144,7 +144,7 @@ extern "C" {
   EXPORT_SYMBOL struct Error awkward_indexedarrayU32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
   EXPORT_SYMBOL struct Error awkward_indexedarray64_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray_reduce_next_adjust_offsets_64(int64_t* outoffsets, const int64_t* offsets, int64_t offsetsoffset, const int64_t* outindex, int64_t outindexoffset, int64_t outindexlength);
+  EXPORT_SYMBOL struct Error awkward_indexedarray_reduce_next_fix_offsets_64(int64_t* outoffsets, const int64_t* starts, int64_t startsoffset, int64_t startslength, int64_t outindexlength);
 
   EXPORT_SYMBOL struct Error awkward_numpyarray_reduce_mask_bytemaskedarray(int8_t* toptr, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
 

--- a/include/awkward/cpu-kernels/reducers.h
+++ b/include/awkward/cpu-kernels/reducers.h
@@ -148,7 +148,7 @@ extern "C" {
 
   EXPORT_SYMBOL struct Error awkward_numpyarray_reduce_mask_bytemaskedarray(int8_t* toptr, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const int8_t* mask, int64_t maskoffset, const int64_t* parents, int64_t parentsoffset, int64_t length, bool validwhen);
+  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int8_t* mask, int64_t maskoffset, const int64_t* parents, int64_t parentsoffset, int64_t length, bool validwhen);
 
 }
 

--- a/include/awkward/cpu-kernels/reducers.h
+++ b/include/awkward/cpu-kernels/reducers.h
@@ -140,9 +140,11 @@ extern "C" {
   EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_local_nextparents_64(int64_t* nextparents, const int64_t* offsets, int64_t offsetsoffset, int64_t length);
   EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_local_outoffsets_64(int64_t* outoffsets, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error awkward_indexedarray32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error awkward_indexedarray64_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
+
+  EXPORT_SYMBOL struct Error awkward_indexedarray_reduce_next_adjust_offsets_64(int64_t* outoffsets, const int64_t* offsets, int64_t offsetsoffset, const int64_t* outindex, int64_t outindexoffset, int64_t outindexlength);
 
   EXPORT_SYMBOL struct Error awkward_numpyarray_reduce_mask_bytemaskedarray(int8_t* toptr, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
 

--- a/include/awkward/util.h
+++ b/include/awkward/util.h
@@ -147,7 +147,7 @@ namespace awkward {
     template <typename T>
     ERROR awkward_listarray_getitem_jagged_descend_64(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const T* fromstarts, int64_t fromstartsoffset, const T* fromstops, int64_t fromstopsoffset);
     template <typename T>
-    ERROR awkward_indexedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const T* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
+    ERROR awkward_indexedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const T* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
     template <typename T>
     ERROR awkward_UnionArray_fillna_64(int64_t* toindex, const T* fromindex, int64_t offset, int64_t length);
 

--- a/src/awkward1/_connect/_autograd.py
+++ b/src/awkward1/_connect/_autograd.py
@@ -52,9 +52,10 @@ def elementwise_grad(fun, argnum=0, *nary_op_args, **nary_op_kwargs):
             else:
                 return None
 
-        out = awkward1._util.broadcast_and_apply(nextargs, getfunction)
+        behavior = awkward1._util.behaviorof(*args)
+        out = awkward1._util.broadcast_and_apply(nextargs, getfunction, behavior)
         assert isinstance(out, tuple) and len(out) == 1
-        return awkward1._util.wrap(out[0], awkward1._util.behaviorof(args))
+        return awkward1._util.wrap(out[0], behavior)
 
     return broadcast
 

--- a/src/awkward1/_connect/_numexpr.py
+++ b/src/awkward1/_connect/_numexpr.py
@@ -59,9 +59,10 @@ def evaluate(expression, local_dict=None, global_dict=None, order="K", casting="
         else:
             return None
 
-    out = awkward1._util.broadcast_and_apply(arrays, getfunction)
+    behavior = awkward1._util.behaviorof(*arrays)
+    out = awkward1._util.broadcast_and_apply(arrays, getfunction, behavior)
     assert isinstance(out, tuple) and len(out) == 1
-    return awkward1._util.wrap(out[0], awkward1._util.behaviorof(arrays))
+    return awkward1._util.wrap(out[0], behavior)
 
 evaluate.evaluate = evaluate
 
@@ -83,8 +84,9 @@ def re_evaluate(local_dict=None):
         else:
             return None
 
-    out = awkward1._util.broadcast_and_apply(arrays, getfunction)
+    behavior = awkward1._util.behaviorof(*arrays)
+    out = awkward1._util.broadcast_and_apply(arrays, getfunction, behavior)
     assert isinstance(out, tuple) and len(out) == 1
-    return awkward1._util.wrap(out[0], awkward1._util.behaviorof(arrays))
+    return awkward1._util.wrap(out[0], behavior)
 
 evaluate.re_evaluate = re_evaluate

--- a/src/awkward1/_connect/_numpy.py
+++ b/src/awkward1/_connect/_numpy.py
@@ -67,7 +67,7 @@ def array_ufunc(ufunc, method, inputs, kwargs, behavior):
 
         return None
 
-    out = awkward1._util.broadcast_and_apply(inputs, getfunction)
+    out = awkward1._util.broadcast_and_apply(inputs, getfunction, behavior)
     assert isinstance(out, tuple) and len(out) == 1
     return awkward1._util.wrap(out[0], behavior)
 

--- a/src/awkward1/behaviors/string.py
+++ b/src/awkward1/behaviors/string.py
@@ -100,6 +100,7 @@ def string_broadcast(layout, offsets):
     parents = numpy.repeat(numpy.arange(len(counts), dtype=counts.dtype), counts)
     return awkward1.layout.IndexedArray64(awkward1.layout.Index64(parents), layout).project()
 
+awkward1.behavior["__broadcast__", "bytestring"] = string_broadcast
 awkward1.behavior["__broadcast__", "string"] = string_broadcast
 
 def string_numba_typer(viewtype):

--- a/src/awkward1/behaviors/string.py
+++ b/src/awkward1/behaviors/string.py
@@ -92,6 +92,16 @@ def string_equal(one, two):
 awkward1.behavior[numpy.equal, "bytestring", "bytestring"] = string_equal
 awkward1.behavior[numpy.equal, "string", "string"] = string_equal
 
+def string_broadcast(layout, offsets):
+    offsets = numpy.asarray(offsets)
+    counts = offsets[1:] - offsets[:-1]
+    if awkward1._util.win:
+        counts = counts.astype(numpy.int32)
+    parents = numpy.repeat(numpy.arange(len(counts), dtype=counts.dtype), counts)
+    return awkward1.layout.IndexedArray64(awkward1.layout.Index64(parents), layout).project()
+
+awkward1.behavior["__broadcast__", "string"] = string_broadcast
+
 def string_numba_typer(viewtype):
     import numba
     return numba.types.string

--- a/src/awkward1/operations/convert.py
+++ b/src/awkward1/operations/convert.py
@@ -308,7 +308,7 @@ def tolayout(array, allowrecord=True, allowother=False, numpytype=(numpy.number,
             out = awkward1.layout.RegularArray(out, size)
         return out
 
-    elif isinstance(array, str) or (awkward1._util.py27 and isinstance(array, unicode)):
+    elif isinstance(array, (str, bytes)) or (awkward1._util.py27 and isinstance(array, unicode)):
         return fromiter([array], highlevel=False)
 
     elif isinstance(array, Iterable):

--- a/src/awkward1/operations/convert.py
+++ b/src/awkward1/operations/convert.py
@@ -338,6 +338,29 @@ def fromawkward0(array, keeplayout=False, regulararray=False, highlevel=True, be
     # See https://github.com/scikit-hep/awkward-0.x/blob/405b7eaeea51b60947a79c782b1abf0d72f6729b/specification.adoc
     import awkward as awkward0
 
+    # If a source of Awkward0 arrays ever starts emitting Awkward1 arrays (e.g. Uproot),
+    # this function turns into a pass-through.
+    if isinstance(array, (awkward1.highlevel.Array, awkward1.highlevel.Record)):
+        if highlevel:
+            return array
+        else:
+            return array.layout
+    elif isinstance(array, awkward1.highlevel.ArrayBuilder):
+        if highlevel:
+            return array.snapshot()
+        else:
+            return array._layout.snapshot()
+    elif isinstance(array, (awkward1.layout.Content, awkward1.layout.Record)):
+        if highlevel:
+            return awkward1._util.wrap(array, behavior)
+        else:
+            return array
+    elif isinstance(array, awkward1.layout.ArrayBuilder):
+        if highlevel:
+            return awkward1._util.wrap(array.snapshot(), behavior)
+        else:
+            return array.snapshot()
+
     def recurse(array):
         if isinstance(array, dict):
             keys = []

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -27,10 +27,11 @@ def withfield(base, what, where=None, highlevel=True):
         else:
             return None
 
-    out = awkward1._util.broadcast_and_apply([base, what], getfunction)
+    behavior = awkward1._util.behaviorof(base, what)
+    out = awkward1._util.broadcast_and_apply([base, what], getfunction, behavior)
     assert isinstance(out, tuple) and len(out) == 1
     if highlevel:
-        return awkward1._util.wrap(out[0], behavior=awkward1._util.behaviorof(base, what))
+        return awkward1._util.wrap(out[0], behavior=behavior)
     else:
         return out[0]
 
@@ -183,10 +184,11 @@ def broadcast_arrays(*arrays, **kwargs):
         else:
             return None
 
-    out = awkward1._util.broadcast_and_apply(inputs, getfunction)
+    behavior = awkward1._util.behaviorof(*arrays)
+    out = awkward1._util.broadcast_and_apply(inputs, getfunction, behavior)
     assert isinstance(out, tuple)
     if highlevel:
-        return [awkward1._util.wrap(x, awkward1._util.behaviorof(arrays)) for x in out]
+        return [awkward1._util.wrap(x, behavior) for x in out]
     else:
         return list(out)
 
@@ -291,10 +293,11 @@ def zip(arrays, depthlimit=None, parameters=None, highlevel=True):
         else:
             return None
 
-    out = awkward1._util.broadcast_and_apply(layouts, getfunction)
+    behavior = awkward1._util.behaviorof(*arrays)
+    out = awkward1._util.broadcast_and_apply(layouts, getfunction, behavior)
     assert isinstance(out, tuple) and len(out) == 1
     if highlevel:
-        return awkward1._util.wrap(out[0], awkward1._util.behaviorof(*arrays))
+        return awkward1._util.wrap(out[0], behavior)
     else:
         return out[0]
 
@@ -323,6 +326,8 @@ def argcross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
             return result
 
 def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
+    behavior = awkward1._util.behaviorof(*arrays)
+
     if axis < 0:
         raise ValueError("cross's 'axis' must be non-negative")
 
@@ -422,7 +427,7 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
             else:
                 return None
 
-        out = awkward1._util.broadcast_and_apply(layouts, getfunction3)
+        out = awkward1._util.broadcast_and_apply(layouts, getfunction3, behavior)
         assert isinstance(out, tuple) and len(out) == 1
         result = out[0]
 
@@ -431,7 +436,7 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
             result = flatten(result, axis=axis, highlevel=False)
 
     if highlevel:
-        return awkward1._util.wrap(result, awkward1._util.behaviorof(*arrays))
+        return awkward1._util.wrap(result, behavior)
     else:
         return result
 
@@ -473,10 +478,11 @@ def tomask(array, mask, validwhen=True, highlevel=True):
     layoutarray = awkward1.operations.convert.tolayout(array, allowrecord=True, allowother=False)
     layoutmask = awkward1.operations.convert.tolayout(mask, allowrecord=True, allowother=False)
 
-    out = awkward1._util.broadcast_and_apply([layoutarray, layoutmask], getfunction)
+    behavior = awkward1._util.behaviorof(array, mask)
+    out = awkward1._util.broadcast_and_apply([layoutarray, layoutmask], getfunction, behavior)
     assert isinstance(out, tuple) and len(out) == 1
     if highlevel:
-        return awkward1._util.wrap(out[0], awkward1._util.behaviorof(array, mask))
+        return awkward1._util.wrap(out[0], behavior)
     else:
         return out[0]
 

--- a/src/cpu-kernels/reducers.cpp
+++ b/src/cpu-kernels/reducers.cpp
@@ -675,13 +675,17 @@ ERROR awkward_numpyarray_reduce_mask_bytemaskedarray(int8_t* toptr, const int64_
   return success();
 }
 
-ERROR awkward_bytemaskedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const int8_t* mask, int64_t maskoffset, const int64_t* parents, int64_t parentsoffset, int64_t length, bool validwhen) {
+ERROR awkward_bytemaskedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int8_t* mask, int64_t maskoffset, const int64_t* parents, int64_t parentsoffset, int64_t length, bool validwhen) {
   int64_t k = 0;
   for (int64_t i = 0;  i < length;  i++) {
     if ((mask[maskoffset + i] != 0) == validwhen) {
       nextcarry[k] = i;
       nextparents[k] = parents[parentsoffset + i];
+      outindex[i] = k;
       k++;
+    }
+    else {
+      outindex[i] = -1;
     }
   }
   return success();

--- a/src/cpu-kernels/reducers.cpp
+++ b/src/cpu-kernels/reducers.cpp
@@ -632,25 +632,50 @@ ERROR awkward_listoffsetarray_reduce_local_outoffsets_64(int64_t* outoffsets, co
 }
 
 template <typename T>
-ERROR awkward_indexedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const T* index, int64_t indexoffset, const int64_t* parents, int64_t parentsoffset, int64_t length) {
+ERROR awkward_indexedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const T* index, int64_t indexoffset, const int64_t* parents, int64_t parentsoffset, int64_t length) {
   int64_t k = 0;
   for (int64_t i = 0;  i < length;  i++) {
     if (index[indexoffset + i] >= 0) {
       nextcarry[k] = index[indexoffset + i];
       nextparents[k] = parents[parentsoffset + i];
+      outindex[i] = k;
       k++;
+    }
+    else {
+      outindex[i] = -1;
     }
   }
   return success();
 }
-ERROR awkward_indexedarray32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-  return awkward_indexedarray_reduce_next_64<int32_t>(nextcarry, nextparents, index, indexoffset, parents, parentsoffset, length);
+ERROR awkward_indexedarray32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
+  return awkward_indexedarray_reduce_next_64<int32_t>(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
 }
-ERROR awkward_indexedarrayU32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-  return awkward_indexedarray_reduce_next_64<uint32_t>(nextcarry, nextparents, index, indexoffset, parents, parentsoffset, length);
+ERROR awkward_indexedarrayU32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
+  return awkward_indexedarray_reduce_next_64<uint32_t>(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
 }
-ERROR awkward_indexedarray64_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-  return awkward_indexedarray_reduce_next_64<int64_t>(nextcarry, nextparents, index, indexoffset, parents, parentsoffset, length);
+ERROR awkward_indexedarray64_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
+  return awkward_indexedarray_reduce_next_64<int64_t>(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
+}
+
+ERROR awkward_indexedarray_reduce_next_adjust_offsets_64(int64_t* outoffsets, const int64_t* offsets, int64_t offsetsoffset, const int64_t* outindex, int64_t outindexoffset, int64_t outindexlength) {
+  int64_t withoutnulls = 0;
+  int64_t withnulls = 0;
+  int64_t k = 0;
+  for (int64_t i = 0;  i < outindexlength;  i++) {
+    while (offsets[offsetsoffset + k] == withoutnulls) {
+      outoffsets[k] = withnulls;
+      k++;
+    }
+    if (outindex[outindexoffset + i] < 0) {
+      withnulls++;
+    }
+    else {
+      withoutnulls++;
+      withnulls++;
+    }
+  }
+  outoffsets[k] = withnulls;
+  return success();
 }
 
 ERROR awkward_numpyarray_reduce_mask_bytemaskedarray(int8_t* toptr, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {

--- a/src/cpu-kernels/reducers.cpp
+++ b/src/cpu-kernels/reducers.cpp
@@ -657,24 +657,11 @@ ERROR awkward_indexedarray64_reduce_next_64(int64_t* nextcarry, int64_t* nextpar
   return awkward_indexedarray_reduce_next_64<int64_t>(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
 }
 
-ERROR awkward_indexedarray_reduce_next_adjust_offsets_64(int64_t* outoffsets, const int64_t* offsets, int64_t offsetsoffset, const int64_t* outindex, int64_t outindexoffset, int64_t outindexlength) {
-  int64_t withoutnulls = 0;
-  int64_t withnulls = 0;
-  int64_t k = 0;
-  for (int64_t i = 0;  i < outindexlength;  i++) {
-    while (offsets[offsetsoffset + k] == withoutnulls) {
-      outoffsets[k] = withnulls;
-      k++;
-    }
-    if (outindex[outindexoffset + i] < 0) {
-      withnulls++;
-    }
-    else {
-      withoutnulls++;
-      withnulls++;
-    }
+ERROR awkward_indexedarray_reduce_next_fix_offsets_64(int64_t* outoffsets, const int64_t* starts, int64_t startsoffset, int64_t startslength, int64_t outindexlength) {
+  for (int64_t i = 0;  i < startslength;  i++) {
+    outoffsets[i] = starts[startsoffset + i];
   }
-  outoffsets[k] = withnulls;
+  outoffsets[startsoffset + startslength] = outindexlength;
   return success();
 }
 

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -19,6 +19,8 @@
 #include "awkward/array/BitMaskedArray.h"
 #include "awkward/array/UnmaskedArray.h"
 #include "awkward/array/UnionArray.h"
+#include "awkward/array/RegularArray.h"
+#include "awkward/array/ListOffsetArray.h"
 
 #include "awkward/array/ByteMaskedArray.h"
 
@@ -585,9 +587,11 @@ namespace awkward {
 
     Index64 nextparents(length() - numnull);
     Index64 nextcarry(length() - numnull);
+    Index64 outindex(length());
     struct Error err2 = awkward_bytemaskedarray_reduce_next_64(
       nextcarry.ptr().get(),
       nextparents.ptr().get(),
+      outindex.ptr().get(),
       mask_.ptr().get(),
       mask_.offset(),
       parents.ptr().get(),
@@ -597,7 +601,35 @@ namespace awkward {
     util::handle_error(err2, classname(), identities_.get());
 
     std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-    return next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
+    std::shared_ptr<Content> out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
+
+    std::pair<bool, int64_t> branchdepth = branch_depth();
+    if (!branchdepth.first  &&  negaxis == branchdepth.second) {
+      return out;
+    }
+    else {
+      if (RegularArray* raw = dynamic_cast<RegularArray*>(out.get())) {
+        out = raw->toListOffsetArray64(true);
+      }
+      if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
+        Index64 outoffsets(starts.length() + 1);
+        if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
+          throw std::runtime_error("reduce_next with unbranching depth > negaxis expects a ListOffsetArray64 whose offsets start at zero");
+        }
+        struct Error err3 = awkward_indexedarray_reduce_next_fix_offsets_64(
+          outoffsets.ptr().get(),
+          starts.ptr().get(),
+          starts.offset(),
+          starts.length(),
+          outindex.length());
+        util::handle_error(err3, classname(), identities_.get());
+
+        return std::make_shared<ListOffsetArray64>(raw->identities(), raw->parameters(), outoffsets, std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), outindex, raw->content()));
+      }
+      else {
+        throw std::runtime_error(std::string("reduce_next with unbranching depth > negaxis is only expected to return RegularArray or ListOffsetArray64; instead, it returned ") + out.get()->classname());
+      }
+    }
   }
 
   const std::shared_ptr<Content> ByteMaskedArray::localindex(int64_t axis, int64_t depth) const {

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -1217,8 +1217,6 @@ namespace awkward {
       index_.length());
     util::handle_error(err1, classname(), identities_.get());
 
-    std::pair<bool, int64_t> branchdepth = branch_depth();
-
     Index64 nextparents(index_.length() - numnull);
     Index64 nextcarry(index_.length() - numnull);
     Index64 outindex(index_.length());
@@ -1236,6 +1234,7 @@ namespace awkward {
     std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
     std::shared_ptr<Content> out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
 
+    std::pair<bool, int64_t> branchdepth = branch_depth();
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
       return out;
     }

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -6,6 +6,7 @@
 #include "awkward/cpu-kernels/identities.h"
 #include "awkward/cpu-kernels/getitem.h"
 #include "awkward/cpu-kernels/operations.h"
+#include "awkward/cpu-kernels/reducers.h"
 #include "awkward/type/OptionType.h"
 #include "awkward/type/ArrayType.h"
 #include "awkward/type/UnknownType.h"
@@ -18,6 +19,8 @@
 #include "awkward/array/ByteMaskedArray.h"
 #include "awkward/array/BitMaskedArray.h"
 #include "awkward/array/UnmaskedArray.h"
+#include "awkward/array/RegularArray.h"
+#include "awkward/array/ListOffsetArray.h"
 
 #include "awkward/array/IndexedArray.h"
 
@@ -1214,11 +1217,15 @@ namespace awkward {
       index_.length());
     util::handle_error(err1, classname(), identities_.get());
 
+    std::pair<bool, int64_t> branchdepth = branch_depth();
+
     Index64 nextparents(index_.length() - numnull);
     Index64 nextcarry(index_.length() - numnull);
+    Index64 outindex(index_.length());
     struct Error err2 = util::awkward_indexedarray_reduce_next_64<T>(
       nextcarry.ptr().get(),
       nextparents.ptr().get(),
+      outindex.ptr().get(),
       index_.ptr().get(),
       index_.offset(),
       parents.ptr().get(),
@@ -1227,7 +1234,35 @@ namespace awkward {
     util::handle_error(err2, classname(), identities_.get());
 
     std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-    return next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
+    std::shared_ptr<Content> out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
+
+    if (!branchdepth.first  &&  negaxis == branchdepth.second) {
+      return out;
+    }
+    else {
+      if (RegularArray* raw = dynamic_cast<RegularArray*>(out.get())) {
+        out = raw->toListOffsetArray64(true);
+      }
+      if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
+        Index64 outoffsets(raw->length() + 1);
+        Index64 tmpoffsets = raw->offsets();
+        struct Error err3 = awkward_indexedarray_reduce_next_adjust_offsets_64(
+          outoffsets.ptr().get(),
+          tmpoffsets.ptr().get(),
+          tmpoffsets.offset(),
+          outindex.ptr().get(),
+          outindex.offset(),
+          outindex.length());
+        util::handle_error(err3, classname(), identities_.get());
+
+        return std::make_shared<ListOffsetArray64>(raw->identities(), raw->parameters(), outoffsets, std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), outindex, raw->content()));
+      }
+      else {
+        throw std::runtime_error(std::string("reduce_next with unbranching depth > negaxis is only expected to return RegularArray or ListOffsetArray64; instead, it returned ") + out.get()->classname());
+      }
+    }
+
+    return out;
   }
 
   template <typename T, bool ISOPTION>

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -1244,14 +1244,15 @@ namespace awkward {
         out = raw->toListOffsetArray64(true);
       }
       if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
-        Index64 outoffsets(raw->length() + 1);
-        Index64 tmpoffsets = raw->offsets();
-        struct Error err3 = awkward_indexedarray_reduce_next_adjust_offsets_64(
+        Index64 outoffsets(starts.length() + 1);
+        if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
+          throw std::runtime_error("reduce_next with unbranching depth > negaxis expects a ListOffsetArray64 whose offsets start at zero");
+        }
+        struct Error err3 = awkward_indexedarray_reduce_next_fix_offsets_64(
           outoffsets.ptr().get(),
-          tmpoffsets.ptr().get(),
-          tmpoffsets.offset(),
-          outindex.ptr().get(),
-          outindex.offset(),
+          starts.ptr().get(),
+          starts.offset(),
+          starts.length(),
           outindex.length());
         util::handle_error(err3, classname(), identities_.get());
 

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -822,18 +822,18 @@ namespace awkward {
     }
 
     template <>
-    Error awkward_indexedarray_reduce_next_64<int32_t>(int64_t* nextcarry, int64_t* nextparents, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-      return awkward_indexedarray32_reduce_next_64(nextcarry, nextparents, index, indexoffset, parents, parentsoffset, length);
+    Error awkward_indexedarray_reduce_next_64<int32_t>(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
+      return awkward_indexedarray32_reduce_next_64(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
     }
 
     template <>
-    Error awkward_indexedarray_reduce_next_64<uint32_t>(int64_t* nextcarry, int64_t* nextparents, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-      return awkward_indexedarrayU32_reduce_next_64(nextcarry, nextparents, index, indexoffset, parents, parentsoffset, length);
+    Error awkward_indexedarray_reduce_next_64<uint32_t>(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
+      return awkward_indexedarrayU32_reduce_next_64(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
     }
 
     template <>
-    Error awkward_indexedarray_reduce_next_64<int64_t>(int64_t* nextcarry, int64_t* nextparents, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-      return awkward_indexedarray64_reduce_next_64(nextcarry, nextparents, index, indexoffset, parents, parentsoffset, length);
+    Error awkward_indexedarray_reduce_next_64<int64_t>(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
+      return awkward_indexedarray64_reduce_next_64(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
     }
 
     template <>

--- a/tests/test_0070-argmin-and-argmax.py
+++ b/tests/test_0070-argmin-and-argmax.py
@@ -46,11 +46,11 @@ def test_jagged():
 
     index3 = awkward1.layout.Index64(numpy.array([4, 3, -1, 4, 0], dtype=numpy.int64))
     array2 = awkward1.layout.IndexedArray64(index3, array)
-    assert awkward1.tolist(array2.argmin(axis=1)) == [2, 0, 2, 1]
+    assert awkward1.tolist(array2.argmin(axis=1)) == [2, 0, None, 2, 1]
 
 def test_missing():
     array = awkward1.Array([[[2.2, 1.1, 3.3]], [[]], [None, None, None], [[-4.4, -5.5, -6.6]]]).layout
-    assert awkward1.tolist(array.argmin(axis=2)) == [[1], [None], [], [2]]
+    assert awkward1.tolist(array.argmin(axis=2)) == [[1], [None], [None, None, None], [2]]
 
 def test_highlevel():
     array = awkward1.Array([

--- a/tests/test_0115-generic-reducer-operation.py
+++ b/tests/test_0115-generic-reducer-operation.py
@@ -482,8 +482,10 @@ def test_IndexedOptionArray():
 
     assert awkward1.tolist(depth2.prod(-1)) == [
         [101 * 103 * 107 * 109 * 113,
+         None,
           53 *  59 *  61 *  67 *  71],
         [ 31 *  37 *  41 *  43 *  47,
+         None,
            2 *   3 *   5 *   7 *  11]]
 
     assert awkward1.tolist(depth2.prod(-2)) == [

--- a/tests/test_0127-tomask-operation.py
+++ b/tests/test_0127-tomask-operation.py
@@ -168,8 +168,10 @@ def test_ByteMaskedArray_reduce():
 
     assert awkward1.tolist(depth2.prod(-1)) == [
         [  2 *   3 *   5 *   7 *  11,
+         None,
           31 *  37 *  41 *  43 *  47],
         [ 53 *  59 *  61 *  67 *  71,
+         None,
          101 * 103 * 107 * 109 * 113]]
 
     assert awkward1.tolist(depth2.prod(-2)) == [

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -52,7 +52,15 @@ def test_0166_ByteMaskedArray():
     assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [30, 1, 77, 13, 323]
 
 def test_0167():
-    pass
+    array = awkward1.Array(["one", "two", "three", "two", "two", "one", "three"])
+    assert awkward1.tolist(array == "two") == [False, True, False, True, True, False, False]
+
+    array = awkward1.Array([["one", "two", "three"], [], ["two"], ["two", "one"], ["three"]])
+    assert awkward1.tolist(array == "two") == [[False, True, False], [], [True], [True, False], [False]]
+
+    array = awkward1.Array([["one", "two", "three"], [], ["two"], ["two", "one"], ["three"]])
+    assert awkward1.tolist(array == ["three", "two", "one", "one", "three"]) == [[False, False, True], [], [False], [False, True], [True]]
+    # assert awkward1.tolist(array == awkward1.Array(["three", "two", "one", "one", "three"])) == [[False, False, True], [], [False], [False, True], [True]]
 
 def test_0170():
     pass

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -10,7 +10,17 @@ import numpy
 import awkward1
 
 def test_0166():
-    pass
+    array = awkward1.Array([[2, 3, 5], None, [], [7, 11], None, [13], None, [17, 19]])
+    assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [30, None, 1, 77, None, 13, None, 323]
+
+    array = awkward1.Array([[[2, 3], [5]], None, [], [[7], [11]], None, [[13]], None, [[17, 19]]])
+    assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [[6, 5], None, [], [7, 11], None, [13], None, [323]]
+
+    array = awkward1.Array([[[2, 3], None, [5]], [], [[7], [11]], [[13]], [None, [17], [19]]])
+    awkward1.tolist(awkward1.prod(array, axis=-1)) == [[6, None, 5], [], [7, 11], [13], [None, 17, 19]]
+
+    array = awkward1.Array([[6, None, 5], [], [7, 11], [13], [None, 17, 19]])
+    assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [30, 1, 77, 13, 323]
 
 def test_0167():
     pass

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -9,7 +9,7 @@ import numpy
 
 import awkward1
 
-def test_0166():
+def test_0166_IndexedOptionArray():
     array = awkward1.Array([[2, 3, 5], None, [], [7, 11], None, [13], None, [17, 19]])
     assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [30, None, 1, 77, None, 13, None, 323]
 
@@ -20,6 +20,35 @@ def test_0166():
     awkward1.tolist(awkward1.prod(array, axis=-1)) == [[6, None, 5], [], [7, 11], [13], [None, 17, 19]]
 
     array = awkward1.Array([[6, None, 5], [], [7, 11], [13], [None, 17, 19]])
+    assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [30, 1, 77, 13, 323]
+
+def test_0166_ByteMaskedArray():
+    content = awkward1.Array([[2, 3, 5], [999], [], [7, 11], [], [13], [123, 999], [17, 19]]).layout
+    mask = awkward1.layout.Index8(numpy.array([0, 1, 0, 0, 1, 0, 1, 0], dtype=numpy.int8))
+    array = awkward1.Array(awkward1.layout.ByteMaskedArray(mask, content, validwhen=False))
+    assert awkward1.tolist(array) == [[2, 3, 5], None, [], [7, 11], None, [13], None, [17, 19]]
+    assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [30, None, 1, 77, None, 13, None, 323]
+
+    content = awkward1.Array([[[2, 3], [5]], [[999]], [], [[7], [11]], [], [[13]], [[123], [999]], [[17, 19]]]).layout
+    mask = awkward1.layout.Index8(numpy.array([0, 1, 0, 0, 1, 0, 1, 0], dtype=numpy.int8))
+    array = awkward1.Array(awkward1.layout.ByteMaskedArray(mask, content, validwhen=False))
+    assert awkward1.tolist(array) == [[[2, 3], [5]], None, [], [[7], [11]], None, [[13]], None, [[17, 19]]]
+    assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [[6, 5], None, [], [7, 11], None, [13], None, [323]]
+
+    content = awkward1.Array([[2, 3], [999], [5], [7], [11], [13], [], [17], [19]]).layout
+    mask = awkward1.layout.Index8(numpy.array([0, 1, 0, 0, 0, 0, 1, 0, 0], dtype=numpy.int8))
+    bytemasked = awkward1.layout.ByteMaskedArray(mask, content, validwhen=False)
+    offsets = awkward1.layout.Index64(numpy.array([0, 3, 3, 5, 6, 9], dtype=numpy.int64))
+    array = awkward1.Array(awkward1.layout.ListOffsetArray64(offsets, bytemasked))
+    array = awkward1.Array([[[2, 3], None, [5]], [], [[7], [11]], [[13]], [None, [17], [19]]])
+    assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [[6, None, 5], [], [7, 11], [13], [None, 17, 19]]
+
+    content = awkward1.Array([6, None, 5, 7, 11, 13, None, 17, 19]).layout
+    mask = awkward1.layout.Index8(numpy.array([0, 1, 0, 0, 0, 0, 1, 0, 0], dtype=numpy.int8))
+    bytemasked = awkward1.layout.ByteMaskedArray(mask, content, validwhen=False)
+    offsets = awkward1.layout.Index64(numpy.array([0, 3, 3, 5, 6, 9], dtype=numpy.int64))
+    array = awkward1.Array(awkward1.layout.ListOffsetArray64(offsets, bytemasked))
+    assert awkward1.tolist(array) == [[6, None, 5], [], [7, 11], [13], [None, 17, 19]]
     assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [30, 1, 77, 13, 323]
 
 def test_0167():

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -51,16 +51,59 @@ def test_0166_ByteMaskedArray():
     assert awkward1.tolist(array) == [[6, None, 5], [], [7, 11], [13], [None, 17, 19]]
     assert awkward1.tolist(awkward1.prod(array, axis=-1)) == [30, 1, 77, 13, 323]
 
-def test_0167():
+def test_0167_strings():
     array = awkward1.Array(["one", "two", "three", "two", "two", "one", "three"])
     assert awkward1.tolist(array == "two") == [False, True, False, True, True, False, False]
+    assert awkward1.tolist("two" == array) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(array == ["two"]) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(["two"] == array) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(array == awkward1.Array(["two"])) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(awkward1.Array(["two"]) == array) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(array < array) == [[False, False, False], [False, False, False], [False, False, False, False, False], [False, False, False], [False, False, False], [False, False, False], [False, False, False, False, False]]
+    assert awkward1.tolist(array <= array) == [[True, True, True], [True, True, True], [True, True, True, True, True], [True, True, True], [True, True, True], [True, True, True], [True, True, True, True, True]]
 
     array = awkward1.Array([["one", "two", "three"], [], ["two"], ["two", "one"], ["three"]])
     assert awkward1.tolist(array == "two") == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist("two" == array) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(array == ["two"]) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(["two"] == array) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(array == awkward1.Array(["two"])) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(awkward1.Array(["two"]) == array) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(array < array) == [[[False, False, False], [False, False, False], [False, False, False, False, False]], [], [[False, False, False]], [[False, False, False], [False, False, False]], [[False, False, False, False, False]]]
+    assert awkward1.tolist(array <= array) == [[[True, True, True], [True, True, True], [True, True, True, True, True]], [], [[True, True, True]], [[True, True, True], [True, True, True]], [[True, True, True, True, True]]]
 
     array = awkward1.Array([["one", "two", "three"], [], ["two"], ["two", "one"], ["three"]])
     assert awkward1.tolist(array == ["three", "two", "one", "one", "three"]) == [[False, False, True], [], [False], [False, True], [True]]
-    # assert awkward1.tolist(array == awkward1.Array(["three", "two", "one", "one", "three"])) == [[False, False, True], [], [False], [False, True], [True]]
+    assert awkward1.tolist(["three", "two", "one", "one", "three"] == array) == [[False, False, True], [], [False], [False, True], [True]]
+    assert awkward1.tolist(array == awkward1.Array(["three", "two", "one", "one", "three"])) == [[False, False, True], [], [False], [False, True], [True]]
+    assert awkward1.tolist(awkward1.Array(["three", "two", "one", "one", "three"]) == array) == [[False, False, True], [], [False], [False, True], [True]]
+
+def test_0167_bytestrings():
+    array = awkward1.Array([b"one", b"two", b"three", b"two", b"two", b"one", b"three"])
+    assert awkward1.tolist(array == b"two") == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(b"two" == array) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(array == [b"two"]) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist([b"two"] == array) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(array == awkward1.Array([b"two"])) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(awkward1.Array([b"two"]) == array) == [False, True, False, True, True, False, False]
+    assert awkward1.tolist(array < array) == [[False, False, False], [False, False, False], [False, False, False, False, False], [False, False, False], [False, False, False], [False, False, False], [False, False, False, False, False]]
+    assert awkward1.tolist(array <= array) == [[True, True, True], [True, True, True], [True, True, True, True, True], [True, True, True], [True, True, True], [True, True, True], [True, True, True, True, True]]
+
+    array = awkward1.Array([[b"one", b"two", b"three"], [], [b"two"], [b"two", b"one"], [b"three"]])
+    assert awkward1.tolist(array == b"two") == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(b"two" == array) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(array == [b"two"]) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist([b"two"] == array) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(array == awkward1.Array([b"two"])) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(awkward1.Array([b"two"]) == array) == [[False, True, False], [], [True], [True, False], [False]]
+    assert awkward1.tolist(array < array) == [[[False, False, False], [False, False, False], [False, False, False, False, False]], [], [[False, False, False]], [[False, False, False], [False, False, False]], [[False, False, False, False, False]]]
+    assert awkward1.tolist(array <= array) == [[[True, True, True], [True, True, True], [True, True, True, True, True]], [], [[True, True, True]], [[True, True, True], [True, True, True]], [[True, True, True, True, True]]]
+
+    array = awkward1.Array([[b"one", b"two", b"three"], [], [b"two"], [b"two", b"one"], [b"three"]])
+    assert awkward1.tolist(array == [b"three", b"two", b"one", b"one", b"three"]) == [[False, False, True], [], [False], [False, True], [True]]
+    assert awkward1.tolist([b"three", b"two", b"one", b"one", b"three"] == array) == [[False, False, True], [], [False], [False, True], [True]]
+    assert awkward1.tolist(array == awkward1.Array([b"three", b"two", b"one", b"one", b"three"])) == [[False, False, True], [], [False], [False, True], [True]]
+    assert awkward1.tolist(awkward1.Array([b"three", b"two", b"one", b"one", b"three"]) == array) == [[False, False, True], [], [False], [False, True], [True]]
 
 def test_0170():
     pass

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/jpivarski/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+
+import pytest
+import numpy
+
+import awkward1
+
+def test_0166():
+    pass
+
+def test_0167():
+    pass
+
+def test_0170():
+    pass

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -104,6 +104,3 @@ def test_0167_bytestrings():
     assert awkward1.tolist([b"three", b"two", b"one", b"one", b"three"] == array) == [[False, False, True], [], [False], [False, True], [True]]
     assert awkward1.tolist(array == awkward1.Array([b"three", b"two", b"one", b"one", b"three"])) == [[False, False, True], [], [False], [False, True], [True]]
     assert awkward1.tolist(awkward1.Array([b"three", b"two", b"one", b"one", b"three"]) == array) == [[False, False, True], [], [False], [False, True], [True]]
-
-def test_0170():
-    pass


### PR DESCRIPTION
They're small enough that they don't need the formality of individually waiting for tests to finish.

   * [x] 166: reducers with `axis=-1` shouldn't drop `None` values from a masked dataset.
      * [x] IndexedOptionArray
      * [x] ByteMaskedArray and BitMaskedArray (the latter is trivial)
   * [x] 167: investigate `numpy.equal` in which one side is a string (or bytestring)
      * [x] Is it broken?
      * [x] Did you fix it?
   * [x] 170: put in a quick check for Awkward1 arrays passed to `ak.fromawkward0`. It should be a pass-through.