### PR TITLE
Enforce a 79 character maximum on all lines, 72 on docstrings/comments.

### DIFF
--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -21,15 +21,15 @@ namespace awkward {
 
   class EXPORT_SYMBOL Content {
   public:
-    Content(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters);
+    Content(const IdentitiesPtr& identities, const util::Parameters& parameters);
     virtual ~Content();
 
     virtual bool isscalar() const;
     virtual const std::string classname() const = 0;
-    virtual const std::shared_ptr<Identities> identities() const;
+    virtual const IdentitiesPtr identities() const;
     virtual void setidentities() = 0;
-    virtual void setidentities(const std::shared_ptr<Identities>& identities) = 0;
-    virtual const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const = 0;
+    virtual void setidentities(const IdentitiesPtr& identities) = 0;
+    virtual const TypePtr type(const std::map<std::string, std::string>& typestrs) const = 0;
     virtual const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const = 0;
     virtual void tojson_part(ToJson& builder) const = 0;
     virtual void nbytes_part(std::map<size_t, int64_t>& largest) const = 0;
@@ -45,8 +45,8 @@ namespace awkward {
     virtual const ContentPtr getitem_field(const std::string& key) const = 0;
     virtual const ContentPtr getitem_fields(const std::vector<std::string>& keys) const = 0;
     virtual const ContentPtr getitem(const Slice& where) const;
-    virtual const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const;
-    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const;
+    virtual const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const;
+    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceItemPtr& slicecontent, const Slice& tail) const;
     virtual const ContentPtr carry(const Index64& carry) const = 0;
     virtual const std::string purelist_parameter(const std::string& key) const = 0;
     virtual bool purelist_isregular() const = 0;
@@ -66,13 +66,13 @@ namespace awkward {
     virtual const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const = 0;
     virtual bool mergeable(const ContentPtr& other, bool mergebool) const = 0;
     virtual const ContentPtr merge(const ContentPtr& other) const = 0;
-    virtual const std::shared_ptr<SliceItem> asslice() const = 0;
+    virtual const SliceItemPtr asslice() const = 0;
     virtual const ContentPtr fillna(const ContentPtr& value) const = 0;
     virtual const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const = 0;
     virtual const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const = 0;
     virtual const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const = 0;
     virtual const ContentPtr localindex(int64_t axis, int64_t depth) const = 0;
-    virtual const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const = 0;
+    virtual const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const = 0;
 
     const std::string tostring() const;
     const std::string tojson(bool pretty, int64_t maxdecimals) const;
@@ -89,7 +89,7 @@ namespace awkward {
     const ContentPtr merge_as_union(const ContentPtr& other) const;
     const ContentPtr rpad_axis0(int64_t target, bool clip) const;
     const ContentPtr localindex_axis0() const;
-    const ContentPtr choose_axis0(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters) const;
+    const ContentPtr choose_axis0(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters) const;
 
     virtual const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const = 0;
     virtual const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const = 0;
@@ -111,7 +111,7 @@ namespace awkward {
     const int64_t axis_wrap_if_negative(int64_t axis) const;
 
   protected:
-    std::shared_ptr<Identities> identities_;
+    IdentitiesPtr identities_;
     util::Parameters parameters_;
   };
 }

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -15,6 +15,10 @@
 #include "awkward/Reducer.h"
 
 namespace awkward {
+  class Content;
+  typedef const std::shared_ptr<Content> ContentPtr;
+  typedef std::vector<std::shared_ptr<Content>> ContentPtrVec;
+
   class EXPORT_SYMBOL Content {
   public:
     Content(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters);
@@ -30,20 +34,20 @@ namespace awkward {
     virtual void tojson_part(ToJson& builder) const = 0;
     virtual void nbytes_part(std::map<size_t, int64_t>& largest) const = 0;
     virtual int64_t length() const = 0;
-    virtual const std::shared_ptr<Content> shallow_copy() const = 0;
-    virtual const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const = 0;
+    virtual ContentPtr shallow_copy() const = 0;
+    virtual ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const = 0;
     virtual void check_for_iteration() const = 0;
-    virtual const std::shared_ptr<Content> getitem_nothing() const = 0;
-    virtual const std::shared_ptr<Content> getitem_at(int64_t at) const = 0;
-    virtual const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const = 0;
-    virtual const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const = 0;
-    virtual const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
-    virtual const std::shared_ptr<Content> getitem_field(const std::string& key) const = 0;
-    virtual const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const = 0;
-    virtual const std::shared_ptr<Content> getitem(const Slice& where) const;
-    virtual const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const;
-    virtual const std::shared_ptr<Content> carry(const Index64& carry) const = 0;
+    virtual ContentPtr getitem_nothing() const = 0;
+    virtual ContentPtr getitem_at(int64_t at) const = 0;
+    virtual ContentPtr getitem_at_nowrap(int64_t at) const = 0;
+    virtual ContentPtr getitem_range(int64_t start, int64_t stop) const = 0;
+    virtual ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
+    virtual ContentPtr getitem_field(const std::string& key) const = 0;
+    virtual ContentPtr getitem_fields(const std::vector<std::string>& keys) const = 0;
+    virtual ContentPtr getitem(const Slice& where) const;
+    virtual ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const;
+    virtual ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const;
+    virtual ContentPtr carry(const Index64& carry) const = 0;
     virtual const std::string purelist_parameter(const std::string& key) const = 0;
     virtual bool purelist_isregular() const = 0;
     virtual int64_t purelist_depth() const = 0;
@@ -57,24 +61,24 @@ namespace awkward {
 
     // operations
     virtual const std::string validityerror(const std::string& path) const = 0;
-    virtual const std::shared_ptr<Content> shallow_simplify() const = 0;
-    virtual const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const = 0;
+    virtual ContentPtr shallow_simplify() const = 0;
+    virtual ContentPtr num(int64_t axis, int64_t depth) const = 0;
     virtual const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const = 0;
-    virtual bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const = 0;
-    virtual const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const = 0;
+    virtual bool mergeable(ContentPtr& other, bool mergebool) const = 0;
+    virtual ContentPtr merge(ContentPtr& other) const = 0;
     virtual const std::shared_ptr<SliceItem> asslice() const = 0;
-    virtual const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const = 0;
-    virtual const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const = 0;
-    virtual const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const = 0;
-    virtual const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const = 0;
-    virtual const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const = 0;
-    virtual const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const = 0;
+    virtual ContentPtr fillna(ContentPtr& value) const = 0;
+    virtual ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const = 0;
+    virtual ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const = 0;
+    virtual ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const = 0;
+    virtual ContentPtr localindex(int64_t axis, int64_t depth) const = 0;
+    virtual ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const = 0;
 
     const std::string tostring() const;
     const std::string tojson(bool pretty, int64_t maxdecimals) const;
     void tojson(FILE* destination, bool pretty, int64_t maxdecimals, int64_t buffersize) const;
     int64_t nbytes() const;
-    const std::shared_ptr<Content> reduce(const Reducer& reducer, int64_t axis, bool mask, bool keepdims) const;
+    ContentPtr reduce(const Reducer& reducer, int64_t axis, bool mask, bool keepdims) const;
 
     const util::Parameters parameters() const;
     void setparameters(const util::Parameters& parameters);
@@ -82,26 +86,26 @@ namespace awkward {
     void setparameter(const std::string& key, const std::string& value);
     bool parameter_equals(const std::string& key, const std::string& value) const;
     bool parameters_equal(const util::Parameters& other) const;
-    const std::shared_ptr<Content> merge_as_union(const std::shared_ptr<Content>& other) const;
-    const std::shared_ptr<Content> rpad_axis0(int64_t target, bool clip) const;
-    const std::shared_ptr<Content> localindex_axis0() const;
-    const std::shared_ptr<Content> choose_axis0(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters) const;
+    ContentPtr merge_as_union(ContentPtr& other) const;
+    ContentPtr rpad_axis0(int64_t target, bool clip) const;
+    ContentPtr localindex_axis0() const;
+    ContentPtr choose_axis0(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters) const;
 
-    virtual const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const = 0;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const = 0;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const = 0;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceMissing64& missing, const Slice& tail, const Index64& advanced) const;
-    virtual const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const = 0;
-    virtual const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const = 0;
-    virtual const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const = 0;
-    virtual const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const = 0;
+    virtual ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const = 0;
+    virtual ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const = 0;
+    virtual ContentPtr getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& advanced) const;
+    virtual ContentPtr getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const;
+    virtual ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const = 0;
+    virtual ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const;
+    virtual ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const;
+    virtual ContentPtr getitem_next(const SliceMissing64& missing, const Slice& tail, const Index64& advanced) const;
+    virtual ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const = 0;
+    virtual ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const = 0;
+    virtual ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const = 0;
+    virtual ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const = 0;
 
   protected:
-    const std::shared_ptr<Content> getitem_next_array_wrap(const std::shared_ptr<Content>& outcontent, const std::vector<int64_t>& shape) const;
+    ContentPtr getitem_next_array_wrap(ContentPtr& outcontent, const std::vector<int64_t>& shape) const;
     const std::string parameters_tostring(const std::string& indent, const std::string& pre, const std::string& post) const;
 
     const int64_t axis_wrap_if_negative(int64_t axis) const;

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -16,8 +16,7 @@
 
 namespace awkward {
   class Content;
-  typedef const std::shared_ptr<Content> ContentPtr;
-  typedef std::vector<std::shared_ptr<Content>> ContentPtrVec;
+  typedef std::shared_ptr<Content> ContentPtr;
 
   class EXPORT_SYMBOL Content {
   public:
@@ -34,20 +33,20 @@ namespace awkward {
     virtual void tojson_part(ToJson& builder) const = 0;
     virtual void nbytes_part(std::map<size_t, int64_t>& largest) const = 0;
     virtual int64_t length() const = 0;
-    virtual ContentPtr shallow_copy() const = 0;
-    virtual ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const = 0;
+    virtual const ContentPtr shallow_copy() const = 0;
+    virtual const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const = 0;
     virtual void check_for_iteration() const = 0;
-    virtual ContentPtr getitem_nothing() const = 0;
-    virtual ContentPtr getitem_at(int64_t at) const = 0;
-    virtual ContentPtr getitem_at_nowrap(int64_t at) const = 0;
-    virtual ContentPtr getitem_range(int64_t start, int64_t stop) const = 0;
-    virtual ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
-    virtual ContentPtr getitem_field(const std::string& key) const = 0;
-    virtual ContentPtr getitem_fields(const std::vector<std::string>& keys) const = 0;
-    virtual ContentPtr getitem(const Slice& where) const;
-    virtual ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const;
-    virtual ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const;
-    virtual ContentPtr carry(const Index64& carry) const = 0;
+    virtual const ContentPtr getitem_nothing() const = 0;
+    virtual const ContentPtr getitem_at(int64_t at) const = 0;
+    virtual const ContentPtr getitem_at_nowrap(int64_t at) const = 0;
+    virtual const ContentPtr getitem_range(int64_t start, int64_t stop) const = 0;
+    virtual const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
+    virtual const ContentPtr getitem_field(const std::string& key) const = 0;
+    virtual const ContentPtr getitem_fields(const std::vector<std::string>& keys) const = 0;
+    virtual const ContentPtr getitem(const Slice& where) const;
+    virtual const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const;
+    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const;
+    virtual const ContentPtr carry(const Index64& carry) const = 0;
     virtual const std::string purelist_parameter(const std::string& key) const = 0;
     virtual bool purelist_isregular() const = 0;
     virtual int64_t purelist_depth() const = 0;
@@ -61,24 +60,24 @@ namespace awkward {
 
     // operations
     virtual const std::string validityerror(const std::string& path) const = 0;
-    virtual ContentPtr shallow_simplify() const = 0;
-    virtual ContentPtr num(int64_t axis, int64_t depth) const = 0;
-    virtual const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const = 0;
-    virtual bool mergeable(ContentPtr& other, bool mergebool) const = 0;
-    virtual ContentPtr merge(ContentPtr& other) const = 0;
+    virtual const ContentPtr shallow_simplify() const = 0;
+    virtual const ContentPtr num(int64_t axis, int64_t depth) const = 0;
+    virtual const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const = 0;
+    virtual bool mergeable(const ContentPtr& other, bool mergebool) const = 0;
+    virtual const ContentPtr merge(const ContentPtr& other) const = 0;
     virtual const std::shared_ptr<SliceItem> asslice() const = 0;
-    virtual ContentPtr fillna(ContentPtr& value) const = 0;
-    virtual ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const = 0;
-    virtual ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const = 0;
-    virtual ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const = 0;
-    virtual ContentPtr localindex(int64_t axis, int64_t depth) const = 0;
-    virtual ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const = 0;
+    virtual const ContentPtr fillna(const ContentPtr& value) const = 0;
+    virtual const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const = 0;
+    virtual const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const = 0;
+    virtual const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const = 0;
+    virtual const ContentPtr localindex(int64_t axis, int64_t depth) const = 0;
+    virtual const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const = 0;
 
     const std::string tostring() const;
     const std::string tojson(bool pretty, int64_t maxdecimals) const;
     void tojson(FILE* destination, bool pretty, int64_t maxdecimals, int64_t buffersize) const;
     int64_t nbytes() const;
-    ContentPtr reduce(const Reducer& reducer, int64_t axis, bool mask, bool keepdims) const;
+    const ContentPtr reduce(const Reducer& reducer, int64_t axis, bool mask, bool keepdims) const;
 
     const util::Parameters parameters() const;
     void setparameters(const util::Parameters& parameters);
@@ -86,26 +85,26 @@ namespace awkward {
     void setparameter(const std::string& key, const std::string& value);
     bool parameter_equals(const std::string& key, const std::string& value) const;
     bool parameters_equal(const util::Parameters& other) const;
-    ContentPtr merge_as_union(ContentPtr& other) const;
-    ContentPtr rpad_axis0(int64_t target, bool clip) const;
-    ContentPtr localindex_axis0() const;
-    ContentPtr choose_axis0(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters) const;
+    const ContentPtr merge_as_union(const ContentPtr& other) const;
+    const ContentPtr rpad_axis0(int64_t target, bool clip) const;
+    const ContentPtr localindex_axis0() const;
+    const ContentPtr choose_axis0(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters) const;
 
-    virtual ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const = 0;
-    virtual ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const = 0;
-    virtual ContentPtr getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& advanced) const;
-    virtual ContentPtr getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const;
-    virtual ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const = 0;
-    virtual ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const;
-    virtual ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const;
-    virtual ContentPtr getitem_next(const SliceMissing64& missing, const Slice& tail, const Index64& advanced) const;
-    virtual ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const = 0;
-    virtual ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const = 0;
-    virtual ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const = 0;
-    virtual ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const = 0;
+    virtual const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const = 0;
+    virtual const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const = 0;
+    virtual const ContentPtr getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& advanced) const;
+    virtual const ContentPtr getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const;
+    virtual const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const = 0;
+    virtual const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const;
+    virtual const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const;
+    virtual const ContentPtr getitem_next(const SliceMissing64& missing, const Slice& tail, const Index64& advanced) const;
+    virtual const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const = 0;
+    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const = 0;
+    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const = 0;
+    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const = 0;
 
   protected:
-    ContentPtr getitem_next_array_wrap(ContentPtr& outcontent, const std::vector<int64_t>& shape) const;
+    const ContentPtr getitem_next_array_wrap(const ContentPtr& outcontent, const std::vector<int64_t>& shape) const;
     const std::string parameters_tostring(const std::string& indent, const std::string& pre, const std::string& post) const;
 
     const int64_t axis_wrap_if_negative(int64_t axis) const;

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -16,8 +16,8 @@
 
 namespace awkward {
   class Content;
-  typedef std::shared_ptr<Content> ContentPtr;
-  typedef std::vector<std::shared_ptr<Content>> ContentPtrVec;
+  using ContentPtr    = std::shared_ptr<Content>;
+  using ContentPtrVec = std::vector<std::shared_ptr<Content>>;
 
   class EXPORT_SYMBOL Content {
   public:

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -17,6 +17,7 @@
 namespace awkward {
   class Content;
   typedef std::shared_ptr<Content> ContentPtr;
+  typedef std::vector<std::shared_ptr<Content>> ContentPtrVec;
 
   class EXPORT_SYMBOL Content {
   public:

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -21,94 +21,302 @@ namespace awkward {
 
   class EXPORT_SYMBOL Content {
   public:
-    Content(const IdentitiesPtr& identities, const util::Parameters& parameters);
+    Content(const IdentitiesPtr& identities,
+            const util::Parameters& parameters);
+
     virtual ~Content();
 
-    virtual bool isscalar() const;
-    virtual const std::string classname() const = 0;
-    virtual const IdentitiesPtr identities() const;
-    virtual void setidentities() = 0;
-    virtual void setidentities(const IdentitiesPtr& identities) = 0;
-    virtual const TypePtr type(const std::map<std::string, std::string>& typestrs) const = 0;
-    virtual const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const = 0;
-    virtual void tojson_part(ToJson& builder) const = 0;
-    virtual void nbytes_part(std::map<size_t, int64_t>& largest) const = 0;
-    virtual int64_t length() const = 0;
-    virtual const ContentPtr shallow_copy() const = 0;
-    virtual const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const = 0;
-    virtual void check_for_iteration() const = 0;
-    virtual const ContentPtr getitem_nothing() const = 0;
-    virtual const ContentPtr getitem_at(int64_t at) const = 0;
-    virtual const ContentPtr getitem_at_nowrap(int64_t at) const = 0;
-    virtual const ContentPtr getitem_range(int64_t start, int64_t stop) const = 0;
-    virtual const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
-    virtual const ContentPtr getitem_field(const std::string& key) const = 0;
-    virtual const ContentPtr getitem_fields(const std::vector<std::string>& keys) const = 0;
-    virtual const ContentPtr getitem(const Slice& where) const;
-    virtual const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const;
-    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceItemPtr& slicecontent, const Slice& tail) const;
-    virtual const ContentPtr carry(const Index64& carry) const = 0;
-    virtual const std::string purelist_parameter(const std::string& key) const = 0;
-    virtual bool purelist_isregular() const = 0;
-    virtual int64_t purelist_depth() const = 0;
-    virtual const std::pair<int64_t, int64_t> minmax_depth() const = 0;
-    virtual const std::pair<bool, int64_t> branch_depth() const = 0;
-    virtual int64_t numfields() const = 0;
-    virtual int64_t fieldindex(const std::string& key) const = 0;
-    virtual const std::string key(int64_t fieldindex) const = 0;
-    virtual bool haskey(const std::string& key) const = 0;
-    virtual const std::vector<std::string> keys() const = 0;
+    virtual bool
+      isscalar() const;
+
+    virtual const std::string
+      classname() const = 0;
+
+    virtual const IdentitiesPtr
+      identities() const;
+
+    virtual void
+      setidentities() = 0;
+
+    virtual void
+      setidentities(const IdentitiesPtr& identities) = 0;
+
+    virtual const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const = 0;
+
+    virtual const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const = 0;
+
+    virtual void
+      tojson_part(ToJson& builder) const = 0;
+
+    virtual void
+      nbytes_part(std::map<size_t, int64_t>& largest) const = 0;
+
+    virtual int64_t
+      length() const = 0;
+
+    virtual const ContentPtr
+      shallow_copy() const = 0;
+
+    virtual const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const = 0;
+
+    virtual void
+      check_for_iteration() const = 0;
+
+    virtual const ContentPtr
+      getitem_nothing() const = 0;
+
+    virtual const ContentPtr
+      getitem_at(int64_t at) const = 0;
+
+    virtual const ContentPtr
+      getitem_at_nowrap(int64_t at) const = 0;
+
+    virtual const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const = 0;
+
+    virtual const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
+
+    virtual const ContentPtr
+      getitem_field(const std::string& key) const = 0;
+
+    virtual const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const = 0;
+
+    virtual const ContentPtr
+      getitem(const Slice& where) const;
+
+    virtual const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const;
+
+    virtual const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceItemPtr& slicecontent,
+                          const Slice& tail) const;
+
+    virtual const ContentPtr
+      carry(const Index64& carry) const = 0;
+
+    virtual const std::string
+      purelist_parameter(const std::string& key) const = 0;
+
+    virtual bool
+      purelist_isregular() const = 0;
+
+    virtual int64_t
+      purelist_depth() const = 0;
+
+    virtual const std::pair<int64_t, int64_t>
+      minmax_depth() const = 0;
+
+    virtual const std::pair<bool, int64_t>
+      branch_depth() const = 0;
+
+    virtual int64_t
+      numfields() const = 0;
+
+    virtual int64_t
+      fieldindex(const std::string& key) const = 0;
+
+    virtual const std::string
+      key(int64_t fieldindex) const = 0;
+
+    virtual bool
+      haskey(const std::string& key) const = 0;
+
+    virtual const std::vector<std::string>
+      keys() const = 0;
 
     // operations
-    virtual const std::string validityerror(const std::string& path) const = 0;
-    virtual const ContentPtr shallow_simplify() const = 0;
-    virtual const ContentPtr num(int64_t axis, int64_t depth) const = 0;
-    virtual const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const = 0;
-    virtual bool mergeable(const ContentPtr& other, bool mergebool) const = 0;
-    virtual const ContentPtr merge(const ContentPtr& other) const = 0;
-    virtual const SliceItemPtr asslice() const = 0;
-    virtual const ContentPtr fillna(const ContentPtr& value) const = 0;
-    virtual const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const = 0;
-    virtual const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const = 0;
-    virtual const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const = 0;
-    virtual const ContentPtr localindex(int64_t axis, int64_t depth) const = 0;
-    virtual const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const = 0;
+    virtual const std::string
+      validityerror(const std::string& path) const = 0;
 
-    const std::string tostring() const;
-    const std::string tojson(bool pretty, int64_t maxdecimals) const;
-    void tojson(FILE* destination, bool pretty, int64_t maxdecimals, int64_t buffersize) const;
-    int64_t nbytes() const;
-    const ContentPtr reduce(const Reducer& reducer, int64_t axis, bool mask, bool keepdims) const;
+    virtual const ContentPtr
+      shallow_simplify() const = 0;
 
-    const util::Parameters parameters() const;
-    void setparameters(const util::Parameters& parameters);
-    const std::string parameter(const std::string& key) const;
-    void setparameter(const std::string& key, const std::string& value);
-    bool parameter_equals(const std::string& key, const std::string& value) const;
-    bool parameters_equal(const util::Parameters& other) const;
-    const ContentPtr merge_as_union(const ContentPtr& other) const;
-    const ContentPtr rpad_axis0(int64_t target, bool clip) const;
-    const ContentPtr localindex_axis0() const;
-    const ContentPtr choose_axis0(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters) const;
+    virtual const ContentPtr
+      num(int64_t axis, int64_t depth) const = 0;
 
-    virtual const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const = 0;
-    virtual const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const = 0;
-    virtual const ContentPtr getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& advanced) const;
-    virtual const ContentPtr getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const;
-    virtual const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const = 0;
-    virtual const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const;
-    virtual const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const;
-    virtual const ContentPtr getitem_next(const SliceMissing64& missing, const Slice& tail, const Index64& advanced) const;
-    virtual const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const = 0;
-    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const = 0;
-    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const = 0;
-    virtual const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const = 0;
+    virtual const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const = 0;
+
+    virtual bool
+      mergeable(const ContentPtr& other, bool mergebool) const = 0;
+
+    virtual const ContentPtr
+      merge(const ContentPtr& other) const = 0;
+
+    virtual const SliceItemPtr
+      asslice() const = 0;
+
+    virtual const ContentPtr
+      fillna(const ContentPtr& value) const = 0;
+
+    virtual const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const = 0;
+
+    virtual const ContentPtr
+      rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const = 0;
+
+    virtual const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const = 0;
+
+    virtual const ContentPtr
+      localindex(int64_t axis, int64_t depth) const = 0;
+
+    virtual const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const = 0;
+
+    const std::string
+      tostring() const;
+
+    const std::string
+      tojson(bool pretty, int64_t maxdecimals) const;
+
+    void
+      tojson(FILE* destination,
+             bool pretty,
+             int64_t maxdecimals,
+             int64_t buffersize) const;
+
+    int64_t
+      nbytes() const;
+
+    const ContentPtr
+      reduce(const Reducer& reducer,
+             int64_t axis,
+             bool mask,
+             bool keepdims) const;
+
+    const util::Parameters
+      parameters() const;
+
+    void
+      setparameters(const util::Parameters& parameters);
+
+    const std::string
+      parameter(const std::string& key) const;
+
+    void
+      setparameter(const std::string& key, const std::string& value);
+
+    bool
+      parameter_equals(const std::string& key, const std::string& value) const;
+
+    bool
+      parameters_equal(const util::Parameters& other) const;
+
+    const ContentPtr
+      merge_as_union(const ContentPtr& other) const;
+
+    const ContentPtr
+      rpad_axis0(int64_t target, bool clip) const;
+
+    const ContentPtr
+      localindex_axis0() const;
+
+    const ContentPtr
+      choose_axis0(int64_t n,
+                   bool diagonal,
+                   const util::RecordLookupPtr& recordlookup,
+                   const util::Parameters& parameters) const;
+
+    virtual const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const = 0;
+
+    virtual const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const = 0;
+
+    virtual const ContentPtr
+      getitem_next(const SliceEllipsis& ellipsis,
+                   const Slice& tail,
+                   const Index64& advanced) const;
+
+    virtual const ContentPtr
+      getitem_next(const SliceNewAxis& newaxis,
+                   const Slice& tail,
+                   const Index64& advanced) const;
+
+    virtual const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const = 0;
+
+    virtual const ContentPtr
+      getitem_next(const SliceField& field,
+                   const Slice& tail,
+                   const Index64& advanced) const;
+
+    virtual const ContentPtr
+      getitem_next(const SliceFields& fields,
+                   const Slice& tail,
+                   const Index64& advanced) const;
+
+    virtual const ContentPtr
+      getitem_next(const SliceMissing64& missing,
+                   const Slice& tail,
+                   const Index64& advanced) const;
+
+    virtual const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const = 0;
+
+    virtual const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const = 0;
+
+    virtual const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const = 0;
+
+    virtual const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const = 0;
 
   protected:
-    const ContentPtr getitem_next_array_wrap(const ContentPtr& outcontent, const std::vector<int64_t>& shape) const;
-    const std::string parameters_tostring(const std::string& indent, const std::string& pre, const std::string& post) const;
+    const ContentPtr
+      getitem_next_array_wrap(const ContentPtr& outcontent,
+                              const std::vector<int64_t>& shape) const;
 
-    const int64_t axis_wrap_if_negative(int64_t axis) const;
+    const std::string
+      parameters_tostring(const std::string& indent,
+                          const std::string& pre,
+                          const std::string& post) const;
+
+    const int64_t
+      axis_wrap_if_negative(int64_t axis) const;
 
   protected:
     IdentitiesPtr identities_;

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -42,7 +42,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) = 0;
 
     virtual const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const = 0;
+      type(const util::TypeStrs& typestrs) const = 0;
 
     virtual const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/Identities.h
+++ b/include/awkward/Identities.h
@@ -12,13 +12,16 @@
 #include "awkward/Index.h"
 
 namespace awkward {
+  class Identities;
+  typedef std::shared_ptr<Identities> IdentitiesPtr;
+
   class EXPORT_SYMBOL Identities {
   public:
     typedef int64_t Ref;
     typedef std::vector<std::pair<int64_t, std::string>> FieldLoc;
 
     static Ref newref();
-    static std::shared_ptr<Identities> none();
+    static IdentitiesPtr none();
 
     Identities(const Ref ref, const FieldLoc& fieldloc, int64_t offset, int64_t width, int64_t length);
     const Ref ref() const;
@@ -29,14 +32,14 @@ namespace awkward {
 
     virtual const std::string classname() const = 0;
     virtual const std::string identity_at(int64_t where) const = 0;
-    virtual const std::shared_ptr<Identities> to64() const = 0;
+    virtual const IdentitiesPtr to64() const = 0;
     virtual const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const = 0;
-    virtual const std::shared_ptr<Identities> getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
+    virtual const IdentitiesPtr getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
     virtual void nbytes_part(std::map<size_t, int64_t>& largest) const = 0;
-    virtual const std::shared_ptr<Identities> shallow_copy() const = 0;
-    virtual const std::shared_ptr<Identities> deep_copy() const = 0;
-    virtual const std::shared_ptr<Identities> getitem_carry_64(const Index64& carry) const = 0;
-    virtual const std::shared_ptr<Identities> withfieldloc(const FieldLoc& fieldloc) const = 0;
+    virtual const IdentitiesPtr shallow_copy() const = 0;
+    virtual const IdentitiesPtr deep_copy() const = 0;
+    virtual const IdentitiesPtr getitem_carry_64(const Index64& carry) const = 0;
+    virtual const IdentitiesPtr withfieldloc(const FieldLoc& fieldloc) const = 0;
     virtual int64_t value(int64_t row, int64_t col) const = 0;
 
     const std::string tostring() const;
@@ -59,19 +62,19 @@ namespace awkward {
 
     const std::string classname() const override;
     const std::string identity_at(int64_t at) const override;
-    const std::shared_ptr<Identities> to64() const override;
+    const IdentitiesPtr to64() const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Identities> getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const IdentitiesPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    const std::shared_ptr<Identities> shallow_copy() const override;
-    const std::shared_ptr<Identities> deep_copy() const override;
-    const std::shared_ptr<Identities> getitem_carry_64(const Index64& carry) const override;
-    const std::shared_ptr<Identities> withfieldloc(const FieldLoc& fieldloc) const override;
+    const IdentitiesPtr shallow_copy() const override;
+    const IdentitiesPtr deep_copy() const override;
+    const IdentitiesPtr getitem_carry_64(const Index64& carry) const override;
+    const IdentitiesPtr withfieldloc(const FieldLoc& fieldloc) const override;
     int64_t value(int64_t row, int64_t col) const override;
 
     const std::vector<T> getitem_at(int64_t at) const;
     const std::vector<T> getitem_at_nowrap(int64_t at) const;
-    const std::shared_ptr<Identities> getitem_range(int64_t start, int64_t stop) const;
+    const IdentitiesPtr getitem_range(int64_t start, int64_t stop) const;
 
   private:
     const std::shared_ptr<T> ptr_;

--- a/include/awkward/Identities.h
+++ b/include/awkward/Identities.h
@@ -18,31 +18,73 @@ namespace awkward {
   class EXPORT_SYMBOL Identities {
   public:
     using Ref = int64_t;
+
     using FieldLoc = std::vector<std::pair<int64_t, std::string>>;
 
-    static Ref newref();
-    static IdentitiesPtr none();
+    static Ref
+      newref();
 
-    Identities(const Ref ref, const FieldLoc& fieldloc, int64_t offset, int64_t width, int64_t length);
-    const Ref ref() const;
-    const FieldLoc fieldloc() const;
-    const int64_t offset() const;
-    const int64_t width() const;
-    const int64_t length() const;
+    static IdentitiesPtr
+      none();
 
-    virtual const std::string classname() const = 0;
-    virtual const std::string identity_at(int64_t where) const = 0;
-    virtual const IdentitiesPtr to64() const = 0;
-    virtual const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const = 0;
-    virtual const IdentitiesPtr getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
-    virtual void nbytes_part(std::map<size_t, int64_t>& largest) const = 0;
-    virtual const IdentitiesPtr shallow_copy() const = 0;
-    virtual const IdentitiesPtr deep_copy() const = 0;
-    virtual const IdentitiesPtr getitem_carry_64(const Index64& carry) const = 0;
-    virtual const IdentitiesPtr withfieldloc(const FieldLoc& fieldloc) const = 0;
-    virtual int64_t value(int64_t row, int64_t col) const = 0;
+    Identities(const Ref ref,
+               const FieldLoc& fieldloc,
+               int64_t offset,
+               int64_t width,
+               int64_t length);
 
-    const std::string tostring() const;
+    const Ref
+      ref() const;
+
+    const FieldLoc
+      fieldloc() const;
+
+    const int64_t
+      offset() const;
+
+    const int64_t
+      width() const;
+
+    const int64_t
+      length() const;
+
+    virtual const std::string
+      classname() const = 0;
+
+    virtual const std::string
+      identity_at(int64_t where) const = 0;
+
+    virtual const IdentitiesPtr
+      to64() const = 0;
+
+    virtual const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const = 0;
+
+    virtual const IdentitiesPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const = 0;
+
+    virtual void
+      nbytes_part(std::map<size_t, int64_t>& largest) const = 0;
+
+    virtual const IdentitiesPtr
+      shallow_copy() const = 0;
+
+    virtual const IdentitiesPtr
+      deep_copy() const = 0;
+
+    virtual const IdentitiesPtr
+      getitem_carry_64(const Index64& carry) const = 0;
+
+    virtual const IdentitiesPtr
+      withfieldloc(const FieldLoc& fieldloc) const = 0;
+
+    virtual int64_t
+      value(int64_t row, int64_t col) const = 0;
+
+    const std::string
+      tostring() const;
 
   protected:
     const Ref ref_;
@@ -55,26 +97,64 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL IdentitiesOf: public Identities {
   public:
-    IdentitiesOf<T>(const Ref ref, const FieldLoc& fieldloc, int64_t width, int64_t length);
-    IdentitiesOf<T>(const Ref ref, const FieldLoc& fieldloc, int64_t offset, int64_t width, int64_t length, const std::shared_ptr<T> ptr);
+    IdentitiesOf<T>(const Ref ref,
+                    const FieldLoc& fieldloc,
+                    int64_t width,
+                    int64_t length);
 
-    const std::shared_ptr<T> ptr() const;
+    IdentitiesOf<T>(const Ref ref,
+                    const FieldLoc& fieldloc,
+                    int64_t offset,
+                    int64_t width,
+                    int64_t length,
+                    const std::shared_ptr<T> ptr);
 
-    const std::string classname() const override;
-    const std::string identity_at(int64_t at) const override;
-    const IdentitiesPtr to64() const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const IdentitiesPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    const IdentitiesPtr shallow_copy() const override;
-    const IdentitiesPtr deep_copy() const override;
-    const IdentitiesPtr getitem_carry_64(const Index64& carry) const override;
-    const IdentitiesPtr withfieldloc(const FieldLoc& fieldloc) const override;
-    int64_t value(int64_t row, int64_t col) const override;
+    const std::shared_ptr<T>
+      ptr() const;
 
-    const std::vector<T> getitem_at(int64_t at) const;
-    const std::vector<T> getitem_at_nowrap(int64_t at) const;
-    const IdentitiesPtr getitem_range(int64_t start, int64_t stop) const;
+    const std::string
+      classname() const override;
+
+    const std::string
+      identity_at(int64_t at) const override;
+
+    const IdentitiesPtr
+      to64() const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    const IdentitiesPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    const IdentitiesPtr
+      shallow_copy() const override;
+
+    const IdentitiesPtr
+      deep_copy() const override;
+
+    const IdentitiesPtr
+      getitem_carry_64(const Index64& carry) const override;
+
+    const IdentitiesPtr
+      withfieldloc(const FieldLoc& fieldloc) const override;
+
+    int64_t
+      value(int64_t row, int64_t col) const override;
+
+    const std::vector<T>
+      getitem_at(int64_t at) const;
+
+    const std::vector<T>
+      getitem_at_nowrap(int64_t at) const;
+
+    const IdentitiesPtr
+      getitem_range(int64_t start, int64_t stop) const;
 
   private:
     const std::shared_ptr<T> ptr_;

--- a/include/awkward/Identities.h
+++ b/include/awkward/Identities.h
@@ -13,12 +13,12 @@
 
 namespace awkward {
   class Identities;
-  typedef std::shared_ptr<Identities> IdentitiesPtr;
+  using IdentitiesPtr = std::shared_ptr<Identities>;
 
   class EXPORT_SYMBOL Identities {
   public:
-    typedef int64_t Ref;
-    typedef std::vector<std::pair<int64_t, std::string>> FieldLoc;
+    using Ref = int64_t;
+    using FieldLoc = std::vector<std::pair<int64_t, std::string>>;
 
     static Ref newref();
     static IdentitiesPtr none();
@@ -80,8 +80,8 @@ namespace awkward {
     const std::shared_ptr<T> ptr_;
   };
 
-  typedef IdentitiesOf<int32_t> Identities32;
-  typedef IdentitiesOf<int64_t> Identities64;
+  using Identities32 = IdentitiesOf<int32_t>;
+  using Identities64 = IdentitiesOf<int64_t>;
 }
 
 #endif // AWKWARD_IDENTITIES_H_

--- a/include/awkward/Index.h
+++ b/include/awkward/Index.h
@@ -49,11 +49,11 @@ namespace awkward {
     const int64_t length_;
   };
 
-  typedef IndexOf<int8_t>   Index8;
-  typedef IndexOf<uint8_t>  IndexU8;
-  typedef IndexOf<int32_t>  Index32;
-  typedef IndexOf<uint32_t> IndexU32;
-  typedef IndexOf<int64_t>  Index64;
+  using Index8   = IndexOf<int8_t>;
+  using IndexU8  = IndexOf<uint8_t>;
+  using Index32  = IndexOf<int32_t>;
+  using IndexU32 = IndexOf<uint32_t>;
+  using Index64  = IndexOf<int64_t>;
 }
 
 #endif // AWKWARD_INDEX_H_

--- a/include/awkward/Index.h
+++ b/include/awkward/Index.h
@@ -15,33 +15,65 @@ namespace awkward {
   class IndexOf;
 
   class EXPORT_SYMBOL Index {
-    virtual const std::shared_ptr<Index> shallow_copy() const = 0;
-    virtual IndexOf<int64_t> to64() const = 0;
+    virtual const std::shared_ptr<Index>
+      shallow_copy() const = 0;
+    virtual IndexOf<int64_t>
+      to64() const = 0;
   };
 
   template <typename T>
   class EXPORT_SYMBOL IndexOf: public Index {
   public:
     IndexOf<T>(int64_t length);
+
     IndexOf<T>(const std::shared_ptr<T>& ptr, int64_t offset, int64_t length);
 
-    const std::shared_ptr<T> ptr() const;
-    int64_t offset() const;
-    int64_t length() const;
+    const std::shared_ptr<T>
+      ptr() const;
 
-    const std::string classname() const;
-    const std::string tostring() const;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const;
-    T getitem_at(int64_t at) const;
-    T getitem_at_nowrap(int64_t at) const;
-    void setitem_at_nowrap(int64_t at, T value) const;
-    IndexOf<T> getitem_range(int64_t start, int64_t stop) const;
-    IndexOf<T> getitem_range_nowrap(int64_t start, int64_t stop) const;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const;
-    const std::shared_ptr<Index> shallow_copy() const override;
-    IndexOf<int64_t> to64() const override;
+    int64_t
+      offset() const;
 
-    const IndexOf<T> deep_copy() const;
+    int64_t
+      length() const;
+
+    const std::string
+      classname() const;
+
+    const std::string
+      tostring() const;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const;
+
+    T
+      getitem_at(int64_t at) const;
+
+    T
+      getitem_at_nowrap(int64_t at) const;
+
+    void
+      setitem_at_nowrap(int64_t at, T value) const;
+
+    IndexOf<T>
+      getitem_range(int64_t start, int64_t stop) const;
+
+    IndexOf<T>
+      getitem_range_nowrap(int64_t start, int64_t stop) const;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const;
+
+    const std::shared_ptr<Index>
+      shallow_copy() const override;
+
+    IndexOf<int64_t>
+      to64() const override;
+
+    const IndexOf<T>
+      deep_copy() const;
 
   private:
     const std::shared_ptr<T> ptr_;

--- a/include/awkward/Iterator.h
+++ b/include/awkward/Iterator.h
@@ -11,12 +11,25 @@ namespace awkward {
   public:
     Iterator(const ContentPtr& content);
 
-    const ContentPtr content() const;
-    const int64_t at() const;
-    const bool isdone() const;
-    const ContentPtr next();
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const;
-    const std::string tostring() const;
+    const ContentPtr
+      content() const;
+
+    const int64_t
+      at() const;
+
+    const bool
+      isdone() const;
+
+    const ContentPtr
+      next();
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const;
+
+    const std::string
+      tostring() const;
 
   private:
     const ContentPtr content_;

--- a/include/awkward/Iterator.h
+++ b/include/awkward/Iterator.h
@@ -9,17 +9,17 @@
 namespace awkward {
   class EXPORT_SYMBOL Iterator {
   public:
-    Iterator(const std::shared_ptr<Content>& content);
+    Iterator(ContentPtr& content);
 
-    const std::shared_ptr<Content> content() const;
+    ContentPtr content() const;
     const int64_t at() const;
     const bool isdone() const;
-    const std::shared_ptr<Content> next();
+    ContentPtr next();
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const;
     const std::string tostring() const;
 
   private:
-    const std::shared_ptr<Content> content_;
+    ContentPtr content_;
     int64_t at_;
   };
 }

--- a/include/awkward/Iterator.h
+++ b/include/awkward/Iterator.h
@@ -9,17 +9,17 @@
 namespace awkward {
   class EXPORT_SYMBOL Iterator {
   public:
-    Iterator(ContentPtr& content);
+    Iterator(const ContentPtr& content);
 
-    ContentPtr content() const;
+    const ContentPtr content() const;
     const int64_t at() const;
     const bool isdone() const;
-    ContentPtr next();
+    const ContentPtr next();
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const;
     const std::string tostring() const;
 
   private:
-    ContentPtr content_;
+    const ContentPtr content_;
     int64_t at_;
   };
 }

--- a/include/awkward/Reducer.h
+++ b/include/awkward/Reducer.h
@@ -10,218 +10,1035 @@
 namespace awkward {
   class EXPORT_SYMBOL Reducer {
   public:
-    virtual const std::string name() const = 0;
-    virtual const std::string preferred_type() const = 0;
-    virtual ssize_t preferred_typesize() const = 0;
-    virtual const std::string return_type(const std::string& given_type) const;
-    virtual ssize_t return_typesize(const std::string& given_type) const;
-    virtual const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
-    virtual const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const = 0;
+    virtual const std::string
+      name() const = 0;
+
+    virtual const std::string
+      preferred_type() const = 0;
+
+    virtual ssize_t
+      preferred_typesize() const = 0;
+
+    virtual const std::string
+      return_type(const std::string& given_type) const;
+
+    virtual ssize_t
+      return_typesize(const std::string& given_type) const;
+
+    virtual const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const = 0;
+
+    virtual const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const = 0;
   };
 
   class EXPORT_SYMBOL ReducerCount: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::string return_type(const std::string& given_type) const override;
-    ssize_t return_typesize(const std::string& given_type) const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::string
+      return_type(const std::string& given_type) const override;
+
+    ssize_t
+      return_typesize(const std::string& given_type) const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerCountNonzero: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::string return_type(const std::string& given_type) const override;
-    ssize_t return_typesize(const std::string& given_type) const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::string
+      return_type(const std::string& given_type) const override;
+
+    ssize_t
+      return_typesize(const std::string& given_type) const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerSum: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::string return_type(const std::string& given_type) const override;
-    ssize_t return_typesize(const std::string& given_type) const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::string
+      return_type(const std::string& given_type) const override;
+
+    ssize_t
+      return_typesize(const std::string& given_type) const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerProd: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::string return_type(const std::string& given_type) const override;
-    ssize_t return_typesize(const std::string& given_type) const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::string
+      return_type(const std::string& given_type) const override;
+
+    ssize_t
+      return_typesize(const std::string& given_type) const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerAny: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::string return_type(const std::string& given_type) const override;
-    ssize_t return_typesize(const std::string& given_type) const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::string
+      return_type(const std::string& given_type) const override;
+
+    ssize_t
+      return_typesize(const std::string& given_type) const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerAll: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::string return_type(const std::string& given_type) const override;
-    ssize_t return_typesize(const std::string& given_type) const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::string
+      return_type(const std::string& given_type) const override;
+
+    ssize_t
+      return_typesize(const std::string& given_type) const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerMin: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerMax: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerArgmin: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::string return_type(const std::string& given_type) const override;
-    ssize_t return_typesize(const std::string& given_type) const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::string
+      return_type(const std::string& given_type) const override;
+
+    ssize_t
+      return_typesize(const std::string& given_type) const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
   class EXPORT_SYMBOL ReducerArgmax: public Reducer {
   public:
-    const std::string name() const override;
-    const std::string preferred_type() const override;
-    ssize_t preferred_typesize() const override;
-    const std::string return_type(const std::string& given_type) const override;
-    ssize_t return_typesize(const std::string& given_type) const override;
-    const std::shared_ptr<void> apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
-    const std::shared_ptr<void> apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const override;
+    const std::string
+      name() const override;
+
+    const std::string
+      preferred_type() const override;
+
+    ssize_t
+      preferred_typesize() const override;
+
+    const std::string
+      return_type(const std::string& given_type) const override;
+
+    ssize_t
+      return_typesize(const std::string& given_type) const override;
+
+    const std::shared_ptr<void>
+      apply_bool(const bool* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int8(const int8_t* data,
+                 int64_t offset,
+                 const Index64& starts,
+                 const Index64& parents,
+                 int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint8(const uint8_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int16(const int16_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint16(const uint16_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int32(const int32_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint32(const uint32_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_int64(const int64_t* data,
+                  int64_t offset,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_uint64(const uint64_t* data,
+                   int64_t offset,
+                   const Index64& starts,
+                   const Index64& parents,
+                   int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float32(const float* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
+
+    const std::shared_ptr<void>
+      apply_float64(const double* data,
+                    int64_t offset,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength) const override;
   };
 
 }

--- a/include/awkward/Slice.h
+++ b/include/awkward/Slice.h
@@ -13,7 +13,7 @@
 
 namespace awkward {
   class SliceItem;
-  typedef std::shared_ptr<SliceItem> SliceItemPtr;
+  using SliceItemPtr = std::shared_ptr<SliceItem>;
 
   class EXPORT_SYMBOL SliceItem {
   public:
@@ -90,7 +90,7 @@ namespace awkward {
     bool frombool_;
   };
 
-  typedef SliceArrayOf<int64_t> SliceArray64;
+  using SliceArray64 = SliceArrayOf<int64_t>;
 
   class EXPORT_SYMBOL SliceField: public SliceItem {
   public:
@@ -132,7 +132,7 @@ namespace awkward {
     const SliceItemPtr content_;
   };
 
-  typedef SliceMissingOf<int64_t> SliceMissing64;
+  using SliceMissing64 = SliceMissingOf<int64_t>;
 
   template <typename T>
   class EXPORT_SYMBOL SliceJaggedOf: public SliceItem {
@@ -150,7 +150,7 @@ namespace awkward {
     const SliceItemPtr content_;
   };
 
-  typedef SliceJaggedOf<int64_t> SliceJagged64;
+  using SliceJagged64 = SliceJaggedOf<int64_t>;
 
   class EXPORT_SYMBOL Slice {
   public:

--- a/include/awkward/Slice.h
+++ b/include/awkward/Slice.h
@@ -18,19 +18,35 @@ namespace awkward {
   class EXPORT_SYMBOL SliceItem {
   public:
     static int64_t none();
+
     virtual ~SliceItem();
-    virtual const SliceItemPtr shallow_copy() const = 0;
-    virtual const std::string tostring() const = 0;
-    virtual bool preserves_type(const Index64& advanced) const = 0;
+
+    virtual const SliceItemPtr
+      shallow_copy() const = 0;
+
+    virtual const std::string
+      tostring() const = 0;
+
+    virtual bool
+      preserves_type(const Index64& advanced) const = 0;
   };
 
   class EXPORT_SYMBOL SliceAt: public SliceItem {
   public:
     SliceAt(int64_t at);
-    int64_t at() const;
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    bool preserves_type(const Index64& advanced) const override;
+
+    int64_t
+      at() const;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
+
   private:
     const int64_t at_;
   };
@@ -38,14 +54,31 @@ namespace awkward {
   class EXPORT_SYMBOL SliceRange: public SliceItem {
   public:
     SliceRange(int64_t start, int64_t stop, int64_t step);
-    int64_t start() const;
-    int64_t stop() const;
-    int64_t step() const;
-    bool hasstart() const;
-    bool hasstop() const;
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    bool preserves_type(const Index64& advanced) const override;
+
+    int64_t
+      start() const;
+
+    int64_t
+      stop() const;
+
+    int64_t
+      step() const;
+
+    bool
+      hasstart() const;
+
+    bool
+      hasstop() const;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
+
   private:
     const int64_t start_;
     const int64_t stop_;
@@ -55,34 +88,71 @@ namespace awkward {
   class EXPORT_SYMBOL SliceEllipsis: public SliceItem {
   public:
     SliceEllipsis();
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    bool preserves_type(const Index64& advanced) const override;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
   };
 
   class EXPORT_SYMBOL SliceNewAxis: public SliceItem {
   public:
     SliceNewAxis();
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    bool preserves_type(const Index64& advanced) const override;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
   };
 
   template <typename T>
   class EXPORT_SYMBOL SliceArrayOf: public SliceItem {
   public:
-    SliceArrayOf<T>(const IndexOf<T>& index, const std::vector<int64_t>& shape, const std::vector<int64_t>& strides, bool frombool);
-    const IndexOf<T> index() const;
-    const int64_t length() const;
-    const std::vector<int64_t> shape() const;
-    const std::vector<int64_t> strides() const;
-    bool frombool() const;
-    int64_t ndim() const;
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    const std::string tostring_part() const;
-    bool preserves_type(const Index64& advanced) const override;
-    const IndexOf<T> ravel() const;
+    SliceArrayOf<T>(const IndexOf<T>& index,
+                    const std::vector<int64_t>& shape,
+                    const std::vector<int64_t>& strides, bool frombool);
+
+    const IndexOf<T>
+      index() const;
+
+    const int64_t
+      length() const;
+
+    const std::vector<int64_t>
+      shape() const;
+
+    const std::vector<int64_t>
+      strides() const;
+
+    bool
+      frombool() const;
+
+    int64_t
+      ndim() const;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    const std::string
+      tostring_part() const;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
+
+    const IndexOf<T>
+      ravel() const;
+
   private:
     const IndexOf<T> index_;
     const std::vector<int64_t> shape_;
@@ -95,10 +165,19 @@ namespace awkward {
   class EXPORT_SYMBOL SliceField: public SliceItem {
   public:
     SliceField(const std::string& key);
-    const std::string key() const;
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    bool preserves_type(const Index64& advanced) const override;
+
+    const std::string
+      key() const;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
+
   private:
     const std::string key_;
   };
@@ -106,10 +185,19 @@ namespace awkward {
   class EXPORT_SYMBOL SliceFields: public SliceItem {
   public:
     SliceFields(const std::vector<std::string>& keys);
-    const std::vector<std::string> keys() const;
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    bool preserves_type(const Index64& advanced) const override;
+
+    const std::vector<std::string>
+      keys() const;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
+
   private:
     const std::vector<std::string> keys_;
   };
@@ -117,15 +205,34 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL SliceMissingOf: public SliceItem {
   public:
-    SliceMissingOf(const IndexOf<T>& index, const Index8& originalmask, const SliceItemPtr& content);
-    int64_t length() const;
-    const IndexOf<T> index() const;
-    const Index8 originalmask() const;
-    const SliceItemPtr content() const;
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    const std::string tostring_part() const;
-    bool preserves_type(const Index64& advanced) const override;
+    SliceMissingOf(const IndexOf<T>& index,
+                   const Index8& originalmask,
+                   const SliceItemPtr& content);
+
+    int64_t
+      length() const;
+
+    const IndexOf<T>
+      index() const;
+
+    const Index8
+      originalmask() const;
+
+    const SliceItemPtr
+      content() const;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    const std::string
+      tostring_part() const;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
+
   private:
     const IndexOf<T> index_;
     const Index8 originalmask_;
@@ -138,13 +245,28 @@ namespace awkward {
   class EXPORT_SYMBOL SliceJaggedOf: public SliceItem {
   public:
     SliceJaggedOf(const IndexOf<T>& offsets, const SliceItemPtr& content);
-    int64_t length() const;
-    const IndexOf<T> offsets() const;
-    const SliceItemPtr content() const;
-    const SliceItemPtr shallow_copy() const override;
-    const std::string tostring() const override;
-    const std::string tostring_part() const;
-    bool preserves_type(const Index64& advanced) const override;
+
+    int64_t
+      length() const;
+
+    const IndexOf<T>
+      offsets() const;
+
+    const SliceItemPtr
+      content() const;
+
+    const SliceItemPtr
+      shallow_copy() const override;
+
+    const std::string
+      tostring() const override;
+
+    const std::string
+      tostring_part() const;
+
+    bool
+      preserves_type(const Index64& advanced) const override;
+
   private:
     const IndexOf<T> offsets_;
     const SliceItemPtr content_;
@@ -157,24 +279,56 @@ namespace awkward {
     static int64_t none();
 
     Slice();
+
     Slice(const std::vector<SliceItemPtr>& items);
+
     Slice(const std::vector<SliceItemPtr>& items, bool sealed);
-    const std::vector<SliceItemPtr> items() const;
-    bool sealed() const;
-    int64_t length() const;
-    int64_t dimlength() const;
-    const SliceItemPtr head() const;
-    const Slice tail() const;
-    const std::string tostring() const;
-    void append(const SliceItemPtr& item);
-    void append(const SliceAt& item);
-    void append(const SliceRange& item);
-    void append(const SliceEllipsis& item);
-    void append(const SliceNewAxis& item);
+
+    const std::vector<SliceItemPtr>
+      items() const;
+
+    bool
+      sealed() const;
+
+    int64_t
+      length() const;
+
+    int64_t
+      dimlength() const;
+
+    const SliceItemPtr
+      head() const;
+
+    const Slice
+      tail() const;
+
+    const std::string
+      tostring() const;
+
+    void
+      append(const SliceItemPtr& item);
+
+    void
+      append(const SliceAt& item);
+
+    void
+      append(const SliceRange& item);
+
+    void
+      append(const SliceEllipsis& item);
+
+    void
+      append(const SliceNewAxis& item);
+
     template <typename T>
-    void append(const SliceArrayOf<T>& item);
-    void become_sealed();
-    bool isadvanced() const;
+    void
+      append(const SliceArrayOf<T>& item);
+
+    void
+      become_sealed();
+
+    bool
+      isadvanced() const;
 
   private:
     std::vector<SliceItemPtr> items_;

--- a/include/awkward/Slice.h
+++ b/include/awkward/Slice.h
@@ -12,11 +12,14 @@
 #include "awkward/Index.h"
 
 namespace awkward {
+  class SliceItem;
+  typedef std::shared_ptr<SliceItem> SliceItemPtr;
+
   class EXPORT_SYMBOL SliceItem {
   public:
     static int64_t none();
     virtual ~SliceItem();
-    virtual const std::shared_ptr<SliceItem> shallow_copy() const = 0;
+    virtual const SliceItemPtr shallow_copy() const = 0;
     virtual const std::string tostring() const = 0;
     virtual bool preserves_type(const Index64& advanced) const = 0;
   };
@@ -25,7 +28,7 @@ namespace awkward {
   public:
     SliceAt(int64_t at);
     int64_t at() const;
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     bool preserves_type(const Index64& advanced) const override;
   private:
@@ -40,7 +43,7 @@ namespace awkward {
     int64_t step() const;
     bool hasstart() const;
     bool hasstop() const;
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     bool preserves_type(const Index64& advanced) const override;
   private:
@@ -52,7 +55,7 @@ namespace awkward {
   class EXPORT_SYMBOL SliceEllipsis: public SliceItem {
   public:
     SliceEllipsis();
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     bool preserves_type(const Index64& advanced) const override;
   };
@@ -60,7 +63,7 @@ namespace awkward {
   class EXPORT_SYMBOL SliceNewAxis: public SliceItem {
   public:
     SliceNewAxis();
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     bool preserves_type(const Index64& advanced) const override;
   };
@@ -75,7 +78,7 @@ namespace awkward {
     const std::vector<int64_t> strides() const;
     bool frombool() const;
     int64_t ndim() const;
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     const std::string tostring_part() const;
     bool preserves_type(const Index64& advanced) const override;
@@ -93,7 +96,7 @@ namespace awkward {
   public:
     SliceField(const std::string& key);
     const std::string key() const;
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     bool preserves_type(const Index64& advanced) const override;
   private:
@@ -104,7 +107,7 @@ namespace awkward {
   public:
     SliceFields(const std::vector<std::string>& keys);
     const std::vector<std::string> keys() const;
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     bool preserves_type(const Index64& advanced) const override;
   private:
@@ -114,19 +117,19 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL SliceMissingOf: public SliceItem {
   public:
-    SliceMissingOf(const IndexOf<T>& index, const Index8& originalmask, const std::shared_ptr<SliceItem>& content);
+    SliceMissingOf(const IndexOf<T>& index, const Index8& originalmask, const SliceItemPtr& content);
     int64_t length() const;
     const IndexOf<T> index() const;
     const Index8 originalmask() const;
-    const std::shared_ptr<SliceItem> content() const;
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr content() const;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     const std::string tostring_part() const;
     bool preserves_type(const Index64& advanced) const override;
   private:
     const IndexOf<T> index_;
     const Index8 originalmask_;
-    const std::shared_ptr<SliceItem> content_;
+    const SliceItemPtr content_;
   };
 
   typedef SliceMissingOf<int64_t> SliceMissing64;
@@ -134,17 +137,17 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL SliceJaggedOf: public SliceItem {
   public:
-    SliceJaggedOf(const IndexOf<T>& offsets, const std::shared_ptr<SliceItem>& content);
+    SliceJaggedOf(const IndexOf<T>& offsets, const SliceItemPtr& content);
     int64_t length() const;
     const IndexOf<T> offsets() const;
-    const std::shared_ptr<SliceItem> content() const;
-    const std::shared_ptr<SliceItem> shallow_copy() const override;
+    const SliceItemPtr content() const;
+    const SliceItemPtr shallow_copy() const override;
     const std::string tostring() const override;
     const std::string tostring_part() const;
     bool preserves_type(const Index64& advanced) const override;
   private:
     const IndexOf<T> offsets_;
-    const std::shared_ptr<SliceItem> content_;
+    const SliceItemPtr content_;
   };
 
   typedef SliceJaggedOf<int64_t> SliceJagged64;
@@ -154,16 +157,16 @@ namespace awkward {
     static int64_t none();
 
     Slice();
-    Slice(const std::vector<std::shared_ptr<SliceItem>>& items);
-    Slice(const std::vector<std::shared_ptr<SliceItem>>& items, bool sealed);
-    const std::vector<std::shared_ptr<SliceItem>> items() const;
+    Slice(const std::vector<SliceItemPtr>& items);
+    Slice(const std::vector<SliceItemPtr>& items, bool sealed);
+    const std::vector<SliceItemPtr> items() const;
     bool sealed() const;
     int64_t length() const;
     int64_t dimlength() const;
-    const std::shared_ptr<SliceItem> head() const;
+    const SliceItemPtr head() const;
     const Slice tail() const;
     const std::string tostring() const;
-    void append(const std::shared_ptr<SliceItem>& item);
+    void append(const SliceItemPtr& item);
     void append(const SliceAt& item);
     void append(const SliceRange& item);
     void append(const SliceEllipsis& item);
@@ -174,7 +177,7 @@ namespace awkward {
     bool isadvanced() const;
 
   private:
-    std::vector<std::shared_ptr<SliceItem>> items_;
+    std::vector<SliceItemPtr> items_;
     bool sealed_;
   };
 }

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -17,15 +17,15 @@
 namespace awkward {
   class EXPORT_SYMBOL BitMaskedArray: public Content {
   public:
-    BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, ContentPtr& content, bool validwhen, int64_t length, bool lsb_order);
+    BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, const ContentPtr& content, bool validwhen, int64_t length, bool lsb_order);
     const IndexU8 mask() const;
-    ContentPtr content() const;
+    const ContentPtr content() const;
     bool validwhen() const;
     bool lsb_order() const;
-    ContentPtr project() const;
-    ContentPtr project(const Index8& mask) const;
+    const ContentPtr project() const;
+    const ContentPtr project(const Index8& mask) const;
     const Index8 bytemask() const;
-    ContentPtr simplify_optiontype() const;
+    const ContentPtr simplify_optiontype() const;
     const std::shared_ptr<ByteMaskedArray> toByteMaskedArray() const;
     const std::shared_ptr<IndexedOptionArray64> toIndexedOptionArray64() const;
 
@@ -37,18 +37,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -62,31 +62,31 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr reverse_merge(ContentPtr& other) const;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr reverse_merge(const ContentPtr& other) const;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
     const IndexU8 mask_;
-    ContentPtr content_;
+    const ContentPtr content_;
     const bool validwhen_;
     const int64_t length_;
     const bool lsb_order_;

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -65,7 +65,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -17,72 +17,233 @@
 namespace awkward {
   class EXPORT_SYMBOL BitMaskedArray: public Content {
   public:
-    BitMaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexU8& mask, const ContentPtr& content, bool validwhen, int64_t length, bool lsb_order);
-    const IndexU8 mask() const;
-    const ContentPtr content() const;
-    bool validwhen() const;
-    bool lsb_order() const;
-    const ContentPtr project() const;
-    const ContentPtr project(const Index8& mask) const;
-    const Index8 bytemask() const;
-    const ContentPtr simplify_optiontype() const;
-    const std::shared_ptr<ByteMaskedArray> toByteMaskedArray() const;
-    const std::shared_ptr<IndexedOptionArray64> toIndexedOptionArray64() const;
+    BitMaskedArray(const IdentitiesPtr& identities,
+                   const util::Parameters& parameters,
+                   const IndexU8& mask,
+                   const ContentPtr& content,
+                   bool validwhen,
+                   int64_t length,
+                   bool lsb_order);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const IndexU8
+      mask() const;
+
+    const ContentPtr
+      content() const;
+
+    bool
+      validwhen() const;
+
+    bool
+      lsb_order() const;
+
+    const ContentPtr
+      project() const;
+
+    const ContentPtr
+      project(const Index8& mask) const;
+
+    const Index8
+      bytemask() const;
+
+    const ContentPtr
+      simplify_optiontype() const;
+
+    const std::shared_ptr<ByteMaskedArray>
+      toByteMaskedArray() const;
+
+    const std::shared_ptr<IndexedOptionArray64>
+      toIndexedOptionArray64() const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr reverse_merge(const ContentPtr& other) const;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      reverse_merge(const ContentPtr& other) const;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   private:
     const IndexU8 mask_;

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -17,15 +17,15 @@
 namespace awkward {
   class EXPORT_SYMBOL BitMaskedArray: public Content {
   public:
-    BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, const std::shared_ptr<Content>& content, bool validwhen, int64_t length, bool lsb_order);
+    BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, ContentPtr& content, bool validwhen, int64_t length, bool lsb_order);
     const IndexU8 mask() const;
-    const std::shared_ptr<Content> content() const;
+    ContentPtr content() const;
     bool validwhen() const;
     bool lsb_order() const;
-    const std::shared_ptr<Content> project() const;
-    const std::shared_ptr<Content> project(const Index8& mask) const;
+    ContentPtr project() const;
+    ContentPtr project(const Index8& mask) const;
     const Index8 bytemask() const;
-    const std::shared_ptr<Content> simplify_optiontype() const;
+    ContentPtr simplify_optiontype() const;
     const std::shared_ptr<ByteMaskedArray> toByteMaskedArray() const;
     const std::shared_ptr<IndexedOptionArray64> toIndexedOptionArray64() const;
 
@@ -37,18 +37,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -62,31 +62,31 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> reverse_merge(const std::shared_ptr<Content>& other) const;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr reverse_merge(ContentPtr& other) const;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
     const IndexU8 mask_;
-    const std::shared_ptr<Content> content_;
+    ContentPtr content_;
     const bool validwhen_;
     const int64_t length_;
     const bool lsb_order_;

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -17,7 +17,7 @@
 namespace awkward {
   class EXPORT_SYMBOL BitMaskedArray: public Content {
   public:
-    BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, const ContentPtr& content, bool validwhen, int64_t length, bool lsb_order);
+    BitMaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexU8& mask, const ContentPtr& content, bool validwhen, int64_t length, bool lsb_order);
     const IndexU8 mask() const;
     const ContentPtr content() const;
     bool validwhen() const;
@@ -31,8 +31,8 @@ namespace awkward {
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -47,7 +47,7 @@ namespace awkward {
     const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
     const ContentPtr getitem_field(const std::string& key) const override;
     const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
@@ -68,13 +68,13 @@ namespace awkward {
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr reverse_merge(const ContentPtr& other) const;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -15,15 +15,15 @@
 namespace awkward {
   class EXPORT_SYMBOL ByteMaskedArray: public Content {
   public:
-    ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, ContentPtr& content, bool validwhen);
+    ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, const ContentPtr& content, bool validwhen);
     const Index8 mask() const;
-    ContentPtr content() const;
+    const ContentPtr content() const;
     bool validwhen() const;
-    ContentPtr project() const;
-    ContentPtr project(const Index8& mask) const;
+    const ContentPtr project() const;
+    const ContentPtr project(const Index8& mask) const;
     const Index8 bytemask() const;
-    ContentPtr simplify_optiontype() const;
-    ContentPtr toIndexedOptionArray64() const;
+    const ContentPtr simplify_optiontype() const;
+    const ContentPtr toIndexedOptionArray64() const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -33,18 +33,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -58,37 +58,37 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr reverse_merge(ContentPtr& other) const;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr reverse_merge(const ContentPtr& other) const;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
     const std::pair<Index64, Index64> nextcarry_outindex(int64_t& numnull) const;
 
   private:
     const Index8 mask_;
-    ContentPtr content_;
+    const ContentPtr content_;
     const bool validwhen_;
   };
 

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -15,15 +15,15 @@
 namespace awkward {
   class EXPORT_SYMBOL ByteMaskedArray: public Content {
   public:
-    ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, const std::shared_ptr<Content>& content, bool validwhen);
+    ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, ContentPtr& content, bool validwhen);
     const Index8 mask() const;
-    const std::shared_ptr<Content> content() const;
+    ContentPtr content() const;
     bool validwhen() const;
-    const std::shared_ptr<Content> project() const;
-    const std::shared_ptr<Content> project(const Index8& mask) const;
+    ContentPtr project() const;
+    ContentPtr project(const Index8& mask) const;
     const Index8 bytemask() const;
-    const std::shared_ptr<Content> simplify_optiontype() const;
-    const std::shared_ptr<Content> toIndexedOptionArray64() const;
+    ContentPtr simplify_optiontype() const;
+    ContentPtr toIndexedOptionArray64() const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -33,18 +33,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -58,37 +58,37 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> reverse_merge(const std::shared_ptr<Content>& other) const;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr reverse_merge(ContentPtr& other) const;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const std::shared_ptr<Content> getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
     const std::pair<Index64, Index64> nextcarry_outindex(int64_t& numnull) const;
 
   private:
     const Index8 mask_;
-    const std::shared_ptr<Content> content_;
+    ContentPtr content_;
     const bool validwhen_;
   };
 

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -15,76 +15,236 @@
 namespace awkward {
   class EXPORT_SYMBOL ByteMaskedArray: public Content {
   public:
-    ByteMaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const Index8& mask, const ContentPtr& content, bool validwhen);
-    const Index8 mask() const;
-    const ContentPtr content() const;
-    bool validwhen() const;
-    const ContentPtr project() const;
-    const ContentPtr project(const Index8& mask) const;
-    const Index8 bytemask() const;
-    const ContentPtr simplify_optiontype() const;
-    const ContentPtr toIndexedOptionArray64() const;
+    ByteMaskedArray(const IdentitiesPtr& identities,
+                    const util::Parameters& parameters,
+                    const Index8& mask,
+                    const ContentPtr& content,
+                    bool validwhen);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const Index8
+      mask() const;
+
+    const ContentPtr
+      content() const;
+
+    bool
+      validwhen() const;
+
+    const ContentPtr
+      project() const;
+
+    const ContentPtr
+      project(const Index8& mask) const;
+
+    const Index8
+      bytemask() const;
+
+    const ContentPtr
+      simplify_optiontype() const;
+
+    const ContentPtr
+      toIndexedOptionArray64() const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr reverse_merge(const ContentPtr& other) const;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      reverse_merge(const ContentPtr& other) const;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr
+      getitem_next_jagged_generic(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const S& slicecontent,
+                                  const Slice& tail) const;
 
-    const std::pair<Index64, Index64> nextcarry_outindex(int64_t& numnull) const;
+    const std::pair<Index64, Index64>
+      nextcarry_outindex(int64_t& numnull) const;
 
   private:
     const Index8 mask_;

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -15,7 +15,7 @@
 namespace awkward {
   class EXPORT_SYMBOL ByteMaskedArray: public Content {
   public:
-    ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, const ContentPtr& content, bool validwhen);
+    ByteMaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const Index8& mask, const ContentPtr& content, bool validwhen);
     const Index8 mask() const;
     const ContentPtr content() const;
     bool validwhen() const;
@@ -27,8 +27,8 @@ namespace awkward {
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -43,7 +43,7 @@ namespace awkward {
     const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
     const ContentPtr getitem_field(const std::string& key) const override;
     const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
@@ -64,13 +64,13 @@ namespace awkward {
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr reverse_merge(const ContentPtr& other) const;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -55,7 +55,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -15,7 +15,7 @@ namespace awkward {
   class EXPORT_SYMBOL EmptyArray: public Content {
   public:
     EmptyArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters);
-    ContentPtr toNumpyArray(const std::string& format, ssize_t itemsize) const;
+    const ContentPtr toNumpyArray(const std::string& format, ssize_t itemsize) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -25,17 +25,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -49,28 +49,28 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
   };
 }
 

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -14,13 +14,13 @@
 namespace awkward {
   class EXPORT_SYMBOL EmptyArray: public Content {
   public:
-    EmptyArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters);
+    EmptyArray(const IdentitiesPtr& identities, const util::Parameters& parameters);
     const ContentPtr toNumpyArray(const std::string& format, ssize_t itemsize) const;
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -54,13 +54,13 @@ namespace awkward {
     const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -31,7 +31,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -15,7 +15,7 @@ namespace awkward {
   class EXPORT_SYMBOL EmptyArray: public Content {
   public:
     EmptyArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters);
-    const std::shared_ptr<Content> toNumpyArray(const std::string& format, ssize_t itemsize) const;
+    ContentPtr toNumpyArray(const std::string& format, ssize_t itemsize) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -25,17 +25,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -49,28 +49,28 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
   };
 }
 

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -14,64 +14,206 @@
 namespace awkward {
   class EXPORT_SYMBOL EmptyArray: public Content {
   public:
-    EmptyArray(const IdentitiesPtr& identities, const util::Parameters& parameters);
-    const ContentPtr toNumpyArray(const std::string& format, ssize_t itemsize) const;
+    EmptyArray(const IdentitiesPtr& identities,
+               const util::Parameters& parameters);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const ContentPtr
+      toNumpyArray(const std::string& format,
+                   ssize_t itemsize) const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceField& field,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceFields& fields,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
   };
+
 }
 
 #endif // AWKWARD_EMPTYARRAY_H_

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -16,76 +16,235 @@ namespace awkward {
   template <typename T, bool ISOPTION>
   class EXPORT_SYMBOL IndexedArrayOf: public Content {
   public:
-    IndexedArrayOf<T, ISOPTION>(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& index, const ContentPtr& content);
-    const IndexOf<T> index() const;
-    const ContentPtr content() const;
-    bool isoption() const;
-    const ContentPtr project() const;
-    const ContentPtr project(const Index8& mask) const;
-    const Index8 bytemask() const;
-    const ContentPtr simplify_optiontype() const;
-    T index_at_nowrap(int64_t at) const;
+    IndexedArrayOf<T, ISOPTION>(const IdentitiesPtr& identities,
+                                const util::Parameters& parameters,
+                                const IndexOf<T>& index,
+                                const ContentPtr& content);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const IndexOf<T>
+      index() const;
+
+    const ContentPtr
+      content() const;
+
+    bool
+      isoption() const;
+
+    const ContentPtr
+      project() const;
+
+    const ContentPtr
+      project(const Index8& mask) const;
+
+    const Index8
+      bytemask() const;
+
+    const ContentPtr
+      simplify_optiontype() const;
+
+    T
+      index_at_nowrap(int64_t at) const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr reverse_merge(const ContentPtr& other) const;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      reverse_merge(const ContentPtr& other) const;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr
+      getitem_next_jagged_generic(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const S& slicecontent,
+                                  const Slice& tail) const;
 
-    const std::pair<Index64, IndexOf<T>> nextcarry_outindex(int64_t& numnull) const;
+    const std::pair<Index64, IndexOf<T>>
+      nextcarry_outindex(int64_t& numnull) const;
 
   private:
     const IndexOf<T> index_;

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -16,14 +16,14 @@ namespace awkward {
   template <typename T, bool ISOPTION>
   class EXPORT_SYMBOL IndexedArrayOf: public Content {
   public:
-    IndexedArrayOf<T, ISOPTION>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, const std::shared_ptr<Content>& content);
+    IndexedArrayOf<T, ISOPTION>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, ContentPtr& content);
     const IndexOf<T> index() const;
-    const std::shared_ptr<Content> content() const;
+    ContentPtr content() const;
     bool isoption() const;
-    const std::shared_ptr<Content> project() const;
-    const std::shared_ptr<Content> project(const Index8& mask) const;
+    ContentPtr project() const;
+    ContentPtr project(const Index8& mask) const;
     const Index8 bytemask() const;
-    const std::shared_ptr<Content> simplify_optiontype() const;
+    ContentPtr simplify_optiontype() const;
     T index_at_nowrap(int64_t at) const;
 
     const std::string classname() const override;
@@ -34,18 +34,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -59,37 +59,37 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> reverse_merge(const std::shared_ptr<Content>& other) const;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr reverse_merge(ContentPtr& other) const;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const std::shared_ptr<Content> getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
     const std::pair<Index64, IndexOf<T>> nextcarry_outindex(int64_t& numnull) const;
 
   private:
     const IndexOf<T> index_;
-    const std::shared_ptr<Content> content_;
+    ContentPtr content_;
   };
 
   typedef IndexedArrayOf<int32_t, false>  IndexedArray32;

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -16,14 +16,14 @@ namespace awkward {
   template <typename T, bool ISOPTION>
   class EXPORT_SYMBOL IndexedArrayOf: public Content {
   public:
-    IndexedArrayOf<T, ISOPTION>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, ContentPtr& content);
+    IndexedArrayOf<T, ISOPTION>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, const ContentPtr& content);
     const IndexOf<T> index() const;
-    ContentPtr content() const;
+    const ContentPtr content() const;
     bool isoption() const;
-    ContentPtr project() const;
-    ContentPtr project(const Index8& mask) const;
+    const ContentPtr project() const;
+    const ContentPtr project(const Index8& mask) const;
     const Index8 bytemask() const;
-    ContentPtr simplify_optiontype() const;
+    const ContentPtr simplify_optiontype() const;
     T index_at_nowrap(int64_t at) const;
 
     const std::string classname() const override;
@@ -34,18 +34,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -59,37 +59,37 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr reverse_merge(ContentPtr& other) const;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr reverse_merge(const ContentPtr& other) const;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
     const std::pair<Index64, IndexOf<T>> nextcarry_outindex(int64_t& numnull) const;
 
   private:
     const IndexOf<T> index_;
-    ContentPtr content_;
+    const ContentPtr content_;
   };
 
   typedef IndexedArrayOf<int32_t, false>  IndexedArray32;

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -92,11 +92,11 @@ namespace awkward {
     const ContentPtr content_;
   };
 
-  typedef IndexedArrayOf<int32_t, false>  IndexedArray32;
-  typedef IndexedArrayOf<uint32_t, false> IndexedArrayU32;
-  typedef IndexedArrayOf<int64_t, false>  IndexedArray64;
-  typedef IndexedArrayOf<int32_t, true>   IndexedOptionArray32;
-  typedef IndexedArrayOf<int64_t, true>   IndexedOptionArray64;
+  using IndexedArray32       = IndexedArrayOf<int32_t, false>;
+  using IndexedArrayU32      = IndexedArrayOf<uint32_t, false>;
+  using IndexedArray64       = IndexedArrayOf<int64_t, false>;
+  using IndexedOptionArray32 = IndexedArrayOf<int32_t, true>;
+  using IndexedOptionArray64 = IndexedArrayOf<int64_t, true>;
 }
 
 #endif // AWKWARD_INDEXEDARRAY_H_

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -55,7 +55,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -16,7 +16,7 @@ namespace awkward {
   template <typename T, bool ISOPTION>
   class EXPORT_SYMBOL IndexedArrayOf: public Content {
   public:
-    IndexedArrayOf<T, ISOPTION>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, const ContentPtr& content);
+    IndexedArrayOf<T, ISOPTION>(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& index, const ContentPtr& content);
     const IndexOf<T> index() const;
     const ContentPtr content() const;
     bool isoption() const;
@@ -28,8 +28,8 @@ namespace awkward {
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -44,7 +44,7 @@ namespace awkward {
     const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
     const ContentPtr getitem_field(const std::string& key) const override;
     const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
@@ -65,13 +65,13 @@ namespace awkward {
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr reverse_merge(const ContentPtr& other) const;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -51,7 +51,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -14,14 +14,14 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL ListArrayOf: public Content {
   public:
-    ListArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, ContentPtr& content);
+    ListArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const ContentPtr& content);
     const IndexOf<T> starts() const;
     const IndexOf<T> stops() const;
-    ContentPtr content() const;
+    const ContentPtr content() const;
     Index64 compact_offsets64(bool start_at_zero) const;
-    ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
-    ContentPtr toRegularArray() const;
-    ContentPtr toListOffsetArray64(bool start_at_zero) const;
+    const ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
+    const ContentPtr toRegularArray() const;
+    const ContentPtr toListOffsetArray64(bool start_at_zero) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -31,17 +31,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -55,31 +55,31 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
     const IndexOf<T> starts_;
     const IndexOf<T> stops_;
-    ContentPtr content_;
+    const ContentPtr content_;
   };
 
   typedef ListArrayOf<int32_t>  ListArray32;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -14,7 +14,7 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL ListArrayOf: public Content {
   public:
-    ListArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const ContentPtr& content);
+    ListArrayOf<T>(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const ContentPtr& content);
     const IndexOf<T> starts() const;
     const IndexOf<T> stops() const;
     const ContentPtr content() const;
@@ -25,8 +25,8 @@ namespace awkward {
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -60,13 +60,13 @@ namespace awkward {
     const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -14,14 +14,14 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL ListArrayOf: public Content {
   public:
-    ListArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const std::shared_ptr<Content>& content);
+    ListArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, ContentPtr& content);
     const IndexOf<T> starts() const;
     const IndexOf<T> stops() const;
-    const std::shared_ptr<Content> content() const;
+    ContentPtr content() const;
     Index64 compact_offsets64(bool start_at_zero) const;
-    const std::shared_ptr<Content> broadcast_tooffsets64(const Index64& offsets) const;
-    const std::shared_ptr<Content> toRegularArray() const;
-    const std::shared_ptr<Content> toListOffsetArray64(bool start_at_zero) const;
+    ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
+    ContentPtr toRegularArray() const;
+    ContentPtr toListOffsetArray64(bool start_at_zero) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -31,17 +31,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -55,31 +55,31 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
     const IndexOf<T> starts_;
     const IndexOf<T> stops_;
-    const std::shared_ptr<Content> content_;
+    ContentPtr content_;
   };
 
   typedef ListArrayOf<int32_t>  ListArray32;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -14,67 +14,214 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL ListArrayOf: public Content {
   public:
-    ListArrayOf<T>(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const ContentPtr& content);
-    const IndexOf<T> starts() const;
-    const IndexOf<T> stops() const;
-    const ContentPtr content() const;
-    Index64 compact_offsets64(bool start_at_zero) const;
-    const ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
-    const ContentPtr toRegularArray() const;
-    const ContentPtr toListOffsetArray64(bool start_at_zero) const;
+    ListArrayOf<T>(const IdentitiesPtr& identities,
+                   const util::Parameters& parameters,
+                   const IndexOf<T>& starts,
+                   const IndexOf<T>& stops,
+                   const ContentPtr& content);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const IndexOf<T>
+      starts() const;
+
+    const IndexOf<T>
+      stops() const;
+
+    const ContentPtr
+      content() const;
+
+    Index64
+      compact_offsets64(bool start_at_zero) const;
+
+    const ContentPtr
+      broadcast_tooffsets64(const Index64& offsets) const;
+
+    const ContentPtr
+      toRegularArray() const;
+
+    const ContentPtr
+      toListOffsetArray64(bool start_at_zero) const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   private:
     const IndexOf<T> starts_;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -82,9 +82,9 @@ namespace awkward {
     const ContentPtr content_;
   };
 
-  typedef ListArrayOf<int32_t>  ListArray32;
-  typedef ListArrayOf<uint32_t> ListArrayU32;
-  typedef ListArrayOf<int64_t>  ListArray64;
+  using ListArray32  = ListArrayOf<int32_t>;
+  using ListArrayU32 = ListArrayOf<uint32_t>;
+  using ListArray64  = ListArrayOf<int64_t>;
 }
 
 #endif // AWKWARD_LISTARRAY_H_

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -53,7 +53,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -14,15 +14,15 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL ListOffsetArrayOf: public Content {
   public:
-    ListOffsetArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, const std::shared_ptr<Content>& content);
+    ListOffsetArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, ContentPtr& content);
     const IndexOf<T> starts() const;
     const IndexOf<T> stops() const;
     const IndexOf<T> offsets() const;
-    const std::shared_ptr<Content> content() const;
+    ContentPtr content() const;
     Index64 compact_offsets64(bool start_at_zero) const;
-    const std::shared_ptr<Content> broadcast_tooffsets64(const Index64& offsets) const;
-    const std::shared_ptr<Content> toRegularArray() const;
-    const std::shared_ptr<Content> toListOffsetArray64(bool start_at_zero) const;
+    ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
+    ContentPtr toRegularArray() const;
+    ContentPtr toListOffsetArray64(bool start_at_zero) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -32,18 +32,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -57,30 +57,30 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
     const IndexOf<T> offsets_;
-    const std::shared_ptr<Content> content_;
+    ContentPtr content_;
   };
 
   typedef ListOffsetArrayOf<int32_t>  ListOffsetArray32;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -14,69 +14,222 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL ListOffsetArrayOf: public Content {
   public:
-    ListOffsetArrayOf<T>(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, const ContentPtr& content);
-    const IndexOf<T> starts() const;
-    const IndexOf<T> stops() const;
-    const IndexOf<T> offsets() const;
-    const ContentPtr content() const;
-    Index64 compact_offsets64(bool start_at_zero) const;
-    const ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
-    const ContentPtr toRegularArray() const;
-    const ContentPtr toListOffsetArray64(bool start_at_zero) const;
+    ListOffsetArrayOf<T>(const IdentitiesPtr& identities,
+                         const util::Parameters& parameters,
+                         const IndexOf<T>& offsets,
+                         const ContentPtr& content);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceItemPtr& slicecontent, const Slice& tail) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const IndexOf<T>
+      starts() const;
+
+    const IndexOf<T>
+      stops() const;
+
+    const IndexOf<T>
+      offsets() const;
+
+    const ContentPtr
+      content() const;
+
+    Index64
+      compact_offsets64(bool start_at_zero) const;
+
+    const ContentPtr
+      broadcast_tooffsets64(const Index64& offsets) const;
+
+    const ContentPtr
+      toRegularArray() const;
+
+    const ContentPtr
+      toListOffsetArray64(bool start_at_zero) const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceItemPtr& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   private:
     const IndexOf<T> offsets_;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -14,15 +14,15 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL ListOffsetArrayOf: public Content {
   public:
-    ListOffsetArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, ContentPtr& content);
+    ListOffsetArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, const ContentPtr& content);
     const IndexOf<T> starts() const;
     const IndexOf<T> stops() const;
     const IndexOf<T> offsets() const;
-    ContentPtr content() const;
+    const ContentPtr content() const;
     Index64 compact_offsets64(bool start_at_zero) const;
-    ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
-    ContentPtr toRegularArray() const;
-    ContentPtr toListOffsetArray64(bool start_at_zero) const;
+    const ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
+    const ContentPtr toRegularArray() const;
+    const ContentPtr toListOffsetArray64(bool start_at_zero) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -32,18 +32,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -57,30 +57,30 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
     const IndexOf<T> offsets_;
-    ContentPtr content_;
+    const ContentPtr content_;
   };
 
   typedef ListOffsetArrayOf<int32_t>  ListOffsetArray32;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -14,7 +14,7 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL ListOffsetArrayOf: public Content {
   public:
-    ListOffsetArrayOf<T>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, const ContentPtr& content);
+    ListOffsetArrayOf<T>(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, const ContentPtr& content);
     const IndexOf<T> starts() const;
     const IndexOf<T> stops() const;
     const IndexOf<T> offsets() const;
@@ -26,8 +26,8 @@ namespace awkward {
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -42,7 +42,7 @@ namespace awkward {
     const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
     const ContentPtr getitem_field(const std::string& key) const override;
     const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceItemPtr& slicecontent, const Slice& tail) const override;
     const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
@@ -62,13 +62,13 @@ namespace awkward {
     const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -83,9 +83,9 @@ namespace awkward {
     const ContentPtr content_;
   };
 
-  typedef ListOffsetArrayOf<int32_t>  ListOffsetArray32;
-  typedef ListOffsetArrayOf<uint32_t> ListOffsetArrayU32;
-  typedef ListOffsetArrayOf<int64_t>  ListOffsetArray64;
+  using ListOffsetArray32  = ListOffsetArrayOf<int32_t>;
+  using ListOffsetArrayU32 = ListOffsetArrayOf<uint32_t>;
+  using ListOffsetArray64  = ListOffsetArrayOf<int64_t>;
 }
 
 #endif // AWKWARD_LISTOFFSETARRAY_H_

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -25,17 +25,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -49,31 +49,31 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
   };
 
-  extern const std::shared_ptr<Content> none;
+  extern ContentPtr none;
 }
 
 #endif // AWKWARD_NONE_H_

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -19,8 +19,8 @@ namespace awkward {
     bool isscalar() const override;
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -54,13 +54,13 @@ namespace awkward {
     const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -16,61 +16,200 @@ namespace awkward {
   public:
     None();
 
-    bool isscalar() const override;
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    bool
+      isscalar() const override;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceField& field,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceFields& fields,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
   };
 
   extern const ContentPtr none;

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -29,7 +29,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -25,17 +25,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -49,31 +49,31 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
   };
 
-  extern ContentPtr none;
+  extern const ContentPtr none;
 }
 
 #endif // AWKWARD_NONE_H_

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -16,10 +16,10 @@
 namespace awkward {
   class EXPORT_SYMBOL NumpyArray: public Content {
   public:
-    static const std::shared_ptr<Type> unwrap_regulartype(const std::shared_ptr<Type>& type, const std::vector<ssize_t>& shape);
+    static const TypePtr unwrap_regulartype(const TypePtr& type, const std::vector<ssize_t>& shape);
     static const std::unordered_map<std::type_index, std::string> format_map;
 
-    NumpyArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::shared_ptr<void>& ptr, const std::vector<ssize_t>& shape, const std::vector<ssize_t>& strides, ssize_t byteoffset, ssize_t itemsize, const std::string format);
+    NumpyArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const std::shared_ptr<void>& ptr, const std::vector<ssize_t>& shape, const std::vector<ssize_t>& strides, ssize_t byteoffset, ssize_t itemsize, const std::string format);
     NumpyArray(const Index8 index);
     NumpyArray(const IndexU8 index);
     NumpyArray(const Index32 index);
@@ -59,8 +59,8 @@ namespace awkward {
     bool isscalar() const override;
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -76,7 +76,7 @@ namespace awkward {
     const ContentPtr getitem_field(const std::string& key) const override;
     const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
     const ContentPtr getitem(const Slice& where) const override;
-    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
@@ -96,13 +96,13 @@ namespace awkward {
     const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     bool iscontiguous() const;
     const NumpyArray contiguous() const;
@@ -116,12 +116,12 @@ namespace awkward {
 
   protected:
     const NumpyArray contiguous_next(const Index64& bytepos) const;
-    const NumpyArray getitem_bystrides(const std::shared_ptr<SliceItem>& head, const Slice& tail, int64_t length) const;
+    const NumpyArray getitem_bystrides(const SliceItemPtr& head, const Slice& tail, int64_t length) const;
     const NumpyArray getitem_bystrides(const SliceAt& at, const Slice& tail, int64_t length) const;
     const NumpyArray getitem_bystrides(const SliceRange& range, const Slice& tail, int64_t length) const;
     const NumpyArray getitem_bystrides(const SliceEllipsis& ellipsis, const Slice& tail, int64_t length) const;
     const NumpyArray getitem_bystrides(const SliceNewAxis& newaxis, const Slice& tail, int64_t length) const;
-    const NumpyArray getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
+    const NumpyArray getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
     const NumpyArray getitem_next(const SliceAt& at, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
     const NumpyArray getitem_next(const SliceRange& range, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
     const NumpyArray getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -54,7 +54,7 @@ namespace awkward {
     uint64_t getuint64(ssize_t at) const;
     float_t getfloat(ssize_t at) const;
     double_t getdouble(ssize_t at) const;
-    ContentPtr toRegularArray() const;
+    const ContentPtr toRegularArray() const;
 
     bool isscalar() const override;
     const std::string classname() const override;
@@ -65,19 +65,19 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr getitem(const Slice& where) const override;
-    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr getitem(const Slice& where) const override;
+    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -91,28 +91,28 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     bool iscontiguous() const;
     const NumpyArray contiguous() const;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
 
   protected:
     const NumpyArray contiguous_next(const Index64& bytepos) const;
@@ -127,9 +127,9 @@ namespace awkward {
     const NumpyArray getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
     const NumpyArray getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
     const NumpyArray getitem_next(const SliceArray64& array, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   void tojson_boolean(ToJson& builder) const;
   template <typename T>

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -123,7 +123,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -54,7 +54,7 @@ namespace awkward {
     uint64_t getuint64(ssize_t at) const;
     float_t getfloat(ssize_t at) const;
     double_t getdouble(ssize_t at) const;
-    const std::shared_ptr<Content> toRegularArray() const;
+    ContentPtr toRegularArray() const;
 
     bool isscalar() const override;
     const std::string classname() const override;
@@ -65,19 +65,19 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> getitem(const Slice& where) const override;
-    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr getitem(const Slice& where) const override;
+    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -91,28 +91,28 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     bool iscontiguous() const;
     const NumpyArray contiguous() const;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
 
   protected:
     const NumpyArray contiguous_next(const Index64& bytepos) const;
@@ -127,9 +127,9 @@ namespace awkward {
     const NumpyArray getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
     const NumpyArray getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
     const NumpyArray getitem_next(const SliceArray64& array, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   void tojson_boolean(ToJson& builder) const;
   template <typename T>

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -16,10 +16,20 @@
 namespace awkward {
   class EXPORT_SYMBOL NumpyArray: public Content {
   public:
-    static const TypePtr unwrap_regulartype(const TypePtr& type, const std::vector<ssize_t>& shape);
+    static const TypePtr
+      unwrap_regulartype(const TypePtr& type,
+                         const std::vector<ssize_t>& shape);
     static const std::unordered_map<std::type_index, std::string> format_map;
 
-    NumpyArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const std::shared_ptr<void>& ptr, const std::vector<ssize_t>& shape, const std::vector<ssize_t>& strides, ssize_t byteoffset, ssize_t itemsize, const std::string format);
+    NumpyArray(const IdentitiesPtr& identities,
+               const util::Parameters& parameters,
+               const std::shared_ptr<void>& ptr,
+               const std::vector<ssize_t>& shape,
+               const std::vector<ssize_t>& strides,
+               ssize_t byteoffset,
+               ssize_t itemsize,
+               const std::string format);
+
     NumpyArray(const Index8 index);
     NumpyArray(const IndexU8 index);
     NumpyArray(const Index32 index);
@@ -31,112 +41,380 @@ namespace awkward {
     NumpyArray(const IndexU32 index, const std::string& format);
     NumpyArray(const Index64 index, const std::string& format);
 
-    const std::shared_ptr<void> ptr() const;
-    const std::vector<ssize_t> shape() const;
-    const std::vector<ssize_t> strides() const;
-    ssize_t byteoffset() const;
-    ssize_t itemsize() const;
-    const std::string format() const;
+    const std::shared_ptr<void>
+      ptr() const;
 
-    ssize_t ndim() const;
-    bool isempty() const;
-    void* byteptr() const;
-    void* byteptr(ssize_t at) const;
-    ssize_t bytelength() const;
-    uint8_t getbyte(ssize_t at) const;
-    int8_t getint8(ssize_t at) const;
-    uint8_t getuint8(ssize_t at) const;
-    int16_t getint16(ssize_t at) const;
-    uint16_t getuint16(ssize_t at) const;
-    int32_t getint32(ssize_t at) const;
-    uint32_t getuint32(ssize_t at) const;
-    int64_t getint64(ssize_t at) const;
-    uint64_t getuint64(ssize_t at) const;
-    float_t getfloat(ssize_t at) const;
-    double_t getdouble(ssize_t at) const;
-    const ContentPtr toRegularArray() const;
+    const std::vector<ssize_t>
+      shape() const;
 
-    bool isscalar() const override;
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem(const Slice& where) const override;
-    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const std::vector<ssize_t>
+      strides() const;
+
+    ssize_t
+      byteoffset() const;
+
+    ssize_t
+      itemsize() const;
+
+    const std::string
+      format() const;
+
+    ssize_t
+      ndim() const;
+
+    bool
+      isempty() const;
+
+    void*
+      byteptr() const;
+
+    void*
+      byteptr(ssize_t at) const;
+
+    ssize_t
+      bytelength() const;
+
+    uint8_t
+      getbyte(ssize_t at) const;
+
+    int8_t
+      getint8(ssize_t at) const;
+
+    uint8_t
+      getuint8(ssize_t at) const;
+
+    int16_t
+      getint16(ssize_t at) const;
+
+    uint16_t
+      getuint16(ssize_t at) const;
+
+    int32_t
+      getint32(ssize_t at) const;
+
+    uint32_t
+      getuint32(ssize_t at) const;
+
+    int64_t
+      getint64(ssize_t at) const;
+
+    uint64_t
+      getuint64(ssize_t at) const;
+
+    float_t
+      getfloat(ssize_t at) const;
+
+    double_t
+      getdouble(ssize_t at) const;
+
+    const ContentPtr
+      toRegularArray() const;
+
+    bool
+      isscalar() const override;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      getitem(const Slice& where) const override;
+
+    const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    bool iscontiguous() const;
-    const NumpyArray contiguous() const;
+    const ContentPtr
+      shallow_simplify() const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    bool
+      iscontiguous() const;
+
+    const NumpyArray
+      contiguous() const;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceField& field,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceFields& fields,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
 
   protected:
-    const NumpyArray contiguous_next(const Index64& bytepos) const;
-    const NumpyArray getitem_bystrides(const SliceItemPtr& head, const Slice& tail, int64_t length) const;
-    const NumpyArray getitem_bystrides(const SliceAt& at, const Slice& tail, int64_t length) const;
-    const NumpyArray getitem_bystrides(const SliceRange& range, const Slice& tail, int64_t length) const;
-    const NumpyArray getitem_bystrides(const SliceEllipsis& ellipsis, const Slice& tail, int64_t length) const;
-    const NumpyArray getitem_bystrides(const SliceNewAxis& newaxis, const Slice& tail, int64_t length) const;
-    const NumpyArray getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
-    const NumpyArray getitem_next(const SliceAt& at, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
-    const NumpyArray getitem_next(const SliceRange& range, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
-    const NumpyArray getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
-    const NumpyArray getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
-    const NumpyArray getitem_next(const SliceArray64& array, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const NumpyArray
+      contiguous_next(const Index64& bytepos) const;
 
-  void tojson_boolean(ToJson& builder) const;
+    const NumpyArray
+      getitem_bystrides(const SliceItemPtr& head,
+                        const Slice& tail,
+                        int64_t length) const;
+
+    const NumpyArray
+      getitem_bystrides(const SliceAt& at,
+                        const Slice& tail,
+                        int64_t length) const;
+
+    const NumpyArray
+      getitem_bystrides(const SliceRange& range,
+                        const Slice& tail,
+                        int64_t length) const;
+
+    const NumpyArray
+      getitem_bystrides(const SliceEllipsis& ellipsis,
+                        const Slice& tail,
+                        int64_t length) const;
+
+    const NumpyArray
+      getitem_bystrides(const SliceNewAxis& newaxis,
+                        const Slice& tail,
+                        int64_t length) const;
+
+    const NumpyArray
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& carry,
+                   const Index64& advanced,
+                   int64_t length,
+                   int64_t stride,
+                   bool first) const;
+
+    const NumpyArray
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& carry,
+                   const Index64& advanced,
+                   int64_t length,
+                   int64_t stride,
+                   bool first) const;
+
+    const NumpyArray
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& carry,
+                   const Index64& advanced,
+                   int64_t length,
+                   int64_t stride,
+                   bool first) const;
+
+    const NumpyArray
+      getitem_next(const SliceEllipsis& ellipsis,
+                   const Slice& tail,
+                   const Index64& carry,
+                   const Index64& advanced,
+                   int64_t length,
+                   int64_t stride,
+                   bool first) const;
+
+    const NumpyArray
+      getitem_next(const SliceNewAxis& newaxis,
+                   const Slice& tail,
+                   const Index64& carry,
+                   const Index64& advanced,
+                   int64_t length,
+                   int64_t stride,
+                   bool first) const;
+
+    const NumpyArray
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& carry,
+                   const Index64& advanced,
+                   int64_t length,
+                   int64_t stride,
+                   bool first) const;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
+
+  void
+    tojson_boolean(ToJson& builder) const;
+
   template <typename T>
-  void tojson_integer(ToJson& builder) const;
+  void
+    tojson_integer(ToJson& builder) const;
+
   template <typename T>
-  void tojson_real(ToJson& builder) const;
-  void tojson_string(ToJson& builder) const;
+  void
+    tojson_real(ToJson& builder) const;
+
+  void
+    tojson_string(ToJson& builder) const;
 
   private:
     std::shared_ptr<void> ptr_;

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -276,11 +276,11 @@ namespace awkward {
       }
     }
 
-    ContentPtr shallow_copy() const override {
+    const ContentPtr shallow_copy() const override {
       return std::make_shared<RawArrayOf<T>>(identities_, parameters_, ptr_, offset_, length_, itemsize_);
     }
 
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override {
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override {
       std::shared_ptr<T> ptr = ptr_;
       int64_t offset = offset_;
       if (copyarrays) {
@@ -301,11 +301,11 @@ namespace awkward {
       }
     }
 
-    ContentPtr getitem_nothing() const override {
+    const ContentPtr getitem_nothing() const override {
       return getitem_range_nowrap(0, 0);
     }
 
-    ContentPtr getitem_at(int64_t at) const override {
+    const ContentPtr getitem_at(int64_t at) const override {
       int64_t regular_at = at;
       if (regular_at < 0) {
         regular_at += length_;
@@ -316,11 +316,11 @@ namespace awkward {
       return getitem_at_nowrap(regular_at);
     }
 
-    ContentPtr getitem_at_nowrap(int64_t at) const override {
+    const ContentPtr getitem_at_nowrap(int64_t at) const override {
       return getitem_range_nowrap(at, at + 1);
     }
 
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override {
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override {
       int64_t regular_start = start;
       int64_t regular_stop = stop;
       awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
@@ -330,7 +330,7 @@ namespace awkward {
       return getitem_range_nowrap(regular_start, regular_stop);
     }
 
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override {
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override {
       std::shared_ptr<Identities> identities(nullptr);
       if (identities_.get() != nullptr) {
         identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -338,29 +338,29 @@ namespace awkward {
       return std::make_shared<RawArrayOf<T>>(identities, parameters_, ptr_, offset_ + start, stop - start, itemsize_);
     }
 
-    ContentPtr getitem_field(const std::string& key) const override {
+    const ContentPtr getitem_field(const std::string& key) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
     }
 
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override {
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
     }
 
-    ContentPtr getitem(const Slice& where) const override {
+    const ContentPtr getitem(const Slice& where) const override {
       std::shared_ptr<SliceItem> nexthead = where.head();
       Slice nexttail = where.tail();
       Index64 nextadvanced(0);
       return getitem_next(nexthead, nexttail, nextadvanced);
     }
 
-    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override {
       if (tail.length() != 0) {
         throw std::invalid_argument("too many indexes for array");
       }
       return Content::getitem_next(head, tail, advanced);
     }
 
-    ContentPtr carry(const Index64& carry) const override {
+    const ContentPtr carry(const Index64& carry) const override {
       std::shared_ptr<T> ptr(new T[(size_t)carry.length()], util::array_deleter<T>());
       struct Error err = awkward_numpyarray_getitem_next_null_64(
         reinterpret_cast<uint8_t*>(ptr.get()),
@@ -425,11 +425,11 @@ namespace awkward {
       return std::string();
     }
 
-    ContentPtr shallow_simplify() const override {
+    const ContentPtr shallow_simplify() const override {
       return shallow_copy();
     }
 
-    ContentPtr num(int64_t axis, int64_t depth) const override {
+    const ContentPtr num(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis == depth) {
         Index64 out(1);
@@ -441,7 +441,7 @@ namespace awkward {
       }
     }
 
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override {
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis == depth) {
         throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -451,7 +451,7 @@ namespace awkward {
       }
     }
 
-    bool mergeable(ContentPtr& other, bool mergebool) const override {
+    bool mergeable(const ContentPtr& other, bool mergebool) const override {
       if (dynamic_cast<EmptyArray*>(other.get())) {
         return true;
       }
@@ -488,7 +488,7 @@ namespace awkward {
       }
     }
 
-    ContentPtr merge(ContentPtr& other) const override {
+    const ContentPtr merge(const ContentPtr& other) const override {
       if (dynamic_cast<EmptyArray*>(other.get())) {
         return shallow_copy();
       }
@@ -532,11 +532,11 @@ namespace awkward {
       throw std::invalid_argument("cannot use RawArray as a slice");
     }
 
-    ContentPtr fillna(ContentPtr& value) const override {
+    const ContentPtr fillna(const ContentPtr& value) const override {
       return shallow_copy();
     }
 
-    ContentPtr rpad(int64_t target, int64_t axis, int64_t depth) const override {
+    const ContentPtr rpad(int64_t target, int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis != depth) {
         throw std::invalid_argument("axis exceeds the depth of this array");
@@ -549,7 +549,7 @@ namespace awkward {
       }
     }
 
-    ContentPtr rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const override {
+    const ContentPtr rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis != depth) {
         throw std::invalid_argument("axis exceeds the depth of this array");
@@ -564,11 +564,11 @@ namespace awkward {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, shallow_copy());
     }
 
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override {
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override {
       throw std::runtime_error("FIXME: RawArray:reduce_next");
     }
 
-    ContentPtr localindex(int64_t axis, int64_t depth) const override {
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (axis == depth) {
         return localindex_axis0();
@@ -578,7 +578,7 @@ namespace awkward {
       }
     }
 
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override {
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override {
       if (n < 1) {
         throw std::invalid_argument("in choose, 'n' must be at least 1");
       }
@@ -591,11 +591,11 @@ namespace awkward {
       }
     }
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override {
       return getitem_at(at.at());
     }
 
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override {
       if (range.step() == Slice::none()  ||  range.step() == 1) {
         return getitem_range(range.start(), range.stop());
       }
@@ -627,7 +627,7 @@ namespace awkward {
       }
     }
 
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override {
       if (advanced.length() != 0) {
         throw std::runtime_error("RawArray::getitem_next(SliceAt): advanced.length() != 0");
       }
@@ -643,27 +643,27 @@ namespace awkward {
       return carry(flathead);
     }
 
-    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a field name because it has no fields"));
     }
 
-    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field names because it has no fields"));
     }
 
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a jagged array because it is one-dimensional"));
     }
 
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override {
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override {
       throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(array)");
     }
 
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override {
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override {
       throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(missing)");
     }
 
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override {
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override {
       throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(jagged)");
     }
 

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -276,11 +276,11 @@ namespace awkward {
       }
     }
 
-    const std::shared_ptr<Content> shallow_copy() const override {
+    ContentPtr shallow_copy() const override {
       return std::make_shared<RawArrayOf<T>>(identities_, parameters_, ptr_, offset_, length_, itemsize_);
     }
 
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override {
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override {
       std::shared_ptr<T> ptr = ptr_;
       int64_t offset = offset_;
       if (copyarrays) {
@@ -301,11 +301,11 @@ namespace awkward {
       }
     }
 
-    const std::shared_ptr<Content> getitem_nothing() const override {
+    ContentPtr getitem_nothing() const override {
       return getitem_range_nowrap(0, 0);
     }
 
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override {
+    ContentPtr getitem_at(int64_t at) const override {
       int64_t regular_at = at;
       if (regular_at < 0) {
         regular_at += length_;
@@ -316,11 +316,11 @@ namespace awkward {
       return getitem_at_nowrap(regular_at);
     }
 
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override {
+    ContentPtr getitem_at_nowrap(int64_t at) const override {
       return getitem_range_nowrap(at, at + 1);
     }
 
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override {
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override {
       int64_t regular_start = start;
       int64_t regular_stop = stop;
       awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
@@ -330,7 +330,7 @@ namespace awkward {
       return getitem_range_nowrap(regular_start, regular_stop);
     }
 
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override {
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override {
       std::shared_ptr<Identities> identities(nullptr);
       if (identities_.get() != nullptr) {
         identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -338,29 +338,29 @@ namespace awkward {
       return std::make_shared<RawArrayOf<T>>(identities, parameters_, ptr_, offset_ + start, stop - start, itemsize_);
     }
 
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override {
+    ContentPtr getitem_field(const std::string& key) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
     }
 
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override {
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
     }
 
-    const std::shared_ptr<Content> getitem(const Slice& where) const override {
+    ContentPtr getitem(const Slice& where) const override {
       std::shared_ptr<SliceItem> nexthead = where.head();
       Slice nexttail = where.tail();
       Index64 nextadvanced(0);
       return getitem_next(nexthead, nexttail, nextadvanced);
     }
 
-    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override {
+    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override {
       if (tail.length() != 0) {
         throw std::invalid_argument("too many indexes for array");
       }
       return Content::getitem_next(head, tail, advanced);
     }
 
-    const std::shared_ptr<Content> carry(const Index64& carry) const override {
+    ContentPtr carry(const Index64& carry) const override {
       std::shared_ptr<T> ptr(new T[(size_t)carry.length()], util::array_deleter<T>());
       struct Error err = awkward_numpyarray_getitem_next_null_64(
         reinterpret_cast<uint8_t*>(ptr.get()),
@@ -425,11 +425,11 @@ namespace awkward {
       return std::string();
     }
 
-    const std::shared_ptr<Content> shallow_simplify() const override {
+    ContentPtr shallow_simplify() const override {
       return shallow_copy();
     }
 
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override {
+    ContentPtr num(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis == depth) {
         Index64 out(1);
@@ -451,7 +451,7 @@ namespace awkward {
       }
     }
 
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override {
+    bool mergeable(ContentPtr& other, bool mergebool) const override {
       if (dynamic_cast<EmptyArray*>(other.get())) {
         return true;
       }
@@ -488,7 +488,7 @@ namespace awkward {
       }
     }
 
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override {
+    ContentPtr merge(ContentPtr& other) const override {
       if (dynamic_cast<EmptyArray*>(other.get())) {
         return shallow_copy();
       }
@@ -532,11 +532,11 @@ namespace awkward {
       throw std::invalid_argument("cannot use RawArray as a slice");
     }
 
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override {
+    ContentPtr fillna(ContentPtr& value) const override {
       return shallow_copy();
     }
 
-    const std::shared_ptr<Content> rpad(int64_t target, int64_t axis, int64_t depth) const override {
+    ContentPtr rpad(int64_t target, int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis != depth) {
         throw std::invalid_argument("axis exceeds the depth of this array");
@@ -549,7 +549,7 @@ namespace awkward {
       }
     }
 
-    const std::shared_ptr<Content> rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const override {
+    ContentPtr rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis != depth) {
         throw std::invalid_argument("axis exceeds the depth of this array");
@@ -564,11 +564,11 @@ namespace awkward {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, shallow_copy());
     }
 
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override {
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override {
       throw std::runtime_error("FIXME: RawArray:reduce_next");
     }
 
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override {
+    ContentPtr localindex(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (axis == depth) {
         return localindex_axis0();
@@ -578,7 +578,7 @@ namespace awkward {
       }
     }
 
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override {
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override {
       if (n < 1) {
         throw std::invalid_argument("in choose, 'n' must be at least 1");
       }
@@ -591,11 +591,11 @@ namespace awkward {
       }
     }
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override {
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override {
       return getitem_at(at.at());
     }
 
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override {
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override {
       if (range.step() == Slice::none()  ||  range.step() == 1) {
         return getitem_range(range.start(), range.stop());
       }
@@ -627,7 +627,7 @@ namespace awkward {
       }
     }
 
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override {
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override {
       if (advanced.length() != 0) {
         throw std::runtime_error("RawArray::getitem_next(SliceAt): advanced.length() != 0");
       }
@@ -643,27 +643,27 @@ namespace awkward {
       return carry(flathead);
     }
 
-    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override {
+    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a field name because it has no fields"));
     }
 
-    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override {
+    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field names because it has no fields"));
     }
 
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override {
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override {
       throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a jagged array because it is one-dimensional"));
     }
 
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override {
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override {
       throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(array)");
     }
 
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override {
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override {
       throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(missing)");
     }
 
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override {
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override {
       throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(jagged)");
     }
 

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -28,21 +28,24 @@
 #include "awkward/array/UnmaskedArray.h"
 
 namespace awkward {
-  void tojson_boolean(ToJson& builder, bool* array, int64_t length) {
+  void
+    tojson_boolean(ToJson& builder, bool* array, int64_t length) {
     for (int i = 0;  i < length;  i++) {
       builder.boolean((bool)array[i]);
     }
   }
 
   template <typename T>
-  void tojson_integer(ToJson& builder, T* array, int64_t length) {
+  void
+    tojson_integer(ToJson& builder, T* array, int64_t length) {
     for (int i = 0;  i < length;  i++) {
       builder.integer((int64_t)array[i]);
     }
   }
 
   template <typename T>
-  void tojson_real(ToJson& builder, T* array, int64_t length) {
+  void
+    tojson_real(ToJson& builder, T* array, int64_t length) {
     for (int i = 0;  i < length;  i++) {
       builder.real((double)array[i]);
     }
@@ -51,7 +54,12 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL RawArrayOf: public Content {
   public:
-    RawArrayOf<T>(const IdentitiesPtr& identities, const util::Parameters& parameters, const std::shared_ptr<T>& ptr, const int64_t offset, const int64_t length, const int64_t itemsize)
+    RawArrayOf<T>(const IdentitiesPtr& identities,
+                  const util::Parameters& parameters,
+                  const std::shared_ptr<T>& ptr,
+                  const int64_t offset,
+                  const int64_t length,
+                  const int64_t itemsize)
         : Content(identities, parameters)
         , ptr_(ptr)
         , offset_(offset)
@@ -62,133 +70,184 @@ namespace awkward {
       }
     }
 
-    RawArrayOf<T>(const IdentitiesPtr& identities, const util::Parameters& parameters, const std::shared_ptr<T>& ptr, const int64_t length)
+    RawArrayOf<T>(const IdentitiesPtr& identities,
+                  const util::Parameters& parameters,
+                  const std::shared_ptr<T>& ptr,
+                  const int64_t length)
         : Content(identities, parameters)
         , ptr_(ptr)
         , offset_(0)
         , length_(length)
         , itemsize_(sizeof(T)) { }
 
-    RawArrayOf<T>(const IdentitiesPtr& identities, const util::Parameters& parameters, const int64_t length)
+    RawArrayOf<T>(const IdentitiesPtr& identities,
+                  const util::Parameters& parameters,
+                  const int64_t length)
         : Content(identities, parameters)
-        , ptr_(std::shared_ptr<T>(new T[(size_t)length], util::array_deleter<T>()))
+        , ptr_(std::shared_ptr<T>(new T[(size_t)length],
+                                  util::array_deleter<T>()))
         , offset_(0)
         , length_(length)
         , itemsize_(sizeof(T)) { }
 
-    const std::shared_ptr<T> ptr() const {
+    const std::shared_ptr<T>
+      ptr() const {
       return ptr_;
     }
 
-    const int64_t offset() const {
+    const int64_t
+      offset() const {
       return offset_;
     }
 
-    const int64_t itemsize() const {
+    const int64_t
+      itemsize() const {
       return itemsize_;
     }
 
-    bool isempty() const {
+    bool
+      isempty() const {
       return length_ == 0;
     }
 
-    ssize_t byteoffset() const {
+    ssize_t
+      byteoffset() const {
       return (ssize_t)itemsize_*(ssize_t)offset_;
     }
 
-    uint8_t* byteptr() const {
-      return reinterpret_cast<uint8_t*>(reinterpret_cast<ssize_t>(ptr_.get()) + byteoffset());
+    uint8_t*
+      byteptr() const {
+      return reinterpret_cast<uint8_t*>(reinterpret_cast<ssize_t>(ptr_.get())
+                                        + byteoffset());
     }
-    ssize_t bytelength() const {
+    ssize_t
+      bytelength() const {
       return (ssize_t)itemsize_*(ssize_t)length_;
     }
-    uint8_t getbyte(ssize_t at) const {
-      return *reinterpret_cast<uint8_t*>(reinterpret_cast<ssize_t>(ptr_.get()) + (ssize_t)(byteoffset() + at));
+    uint8_t
+      getbyte(ssize_t at) const {
+      return *reinterpret_cast<uint8_t*>(reinterpret_cast<ssize_t>(ptr_.get())
+                                         + (ssize_t)(byteoffset() + at));
     }
 
-    T* borrow(int64_t at) const {
-      return reinterpret_cast<T*>(reinterpret_cast<ssize_t>(ptr_.get()) + (ssize_t)itemsize_*(ssize_t)(offset_ + at));
+    T*
+      borrow(int64_t at) const {
+      return reinterpret_cast<T*>(
+        reinterpret_cast<ssize_t>(ptr_.get()) +
+        (ssize_t)itemsize_*(ssize_t)(offset_ + at));
     }
 
-    const std::string classname() const override {
-      return std::string("RawArrayOf<") + std::string(typeid(T).name()) + std::string(">");
+    const std::string
+      classname() const override {
+      return std::string("RawArrayOf<") + std::string(typeid(T).name()) +
+        std::string(">");
     }
 
-    void setidentities() override {
+    void
+      setidentities() override {
       if (length() <= kMaxInt32) {
-        IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-        Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
+        IdentitiesPtr newidentities =
+          std::make_shared<Identities32>(Identities::newref(),
+                                         Identities::FieldLoc(), 1, length());
+        Identities32* rawidentities =
+          reinterpret_cast<Identities32*>(newidentities.get());
         awkward_new_identities32(rawidentities->ptr().get(), length());
         setidentities(newidentities);
       }
       else {
-        IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-        Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
+        IdentitiesPtr newidentities =
+          std::make_shared<Identities64>(Identities::newref(),
+                                         Identities::FieldLoc(), 1, length());
+        Identities64* rawidentities =
+          reinterpret_cast<Identities64*>(newidentities.get());
         awkward_new_identities64(rawidentities->ptr().get(), length());
         setidentities(newidentities);
       }
     }
 
-    void setidentities(const IdentitiesPtr& identities) override {
-      if (identities.get() != nullptr  &&  length() != identities.get()->length()) {
-        throw std::invalid_argument("content and its identities must have the same length");
+    void
+      setidentities(const IdentitiesPtr& identities) override {
+      if (identities.get() != nullptr  &&
+          length() != identities.get()->length()) {
+        throw std::invalid_argument(
+          "content and its identities must have the same length");
       }
       identities_ = identities;
     }
 
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override {
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override {
       if (std::is_same<T, double>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::float64);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::float64);
       }
       else if (std::is_same<T, float>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::float32);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::float32);
       }
       else if (std::is_same<T, int64_t>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::int64);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::int64);
       }
       else if (std::is_same<T, uint64_t>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::uint64);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::uint64);
       }
       else if (std::is_same<T, int32_t>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::int32);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::int32);
       }
       else if (std::is_same<T, uint32_t>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::uint32);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::uint32);
       }
       else if (std::is_same<T, int16_t>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::int16);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::int16);
       }
       else if (std::is_same<T, uint16_t>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::uint16);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::uint16);
       }
       else if (std::is_same<T, int8_t>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::int8);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::int8);
       }
       else if (std::is_same<T, uint8_t>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::uint8);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::uint8);
       }
       else if (std::is_same<T, bool>::value) {
-        return std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::boolean);
+        return std::make_shared<PrimitiveType>(parameters_,
+          util::gettypestr(parameters_, typestrs), PrimitiveType::boolean);
       }
       else {
-        throw std::invalid_argument(std::string("RawArrayOf<") + typeid(T).name() + std::string("> does not have a known type"));
+        throw std::invalid_argument(std::string("RawArrayOf<") +
+          typeid(T).name() + std::string("> does not have a known type"));
       }
     }
 
-    const std::string tostring() {
+    const std::string
+      tostring() {
       return tostring_part("", "", "");
     }
 
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override {
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override {
       std::stringstream out;
-      out << indent << pre << "<RawArray of=\"" << typeid(T).name() << "\" length=\"" << length_ << "\" itemsize=\"" << itemsize_ << "\" data=\"";
+      out << indent << pre << "<RawArray of=\"" << typeid(T).name()
+          << "\" length=\"" << length_ << "\" itemsize=\"" << itemsize_
+          << "\" data=\"";
       ssize_t len = bytelength();
       if (len <= 32) {
         for (ssize_t i = 0;  i < len;  i++) {
           if (i != 0  &&  i % 4 == 0) {
             out << " ";
           }
-          out << std::hex << std::setw(2) << std::setfill('0') << int(getbyte(i));
+          out << std::hex << std::setw(2) << std::setfill('0')
+              << int(getbyte(i));
         }
       }
       else {
@@ -196,24 +255,28 @@ namespace awkward {
           if (i != 0  &&  i % 4 == 0) {
             out << " ";
           }
-          out << std::hex << std::setw(2) << std::setfill('0') << int(getbyte(i));
+          out << std::hex << std::setw(2) << std::setfill('0')
+              << int(getbyte(i));
         }
         out << " ... ";
         for (ssize_t i = len - 16;  i < len;  i++) {
           if (i != len - 16  &&  i % 4 == 0) {
             out << " ";
           }
-          out << std::hex << std::setw(2) << std::setfill('0') << int(getbyte(i));
+          out << std::hex << std::setw(2) << std::setfill('0')
+              << int(getbyte(i));
         }
       }
       out << "\" at=\"0x";
-      out << std::hex << std::setw(12) << std::setfill('0') << reinterpret_cast<ssize_t>(ptr_.get());
+      out << std::hex << std::setw(12) << std::setfill('0')
+          << reinterpret_cast<ssize_t>(ptr_.get());
       if (identities_.get() == nullptr  &&  parameters_.empty()) {
         out << "\"/>" << post;
       }
       else {
         out << "\">\n";
-        out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+        out << identities_.get()->tostring_part(indent
+                 + std::string("    "), "", "\n");
         if (!parameters_.empty()) {
           out << parameters_tostring(indent + std::string("    "), "", "\n");
         }
@@ -222,50 +285,65 @@ namespace awkward {
       return out.str();
     }
 
-    void tojson_part(ToJson& builder) const override {
+    void
+      tojson_part(ToJson& builder) const override {
       if (std::is_same<T, double>::value) {
-        tojson_real(builder, reinterpret_cast<double*>(byteptr()), length());
+        tojson_real(builder,
+                    reinterpret_cast<double*>(byteptr()), length());
       }
       else if (std::is_same<T, float>::value) {
-        tojson_real(builder, reinterpret_cast<float*>(byteptr()), length());
+        tojson_real(builder,
+                    reinterpret_cast<float*>(byteptr()), length());
       }
       else if (std::is_same<T, int64_t>::value) {
-        tojson_integer(builder, reinterpret_cast<int64_t*>(byteptr()), length());
+        tojson_integer(builder,
+                       reinterpret_cast<int64_t*>(byteptr()), length());
       }
       else if (std::is_same<T, uint64_t>::value) {
-        tojson_integer(builder, reinterpret_cast<uint64_t*>(byteptr()), length());
+        tojson_integer(builder,
+                       reinterpret_cast<uint64_t*>(byteptr()), length());
       }
       else if (std::is_same<T, int32_t>::value) {
-        tojson_integer(builder, reinterpret_cast<int32_t*>(byteptr()), length());
+        tojson_integer(builder,
+                       reinterpret_cast<int32_t*>(byteptr()), length());
       }
       else if (std::is_same<T, uint32_t>::value) {
-        tojson_integer(builder, reinterpret_cast<uint32_t*>(byteptr()), length());
+        tojson_integer(builder,
+                       reinterpret_cast<uint32_t*>(byteptr()), length());
       }
       else if (std::is_same<T, int16_t>::value) {
-        tojson_integer(builder, reinterpret_cast<int16_t*>(byteptr()), length());
+        tojson_integer(builder,
+                       reinterpret_cast<int16_t*>(byteptr()), length());
       }
       else if (std::is_same<T, uint16_t>::value) {
-        tojson_integer(builder, reinterpret_cast<uint16_t*>(byteptr()), length());
+        tojson_integer(builder,
+                       reinterpret_cast<uint16_t*>(byteptr()), length());
       }
       else if (std::is_same<T, int8_t>::value) {
-        tojson_integer(builder, reinterpret_cast<int8_t*>(byteptr()), length());
+        tojson_integer(builder,
+                       reinterpret_cast<int8_t*>(byteptr()), length());
       }
       else if (std::is_same<T, uint8_t>::value) {
-        tojson_integer(builder, reinterpret_cast<uint8_t*>(byteptr()), length());
+        tojson_integer(builder,
+                       reinterpret_cast<uint8_t*>(byteptr()), length());
       }
       else if (std::is_same<T, bool>::value) {
-        tojson_boolean(builder, reinterpret_cast<bool*>(byteptr()), length());
+        tojson_boolean(builder,
+                       reinterpret_cast<bool*>(byteptr()), length());
       }
       else {
-        throw std::invalid_argument(std::string("cannot convert RawArrayOf<") + typeid(T).name() + std::string("> into JSON"));
+        throw std::invalid_argument(std::string("cannot convert RawArrayOf<")
+          + typeid(T).name() + std::string("> into JSON"));
       }
     }
 
-    int64_t length() const override {
+    int64_t
+      length() const override {
       return length_;
     }
 
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override {
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override {
       size_t x = (size_t)ptr_.get();
       auto it = largest.find(x);
       if (it == largest.end()  ||  it->second < (int64_t)(sizeof(T)*length_)) {
@@ -276,84 +354,122 @@ namespace awkward {
       }
     }
 
-    const ContentPtr shallow_copy() const override {
-      return std::make_shared<RawArrayOf<T>>(identities_, parameters_, ptr_, offset_, length_, itemsize_);
+    const ContentPtr
+      shallow_copy() const override {
+      return std::make_shared<RawArrayOf<T>>(identities_, parameters_, ptr_,
+                                             offset_, length_, itemsize_);
     }
 
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override {
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override {
       std::shared_ptr<T> ptr = ptr_;
       int64_t offset = offset_;
       if (copyarrays) {
-        ptr = std::shared_ptr<T>(new T[(size_t)length_], util::array_deleter<T>());
-        memcpy(ptr.get(), &ptr_.get()[(size_t)offset_], sizeof(T)*((size_t)length_));
+        ptr = std::shared_ptr<T>(new T[(size_t)length_],
+                                 util::array_deleter<T>());
+        memcpy(ptr.get(), &ptr_.get()[(size_t)offset_],
+               sizeof(T)*((size_t)length_));
         offset = 0;
       }
       IdentitiesPtr identities = identities_;
       if (copyidentities  &&  identities_.get() != nullptr) {
         identities = identities_.get()->deep_copy();
       }
-      return std::make_shared<RawArrayOf<T>>(identities, parameters_, ptr, offset, length_, itemsize_);
+      return std::make_shared<RawArrayOf<T>>(identities,
+                                             parameters_,
+                                             ptr,
+                                             offset,
+                                             length_,
+                                             itemsize_);
     }
 
-    void check_for_iteration() const override {
-      if (identities_.get() != nullptr  &&  identities_.get()->length() < length_) {
-        util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+    void
+      check_for_iteration() const override {
+      if (identities_.get() != nullptr  &&
+          identities_.get()->length() < length_) {
+        util::handle_error(failure("len(identities) < len(array)", kSliceNone,
+          kSliceNone), identities_.get()->classname(), nullptr);
       }
     }
 
-    const ContentPtr getitem_nothing() const override {
+    const ContentPtr
+      getitem_nothing() const override {
       return getitem_range_nowrap(0, 0);
     }
 
-    const ContentPtr getitem_at(int64_t at) const override {
+    const ContentPtr
+      getitem_at(int64_t at) const override {
       int64_t regular_at = at;
       if (regular_at < 0) {
         regular_at += length_;
       }
       if (!(0 <= regular_at  &&  regular_at < length_)) {
-        util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+        util::handle_error(failure("index out of range", kSliceNone, at),
+                           classname(),
+                           identities_.get());
       }
       return getitem_at_nowrap(regular_at);
     }
 
-    const ContentPtr getitem_at_nowrap(int64_t at) const override {
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override {
       return getitem_range_nowrap(at, at + 1);
     }
 
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override {
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override {
       int64_t regular_start = start;
       int64_t regular_stop = stop;
-      awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
-      if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-        util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+      awkward_regularize_rangeslice(&regular_start, &regular_stop, true,
+        start != Slice::none(), stop != Slice::none(), length_);
+      if (identities_.get() != nullptr  &&
+          regular_stop > identities_.get()->length()) {
+        util::handle_error(failure("index out of range", kSliceNone, stop),
+          identities_.get()->classname(), nullptr);
       }
       return getitem_range_nowrap(regular_start, regular_stop);
     }
 
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override {
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override {
       IdentitiesPtr identities(nullptr);
       if (identities_.get() != nullptr) {
         identities = identities_.get()->getitem_range_nowrap(start, stop);
       }
-      return std::make_shared<RawArrayOf<T>>(identities, parameters_, ptr_, offset_ + start, stop - start, itemsize_);
+      return std::make_shared<RawArrayOf<T>>(identities,
+                                             parameters_,
+                                             ptr_,
+                                             offset_ + start,
+                                             stop - start,
+                                             itemsize_);
     }
 
-    const ContentPtr getitem_field(const std::string& key) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
+    const ContentPtr
+      getitem_field(const std::string& key) const override {
+      throw std::invalid_argument(std::string("cannot slice ") + classname()
+        + std::string(" by field name"));
     }
 
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override {
+      throw std::invalid_argument(std::string("cannot slice ") + classname()
+        + std::string(" by field name"));
     }
 
-    const ContentPtr getitem(const Slice& where) const override {
+    const ContentPtr
+      getitem(const Slice& where) const override {
       SliceItemPtr nexthead = where.head();
       Slice nexttail = where.tail();
       Index64 nextadvanced(0);
       return getitem_next(nexthead, nexttail, nextadvanced);
     }
 
-    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const override {
       if (tail.length() != 0) {
         throw std::invalid_argument("too many indexes for array");
       }
@@ -361,7 +477,8 @@ namespace awkward {
     }
 
     const ContentPtr carry(const Index64& carry) const override {
-      std::shared_ptr<T> ptr(new T[(size_t)carry.length()], util::array_deleter<T>());
+      std::shared_ptr<T> ptr(new T[(size_t)carry.length()],
+                             util::array_deleter<T>());
       struct Error err = awkward_numpyarray_getitem_next_null_64(
         reinterpret_cast<uint8_t*>(ptr.get()),
         reinterpret_cast<uint8_t*>(ptr_.get()),
@@ -376,72 +493,99 @@ namespace awkward {
         identities = identities_.get()->getitem_carry_64(carry);
       }
 
-      return std::make_shared<RawArrayOf<T>>(identities, parameters_, ptr, 0, carry.length(), itemsize_);
+      return std::make_shared<RawArrayOf<T>>(identities,
+                                             parameters_,
+                                             ptr,
+                                             0,
+                                             carry.length(),
+                                             itemsize_);
     }
 
-    const std::string purelist_parameter(const std::string& key) const override {
+    const std::string
+      purelist_parameter(const std::string& key) const override {
       return parameter(key);
     }
 
-    bool purelist_isregular() const override {
+    bool
+      purelist_isregular() const override {
       return true;
     }
 
-    int64_t purelist_depth() const override {
+    int64_t
+      purelist_depth() const override {
       return 1;
     }
 
-    const std::pair<int64_t, int64_t> minmax_depth() const override {
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override {
       return std::pair<int64_t, int64_t>(1, 1);
     }
 
-    const std::pair<bool, int64_t> branch_depth() const override {
+    const std::pair<bool, int64_t>
+      branch_depth() const override {
       return std::pair<bool, int64_t>(false, 1);
     }
 
-    int64_t numfields() const override {
+    int64_t
+      numfields() const override {
       return -1;
     }
 
-    int64_t fieldindex(const std::string& key) const override {
-      throw std::invalid_argument(std::string("key ") + util::quote(key, true) + std::string(" does not exist (data are not records)"));
+    int64_t
+      fieldindex(const std::string& key) const override {
+      throw std::invalid_argument(std::string("key ") + util::quote(key, true)
+        + std::string(" does not exist (data are not records)"));
     }
 
-    const std::string key(int64_t fieldindex) const override {
-      throw std::invalid_argument(std::string("fieldindex \"") + std::to_string(fieldindex) + std::string("\" does not exist (data are not records)"));
+    const std::string
+      key(int64_t fieldindex) const override {
+      throw std::invalid_argument(std::string("fieldindex \"")
+        + std::to_string(fieldindex)
+        + std::string("\" does not exist (data are not records)"));
     }
 
-    bool haskey(const std::string& key) const override {
+    bool
+      haskey(const std::string& key) const override {
       return false;
     }
 
-    const std::vector<std::string> keys() const override {
+    const std::vector<std::string>
+      keys() const override {
       return std::vector<std::string>();
     }
 
     // operations
 
-    const std::string validityerror(const std::string& path) const override {
+    const std::string
+      validityerror(const std::string& path) const override {
       return std::string();
     }
 
-    const ContentPtr shallow_simplify() const override {
+    const ContentPtr
+      shallow_simplify() const override {
       return shallow_copy();
     }
 
-    const ContentPtr num(int64_t axis, int64_t depth) const override {
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis == depth) {
         Index64 out(1);
         out.setitem_at_nowrap(0, length());
-        return std::make_shared<RawArrayOf<int64_t>>(Identities::none(), util::Parameters(), out.ptr(), 0, 1, sizeof(int64_t));
+        return std::make_shared<RawArrayOf<int64_t>>(Identities::none(),
+                                                     util::Parameters(),
+                                                     out.ptr(),
+                                                     0,
+                                                     1,
+                                                     sizeof(int64_t));
       }
       else {
         throw std::invalid_argument("'axis' out of range for 'num'");
       }
     }
 
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override {
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis == depth) {
         throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -451,36 +595,46 @@ namespace awkward {
       }
     }
 
-    bool mergeable(const ContentPtr& other, bool mergebool) const override {
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override {
       if (dynamic_cast<EmptyArray*>(other.get())) {
         return true;
       }
-      else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+      else if (IndexedArray32* rawother =
+               dynamic_cast<IndexedArray32*>(other.get())) {
         return mergeable(rawother->content(), mergebool);
       }
-      else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+      else if (IndexedArrayU32* rawother =
+               dynamic_cast<IndexedArrayU32*>(other.get())) {
         return mergeable(rawother->content(), mergebool);
       }
-      else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+      else if (IndexedArray64* rawother =
+               dynamic_cast<IndexedArray64*>(other.get())) {
         return mergeable(rawother->content(), mergebool);
       }
-      else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+      else if (IndexedOptionArray32* rawother =
+               dynamic_cast<IndexedOptionArray32*>(other.get())) {
         return mergeable(rawother->content(), mergebool);
       }
-      else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+      else if (IndexedOptionArray64* rawother =
+               dynamic_cast<IndexedOptionArray64*>(other.get())) {
         return mergeable(rawother->content(), mergebool);
       }
-      else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+      else if (ByteMaskedArray* rawother =
+               dynamic_cast<ByteMaskedArray*>(other.get())) {
         return mergeable(rawother->content(), mergebool);
       }
-      else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+      else if (BitMaskedArray* rawother =
+               dynamic_cast<BitMaskedArray*>(other.get())) {
         return mergeable(rawother->content(), mergebool);
       }
-      else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+      else if (UnmaskedArray* rawother =
+               dynamic_cast<UnmaskedArray*>(other.get())) {
         return mergeable(rawother->content(), mergebool);
       }
 
-      if (RawArrayOf<T>* rawother = dynamic_cast<RawArrayOf<T>*>(other.get())) {
+      if (RawArrayOf<T>* rawother =
+          dynamic_cast<RawArrayOf<T>*>(other.get())) {
         return true;
       }
       else {
@@ -488,55 +642,80 @@ namespace awkward {
       }
     }
 
-    const ContentPtr merge(const ContentPtr& other) const override {
+    const ContentPtr
+      merge(const ContentPtr& other) const override {
       if (dynamic_cast<EmptyArray*>(other.get())) {
         return shallow_copy();
       }
-      else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+      else if (IndexedArray32* rawother =
+               dynamic_cast<IndexedArray32*>(other.get())) {
         return rawother->reverse_merge(shallow_copy());
       }
-      else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+      else if (IndexedArrayU32* rawother =
+               dynamic_cast<IndexedArrayU32*>(other.get())) {
         return rawother->reverse_merge(shallow_copy());
       }
-      else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+      else if (IndexedArray64* rawother =
+               dynamic_cast<IndexedArray64*>(other.get())) {
         return rawother->reverse_merge(shallow_copy());
       }
-      else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+      else if (IndexedOptionArray32* rawother =
+               dynamic_cast<IndexedOptionArray32*>(other.get())) {
         return rawother->reverse_merge(shallow_copy());
       }
-      else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+      else if (IndexedOptionArray64* rawother =
+               dynamic_cast<IndexedOptionArray64*>(other.get())) {
         return rawother->reverse_merge(shallow_copy());
       }
-      else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+      else if (ByteMaskedArray* rawother =
+               dynamic_cast<ByteMaskedArray*>(other.get())) {
         return rawother->reverse_merge(shallow_copy());
       }
-      else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+      else if (BitMaskedArray* rawother =
+               dynamic_cast<BitMaskedArray*>(other.get())) {
         return rawother->reverse_merge(shallow_copy());
       }
-      else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+      else if (UnmaskedArray* rawother =
+               dynamic_cast<UnmaskedArray*>(other.get())) {
         return rawother->reverse_merge(shallow_copy());
       }
 
-      if (RawArrayOf<T>* rawother = dynamic_cast<RawArrayOf<T>*>(other.get())) {
-        std::shared_ptr<T> ptr = std::shared_ptr<T>(new T[(size_t)(length_ + rawother->length())], util::array_deleter<T>());
-        memcpy(ptr.get(), &ptr_.get()[(size_t)offset_], sizeof(T)*((size_t)length_));
-        memcpy(&ptr.get()[(size_t)length_], &rawother->ptr().get()[(size_t)rawother->offset()], sizeof(T)*((size_t)rawother->length()));
-        return std::make_shared<RawArrayOf<T>>(Identities::none(), util::Parameters(), ptr, 0, length_ + rawother->length(), itemsize_);
+      if (RawArrayOf<T>* rawother =
+          dynamic_cast<RawArrayOf<T>*>(other.get())) {
+        std::shared_ptr<T> ptr =
+          std::shared_ptr<T>(new T[(size_t)(length_ + rawother->length())],
+                             util::array_deleter<T>());
+        memcpy(ptr.get(),
+               &ptr_.get()[(size_t)offset_],
+               sizeof(T)*((size_t)length_));
+        memcpy(&ptr.get()[(size_t)length_],
+               &rawother->ptr().get()[(size_t)rawother->offset()],
+               sizeof(T)*((size_t)rawother->length()));
+        return std::make_shared<RawArrayOf<T>>(Identities::none(),
+                                               util::Parameters(),
+                                               ptr,
+                                               0,
+                                               length_ + rawother->length(),
+                                               itemsize_);
       }
       else {
-        throw std::invalid_argument(std::string("cannot merge ") + classname() + std::string(" with ") + other.get()->classname());
+        throw std::invalid_argument(std::string("cannot merge ") + classname()
+          + std::string(" with ") + other.get()->classname());
       }
     }
 
-    const SliceItemPtr asslice() const override {
+    const SliceItemPtr
+      asslice() const override {
       throw std::invalid_argument("cannot use RawArray as a slice");
     }
 
-    const ContentPtr fillna(const ContentPtr& value) const override {
+    const ContentPtr
+      fillna(const ContentPtr& value) const override {
       return shallow_copy();
     }
 
-    const ContentPtr rpad(int64_t target, int64_t axis, int64_t depth) const override {
+    const ContentPtr
+      rpad(int64_t target, int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis != depth) {
         throw std::invalid_argument("axis exceeds the depth of this array");
@@ -549,7 +728,10 @@ namespace awkward {
       }
     }
 
-    const ContentPtr rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const override {
+    const ContentPtr
+      rpad_and_clip(int64_t target,
+                    int64_t axis,
+                    int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis != depth) {
         throw std::invalid_argument("axis exceeds the depth of this array");
@@ -561,14 +743,25 @@ namespace awkward {
         length());
       util::handle_error(err, classname(), identities_.get());
 
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, shallow_copy());
+      return std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                                    util::Parameters(),
+                                                    index,
+                                                    shallow_copy());
     }
 
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override {
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override {
       throw std::runtime_error("FIXME: RawArray:reduce_next");
     }
 
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override {
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (axis == depth) {
         return localindex_axis0();
@@ -578,7 +771,13 @@ namespace awkward {
       }
     }
 
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override {
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override {
       if (n < 1) {
         throw std::invalid_argument("in choose, 'n' must be at least 1");
       }
@@ -591,11 +790,17 @@ namespace awkward {
       }
     }
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override {
       return getitem_at(at.at());
     }
 
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override {
       if (range.step() == Slice::none()  ||  range.step() == 1) {
         return getitem_range(range.start(), range.stop());
       }
@@ -609,7 +814,8 @@ namespace awkward {
         else if (step == 0) {
           throw std::invalid_argument("slice step must not be 0");
         }
-        awkward_regularize_rangeslice(&start, &stop, step > 0, range.hasstart(), range.hasstop(), length_);
+        awkward_regularize_rangeslice(&start, &stop, step > 0,
+          range.hasstart(), range.hasstop(), length_);
 
         int64_t numer = std::abs(start - stop);
         int64_t denom = std::abs(step);
@@ -627,9 +833,13 @@ namespace awkward {
       }
     }
 
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override {
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override {
       if (advanced.length() != 0) {
-        throw std::runtime_error("RawArray::getitem_next(SliceAt): advanced.length() != 0");
+        throw std::runtime_error(
+          "RawArray::getitem_next(SliceAt): advanced.length() != 0");
       }
       if (array.shape().size() != 1) {
         throw std::runtime_error("array.ndim != 1");
@@ -643,28 +853,55 @@ namespace awkward {
       return carry(flathead);
     }
 
-    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a field name because it has no fields"));
+    const ContentPtr
+      getitem_next(const SliceField& field,
+                   const Slice& tail,
+                   const Index64& advanced) const override {
+      throw std::invalid_argument(std::string("cannot slice ") + classname()
+        + std::string(" by a field name because it has no fields"));
     }
 
-    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field names because it has no fields"));
+    const ContentPtr
+      getitem_next(const SliceFields& fields,
+                   const Slice& tail,
+                   const Index64& advanced) const override {
+      throw std::invalid_argument(std::string("cannot slice ") + classname()
+        + std::string(" by field names because it has no fields"));
     }
 
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a jagged array because it is one-dimensional"));
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override {
+      throw std::invalid_argument(std::string("cannot slice ") + classname()
+        + std::string(" by a jagged array because it is one-dimensional"));
     }
 
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override {
-      throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(array)");
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override {
+      throw std::runtime_error(
+        "undefined operation: RawArray::getitem_next_jagged(array)");
     }
 
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override {
-      throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(missing)");
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override {
+      throw std::runtime_error(
+        "undefined operation: RawArray::getitem_next_jagged(missing)");
     }
 
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override {
-      throw std::runtime_error("undefined operation: RawArray::getitem_next_jagged(jagged)");
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override {
+      throw std::runtime_error(
+        "undefined operation: RawArray::getitem_next_jagged(jagged)");
     }
 
   private:

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -176,7 +176,7 @@ namespace awkward {
     }
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override {
+      type(const util::TypeStrs& typestrs) const override {
       if (std::is_same<T, double>::value) {
         return std::make_shared<PrimitiveType>(parameters_,
           util::gettypestr(parameters_, typestrs), PrimitiveType::float64);

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -41,7 +41,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -11,7 +11,7 @@ namespace awkward {
     Record(const std::shared_ptr<const RecordArray> array, int64_t at);
     const std::shared_ptr<const RecordArray> array() const;
     int64_t at() const;
-    const std::vector<ContentPtr> contents() const;
+    const ContentPtrVec contents() const;
     const std::shared_ptr<util::RecordLookup> recordlookup() const;
     bool istuple() const;
 
@@ -64,7 +64,7 @@ namespace awkward {
 
     const ContentPtr field(int64_t fieldindex) const;
     const ContentPtr field(const std::string& key) const;
-    const std::vector<ContentPtr> fields() const;
+    const ContentPtrVec fields() const;
     const std::vector<std::pair<std::string, ContentPtr>> fielditems() const;
     const std::shared_ptr<Record> astuple() const;
 

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -25,17 +25,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -49,34 +49,34 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> field(int64_t fieldindex) const;
-    const std::shared_ptr<Content> field(const std::string& key) const;
+    ContentPtr field(int64_t fieldindex) const;
+    ContentPtr field(const std::string& key) const;
     const std::vector<std::shared_ptr<Content>> fields() const;
     const std::vector<std::pair<std::string, std::shared_ptr<Content>>> fielditems() const;
     const std::shared_ptr<Record> astuple() const;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
     const std::shared_ptr<const RecordArray> array_;

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -12,15 +12,15 @@ namespace awkward {
     const std::shared_ptr<const RecordArray> array() const;
     int64_t at() const;
     const ContentPtrVec contents() const;
-    const std::shared_ptr<util::RecordLookup> recordlookup() const;
+    const util::RecordLookupPtr recordlookup() const;
     bool istuple() const;
 
     bool isscalar() const override;
     const std::string classname() const override;
-    const std::shared_ptr<Identities> identities() const override;
+    const IdentitiesPtr identities() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -54,13 +54,13 @@ namespace awkward {
     const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr field(int64_t fieldindex) const;
     const ContentPtr field(const std::string& key) const;

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -11,7 +11,7 @@ namespace awkward {
     Record(const std::shared_ptr<const RecordArray> array, int64_t at);
     const std::shared_ptr<const RecordArray> array() const;
     int64_t at() const;
-    const std::vector<std::shared_ptr<Content>> contents() const;
+    const std::vector<ContentPtr> contents() const;
     const std::shared_ptr<util::RecordLookup> recordlookup() const;
     bool istuple() const;
 
@@ -25,17 +25,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -49,34 +49,34 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr field(int64_t fieldindex) const;
-    ContentPtr field(const std::string& key) const;
-    const std::vector<std::shared_ptr<Content>> fields() const;
-    const std::vector<std::pair<std::string, std::shared_ptr<Content>>> fielditems() const;
+    const ContentPtr field(int64_t fieldindex) const;
+    const ContentPtr field(const std::string& key) const;
+    const std::vector<ContentPtr> fields() const;
+    const std::vector<std::pair<std::string, ContentPtr>> fielditems() const;
     const std::shared_ptr<Record> astuple() const;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
     const std::shared_ptr<const RecordArray> array_;

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -9,74 +9,234 @@ namespace awkward {
   class EXPORT_SYMBOL Record: public Content {
   public:
     Record(const std::shared_ptr<const RecordArray> array, int64_t at);
-    const std::shared_ptr<const RecordArray> array() const;
-    int64_t at() const;
-    const ContentPtrVec contents() const;
-    const util::RecordLookupPtr recordlookup() const;
-    bool istuple() const;
 
-    bool isscalar() const override;
-    const std::string classname() const override;
-    const IdentitiesPtr identities() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const std::shared_ptr<const RecordArray>
+      array() const;
+
+    int64_t
+      at() const;
+
+    const ContentPtrVec
+      contents() const;
+
+    const util::RecordLookupPtr
+      recordlookup() const;
+
+    bool
+      istuple() const;
+
+    bool
+      isscalar() const override;
+
+    const std::string
+      classname() const override;
+
+    const IdentitiesPtr
+      identities() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr field(int64_t fieldindex) const;
-    const ContentPtr field(const std::string& key) const;
-    const ContentPtrVec fields() const;
-    const std::vector<std::pair<std::string, ContentPtr>> fielditems() const;
-    const std::shared_ptr<Record> astuple() const;
+    const ContentPtr
+      shallow_simplify() const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      field(int64_t fieldindex) const;
+
+    const ContentPtr
+      field(const std::string& key) const;
+
+    const ContentPtrVec
+      fields() const;
+
+    const std::vector<std::pair<std::string, ContentPtr>>
+      fielditems() const;
+
+    const std::shared_ptr<Record>
+      astuple() const;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceField& field,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceFields& fields,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   private:
     const std::shared_ptr<const RecordArray> array_;

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -12,82 +12,255 @@
 #include "awkward/Content.h"
 
 namespace awkward {
-  class EXPORT_SYMBOL RecordArray: public Content, public std::enable_shared_from_this<RecordArray> {
+  class EXPORT_SYMBOL RecordArray:
+    public Content,
+    public std::enable_shared_from_this<RecordArray> {
   public:
-    RecordArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const util::RecordLookupPtr& recordlookup, int64_t length);
-    RecordArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const util::RecordLookupPtr& recordlookup);
+    RecordArray(const IdentitiesPtr& identities,
+                const util::Parameters& parameters,
+                const ContentPtrVec& contents,
+                const util::RecordLookupPtr& recordlookup,
+                int64_t length);
 
-    const ContentPtrVec contents() const;
-    const util::RecordLookupPtr recordlookup() const;
-    bool istuple() const;
-    const ContentPtr setitem_field(int64_t where, const ContentPtr& what) const;
-    const ContentPtr setitem_field(const std::string& where, const ContentPtr& what) const;
+    RecordArray(const IdentitiesPtr& identities,
+                const util::Parameters& parameters,
+                const ContentPtrVec& contents,
+                const util::RecordLookupPtr& recordlookup);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const ContentPtrVec
+      contents() const;
+
+    const util::RecordLookupPtr
+      recordlookup() const;
+
+    bool
+      istuple() const;
+
+    const ContentPtr
+      setitem_field(int64_t where, const ContentPtr& what) const;
+
+    const ContentPtr
+      setitem_field(const std::string& where, const ContentPtr& what) const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr field(int64_t fieldindex) const;
-    const ContentPtr field(const std::string& key) const;
-    const ContentPtrVec fields() const;
-    const std::vector<std::pair<std::string, ContentPtr>> fielditems() const;
-    const std::shared_ptr<RecordArray> astuple() const;
+    const ContentPtr
+      shallow_simplify() const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      field(int64_t fieldindex) const;
+
+    const ContentPtr
+      field(const std::string& key) const;
+
+    const ContentPtrVec
+      fields() const;
+
+    const std::vector<std::pair<std::string, ContentPtr>>
+      fielditems() const;
+
+    const std::shared_ptr<RecordArray>
+      astuple() const;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceField& field,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceFields& fields,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr
+      getitem_next_jagged_generic(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const S& slicecontent,
+                                  const Slice& tail) const;
 
   private:
     const ContentPtrVec contents_;

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -14,20 +14,20 @@
 namespace awkward {
   class EXPORT_SYMBOL RecordArray: public Content, public std::enable_shared_from_this<RecordArray> {
   public:
-    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const std::shared_ptr<util::RecordLookup>& recordlookup, int64_t length);
-    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const std::shared_ptr<util::RecordLookup>& recordlookup);
+    RecordArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const util::RecordLookupPtr& recordlookup, int64_t length);
+    RecordArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const util::RecordLookupPtr& recordlookup);
 
     const ContentPtrVec contents() const;
-    const std::shared_ptr<util::RecordLookup> recordlookup() const;
+    const util::RecordLookupPtr recordlookup() const;
     bool istuple() const;
     const ContentPtr setitem_field(int64_t where, const ContentPtr& what) const;
     const ContentPtr setitem_field(const std::string& where, const ContentPtr& what) const;
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
+    void setidentities(const IdentitiesPtr& identities) override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
@@ -41,7 +41,7 @@ namespace awkward {
     const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
     const ContentPtr getitem_field(const std::string& key) const override;
     const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
@@ -61,13 +61,13 @@ namespace awkward {
     const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr field(int64_t fieldindex) const;
     const ContentPtr field(const std::string& key) const;
@@ -91,7 +91,7 @@ namespace awkward {
 
   private:
     const ContentPtrVec contents_;
-    const std::shared_ptr<util::RecordLookup> recordlookup_;
+    const util::RecordLookupPtr recordlookup_;
     int64_t length_;
   };
 }

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -14,10 +14,10 @@
 namespace awkward {
   class EXPORT_SYMBOL RecordArray: public Content, public std::enable_shared_from_this<RecordArray> {
   public:
-    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<ContentPtr>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup, int64_t length);
-    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<ContentPtr>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup);
+    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const std::shared_ptr<util::RecordLookup>& recordlookup, int64_t length);
+    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const std::shared_ptr<util::RecordLookup>& recordlookup);
 
-    const std::vector<ContentPtr> contents() const;
+    const ContentPtrVec contents() const;
     const std::shared_ptr<util::RecordLookup> recordlookup() const;
     bool istuple() const;
     const ContentPtr setitem_field(int64_t where, const ContentPtr& what) const;
@@ -71,7 +71,7 @@ namespace awkward {
 
     const ContentPtr field(int64_t fieldindex) const;
     const ContentPtr field(const std::string& key) const;
-    const std::vector<ContentPtr> fields() const;
+    const ContentPtrVec fields() const;
     const std::vector<std::pair<std::string, ContentPtr>> fielditems() const;
     const std::shared_ptr<RecordArray> astuple() const;
 
@@ -90,7 +90,7 @@ namespace awkward {
     const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
   private:
-    const std::vector<ContentPtr> contents_;
+    const ContentPtrVec contents_;
     const std::shared_ptr<util::RecordLookup> recordlookup_;
     int64_t length_;
   };

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -57,7 +57,7 @@ namespace awkward {
                     const std::string& post) const override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     void
       tojson_part(ToJson& builder) const override;

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -14,14 +14,14 @@
 namespace awkward {
   class EXPORT_SYMBOL RecordArray: public Content, public std::enable_shared_from_this<RecordArray> {
   public:
-    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<std::shared_ptr<Content>>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup, int64_t length);
-    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<std::shared_ptr<Content>>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup);
+    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<ContentPtr>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup, int64_t length);
+    RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<ContentPtr>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup);
 
-    const std::vector<std::shared_ptr<Content>> contents() const;
+    const std::vector<ContentPtr> contents() const;
     const std::shared_ptr<util::RecordLookup> recordlookup() const;
     bool istuple() const;
-    ContentPtr setitem_field(int64_t where, ContentPtr& what) const;
-    ContentPtr setitem_field(const std::string& where, ContentPtr& what) const;
+    const ContentPtr setitem_field(int64_t where, const ContentPtr& what) const;
+    const ContentPtr setitem_field(const std::string& where, const ContentPtr& what) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -31,18 +31,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -56,41 +56,41 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr field(int64_t fieldindex) const;
-    ContentPtr field(const std::string& key) const;
-    const std::vector<std::shared_ptr<Content>> fields() const;
-    const std::vector<std::pair<std::string, std::shared_ptr<Content>>> fielditems() const;
+    const ContentPtr field(int64_t fieldindex) const;
+    const ContentPtr field(const std::string& key) const;
+    const std::vector<ContentPtr> fields() const;
+    const std::vector<std::pair<std::string, ContentPtr>> fielditems() const;
     const std::shared_ptr<RecordArray> astuple() const;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
   private:
-    const std::vector<std::shared_ptr<Content>> contents_;
+    const std::vector<ContentPtr> contents_;
     const std::shared_ptr<util::RecordLookup> recordlookup_;
     int64_t length_;
   };

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -20,8 +20,8 @@ namespace awkward {
     const std::vector<std::shared_ptr<Content>> contents() const;
     const std::shared_ptr<util::RecordLookup> recordlookup() const;
     bool istuple() const;
-    const std::shared_ptr<Content> setitem_field(int64_t where, const std::shared_ptr<Content>& what) const;
-    const std::shared_ptr<Content> setitem_field(const std::string& where, const std::shared_ptr<Content>& what) const;
+    ContentPtr setitem_field(int64_t where, ContentPtr& what) const;
+    ContentPtr setitem_field(const std::string& where, ContentPtr& what) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -31,18 +31,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -56,38 +56,38 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> field(int64_t fieldindex) const;
-    const std::shared_ptr<Content> field(const std::string& key) const;
+    ContentPtr field(int64_t fieldindex) const;
+    ContentPtr field(const std::string& key) const;
     const std::vector<std::shared_ptr<Content>> fields() const;
     const std::vector<std::pair<std::string, std::shared_ptr<Content>>> fielditems() const;
     const std::shared_ptr<RecordArray> astuple() const;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const std::shared_ptr<Content> getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
   private:
     const std::vector<std::shared_ptr<Content>> contents_;

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -14,13 +14,13 @@
 namespace awkward {
   class EXPORT_SYMBOL RegularArray: public Content {
   public:
-    RegularArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, ContentPtr& content, int64_t size);
-    ContentPtr content() const;
+    RegularArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtr& content, int64_t size);
+    const ContentPtr content() const;
     int64_t size() const;
     Index64 compact_offsets64(bool start_at_zero) const;
-    ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
-    ContentPtr toRegularArray() const;
-    ContentPtr toListOffsetArray64(bool start_at_zero) const;
+    const ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
+    const ContentPtr toRegularArray() const;
+    const ContentPtr toListOffsetArray64(bool start_at_zero) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -30,17 +30,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -54,29 +54,29 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
-    ContentPtr content_;
+    const ContentPtr content_;
     int64_t size_;
   };
 }

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -14,66 +14,210 @@
 namespace awkward {
   class EXPORT_SYMBOL RegularArray: public Content {
   public:
-    RegularArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtr& content, int64_t size);
-    const ContentPtr content() const;
-    int64_t size() const;
-    Index64 compact_offsets64(bool start_at_zero) const;
-    const ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
-    const ContentPtr toRegularArray() const;
-    const ContentPtr toListOffsetArray64(bool start_at_zero) const;
+    RegularArray(const IdentitiesPtr& identities,
+                 const util::Parameters& parameters,
+                 const ContentPtr& content,
+                 int64_t size);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const ContentPtr
+      content() const;
+
+    int64_t
+      size() const;
+
+    Index64
+      compact_offsets64(bool start_at_zero) const;
+
+    const ContentPtr
+      broadcast_tooffsets64(const Index64& offsets) const;
+
+    const ContentPtr
+      toRegularArray() const;
+
+    const ContentPtr
+      toListOffsetArray64(bool start_at_zero) const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   private:
     const ContentPtr content_;

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -14,7 +14,7 @@
 namespace awkward {
   class EXPORT_SYMBOL RegularArray: public Content {
   public:
-    RegularArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtr& content, int64_t size);
+    RegularArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtr& content, int64_t size);
     const ContentPtr content() const;
     int64_t size() const;
     Index64 compact_offsets64(bool start_at_zero) const;
@@ -24,8 +24,8 @@ namespace awkward {
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -59,13 +59,13 @@ namespace awkward {
     const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -14,13 +14,13 @@
 namespace awkward {
   class EXPORT_SYMBOL RegularArray: public Content {
   public:
-    RegularArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::shared_ptr<Content>& content, int64_t size);
-    const std::shared_ptr<Content> content() const;
+    RegularArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, ContentPtr& content, int64_t size);
+    ContentPtr content() const;
     int64_t size() const;
     Index64 compact_offsets64(bool start_at_zero) const;
-    const std::shared_ptr<Content> broadcast_tooffsets64(const Index64& offsets) const;
-    const std::shared_ptr<Content> toRegularArray() const;
-    const std::shared_ptr<Content> toListOffsetArray64(bool start_at_zero) const;
+    ContentPtr broadcast_tooffsets64(const Index64& offsets) const;
+    ContentPtr toRegularArray() const;
+    ContentPtr toListOffsetArray64(bool start_at_zero) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -30,17 +30,17 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -54,29 +54,29 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   private:
-    const std::shared_ptr<Content> content_;
+    ContentPtr content_;
     int64_t size_;
   };
 }

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -47,7 +47,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -92,9 +92,9 @@ namespace awkward {
     const ContentPtrVec contents_;
   };
 
-  typedef UnionArrayOf<int8_t, int32_t>  UnionArray8_32;
-  typedef UnionArrayOf<int8_t, uint32_t> UnionArray8_U32;
-  typedef UnionArrayOf<int8_t, int64_t>  UnionArray8_64;
+  using UnionArray8_32  = UnionArrayOf<int8_t, int32_t>;
+  using UnionArray8_U32 = UnionArrayOf<int8_t, uint32_t>;
+  using UnionArray8_64  = UnionArrayOf<int8_t, int64_t>;
 }
 
 #endif // AWKWARD_UNIONARRAY_H_

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -16,75 +16,233 @@ namespace awkward {
   template <typename T, typename I>
   class EXPORT_SYMBOL UnionArrayOf: public Content {
   public:
-    static const IndexOf<I> regular_index(const IndexOf<T>& tags);
+    static const IndexOf<I>
+      regular_index(const IndexOf<T>& tags);
 
-    UnionArrayOf<T, I>(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T> tags, const IndexOf<I>& index, const ContentPtrVec& contents);
-    const IndexOf<T> tags() const;
-    const IndexOf<I> index() const;
-    const ContentPtrVec contents() const;
-    int64_t numcontents() const;
-    const ContentPtr content(int64_t index) const;
-    const ContentPtr project(int64_t index) const;
-    const ContentPtr simplify_uniontype(bool mergebool) const;
+    UnionArrayOf<T, I>(const IdentitiesPtr& identities,
+                       const util::Parameters& parameters,
+                       const IndexOf<T> tags,
+                       const IndexOf<I>& index,
+                       const ContentPtrVec& contents);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const IndexOf<T>
+      tags() const;
+
+    const IndexOf<I>
+      index() const;
+
+    const ContentPtrVec
+      contents() const;
+
+    int64_t
+      numcontents() const;
+
+    const ContentPtr
+      content(int64_t index) const;
+
+    const ContentPtr
+      project(int64_t index) const;
+
+    const ContentPtr
+      simplify_uniontype(bool mergebool) const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr reverse_merge(const ContentPtr& other) const;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      reverse_merge(const ContentPtr& other) const;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr
+      getitem_next_jagged_generic(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const S& slicecontent,
+                                  const Slice& tail) const;
 
   private:
     const IndexOf<T> tags_;

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -23,9 +23,9 @@ namespace awkward {
     const IndexOf<I> index() const;
     const std::vector<std::shared_ptr<Content>> contents() const;
     int64_t numcontents() const;
-    const std::shared_ptr<Content> content(int64_t index) const;
-    const std::shared_ptr<Content> project(int64_t index) const;
-    const std::shared_ptr<Content> simplify_uniontype(bool mergebool) const;
+    ContentPtr content(int64_t index) const;
+    ContentPtr project(int64_t index) const;
+    ContentPtr simplify_uniontype(bool mergebool) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -35,18 +35,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -60,31 +60,31 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> reverse_merge(const std::shared_ptr<Content>& other) const;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr reverse_merge(ContentPtr& other) const;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const std::shared_ptr<Content> getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
   private:
     const IndexOf<T> tags_;

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -56,7 +56,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -18,7 +18,7 @@ namespace awkward {
   public:
     static const IndexOf<I> regular_index(const IndexOf<T>& tags);
 
-    UnionArrayOf<T, I>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T> tags, const IndexOf<I>& index, const ContentPtrVec& contents);
+    UnionArrayOf<T, I>(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T> tags, const IndexOf<I>& index, const ContentPtrVec& contents);
     const IndexOf<T> tags() const;
     const IndexOf<I> index() const;
     const ContentPtrVec contents() const;
@@ -29,8 +29,8 @@ namespace awkward {
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -45,7 +45,7 @@ namespace awkward {
     const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
     const ContentPtr getitem_field(const std::string& key) const override;
     const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
@@ -66,13 +66,13 @@ namespace awkward {
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr reverse_merge(const ContentPtr& other) const;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -18,10 +18,10 @@ namespace awkward {
   public:
     static const IndexOf<I> regular_index(const IndexOf<T>& tags);
 
-    UnionArrayOf<T, I>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T> tags, const IndexOf<I>& index, const std::vector<ContentPtr>& contents);
+    UnionArrayOf<T, I>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T> tags, const IndexOf<I>& index, const ContentPtrVec& contents);
     const IndexOf<T> tags() const;
     const IndexOf<I> index() const;
-    const std::vector<ContentPtr> contents() const;
+    const ContentPtrVec contents() const;
     int64_t numcontents() const;
     const ContentPtr content(int64_t index) const;
     const ContentPtr project(int64_t index) const;
@@ -89,7 +89,7 @@ namespace awkward {
   private:
     const IndexOf<T> tags_;
     const IndexOf<I> index_;
-    const std::vector<ContentPtr> contents_;
+    const ContentPtrVec contents_;
   };
 
   typedef UnionArrayOf<int8_t, int32_t>  UnionArray8_32;

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -18,14 +18,14 @@ namespace awkward {
   public:
     static const IndexOf<I> regular_index(const IndexOf<T>& tags);
 
-    UnionArrayOf<T, I>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T> tags, const IndexOf<I>& index, const std::vector<std::shared_ptr<Content>>& contents);
+    UnionArrayOf<T, I>(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T> tags, const IndexOf<I>& index, const std::vector<ContentPtr>& contents);
     const IndexOf<T> tags() const;
     const IndexOf<I> index() const;
-    const std::vector<std::shared_ptr<Content>> contents() const;
+    const std::vector<ContentPtr> contents() const;
     int64_t numcontents() const;
-    ContentPtr content(int64_t index) const;
-    ContentPtr project(int64_t index) const;
-    ContentPtr simplify_uniontype(bool mergebool) const;
+    const ContentPtr content(int64_t index) const;
+    const ContentPtr project(int64_t index) const;
+    const ContentPtr simplify_uniontype(bool mergebool) const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -35,18 +35,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -60,36 +60,36 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr reverse_merge(ContentPtr& other) const;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr reverse_merge(const ContentPtr& other) const;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
   private:
     const IndexOf<T> tags_;
     const IndexOf<I> index_;
-    const std::vector<std::shared_ptr<Content>> contents_;
+    const std::vector<ContentPtr> contents_;
   };
 
   typedef UnionArrayOf<int8_t, int32_t>  UnionArray8_32;

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -15,7 +15,7 @@
 namespace awkward {
   class EXPORT_SYMBOL UnmaskedArray: public Content {
   public:
-    UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtr& content);
+    UnmaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtr& content);
     const ContentPtr content() const;
     const ContentPtr project() const;
     const ContentPtr project(const Index8& mask) const;
@@ -25,8 +25,8 @@ namespace awkward {
 
     const std::string classname() const override;
     void setidentities() override;
-    void setidentities(const std::shared_ptr<Identities>& identities) override;
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const override;
+    void setidentities(const IdentitiesPtr& identities) override;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
     const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
@@ -41,7 +41,7 @@ namespace awkward {
     const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
     const ContentPtr getitem_field(const std::string& key) const override;
     const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
@@ -62,13 +62,13 @@ namespace awkward {
     bool mergeable(const ContentPtr& other, bool mergebool) const override;
     const ContentPtr reverse_merge(const ContentPtr& other) const;
     const ContentPtr merge(const ContentPtr& other) const override;
-    const std::shared_ptr<SliceItem> asslice() const override;
+    const SliceItemPtr asslice() const override;
     const ContentPtr fillna(const ContentPtr& value) const override;
     const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
     const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
     const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
     const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
     const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -15,77 +15,230 @@
 namespace awkward {
   class EXPORT_SYMBOL UnmaskedArray: public Content {
   public:
-    UnmaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtr& content);
-    const ContentPtr content() const;
-    const ContentPtr project() const;
-    const ContentPtr project(const Index8& mask) const;
-    const Index8 bytemask() const;
-    const ContentPtr simplify_optiontype() const;
-    const ContentPtr toIndexedOptionArray64() const;
+    UnmaskedArray(const IdentitiesPtr& identities,
+                  const util::Parameters& parameters,
+                  const ContentPtr& content);
 
-    const std::string classname() const override;
-    void setidentities() override;
-    void setidentities(const IdentitiesPtr& identities) override;
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const override;
-    const std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    void tojson_part(ToJson& builder) const override;
-    void nbytes_part(std::map<size_t, int64_t>& largest) const override;
-    int64_t length() const override;
-    const ContentPtr shallow_copy() const override;
-    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
-    void check_for_iteration() const override;
-    const ContentPtr getitem_nothing() const override;
-    const ContentPtr getitem_at(int64_t at) const override;
-    const ContentPtr getitem_at_nowrap(int64_t at) const override;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const ContentPtr getitem_field(const std::string& key) const override;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    const ContentPtr getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr carry(const Index64& carry) const override;
-    const std::string purelist_parameter(const std::string& key) const override;
-    bool purelist_isregular() const override;
-    int64_t purelist_depth() const override;
-    const std::pair<int64_t, int64_t> minmax_depth() const override;
-    const std::pair<bool, int64_t> branch_depth() const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
+    const ContentPtr
+      content() const;
+
+    const ContentPtr
+      project() const;
+
+    const ContentPtr
+      project(const Index8& mask) const;
+
+    const Index8
+      bytemask() const;
+
+    const ContentPtr
+      simplify_optiontype() const;
+
+    const ContentPtr
+      toIndexedOptionArray64() const;
+
+    const std::string
+      classname() const override;
+
+    void
+      setidentities() override;
+
+    void
+      setidentities(const IdentitiesPtr& identities) override;
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const override;
+
+    const std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    void
+      tojson_part(ToJson& builder) const override;
+
+    void
+      nbytes_part(std::map<size_t, int64_t>& largest) const override;
+
+    int64_t
+      length() const override;
+
+    const ContentPtr
+      shallow_copy() const override;
+
+    const ContentPtr
+      deep_copy(bool copyarrays,
+                bool copyindexes,
+                bool copyidentities) const override;
+
+    void
+      check_for_iteration() const override;
+
+    const ContentPtr
+      getitem_nothing() const override;
+
+    const ContentPtr
+      getitem_at(int64_t at) const override;
+
+    const ContentPtr
+      getitem_at_nowrap(int64_t at) const override;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_range_nowrap(int64_t start, int64_t stop) const override;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const override;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const override;
+
+    const ContentPtr
+      getitem_next(const SliceItemPtr& head,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      carry(const Index64& carry) const override;
+
+    const std::string
+      purelist_parameter(const std::string& key) const override;
+
+    bool
+      purelist_isregular() const override;
+
+    int64_t
+      purelist_depth() const override;
+
+    const std::pair<int64_t, int64_t>
+      minmax_depth() const override;
+
+    const std::pair<bool, int64_t>
+      branch_depth() const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
 
     // operations
-    const std::string validityerror(const std::string& path) const override;
-    const ContentPtr shallow_simplify() const override;
-    const ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const ContentPtr& other, bool mergebool) const override;
-    const ContentPtr reverse_merge(const ContentPtr& other) const;
-    const ContentPtr merge(const ContentPtr& other) const override;
-    const SliceItemPtr asslice() const override;
-    const ContentPtr fillna(const ContentPtr& value) const override;
-    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    const ContentPtr choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const std::string
+      validityerror(const std::string& path) const override;
 
-    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr
+      shallow_simplify() const override;
+
+    const ContentPtr
+      num(int64_t axis, int64_t depth) const override;
+
+    const std::pair<Index64, ContentPtr>
+      offsets_and_flattened(int64_t axis, int64_t depth) const override;
+
+    bool
+      mergeable(const ContentPtr& other, bool mergebool) const override;
+
+    const ContentPtr
+      reverse_merge(const ContentPtr& other) const;
+
+    const ContentPtr
+      merge(const ContentPtr& other) const override;
+
+    const SliceItemPtr
+      asslice() const override;
+
+    const ContentPtr
+      fillna(const ContentPtr& value) const override;
+
+    const ContentPtr
+      rpad(int64_t length, int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      rpad_and_clip(int64_t length,
+                    int64_t axis,
+                    int64_t depth) const override;
+
+    const ContentPtr
+      reduce_next(const Reducer& reducer,
+                  int64_t negaxis,
+                  const Index64& starts,
+                  const Index64& parents,
+                  int64_t outlength,
+                  bool mask,
+                  bool keepdims) const override;
+
+    const ContentPtr
+      localindex(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
+      choose(int64_t n,
+             bool diagonal,
+             const util::RecordLookupPtr& recordlookup,
+             const util::Parameters& parameters,
+             int64_t axis,
+             int64_t depth) const override;
+
+    const ContentPtr
+      getitem_next(const SliceAt& at,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceRange& range,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceArray64& array,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next(const SliceJagged64& jagged,
+                   const Slice& tail,
+                   const Index64& advanced) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceArray64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceMissing64& slicecontent,
+                          const Slice& tail) const override;
+
+    const ContentPtr
+      getitem_next_jagged(const Index64& slicestarts,
+                          const Index64& slicestops,
+                          const SliceJagged64& slicecontent,
+                          const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+      const ContentPtr
+      getitem_next_jagged_generic(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const S& slicecontent,
+                                  const Slice& tail) const;
 
   private:
     const ContentPtr content_;
-  };
 
+  };
 }
 
 #endif // AWKWARD_UNMASKEDARRAY_H_

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -15,13 +15,13 @@
 namespace awkward {
   class EXPORT_SYMBOL UnmaskedArray: public Content {
   public:
-    UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, ContentPtr& content);
-    ContentPtr content() const;
-    ContentPtr project() const;
-    ContentPtr project(const Index8& mask) const;
+    UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtr& content);
+    const ContentPtr content() const;
+    const ContentPtr project() const;
+    const ContentPtr project(const Index8& mask) const;
     const Index8 bytemask() const;
-    ContentPtr simplify_optiontype() const;
-    ContentPtr toIndexedOptionArray64() const;
+    const ContentPtr simplify_optiontype() const;
+    const ContentPtr toIndexedOptionArray64() const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -31,18 +31,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    ContentPtr shallow_copy() const override;
-    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    const ContentPtr shallow_copy() const override;
+    const ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    ContentPtr getitem_nothing() const override;
-    ContentPtr getitem_at(int64_t at) const override;
-    ContentPtr getitem_at_nowrap(int64_t at) const override;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    ContentPtr getitem_field(const std::string& key) const override;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
-    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr carry(const Index64& carry) const override;
+    const ContentPtr getitem_nothing() const override;
+    const ContentPtr getitem_at(int64_t at) const override;
+    const ContentPtr getitem_at_nowrap(int64_t at) const override;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    const ContentPtr getitem_field(const std::string& key) const override;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    const ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -56,34 +56,34 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    ContentPtr shallow_simplify() const override;
-    ContentPtr num(int64_t axis, int64_t depth) const override;
-    const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(ContentPtr& other, bool mergebool) const override;
-    ContentPtr reverse_merge(ContentPtr& other) const;
-    ContentPtr merge(ContentPtr& other) const override;
+    const ContentPtr shallow_simplify() const override;
+    const ContentPtr num(int64_t axis, int64_t depth) const override;
+    const std::pair<Index64, ContentPtr> offsets_and_flattened(int64_t axis, int64_t depth) const override;
+    bool mergeable(const ContentPtr& other, bool mergebool) const override;
+    const ContentPtr reverse_merge(const ContentPtr& other) const;
+    const ContentPtr merge(const ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    ContentPtr fillna(ContentPtr& value) const override;
-    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    ContentPtr localindex(int64_t axis, int64_t depth) const override;
-    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    const ContentPtr fillna(const ContentPtr& value) const override;
+    const ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    const ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    const ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    const ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    const ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    const ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
   private:
-    ContentPtr content_;
+    const ContentPtr content_;
   };
 
 }

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -47,7 +47,7 @@ namespace awkward {
       setidentities(const IdentitiesPtr& identities) override;
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const override;
+      type(const util::TypeStrs& typestrs) const override;
 
     const std::string
       tostring_part(const std::string& indent,

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -15,13 +15,13 @@
 namespace awkward {
   class EXPORT_SYMBOL UnmaskedArray: public Content {
   public:
-    UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::shared_ptr<Content>& content);
-    const std::shared_ptr<Content> content() const;
-    const std::shared_ptr<Content> project() const;
-    const std::shared_ptr<Content> project(const Index8& mask) const;
+    UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, ContentPtr& content);
+    ContentPtr content() const;
+    ContentPtr project() const;
+    ContentPtr project(const Index8& mask) const;
     const Index8 bytemask() const;
-    const std::shared_ptr<Content> simplify_optiontype() const;
-    const std::shared_ptr<Content> toIndexedOptionArray64() const;
+    ContentPtr simplify_optiontype() const;
+    ContentPtr toIndexedOptionArray64() const;
 
     const std::string classname() const override;
     void setidentities() override;
@@ -31,18 +31,18 @@ namespace awkward {
     void tojson_part(ToJson& builder) const override;
     void nbytes_part(std::map<size_t, int64_t>& largest) const override;
     int64_t length() const override;
-    const std::shared_ptr<Content> shallow_copy() const override;
-    const std::shared_ptr<Content> deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
+    ContentPtr shallow_copy() const override;
+    ContentPtr deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const override;
     void check_for_iteration() const override;
-    const std::shared_ptr<Content> getitem_nothing() const override;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_at_nowrap(int64_t at) const override;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_range_nowrap(int64_t start, int64_t stop) const override;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const override;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const override;
-    const std::shared_ptr<Content> getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> carry(const Index64& carry) const override;
+    ContentPtr getitem_nothing() const override;
+    ContentPtr getitem_at(int64_t at) const override;
+    ContentPtr getitem_at_nowrap(int64_t at) const override;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_range_nowrap(int64_t start, int64_t stop) const override;
+    ContentPtr getitem_field(const std::string& key) const override;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const override;
+    ContentPtr getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr carry(const Index64& carry) const override;
     const std::string purelist_parameter(const std::string& key) const override;
     bool purelist_isregular() const override;
     int64_t purelist_depth() const override;
@@ -56,34 +56,34 @@ namespace awkward {
 
     // operations
     const std::string validityerror(const std::string& path) const override;
-    const std::shared_ptr<Content> shallow_simplify() const override;
-    const std::shared_ptr<Content> num(int64_t axis, int64_t depth) const override;
+    ContentPtr shallow_simplify() const override;
+    ContentPtr num(int64_t axis, int64_t depth) const override;
     const std::pair<Index64, std::shared_ptr<Content>> offsets_and_flattened(int64_t axis, int64_t depth) const override;
-    bool mergeable(const std::shared_ptr<Content>& other, bool mergebool) const override;
-    const std::shared_ptr<Content> reverse_merge(const std::shared_ptr<Content>& other) const;
-    const std::shared_ptr<Content> merge(const std::shared_ptr<Content>& other) const override;
+    bool mergeable(ContentPtr& other, bool mergebool) const override;
+    ContentPtr reverse_merge(ContentPtr& other) const;
+    ContentPtr merge(ContentPtr& other) const override;
     const std::shared_ptr<SliceItem> asslice() const override;
-    const std::shared_ptr<Content> fillna(const std::shared_ptr<Content>& value) const override;
-    const std::shared_ptr<Content> rpad(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
-    const std::shared_ptr<Content> localindex(int64_t axis, int64_t depth) const override;
-    const std::shared_ptr<Content> choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
+    ContentPtr fillna(ContentPtr& value) const override;
+    ContentPtr rpad(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const override;
+    ContentPtr reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const override;
+    ContentPtr localindex(int64_t axis, int64_t depth) const override;
+    ContentPtr choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const override;
 
-    const std::shared_ptr<Content> getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
-    const std::shared_ptr<Content> getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const override;
+    ContentPtr getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const override;
 
   protected:
     template <typename S>
-    const std::shared_ptr<Content> getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
+    ContentPtr getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const;
 
   private:
-    const std::shared_ptr<Content> content_;
+    ContentPtr content_;
   };
 
 }

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -25,7 +25,7 @@ namespace awkward {
       clear();
 
     const TypePtr
-      type(const std::map<std::string, std::string>& typestrs) const;
+      type(const util::TypeStrs& typestrs) const;
 
     const ContentPtr
       snapshot() const;

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -19,12 +19,12 @@ namespace awkward {
     int64_t length() const;
     void clear();
     const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const;
-    const std::shared_ptr<Content> snapshot() const;
-    const std::shared_ptr<Content> getitem_at(int64_t at) const;
-    const std::shared_ptr<Content> getitem_range(int64_t start, int64_t stop) const;
-    const std::shared_ptr<Content> getitem_field(const std::string& key) const;
-    const std::shared_ptr<Content> getitem_fields(const std::vector<std::string>& keys) const;
-    const std::shared_ptr<Content> getitem(const Slice& where) const;
+    ContentPtr snapshot() const;
+    ContentPtr getitem_at(int64_t at) const;
+    ContentPtr getitem_range(int64_t start, int64_t stop) const;
+    ContentPtr getitem_field(const std::string& key) const;
+    ContentPtr getitem_fields(const std::vector<std::string>& keys) const;
+    ContentPtr getitem(const Slice& where) const;
 
     void null();
     void boolean(bool x);
@@ -49,9 +49,9 @@ namespace awkward {
     void field_check(const char* key);
     void field_check(const std::string& key);
     void endrecord();
-    void append(const std::shared_ptr<Content>& array, int64_t at);
-    void append_nowrap(const std::shared_ptr<Content>& array, int64_t at);
-    void extend(const std::shared_ptr<Content>& array);
+    void append(ContentPtr& array, int64_t at);
+    void append_nowrap(ContentPtr& array, int64_t at);
+    void extend(ContentPtr& array);
 
   private:
     void maybeupdate(const std::shared_ptr<Builder>& tmp);

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string tostring() const;
     int64_t length() const;
     void clear();
-    const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const;
+    const TypePtr type(const std::map<std::string, std::string>& typestrs) const;
     const ContentPtr snapshot() const;
     const ContentPtr getitem_at(int64_t at) const;
     const ContentPtr getitem_range(int64_t start, int64_t stop) const;
@@ -54,12 +54,12 @@ namespace awkward {
     void extend(const ContentPtr& array);
 
   private:
-    void maybeupdate(const std::shared_ptr<Builder>& tmp);
+    void maybeupdate(const BuilderPtr& tmp);
 
     static const char* no_encoding;
     static const char* utf8_encoding;
 
-    std::shared_ptr<Builder> builder_;
+    BuilderPtr builder_;
   };
 }
 

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -15,78 +15,188 @@ namespace awkward {
   public:
     ArrayBuilder(const ArrayBuilderOptions& options);
 
-    const std::string tostring() const;
-    int64_t length() const;
-    void clear();
-    const TypePtr type(const std::map<std::string, std::string>& typestrs) const;
-    const ContentPtr snapshot() const;
-    const ContentPtr getitem_at(int64_t at) const;
-    const ContentPtr getitem_range(int64_t start, int64_t stop) const;
-    const ContentPtr getitem_field(const std::string& key) const;
-    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const;
-    const ContentPtr getitem(const Slice& where) const;
+    const std::string
+      tostring() const;
 
-    void null();
-    void boolean(bool x);
-    void integer(int64_t x);
-    void real(double x);
-    void bytestring(const char* x);
-    void bytestring(const char* x, int64_t length);
-    void bytestring(const std::string& x);
-    void string(const char* x);
-    void string(const char* x, int64_t length);
-    void string(const std::string& x);
-    void beginlist();
-    void endlist();
-    void begintuple(int64_t numfields);
-    void index(int64_t index);
-    void endtuple();
-    void beginrecord();
-    void beginrecord_fast(const char* name);
-    void beginrecord_check(const char* name);
-    void beginrecord_check(const std::string& name);
-    void field_fast(const char* key);
-    void field_check(const char* key);
-    void field_check(const std::string& key);
-    void endrecord();
-    void append(const ContentPtr& array, int64_t at);
-    void append_nowrap(const ContentPtr& array, int64_t at);
-    void extend(const ContentPtr& array);
+    int64_t
+      length() const;
+
+    void
+      clear();
+
+    const TypePtr
+      type(const std::map<std::string, std::string>& typestrs) const;
+
+    const ContentPtr
+      snapshot() const;
+
+    const ContentPtr
+      getitem_at(int64_t at) const;
+
+    const ContentPtr
+      getitem_range(int64_t start, int64_t stop) const;
+
+    const ContentPtr
+      getitem_field(const std::string& key) const;
+
+    const ContentPtr
+      getitem_fields(const std::vector<std::string>& keys) const;
+
+    const ContentPtr
+      getitem(const Slice& where) const;
+
+    void
+      null();
+
+    void
+      boolean(bool x);
+
+    void
+      integer(int64_t x);
+
+    void
+      real(double x);
+
+    void
+      bytestring(const char* x);
+
+    void
+      bytestring(const char* x, int64_t length);
+
+    void
+      bytestring(const std::string& x);
+
+    void
+      string(const char* x);
+
+    void
+      string(const char* x, int64_t length);
+
+    void
+      string(const std::string& x);
+
+    void
+      beginlist();
+
+    void
+      endlist();
+
+    void
+      begintuple(int64_t numfields);
+
+    void
+      index(int64_t index);
+
+    void
+      endtuple();
+
+    void
+      beginrecord();
+
+    void
+      beginrecord_fast(const char* name);
+
+    void
+      beginrecord_check(const char* name);
+
+    void
+      beginrecord_check(const std::string& name);
+
+    void
+      field_fast(const char* key);
+
+    void
+      field_check(const char* key);
+
+    void
+      field_check(const std::string& key);
+
+    void
+      endrecord();
+
+    void
+      append(const ContentPtr& array, int64_t at);
+
+    void
+      append_nowrap(const ContentPtr& array, int64_t at);
+
+    void
+      extend(const ContentPtr& array);
 
   private:
-    void maybeupdate(const BuilderPtr& tmp);
+    void
+      maybeupdate(const BuilderPtr& tmp);
 
     static const char* no_encoding;
     static const char* utf8_encoding;
-
     BuilderPtr builder_;
   };
 }
 
 extern "C" {
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_length(void* arraybuilder, int64_t* result);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_clear(void* arraybuilder);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_length(void* arraybuilder,
+                                int64_t* result);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_clear(void* arraybuilder);
 
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_null(void* arraybuilder);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_boolean(void* arraybuilder, bool x);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_integer(void* arraybuilder, int64_t x);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_real(void* arraybuilder, double x);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_bytestring(void* arraybuilder, const char* x);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_bytestring_length(void* arraybuilder, const char* x, int64_t length);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_string(void* arraybuilder, const char* x);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_string_length(void* arraybuilder, const char* x, int64_t length);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_beginlist(void* arraybuilder);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_endlist(void* arraybuilder);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_begintuple(void* arraybuilder, int64_t numfields);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_index(void* arraybuilder, int64_t index);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_endtuple(void* arraybuilder);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_beginrecord(void* arraybuilder);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder, const char* name);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_beginrecord_check(void* arraybuilder, const char* name);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_field_fast(void* arraybuilder, const char* key);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_field_check(void* arraybuilder, const char* key);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_endrecord(void* arraybuilder);
-  EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_append_nowrap(void* arraybuilder, const void* shared_ptr_ptr, int64_t at);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_null(void* arraybuilder);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_boolean(void* arraybuilder,
+                                 bool x);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_integer(void* arraybuilder,
+                                 int64_t x);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_real(void* arraybuilder,
+                              double x);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_bytestring(void* arraybuilder,
+                                    const char* x);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
+                                           const char* x,
+                                           int64_t length);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_string(void* arraybuilder,
+                                const char* x);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_string_length(void* arraybuilder,
+                                       const char* x,
+                                       int64_t length);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_beginlist(void* arraybuilder);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_endlist(void* arraybuilder);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_begintuple(void* arraybuilder,
+                                    int64_t numfields);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_index(void* arraybuilder,
+                               int64_t index);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_endtuple(void* arraybuilder);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_beginrecord(void* arraybuilder);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
+                                          const char* name);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
+                                           const char* name);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_field_fast(void* arraybuilder,
+                                    const char* key);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_field_check(void* arraybuilder,
+                                     const char* key);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_endrecord(void* arraybuilder);
+  EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_append_nowrap(void* arraybuilder,
+                                       const void* shared_ptr_ptr,
+                                       int64_t at);
 }
 
 #endif // AWKWARD_ARRAYBUILDER_H_

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -19,12 +19,12 @@ namespace awkward {
     int64_t length() const;
     void clear();
     const std::shared_ptr<Type> type(const std::map<std::string, std::string>& typestrs) const;
-    ContentPtr snapshot() const;
-    ContentPtr getitem_at(int64_t at) const;
-    ContentPtr getitem_range(int64_t start, int64_t stop) const;
-    ContentPtr getitem_field(const std::string& key) const;
-    ContentPtr getitem_fields(const std::vector<std::string>& keys) const;
-    ContentPtr getitem(const Slice& where) const;
+    const ContentPtr snapshot() const;
+    const ContentPtr getitem_at(int64_t at) const;
+    const ContentPtr getitem_range(int64_t start, int64_t stop) const;
+    const ContentPtr getitem_field(const std::string& key) const;
+    const ContentPtr getitem_fields(const std::vector<std::string>& keys) const;
+    const ContentPtr getitem(const Slice& where) const;
 
     void null();
     void boolean(bool x);
@@ -49,9 +49,9 @@ namespace awkward {
     void field_check(const char* key);
     void field_check(const std::string& key);
     void endrecord();
-    void append(ContentPtr& array, int64_t at);
-    void append_nowrap(ContentPtr& array, int64_t at);
-    void extend(ContentPtr& array);
+    void append(const ContentPtr& array, int64_t at);
+    void append_nowrap(const ContentPtr& array, int64_t at);
+    void extend(const ContentPtr& array);
 
   private:
     void maybeupdate(const std::shared_ptr<Builder>& tmp);

--- a/include/awkward/builder/ArrayBuilderOptions.h
+++ b/include/awkward/builder/ArrayBuilderOptions.h
@@ -12,8 +12,12 @@ namespace awkward {
   class EXPORT_SYMBOL ArrayBuilderOptions {
   public:
     ArrayBuilderOptions(int64_t initial, double resize);
-    int64_t initial() const;
-    double resize() const;
+
+    int64_t
+      initial() const;
+
+    double
+      resize() const;
 
   private:
     int64_t initial_;

--- a/include/awkward/builder/BoolBuilder.h
+++ b/include/awkward/builder/BoolBuilder.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -34,7 +34,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/BoolBuilder.h
+++ b/include/awkward/builder/BoolBuilder.h
@@ -11,7 +11,7 @@
 namespace awkward {
   class EXPORT_SYMBOL BoolBuilder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
 
     BoolBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<uint8_t>& buffer);
 
@@ -21,20 +21,20 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/BoolBuilder.h
+++ b/include/awkward/builder/BoolBuilder.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -34,7 +34,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/BoolBuilder.h
+++ b/include/awkward/builder/BoolBuilder.h
@@ -11,35 +11,74 @@
 namespace awkward {
   class EXPORT_SYMBOL BoolBuilder: public Builder {
   public:
-    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr
+      fromempty(const ArrayBuilderOptions& options);
 
-    BoolBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<uint8_t>& buffer);
+    BoolBuilder(const ArrayBuilderOptions& options,
+                const GrowableBuffer<uint8_t>& buffer);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    const std::string
+      classname() const override;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
     GrowableBuffer<uint8_t> buffer_;
   };
+
 }
 
 #endif // AWKWARD_BOOLBUILDER_H_

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -18,28 +18,65 @@ namespace awkward {
   public:
     virtual ~Builder();
 
-    virtual const std::string classname() const = 0;
-    virtual int64_t length() const = 0;
-    virtual void clear() = 0;
-    virtual const ContentPtr snapshot() const = 0;
+    virtual const std::string
+      classname() const = 0;
 
-    virtual bool active() const = 0;
-    virtual const BuilderPtr null() = 0;
-    virtual const BuilderPtr boolean(bool x) = 0;
-    virtual const BuilderPtr integer(int64_t x) = 0;
-    virtual const BuilderPtr real(double x) = 0;
-    virtual const BuilderPtr string(const char* x, int64_t length, const char* encoding) = 0;
-    virtual const BuilderPtr beginlist() = 0;
-    virtual const BuilderPtr endlist() = 0;
-    virtual const BuilderPtr begintuple(int64_t numfields) = 0;
-    virtual const BuilderPtr index(int64_t index) = 0;
-    virtual const BuilderPtr endtuple() = 0;
-    virtual const BuilderPtr beginrecord(const char* name, bool check) = 0;
-    virtual const BuilderPtr field(const char* key, bool check) = 0;
-    virtual const BuilderPtr endrecord() = 0;
-    virtual const BuilderPtr append(const ContentPtr& array, int64_t at) = 0;
+    virtual int64_t
+      length() const = 0;
 
-    void setthat(const BuilderPtr& that);
+    virtual void
+      clear() = 0;
+
+    virtual const ContentPtr
+      snapshot() const = 0;
+
+    virtual bool
+      active() const = 0;
+
+    virtual const BuilderPtr
+      null() = 0;
+
+    virtual const BuilderPtr
+      boolean(bool x) = 0;
+
+    virtual const BuilderPtr
+      integer(int64_t x) = 0;
+
+    virtual const BuilderPtr
+      real(double x) = 0;
+
+    virtual const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) = 0;
+
+    virtual const BuilderPtr
+      beginlist() = 0;
+
+    virtual const BuilderPtr
+      endlist() = 0;
+
+    virtual const BuilderPtr
+      begintuple(int64_t numfields) = 0;
+
+    virtual const BuilderPtr
+      index(int64_t index) = 0;
+
+    virtual const BuilderPtr
+      endtuple() = 0;
+
+    virtual const BuilderPtr
+      beginrecord(const char* name, bool check) = 0;
+
+    virtual const BuilderPtr
+      field(const char* key, bool check) = 0;
+
+    virtual const BuilderPtr
+      endrecord() = 0;
+
+    virtual const BuilderPtr
+      append(const ContentPtr& array, int64_t at) = 0;
+
+    void
+      setthat(const BuilderPtr& that);
 
   protected:
     BuilderPtr that_;

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -18,7 +18,7 @@ namespace awkward {
     virtual const std::string classname() const = 0;
     virtual int64_t length() const = 0;
     virtual void clear() = 0;
-    virtual ContentPtr snapshot() const = 0;
+    virtual const ContentPtr snapshot() const = 0;
 
     virtual bool active() const = 0;
     virtual const std::shared_ptr<Builder> null() = 0;
@@ -34,7 +34,7 @@ namespace awkward {
     virtual const std::shared_ptr<Builder> beginrecord(const char* name, bool check) = 0;
     virtual const std::shared_ptr<Builder> field(const char* key, bool check) = 0;
     virtual const std::shared_ptr<Builder> endrecord() = 0;
-    virtual const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) = 0;
+    virtual const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) = 0;
 
     void setthat(const std::shared_ptr<Builder>& that);
 

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -18,7 +18,7 @@ namespace awkward {
     virtual const std::string classname() const = 0;
     virtual int64_t length() const = 0;
     virtual void clear() = 0;
-    virtual const std::shared_ptr<Content> snapshot() const = 0;
+    virtual ContentPtr snapshot() const = 0;
 
     virtual bool active() const = 0;
     virtual const std::shared_ptr<Builder> null() = 0;
@@ -34,7 +34,7 @@ namespace awkward {
     virtual const std::shared_ptr<Builder> beginrecord(const char* name, bool check) = 0;
     virtual const std::shared_ptr<Builder> field(const char* key, bool check) = 0;
     virtual const std::shared_ptr<Builder> endrecord() = 0;
-    virtual const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) = 0;
+    virtual const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) = 0;
 
     void setthat(const std::shared_ptr<Builder>& that);
 

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -12,7 +12,7 @@
 
 namespace awkward {
   class Builder;
-  typedef std::shared_ptr<Builder> BuilderPtr;
+  using BuilderPtr = std::shared_ptr<Builder>;
 
   class EXPORT_SYMBOL Builder {
   public:

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -11,6 +11,9 @@
 #include "awkward/type/Type.h"
 
 namespace awkward {
+  class Builder;
+  typedef std::shared_ptr<Builder> BuilderPtr;
+
   class EXPORT_SYMBOL Builder {
   public:
     virtual ~Builder();
@@ -21,25 +24,25 @@ namespace awkward {
     virtual const ContentPtr snapshot() const = 0;
 
     virtual bool active() const = 0;
-    virtual const std::shared_ptr<Builder> null() = 0;
-    virtual const std::shared_ptr<Builder> boolean(bool x) = 0;
-    virtual const std::shared_ptr<Builder> integer(int64_t x) = 0;
-    virtual const std::shared_ptr<Builder> real(double x) = 0;
-    virtual const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) = 0;
-    virtual const std::shared_ptr<Builder> beginlist() = 0;
-    virtual const std::shared_ptr<Builder> endlist() = 0;
-    virtual const std::shared_ptr<Builder> begintuple(int64_t numfields) = 0;
-    virtual const std::shared_ptr<Builder> index(int64_t index) = 0;
-    virtual const std::shared_ptr<Builder> endtuple() = 0;
-    virtual const std::shared_ptr<Builder> beginrecord(const char* name, bool check) = 0;
-    virtual const std::shared_ptr<Builder> field(const char* key, bool check) = 0;
-    virtual const std::shared_ptr<Builder> endrecord() = 0;
-    virtual const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) = 0;
+    virtual const BuilderPtr null() = 0;
+    virtual const BuilderPtr boolean(bool x) = 0;
+    virtual const BuilderPtr integer(int64_t x) = 0;
+    virtual const BuilderPtr real(double x) = 0;
+    virtual const BuilderPtr string(const char* x, int64_t length, const char* encoding) = 0;
+    virtual const BuilderPtr beginlist() = 0;
+    virtual const BuilderPtr endlist() = 0;
+    virtual const BuilderPtr begintuple(int64_t numfields) = 0;
+    virtual const BuilderPtr index(int64_t index) = 0;
+    virtual const BuilderPtr endtuple() = 0;
+    virtual const BuilderPtr beginrecord(const char* name, bool check) = 0;
+    virtual const BuilderPtr field(const char* key, bool check) = 0;
+    virtual const BuilderPtr endrecord() = 0;
+    virtual const BuilderPtr append(const ContentPtr& array, int64_t at) = 0;
 
-    void setthat(const std::shared_ptr<Builder>& that);
+    void setthat(const BuilderPtr& that);
 
   protected:
-    std::shared_ptr<Builder> that_;
+    BuilderPtr that_;
   };
 }
 

--- a/include/awkward/builder/Float64Builder.h
+++ b/include/awkward/builder/Float64Builder.h
@@ -19,7 +19,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -35,7 +35,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/Float64Builder.h
+++ b/include/awkward/builder/Float64Builder.h
@@ -11,36 +11,78 @@
 namespace awkward {
   class EXPORT_SYMBOL Float64Builder: public Builder {
   public:
-    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
-    static const BuilderPtr fromint64(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& old);
+    static const BuilderPtr
+      fromempty(const ArrayBuilderOptions& options);
 
-    Float64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<double>& buffer);
+    static const BuilderPtr
+      fromint64(const ArrayBuilderOptions& options,
+                const GrowableBuffer<int64_t>& old);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+   Float64Builder(const ArrayBuilderOptions& options,
+                  const GrowableBuffer<double>& buffer);
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
     GrowableBuffer<double> buffer_;
   };
+
 }
 
 #endif // AWKWARD_FLOAT64BUILDER_H_

--- a/include/awkward/builder/Float64Builder.h
+++ b/include/awkward/builder/Float64Builder.h
@@ -11,8 +11,8 @@
 namespace awkward {
   class EXPORT_SYMBOL Float64Builder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromempty(const ArrayBuilderOptions& options);
-    static const std::shared_ptr<Builder> fromint64(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& old);
+    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr fromint64(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& old);
 
     Float64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<double>& buffer);
 
@@ -22,20 +22,20 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/Float64Builder.h
+++ b/include/awkward/builder/Float64Builder.h
@@ -19,7 +19,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -35,7 +35,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/GrowableBuffer.h
+++ b/include/awkward/builder/GrowableBuffer.h
@@ -14,21 +14,48 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL GrowableBuffer {
   public:
-    static GrowableBuffer<T> empty(const ArrayBuilderOptions& options);
-    static GrowableBuffer<T> empty(const ArrayBuilderOptions& options, int64_t minreserve);
-    static GrowableBuffer<T> full(const ArrayBuilderOptions& options, T value, int64_t length);
-    static GrowableBuffer<T> arange(const ArrayBuilderOptions& options, int64_t length);
+    static GrowableBuffer<T>
+      empty(const ArrayBuilderOptions& options);
 
-    GrowableBuffer(const ArrayBuilderOptions& options, std::shared_ptr<T> ptr, int64_t length, int64_t reserved);
+    static GrowableBuffer<T>
+      empty(const ArrayBuilderOptions& options, int64_t minreserve);
+
+    static GrowableBuffer<T>
+      full(const ArrayBuilderOptions& options, T value, int64_t length);
+
+    static GrowableBuffer<T>
+      arange(const ArrayBuilderOptions& options, int64_t length);
+
+    GrowableBuffer(const ArrayBuilderOptions& options,
+                   std::shared_ptr<T> ptr,
+                   int64_t length,
+                   int64_t reserved);
+
     GrowableBuffer(const ArrayBuilderOptions& options);
-    const std::shared_ptr<T> ptr() const;
-    int64_t length() const;
-    void set_length(int64_t newlength);
-    int64_t reserved() const;
-    void set_reserved(int64_t minreserved);
-    void clear();
-    void append(T datum);
-    T getitem_at_nowrap(int64_t at) const;
+
+    const std::shared_ptr<T>
+      ptr() const;
+
+    int64_t
+      length() const;
+
+    void
+      set_length(int64_t newlength);
+
+    int64_t
+      reserved() const;
+
+    void
+      set_reserved(int64_t minreserved);
+
+    void
+      clear();
+
+    void
+      append(T datum);
+
+    T
+      getitem_at_nowrap(int64_t at) const;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/IndexedBuilder.h
+++ b/include/awkward/builder/IndexedBuilder.h
@@ -46,13 +46,13 @@ namespace awkward {
 
   class IndexedGenericBuilder: public IndexedBuilder<Content> {
   public:
-    static const std::shared_ptr<Builder> fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const std::shared_ptr<Content>& array);
+    static const std::shared_ptr<Builder> fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, ContentPtr& array);
 
-    IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<Content>& array, bool hasnull);
+    IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, ContentPtr& array, bool hasnull);
 
     const std::string classname() const override;
-    const std::shared_ptr<Content> snapshot() const override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
   };
 
   class IndexedI32Builder: public IndexedBuilder<IndexedArray32> {
@@ -60,8 +60,8 @@ namespace awkward {
     IndexedI32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArray32>& array, bool hasnull);
 
     const std::string classname() const override;
-    const std::shared_ptr<Content> snapshot() const override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIU32Builder: public IndexedBuilder<IndexedArrayU32> {
@@ -69,8 +69,8 @@ namespace awkward {
     IndexedIU32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArrayU32>& array, bool hasnull);
 
     const std::string classname() const override;
-    const std::shared_ptr<Content> snapshot() const override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
   };
 
   class IndexedI64Builder: public IndexedBuilder<IndexedArray64> {
@@ -78,8 +78,8 @@ namespace awkward {
     IndexedI64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArray64>& array, bool hasnull);
 
     const std::string classname() const override;
-    const std::shared_ptr<Content> snapshot() const override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIO32Builder: public IndexedBuilder<IndexedOptionArray32> {
@@ -87,8 +87,8 @@ namespace awkward {
     IndexedIO32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray32>& array, bool hasnull);
 
     const std::string classname() const override;
-    const std::shared_ptr<Content> snapshot() const override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIO64Builder: public IndexedBuilder<IndexedOptionArray64> {
@@ -96,8 +96,8 @@ namespace awkward {
     IndexedIO64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray64>& array, bool hasnull);
 
     const std::string classname() const override;
-    const std::shared_ptr<Content> snapshot() const override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
   };
 
 }

--- a/include/awkward/builder/IndexedBuilder.h
+++ b/include/awkward/builder/IndexedBuilder.h
@@ -23,19 +23,19 @@ namespace awkward {
     void clear() override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
 
   protected:
     const ArrayBuilderOptions options_;
@@ -46,13 +46,13 @@ namespace awkward {
 
   class IndexedGenericBuilder: public IndexedBuilder<Content> {
   public:
-    static const std::shared_ptr<Builder> fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const ContentPtr& array);
+    static const BuilderPtr fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const ContentPtr& array);
 
     IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const ContentPtr& array, bool hasnull);
 
     const std::string classname() const override;
     const ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedI32Builder: public IndexedBuilder<IndexedArray32> {
@@ -61,7 +61,7 @@ namespace awkward {
 
     const std::string classname() const override;
     const ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIU32Builder: public IndexedBuilder<IndexedArrayU32> {
@@ -70,7 +70,7 @@ namespace awkward {
 
     const std::string classname() const override;
     const ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedI64Builder: public IndexedBuilder<IndexedArray64> {
@@ -79,7 +79,7 @@ namespace awkward {
 
     const std::string classname() const override;
     const ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIO32Builder: public IndexedBuilder<IndexedOptionArray32> {
@@ -88,7 +88,7 @@ namespace awkward {
 
     const std::string classname() const override;
     const ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIO64Builder: public IndexedBuilder<IndexedOptionArray64> {
@@ -97,7 +97,7 @@ namespace awkward {
 
     const std::string classname() const override;
     const ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
   };
 
 }

--- a/include/awkward/builder/IndexedBuilder.h
+++ b/include/awkward/builder/IndexedBuilder.h
@@ -15,27 +15,61 @@ namespace awkward {
   template <typename T>
   class EXPORT_SYMBOL IndexedBuilder: public Builder {
   public:
-    IndexedBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<T>& array, bool hasnull);
+    IndexedBuilder(const ArrayBuilderOptions& options,
+                   const GrowableBuffer<int64_t>& index,
+                   const std::shared_ptr<T>& array,
+                   bool hasnull);
 
-    const Content* arrayptr() const;
+    const Content*
+      arrayptr() const;
 
-    int64_t length() const override;
-    void clear() override;
+    int64_t
+      length() const override;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
+    void
+      clear() override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
 
   protected:
     const ArrayBuilderOptions options_;
@@ -46,58 +80,109 @@ namespace awkward {
 
   class IndexedGenericBuilder: public IndexedBuilder<Content> {
   public:
-    static const BuilderPtr fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const ContentPtr& array);
+    static const BuilderPtr
+    fromnulls(const ArrayBuilderOptions& options,
+              int64_t nullcount,
+              const ContentPtr& array);
 
-    IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const ContentPtr& array, bool hasnull);
+    IndexedGenericBuilder(const ArrayBuilderOptions& options,
+                          const GrowableBuffer<int64_t>& index,
+                          const ContentPtr& array,
+                          bool hasnull);
 
-    const std::string classname() const override;
-    const ContentPtr snapshot() const override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedI32Builder: public IndexedBuilder<IndexedArray32> {
   public:
-    IndexedI32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArray32>& array, bool hasnull);
+    IndexedI32Builder(const ArrayBuilderOptions& options,
+                      const GrowableBuffer<int64_t>& index,
+                      const std::shared_ptr<IndexedArray32>& array,
+                      bool hasnull);
 
-    const std::string classname() const override;
-    const ContentPtr snapshot() const override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIU32Builder: public IndexedBuilder<IndexedArrayU32> {
   public:
-    IndexedIU32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArrayU32>& array, bool hasnull);
+    IndexedIU32Builder(const ArrayBuilderOptions& options,
+                       const GrowableBuffer<int64_t>& index,
+                       const std::shared_ptr<IndexedArrayU32>& array,
+                       bool hasnull);
 
-    const std::string classname() const override;
-    const ContentPtr snapshot() const override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedI64Builder: public IndexedBuilder<IndexedArray64> {
   public:
-    IndexedI64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArray64>& array, bool hasnull);
+    IndexedI64Builder(const ArrayBuilderOptions& options,
+                      const GrowableBuffer<int64_t>& index,
+                      const std::shared_ptr<IndexedArray64>& array,
+                      bool hasnull);
 
-    const std::string classname() const override;
-    const ContentPtr snapshot() const override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIO32Builder: public IndexedBuilder<IndexedOptionArray32> {
   public:
-    IndexedIO32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray32>& array, bool hasnull);
+    IndexedIO32Builder(const ArrayBuilderOptions& options,
+                       const GrowableBuffer<int64_t>& index,
+                       const std::shared_ptr<IndexedOptionArray32>& array,
+                       bool hasnull);
 
-    const std::string classname() const override;
-    const ContentPtr snapshot() const override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIO64Builder: public IndexedBuilder<IndexedOptionArray64> {
   public:
-    IndexedIO64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray64>& array, bool hasnull);
+    IndexedIO64Builder(const ArrayBuilderOptions& options,
+                       const GrowableBuffer<int64_t>& index,
+                       const std::shared_ptr<IndexedOptionArray64>& array,
+                       bool hasnull);
 
-    const std::string classname() const override;
-    const ContentPtr snapshot() const override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
   };
 
 }

--- a/include/awkward/builder/IndexedBuilder.h
+++ b/include/awkward/builder/IndexedBuilder.h
@@ -46,13 +46,13 @@ namespace awkward {
 
   class IndexedGenericBuilder: public IndexedBuilder<Content> {
   public:
-    static const std::shared_ptr<Builder> fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, ContentPtr& array);
+    static const std::shared_ptr<Builder> fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const ContentPtr& array);
 
-    IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, ContentPtr& array, bool hasnull);
+    IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const ContentPtr& array, bool hasnull);
 
     const std::string classname() const override;
-    ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedI32Builder: public IndexedBuilder<IndexedArray32> {
@@ -60,8 +60,8 @@ namespace awkward {
     IndexedI32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArray32>& array, bool hasnull);
 
     const std::string classname() const override;
-    ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIU32Builder: public IndexedBuilder<IndexedArrayU32> {
@@ -69,8 +69,8 @@ namespace awkward {
     IndexedIU32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArrayU32>& array, bool hasnull);
 
     const std::string classname() const override;
-    ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedI64Builder: public IndexedBuilder<IndexedArray64> {
@@ -78,8 +78,8 @@ namespace awkward {
     IndexedI64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArray64>& array, bool hasnull);
 
     const std::string classname() const override;
-    ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIO32Builder: public IndexedBuilder<IndexedOptionArray32> {
@@ -87,8 +87,8 @@ namespace awkward {
     IndexedIO32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray32>& array, bool hasnull);
 
     const std::string classname() const override;
-    ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
   };
 
   class IndexedIO64Builder: public IndexedBuilder<IndexedOptionArray64> {
@@ -96,8 +96,8 @@ namespace awkward {
     IndexedIO64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray64>& array, bool hasnull);
 
     const std::string classname() const override;
-    ContentPtr snapshot() const override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const ContentPtr snapshot() const override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
   };
 
 }

--- a/include/awkward/builder/Int64Builder.h
+++ b/include/awkward/builder/Int64Builder.h
@@ -19,7 +19,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -35,7 +35,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/Int64Builder.h
+++ b/include/awkward/builder/Int64Builder.h
@@ -11,31 +11,71 @@
 namespace awkward {
   class EXPORT_SYMBOL Int64Builder: public Builder {
   public:
-    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr
+      fromempty(const ArrayBuilderOptions& options);
 
-    Int64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& buffer);
-    const GrowableBuffer<int64_t> buffer() const;
+    Int64Builder(const ArrayBuilderOptions& options,
+                 const GrowableBuffer<int64_t>& buffer);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    const GrowableBuffer<int64_t>
+      buffer() const;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/Int64Builder.h
+++ b/include/awkward/builder/Int64Builder.h
@@ -11,7 +11,7 @@
 namespace awkward {
   class EXPORT_SYMBOL Int64Builder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
 
     Int64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& buffer);
     const GrowableBuffer<int64_t> buffer() const;
@@ -22,20 +22,20 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/Int64Builder.h
+++ b/include/awkward/builder/Int64Builder.h
@@ -19,7 +19,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -35,7 +35,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/ListBuilder.h
+++ b/include/awkward/builder/ListBuilder.h
@@ -21,7 +21,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -37,7 +37,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/ListBuilder.h
+++ b/include/awkward/builder/ListBuilder.h
@@ -21,7 +21,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -37,7 +37,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/ListBuilder.h
+++ b/include/awkward/builder/ListBuilder.h
@@ -14,30 +14,70 @@
 namespace awkward {
   class EXPORT_SYMBOL ListBuilder: public Builder {
   public:
-    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr
+      fromempty(const ArrayBuilderOptions& options);
 
-    ListBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const BuilderPtr& content, bool begun);
+    ListBuilder(const ArrayBuilderOptions& options,
+                const GrowableBuffer<int64_t>& offsets,
+                const BuilderPtr& content,
+                bool begun);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    const std::string
+      classname() const override;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
@@ -45,7 +85,8 @@ namespace awkward {
     BuilderPtr content_;
     bool begun_;
 
-    void maybeupdate(const BuilderPtr& tmp);
+    void
+      maybeupdate(const BuilderPtr& tmp);
   };
 }
 

--- a/include/awkward/builder/ListBuilder.h
+++ b/include/awkward/builder/ListBuilder.h
@@ -14,9 +14,9 @@
 namespace awkward {
   class EXPORT_SYMBOL ListBuilder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
 
-    ListBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const std::shared_ptr<Builder>& content, bool begun);
+    ListBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const BuilderPtr& content, bool begun);
 
     const std::string classname() const override;
     int64_t length() const override;
@@ -24,28 +24,28 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
     GrowableBuffer<int64_t> offsets_;
-    std::shared_ptr<Builder> content_;
+    BuilderPtr content_;
     bool begun_;
 
-    void maybeupdate(const std::shared_ptr<Builder>& tmp);
+    void maybeupdate(const BuilderPtr& tmp);
   };
 }
 

--- a/include/awkward/builder/OptionBuilder.h
+++ b/include/awkward/builder/OptionBuilder.h
@@ -13,39 +13,85 @@
 namespace awkward {
   class EXPORT_SYMBOL OptionBuilder: public Builder {
   public:
-    static const BuilderPtr fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const BuilderPtr& content);
-    static const BuilderPtr fromvalids(const ArrayBuilderOptions& options, const BuilderPtr& content);
+    static const BuilderPtr
+      fromnulls(const ArrayBuilderOptions& options,
+                int64_t nullcount,
+                const BuilderPtr& content);
 
-    OptionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const BuilderPtr& content);
+    static const BuilderPtr
+      fromvalids(const ArrayBuilderOptions& options,
+                 const BuilderPtr& content);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    OptionBuilder(const ArrayBuilderOptions& options,
+                  const GrowableBuffer<int64_t>& offsets,
+                  const BuilderPtr& content);
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
     GrowableBuffer<int64_t> offsets_;
     BuilderPtr content_;
 
-    void maybeupdate(const BuilderPtr& tmp);
+    void
+      maybeupdate(const BuilderPtr& tmp);
   };
+
 }
 
 #endif // AWKWARD_OPTIONBUILDER_H_

--- a/include/awkward/builder/OptionBuilder.h
+++ b/include/awkward/builder/OptionBuilder.h
@@ -21,7 +21,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -37,7 +37,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/OptionBuilder.h
+++ b/include/awkward/builder/OptionBuilder.h
@@ -21,7 +21,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -37,7 +37,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/OptionBuilder.h
+++ b/include/awkward/builder/OptionBuilder.h
@@ -13,10 +13,10 @@
 namespace awkward {
   class EXPORT_SYMBOL OptionBuilder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const std::shared_ptr<Builder>& content);
-    static const std::shared_ptr<Builder> fromvalids(const ArrayBuilderOptions& options, const std::shared_ptr<Builder>& content);
+    static const BuilderPtr fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const BuilderPtr& content);
+    static const BuilderPtr fromvalids(const ArrayBuilderOptions& options, const BuilderPtr& content);
 
-    OptionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const std::shared_ptr<Builder>& content);
+    OptionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const BuilderPtr& content);
 
     const std::string classname() const override;
     int64_t length() const override;
@@ -24,27 +24,27 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
     GrowableBuffer<int64_t> offsets_;
-    std::shared_ptr<Builder> content_;
+    BuilderPtr content_;
 
-    void maybeupdate(const std::shared_ptr<Builder>& tmp);
+    void maybeupdate(const BuilderPtr& tmp);
   };
 }
 

--- a/include/awkward/builder/RecordBuilder.h
+++ b/include/awkward/builder/RecordBuilder.h
@@ -24,7 +24,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -40,7 +40,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const std::shared_ptr<Builder> field_fast(const char* key);

--- a/include/awkward/builder/RecordBuilder.h
+++ b/include/awkward/builder/RecordBuilder.h
@@ -14,37 +14,89 @@
 namespace awkward {
   class EXPORT_SYMBOL RecordBuilder: public Builder {
   public:
-    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr
+      fromempty(const ArrayBuilderOptions& options);
 
-    RecordBuilder(const ArrayBuilderOptions& options, const std::vector<BuilderPtr>& contents, const std::vector<std::string>& keys, const std::vector<const char*>& pointers, const std::string& name, const char* nameptr, int64_t length, bool begun, int64_t nextindex, int64_t nexttotry);
+    RecordBuilder(const ArrayBuilderOptions& options,
+                  const std::vector<BuilderPtr>& contents,
+                  const std::vector<std::string>& keys,
+                  const std::vector<const char*>& pointers,
+                  const std::string& name,
+                  const char* nameptr,
+                  int64_t length,
+                  bool begun,
+                  int64_t nextindex,
+                  int64_t nexttotry);
 
-    const std::string name() const;
-    const char* nameptr() const;
+    const std::string
+      name() const;
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    const char*
+      nameptr() const;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
-    const BuilderPtr field_fast(const char* key);
-    const BuilderPtr field_check(const char* key);
+    const BuilderPtr
+      field_fast(const char* key);
+
+    const BuilderPtr
+      field_check(const char* key);
 
     const ArrayBuilderOptions options_;
     std::vector<BuilderPtr> contents_;
@@ -57,7 +109,8 @@ namespace awkward {
     int64_t nextindex_;
     int64_t nexttotry_;
 
-    void maybeupdate(int64_t i, const BuilderPtr& tmp);
+    void
+      maybeupdate(int64_t i, const BuilderPtr& tmp);
   };
 }
 

--- a/include/awkward/builder/RecordBuilder.h
+++ b/include/awkward/builder/RecordBuilder.h
@@ -24,7 +24,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -40,7 +40,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const std::shared_ptr<Builder> field_fast(const char* key);

--- a/include/awkward/builder/RecordBuilder.h
+++ b/include/awkward/builder/RecordBuilder.h
@@ -14,9 +14,9 @@
 namespace awkward {
   class EXPORT_SYMBOL RecordBuilder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
 
-    RecordBuilder(const ArrayBuilderOptions& options, const std::vector<std::shared_ptr<Builder>>& contents, const std::vector<std::string>& keys, const std::vector<const char*>& pointers, const std::string& name, const char* nameptr, int64_t length, bool begun, int64_t nextindex, int64_t nexttotry);
+    RecordBuilder(const ArrayBuilderOptions& options, const std::vector<BuilderPtr>& contents, const std::vector<std::string>& keys, const std::vector<const char*>& pointers, const std::string& name, const char* nameptr, int64_t length, bool begun, int64_t nextindex, int64_t nexttotry);
 
     const std::string name() const;
     const char* nameptr() const;
@@ -27,27 +27,27 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
-    const std::shared_ptr<Builder> field_fast(const char* key);
-    const std::shared_ptr<Builder> field_check(const char* key);
+    const BuilderPtr field_fast(const char* key);
+    const BuilderPtr field_check(const char* key);
 
     const ArrayBuilderOptions options_;
-    std::vector<std::shared_ptr<Builder>> contents_;
+    std::vector<BuilderPtr> contents_;
     std::vector<std::string> keys_;
     std::vector<const char*> pointers_;
     std::string name_;
@@ -57,7 +57,7 @@ namespace awkward {
     int64_t nextindex_;
     int64_t nexttotry_;
 
-    void maybeupdate(int64_t i, const std::shared_ptr<Builder>& tmp);
+    void maybeupdate(int64_t i, const BuilderPtr& tmp);
   };
 }
 

--- a/include/awkward/builder/StringBuilder.h
+++ b/include/awkward/builder/StringBuilder.h
@@ -19,7 +19,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -35,7 +35,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/StringBuilder.h
+++ b/include/awkward/builder/StringBuilder.h
@@ -11,7 +11,7 @@
 namespace awkward {
   class EXPORT_SYMBOL StringBuilder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromempty(const ArrayBuilderOptions& options, const char* encoding);
+    static const BuilderPtr fromempty(const ArrayBuilderOptions& options, const char* encoding);
 
     StringBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const GrowableBuffer<uint8_t>& content, const char* encoding);
     const char* encoding() const;
@@ -22,20 +22,20 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/StringBuilder.h
+++ b/include/awkward/builder/StringBuilder.h
@@ -11,31 +11,73 @@
 namespace awkward {
   class EXPORT_SYMBOL StringBuilder: public Builder {
   public:
-    static const BuilderPtr fromempty(const ArrayBuilderOptions& options, const char* encoding);
+    static const BuilderPtr
+      fromempty(const ArrayBuilderOptions& options, const char* encoding);
 
-    StringBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const GrowableBuffer<uint8_t>& content, const char* encoding);
-    const char* encoding() const;
+    StringBuilder(const ArrayBuilderOptions& options,
+                  const GrowableBuffer<int64_t>& offsets,
+                  const GrowableBuffer<uint8_t>& content,
+                  const char* encoding);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    const char*
+      encoding() const;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
@@ -43,6 +85,7 @@ namespace awkward {
     GrowableBuffer<uint8_t> content_;
     const char* encoding_;
   };
+
 }
 
 #endif // AWKWARD_STRINGBUILDER_H_

--- a/include/awkward/builder/StringBuilder.h
+++ b/include/awkward/builder/StringBuilder.h
@@ -19,7 +19,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -35,7 +35,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/TupleBuilder.h
+++ b/include/awkward/builder/TupleBuilder.h
@@ -14,9 +14,9 @@
 namespace awkward {
   class EXPORT_SYMBOL TupleBuilder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
 
-    TupleBuilder(const ArrayBuilderOptions& options, const std::vector<std::shared_ptr<Builder>>& contents, int64_t length, bool begun, size_t nextindex);
+    TupleBuilder(const ArrayBuilderOptions& options, const std::vector<BuilderPtr>& contents, int64_t length, bool begun, size_t nextindex);
     int64_t numfields() const;
 
     const std::string classname() const override;
@@ -25,29 +25,29 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
-    std::vector<std::shared_ptr<Builder>> contents_;
+    std::vector<BuilderPtr> contents_;
     int64_t length_;
     bool begun_;
     int64_t nextindex_;
 
-    void maybeupdate(int64_t i, const std::shared_ptr<Builder>& tmp);
+    void maybeupdate(int64_t i, const BuilderPtr& tmp);
   };
 }
 

--- a/include/awkward/builder/TupleBuilder.h
+++ b/include/awkward/builder/TupleBuilder.h
@@ -22,7 +22,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -38,7 +38,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/TupleBuilder.h
+++ b/include/awkward/builder/TupleBuilder.h
@@ -14,31 +14,74 @@
 namespace awkward {
   class EXPORT_SYMBOL TupleBuilder: public Builder {
   public:
-    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr
+      fromempty(const ArrayBuilderOptions& options);
 
-    TupleBuilder(const ArrayBuilderOptions& options, const std::vector<BuilderPtr>& contents, int64_t length, bool begun, size_t nextindex);
-    int64_t numfields() const;
+    TupleBuilder(const ArrayBuilderOptions& options,
+                 const std::vector<BuilderPtr>& contents,
+                 int64_t length,
+                 bool begun,
+                 size_t nextindex);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    int64_t
+      numfields() const;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    const std::string
+      classname() const override;
+
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
@@ -47,7 +90,8 @@ namespace awkward {
     bool begun_;
     int64_t nextindex_;
 
-    void maybeupdate(int64_t i, const BuilderPtr& tmp);
+    void
+      maybeupdate(int64_t i, const BuilderPtr& tmp);
   };
 }
 

--- a/include/awkward/builder/TupleBuilder.h
+++ b/include/awkward/builder/TupleBuilder.h
@@ -22,7 +22,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -38,7 +38,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/UnionBuilder.h
+++ b/include/awkward/builder/UnionBuilder.h
@@ -23,7 +23,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -39,7 +39,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/UnionBuilder.h
+++ b/include/awkward/builder/UnionBuilder.h
@@ -16,9 +16,9 @@ namespace awkward {
 
   class EXPORT_SYMBOL UnionBuilder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromsingle(const ArrayBuilderOptions& options, const std::shared_ptr<Builder>& firstcontent);
+    static const BuilderPtr fromsingle(const ArrayBuilderOptions& options, const BuilderPtr& firstcontent);
 
-    UnionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int8_t>& types, const GrowableBuffer<int64_t>& offsets, std::vector<std::shared_ptr<Builder>>& contents);
+    UnionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int8_t>& types, const GrowableBuffer<int64_t>& offsets, std::vector<BuilderPtr>& contents);
 
     const std::string classname() const override;
     int64_t length() const override;
@@ -26,26 +26,26 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;
     GrowableBuffer<int8_t> types_;
     GrowableBuffer<int64_t> offsets_;
-    std::vector<std::shared_ptr<Builder>> contents_;
+    std::vector<BuilderPtr> contents_;
     int8_t current_;
   };
 }

--- a/include/awkward/builder/UnionBuilder.h
+++ b/include/awkward/builder/UnionBuilder.h
@@ -16,30 +16,71 @@ namespace awkward {
 
   class EXPORT_SYMBOL UnionBuilder: public Builder {
   public:
-    static const BuilderPtr fromsingle(const ArrayBuilderOptions& options, const BuilderPtr& firstcontent);
+    static const BuilderPtr
+      fromsingle(const ArrayBuilderOptions& options,
+                 const BuilderPtr& firstcontent);
 
-    UnionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int8_t>& types, const GrowableBuffer<int64_t>& offsets, std::vector<BuilderPtr>& contents);
+    UnionBuilder(const ArrayBuilderOptions& options,
+                 const GrowableBuffer<int8_t>& types,
+                 const GrowableBuffer<int64_t>& offsets,
+                 std::vector<BuilderPtr>& contents);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    const std::string
+      classname() const override;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/UnionBuilder.h
+++ b/include/awkward/builder/UnionBuilder.h
@@ -23,7 +23,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -39,7 +39,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -19,7 +19,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    const std::shared_ptr<Content> snapshot() const override;
+    ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -35,7 +35,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const std::shared_ptr<Content>& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -12,30 +12,67 @@
 namespace awkward {
   class EXPORT_SYMBOL UnknownBuilder: public Builder {
   public:
-    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr
+      fromempty(const ArrayBuilderOptions& options);
 
     UnknownBuilder(const ArrayBuilderOptions& options, int64_t nullcount);
 
-    const std::string classname() const override;
-    int64_t length() const override;
-    void clear() override;
-    const ContentPtr snapshot() const override;
+    const std::string
+      classname() const override;
 
-    bool active() const override;
-    const BuilderPtr null() override;
-    const BuilderPtr boolean(bool x) override;
-    const BuilderPtr integer(int64_t x) override;
-    const BuilderPtr real(double x) override;
-    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
-    const BuilderPtr beginlist() override;
-    const BuilderPtr endlist() override;
-    const BuilderPtr begintuple(int64_t numfields) override;
-    const BuilderPtr index(int64_t index) override;
-    const BuilderPtr endtuple() override;
-    const BuilderPtr beginrecord(const char* name, bool check) override;
-    const BuilderPtr field(const char* key, bool check) override;
-    const BuilderPtr endrecord() override;
-    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
+    int64_t
+      length() const override;
+
+    void
+      clear() override;
+
+    const ContentPtr
+      snapshot() const override;
+
+    bool
+      active() const override;
+
+    const BuilderPtr
+      null() override;
+
+    const BuilderPtr
+      boolean(bool x) override;
+
+    const BuilderPtr
+      integer(int64_t x) override;
+
+    const BuilderPtr
+      real(double x) override;
+
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
+
+    const BuilderPtr
+      beginlist() override;
+
+    const BuilderPtr
+      endlist() override;
+
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
+
+    const BuilderPtr
+      index(int64_t index) override;
+
+    const BuilderPtr
+      endtuple() override;
+
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
+
+    const BuilderPtr
+      field(const char* key, bool check) override;
+
+    const BuilderPtr
+      endrecord() override;
+
+    const BuilderPtr
+      append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -12,7 +12,7 @@
 namespace awkward {
   class EXPORT_SYMBOL UnknownBuilder: public Builder {
   public:
-    static const std::shared_ptr<Builder> fromempty(const ArrayBuilderOptions& options);
+    static const BuilderPtr fromempty(const ArrayBuilderOptions& options);
 
     UnknownBuilder(const ArrayBuilderOptions& options, int64_t nullcount);
 
@@ -22,20 +22,20 @@ namespace awkward {
     const ContentPtr snapshot() const override;
 
     bool active() const override;
-    const std::shared_ptr<Builder> null() override;
-    const std::shared_ptr<Builder> boolean(bool x) override;
-    const std::shared_ptr<Builder> integer(int64_t x) override;
-    const std::shared_ptr<Builder> real(double x) override;
-    const std::shared_ptr<Builder> string(const char* x, int64_t length, const char* encoding) override;
-    const std::shared_ptr<Builder> beginlist() override;
-    const std::shared_ptr<Builder> endlist() override;
-    const std::shared_ptr<Builder> begintuple(int64_t numfields) override;
-    const std::shared_ptr<Builder> index(int64_t index) override;
-    const std::shared_ptr<Builder> endtuple() override;
-    const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
-    const std::shared_ptr<Builder> field(const char* key, bool check) override;
-    const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
+    const BuilderPtr null() override;
+    const BuilderPtr boolean(bool x) override;
+    const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr real(double x) override;
+    const BuilderPtr string(const char* x, int64_t length, const char* encoding) override;
+    const BuilderPtr beginlist() override;
+    const BuilderPtr endlist() override;
+    const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr index(int64_t index) override;
+    const BuilderPtr endtuple() override;
+    const BuilderPtr beginrecord(const char* name, bool check) override;
+    const BuilderPtr field(const char* key, bool check) override;
+    const BuilderPtr endrecord() override;
+    const BuilderPtr append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -19,7 +19,7 @@ namespace awkward {
     const std::string classname() const override;
     int64_t length() const override;
     void clear() override;
-    ContentPtr snapshot() const override;
+    const ContentPtr snapshot() const override;
 
     bool active() const override;
     const std::shared_ptr<Builder> null() override;
@@ -35,7 +35,7 @@ namespace awkward {
     const std::shared_ptr<Builder> beginrecord(const char* name, bool check) override;
     const std::shared_ptr<Builder> field(const char* key, bool check) override;
     const std::shared_ptr<Builder> endrecord() override;
-    const std::shared_ptr<Builder> append(ContentPtr& array, int64_t at) override;
+    const std::shared_ptr<Builder> append(const ContentPtr& array, int64_t at) override;
 
   private:
     const ArrayBuilderOptions options_;

--- a/include/awkward/cpu-kernels/getitem.h
+++ b/include/awkward/cpu-kernels/getitem.h
@@ -6,164 +6,1022 @@
 #include "awkward/cpu-kernels/util.h"
 
 extern "C" {
-  EXPORT_SYMBOL void awkward_regularize_rangeslice(int64_t* start, int64_t* stop, bool posstep, bool hasstart, bool hasstop, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_regularize_arrayslice_64(int64_t* flatheadptr, int64_t lenflathead, int64_t length);
+  EXPORT_SYMBOL void
+    awkward_regularize_rangeslice(
+      int64_t* start,
+      int64_t* stop,
+      bool posstep,
+      bool hasstart,
+      bool hasstop,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_regularize_arrayslice_64(
+      int64_t* flatheadptr,
+      int64_t lenflathead,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_index8_to_index64(int64_t* toptr, const int8_t* fromptr, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexU8_to_index64(int64_t* toptr, const uint8_t* fromptr, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_index32_to_index64(int64_t* toptr, const int32_t* fromptr, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexU32_to_index64(int64_t* toptr, const uint32_t* fromptr, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index8_to_index64(
+      int64_t* toptr,
+      const int8_t* fromptr,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexU8_to_index64(
+      int64_t* toptr,
+      const uint8_t* fromptr,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index32_to_index64(
+      int64_t* toptr,
+      const int32_t* fromptr,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexU32_to_index64(
+      int64_t* toptr,
+      const uint32_t* fromptr,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_index8_carry_64(int8_t* toindex, const int8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexU8_carry_64(uint8_t* toindex, const uint8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_index32_carry_64(int32_t* toindex, const int32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexU32_carry_64(uint32_t* toindex, const uint32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_index64_carry_64(int64_t* toindex, const int64_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index8_carry_64(
+      int8_t* toindex,
+      const int8_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexU8_carry_64(
+      uint8_t* toindex,
+      const uint8_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index32_carry_64(
+      int32_t* toindex,
+      const int32_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexU32_carry_64(
+      uint32_t* toindex,
+      const uint32_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index64_carry_64(
+      int64_t* toindex,
+      const int64_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_index8_carry_nocheck_64(int8_t* toindex, const int8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexU8_carry_nocheck_64(uint8_t* toindex, const uint8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_index32_carry_nocheck_64(int32_t* toindex, const int32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexU32_carry_nocheck_64(uint32_t* toindex, const uint32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_index64_carry_nocheck_64(int64_t* toindex, const int64_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index8_carry_nocheck_64(
+      int8_t* toindex,
+      const int8_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexU8_carry_nocheck_64(
+      uint8_t* toindex,
+      const uint8_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index32_carry_nocheck_64(
+      int32_t* toindex,
+      const int32_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexU32_carry_nocheck_64(
+      uint32_t* toindex,
+      const uint32_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index64_carry_nocheck_64(
+      int64_t* toindex,
+      const int64_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_slicearray_ravel_64(int64_t* toptr, const int64_t* fromptr, int64_t ndim, const int64_t* shape, const int64_t* strides);
+  EXPORT_SYMBOL struct Error
+    awkward_slicearray_ravel_64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t ndim,
+      const int64_t* shape,
+      const int64_t* strides);
 
-  EXPORT_SYMBOL struct Error awkward_slicemissing_check_same(bool* same, const int8_t* bytemask, int64_t bytemaskoffset, const int64_t* missingindex, int64_t missingindexoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_slicemissing_check_same(
+      bool* same,
+      const int8_t* bytemask,
+      int64_t bytemaskoffset,
+      const int64_t* missingindex,
+      int64_t missingindexoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_carry_arange_64(int64_t* toptr, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_carry_arange_64(
+      int64_t* toptr,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_identities32_getitem_carry_64(int32_t* newidentitiesptr, const int32_t* identitiesptr, const int64_t* carryptr, int64_t lencarry, int64_t offset, int64_t width, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_identities64_getitem_carry_64(int64_t* newidentitiesptr, const int64_t* identitiesptr, const int64_t* carryptr, int64_t lencarry, int64_t offset, int64_t width, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_getitem_carry_64(
+      int32_t* newidentitiesptr,
+      const int32_t* identitiesptr,
+      const int64_t* carryptr,
+      int64_t lencarry,
+      int64_t offset,
+      int64_t width,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_getitem_carry_64(
+      int64_t* newidentitiesptr,
+      const int64_t* identitiesptr,
+      const int64_t* carryptr,
+      int64_t lencarry,
+      int64_t offset,
+      int64_t width,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_numpyarray_contiguous_init_64(int64_t* toptr, int64_t skip, int64_t stride);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_contiguous_copy_64(uint8_t* toptr, const uint8_t* fromptr, int64_t len, int64_t stride, int64_t offset, const int64_t* pos);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_contiguous_next_64(int64_t* topos, const int64_t* frompos, int64_t len, int64_t skip, int64_t stride);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_contiguous_init_64(
+      int64_t* toptr,
+      int64_t skip,
+      int64_t stride);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_contiguous_copy_64(
+      uint8_t* toptr,
+      const uint8_t* fromptr,
+      int64_t len,
+      int64_t stride,
+      int64_t offset,
+      const int64_t* pos);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_contiguous_next_64(
+      int64_t* topos,
+      const int64_t* frompos,
+      int64_t len,
+      int64_t skip,
+      int64_t stride);
 
-  EXPORT_SYMBOL struct Error awkward_numpyarray_getitem_next_null_64(uint8_t* toptr, const uint8_t* fromptr, int64_t len, int64_t stride, int64_t offset, const int64_t* pos);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_getitem_next_at_64(int64_t* nextcarryptr, const int64_t* carryptr, int64_t lencarry, int64_t skip, int64_t at);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_getitem_next_range_64(int64_t* nextcarryptr, const int64_t* carryptr, int64_t lencarry, int64_t lenhead, int64_t skip, int64_t start, int64_t step);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_getitem_next_range_advanced_64(int64_t* nextcarryptr, int64_t* nextadvancedptr, const int64_t* carryptr, const int64_t* advancedptr, int64_t lencarry, int64_t lenhead, int64_t skip, int64_t start, int64_t step);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_getitem_next_array_64(int64_t* nextcarryptr, int64_t* nextadvancedptr, const int64_t* carryptr, const int64_t* flatheadptr, int64_t lencarry, int64_t lenflathead, int64_t skip);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_getitem_next_array_advanced_64(int64_t* nextcarryptr, const int64_t* carryptr, const int64_t* advancedptr, const int64_t* flatheadptr, int64_t lencarry, int64_t skip);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_getitem_next_null_64(
+      uint8_t* toptr,
+      const uint8_t* fromptr,
+      int64_t len,
+      int64_t stride,
+      int64_t offset,
+      const int64_t* pos);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_getitem_next_at_64(
+      int64_t* nextcarryptr,
+      const int64_t* carryptr,
+      int64_t lencarry,
+      int64_t skip,
+      int64_t at);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_getitem_next_range_64(
+      int64_t* nextcarryptr,
+      const int64_t* carryptr,
+      int64_t lencarry,
+      int64_t lenhead,
+      int64_t skip,
+      int64_t start,
+      int64_t step);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_getitem_next_range_advanced_64(
+      int64_t* nextcarryptr,
+      int64_t* nextadvancedptr,
+      const int64_t* carryptr,
+      const int64_t* advancedptr,
+      int64_t lencarry,
+      int64_t lenhead,
+      int64_t skip,
+      int64_t start,
+      int64_t step);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_getitem_next_array_64(
+      int64_t* nextcarryptr,
+      int64_t* nextadvancedptr,
+      const int64_t* carryptr,
+      const int64_t* flatheadptr,
+      int64_t lencarry,
+      int64_t lenflathead,
+      int64_t skip);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_getitem_next_array_advanced_64(
+      int64_t* nextcarryptr,
+      const int64_t* carryptr,
+      const int64_t* advancedptr,
+      const int64_t* flatheadptr,
+      int64_t lencarry,
+      int64_t skip);
 
-  EXPORT_SYMBOL struct Error awkward_numpyarray_getitem_boolean_numtrue(int64_t* numtrue, const int8_t* fromptr, int64_t byteoffset, int64_t length, int64_t stride);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_getitem_boolean_nonzero_64(int64_t* toptr, const int8_t* fromptr, int64_t byteoffset, int64_t length, int64_t stride);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_getitem_boolean_numtrue(
+      int64_t* numtrue,
+      const int8_t* fromptr,
+      int64_t byteoffset,
+      int64_t length,
+      int64_t stride);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_getitem_boolean_nonzero_64(
+      int64_t* toptr,
+      const int8_t* fromptr,
+      int64_t byteoffset,
+      int64_t length,
+      int64_t stride);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_next_at_64(int64_t* tocarry, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_next_at_64(int64_t* tocarry, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_next_at_64(int64_t* tocarry, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_next_at_64(
+      int64_t* tocarry,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t at);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_next_at_64(
+      int64_t* tocarry,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t at);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_next_at_64(
+      int64_t* tocarry,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t at);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_next_range_carrylength(int64_t* carrylength, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_next_range_carrylength(int64_t* carrylength, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_next_range_carrylength(int64_t* carrylength, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_next_range_carrylength(
+      int64_t* carrylength,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_next_range_carrylength(
+      int64_t* carrylength,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_next_range_carrylength(
+      int64_t* carrylength,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_next_range_64(int32_t* tooffsets, int64_t* tocarry, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_next_range_64(uint32_t* tooffsets, int64_t* tocarry, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_next_range_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_next_range_64(
+      int32_t* tooffsets,
+      int64_t* tocarry,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_next_range_64(
+      uint32_t* tooffsets,
+      int64_t* tocarry,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_next_range_64(
+      int64_t* tooffsets,
+      int64_t* tocarry,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_next_range_counts_64(int64_t* total, const int32_t* fromoffsets, int64_t lenstarts);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_next_range_counts_64(int64_t* total, const uint32_t* fromoffsets, int64_t lenstarts);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_next_range_counts_64(int64_t* total, const int64_t* fromoffsets, int64_t lenstarts);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_next_range_counts_64(
+      int64_t* total,
+      const int32_t* fromoffsets,
+      int64_t lenstarts);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_next_range_counts_64(
+      int64_t* total,
+      const uint32_t* fromoffsets,
+      int64_t lenstarts);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_next_range_counts_64(
+      int64_t* total,
+      const int64_t* fromoffsets,
+      int64_t lenstarts);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, const int32_t* fromoffsets, int64_t lenstarts);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, const uint32_t* fromoffsets, int64_t lenstarts);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, const int64_t* fromoffsets, int64_t lenstarts);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_next_range_spreadadvanced_64(
+      int64_t* toadvanced,
+      const int64_t* fromadvanced,
+      const int32_t* fromoffsets,
+      int64_t lenstarts);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_next_range_spreadadvanced_64(
+      int64_t* toadvanced,
+      const int64_t* fromadvanced,
+      const uint32_t* fromoffsets,
+      int64_t lenstarts);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_next_range_spreadadvanced_64(
+      int64_t* toadvanced,
+      const int64_t* fromadvanced,
+      const int64_t* fromoffsets,
+      int64_t lenstarts);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_next_array_64(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      const int64_t* fromarray,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_next_array_64(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      const int64_t* fromarray,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_next_array_64(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      const int64_t* fromarray,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_next_array_advanced_64(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      const int64_t* fromarray,
+      const int64_t* fromadvanced,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_next_array_advanced_64(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      const int64_t* fromarray,
+      const int64_t* fromadvanced,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_next_array_advanced_64(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      const int64_t* fromarray,
+      const int64_t* fromadvanced,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_carry_64(int32_t* tostarts, int32_t* tostops, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_carry_64(uint32_t* tostarts, uint32_t* tostops, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_carry_64(int64_t* tostarts, int64_t* tostops, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_carry_64(
+      int32_t* tostarts,
+      int32_t* tostops,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      const int64_t* fromcarry,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lencarry);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_carry_64(
+      uint32_t* tostarts,
+      uint32_t* tostops,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      const int64_t* fromcarry,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lencarry);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_carry_64(
+      int64_t* tostarts,
+      int64_t* tostops,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      const int64_t* fromcarry,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lencarry);
 
-  EXPORT_SYMBOL struct Error awkward_regulararray_getitem_next_at_64(int64_t* tocarry, int64_t at, int64_t len, int64_t size);
-  EXPORT_SYMBOL struct Error awkward_regulararray_getitem_next_range_64(int64_t* tocarry, int64_t regular_start, int64_t step, int64_t len, int64_t size, int64_t nextsize);
-  EXPORT_SYMBOL struct Error awkward_regulararray_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, int64_t len, int64_t nextsize);
-  EXPORT_SYMBOL struct Error awkward_regulararray_getitem_next_array_regularize_64(int64_t* toarray, const int64_t* fromarray, int64_t lenarray, int64_t size);
-  EXPORT_SYMBOL struct Error awkward_regulararray_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromarray, int64_t len, int64_t lenarray, int64_t size);
-  EXPORT_SYMBOL struct Error awkward_regulararray_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromadvanced, const int64_t* fromarray, int64_t len, int64_t lenarray, int64_t size);
-  EXPORT_SYMBOL struct Error awkward_regulararray_getitem_carry_64(int64_t* tocarry, const int64_t* fromcarry, int64_t lencarry, int64_t size);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_getitem_next_at_64(
+      int64_t* tocarry,
+      int64_t at,
+      int64_t len,
+      int64_t size);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_getitem_next_range_64(
+      int64_t* tocarry,
+      int64_t regular_start,
+      int64_t step,
+      int64_t len,
+      int64_t size,
+      int64_t nextsize);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_getitem_next_range_spreadadvanced_64(
+      int64_t* toadvanced,
+      const int64_t* fromadvanced,
+      int64_t len,
+      int64_t nextsize);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_getitem_next_array_regularize_64(
+      int64_t* toarray,
+      const int64_t* fromarray,
+      int64_t lenarray,
+      int64_t size);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_getitem_next_array_64(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int64_t* fromarray,
+      int64_t len,
+      int64_t lenarray,
+      int64_t size);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_getitem_next_array_advanced_64(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int64_t* fromadvanced,
+      const int64_t* fromarray,
+      int64_t len,
+      int64_t lenarray,
+      int64_t size);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_getitem_carry_64(
+      int64_t* tocarry,
+      const int64_t* fromcarry,
+      int64_t lencarry,
+      int64_t size);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_numnull(int64_t* numnull, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_numnull(int64_t* numnull, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_numnull(int64_t* numnull, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_numnull(
+      int64_t* numnull,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_numnull(
+      int64_t* numnull,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_numnull(
+      int64_t* numnull,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_getitem_nextcarry_outindex_64(int64_t* tocarry, int32_t* toindex, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_getitem_nextcarry_outindex_64(int64_t* tocarry, uint32_t* toindex, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_getitem_nextcarry_outindex_64(int64_t* tocarry, int64_t* toindex, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_getitem_nextcarry_outindex_64(
+      int64_t* tocarry,
+      int32_t* toindex,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_getitem_nextcarry_outindex_64(
+      int64_t* tocarry,
+      uint32_t* toindex,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_getitem_nextcarry_outindex_64(
+      int64_t* tocarry,
+      int64_t* toindex,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_getitem_nextcarry_outindex_mask_64(int64_t* tocarry, int64_t* toindex, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_getitem_nextcarry_outindex_mask_64(int64_t* tocarry, int64_t* toindex, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_getitem_nextcarry_outindex_mask_64(int64_t* tocarry, int64_t* toindex, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_getitem_nextcarry_outindex_mask_64(
+      int64_t* tocarry,
+      int64_t* toindex,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_getitem_nextcarry_outindex_mask_64(
+      int64_t* tocarry,
+      int64_t* toindex,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_getitem_nextcarry_outindex_mask_64(
+      int64_t* tocarry,
+      int64_t* toindex,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
 
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_getitem_adjust_offsets_64(int64_t* tooffsets, int64_t* tononzero, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length, const int64_t* nonzero, int64_t nonzerooffset, int64_t nonzerolength);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_getitem_adjust_offsets_64(
+      int64_t* tooffsets,
+      int64_t* tononzero,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      const int64_t* nonzero,
+      int64_t nonzerooffset,
+      int64_t nonzerolength);
 
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_getitem_adjust_offsets_index_64(int64_t* tooffsets, int64_t* tononzero, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length, const int64_t* index, int64_t indexoffset, int64_t indexlength, const int64_t* nonzero, int64_t nonzerooffset, int64_t nonzerolength, const int8_t* originalmask, int64_t maskoffset, int64_t masklength);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_getitem_adjust_offsets_index_64(
+      int64_t* tooffsets,
+      int64_t* tononzero,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      const int64_t* index,
+      int64_t indexoffset,
+      int64_t indexlength,
+      const int64_t* nonzero,
+      int64_t nonzerooffset,
+      int64_t nonzerolength,
+      const int8_t* originalmask,
+      int64_t maskoffset,
+      int64_t masklength);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray_getitem_adjust_outindex_64(int8_t* tomask, int64_t* toindex, int64_t* tononzero, const int64_t* fromindex, int64_t fromindexoffset, int64_t fromindexlength, const int64_t* nonzero, int64_t nonzerooffset, int64_t nonzerolength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray_getitem_adjust_outindex_64(
+      int8_t* tomask,
+      int64_t* toindex,
+      int64_t* tononzero,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t fromindexlength,
+      const int64_t* nonzero,
+      int64_t nonzerooffset,
+      int64_t nonzerolength);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_getitem_nextcarry_64(int64_t* tocarry, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_getitem_nextcarry_64(int64_t* tocarry, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_getitem_nextcarry_64(int64_t* tocarry, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_getitem_nextcarry_64(
+      int64_t* tocarry,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_getitem_nextcarry_64(
+      int64_t* tocarry,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_getitem_nextcarry_64(
+      int64_t* tocarry,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_getitem_carry_64(int32_t* toindex, const int32_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_getitem_carry_64(uint32_t* toindex, const uint32_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_getitem_carry_64(int64_t* toindex, const int64_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_getitem_carry_64(
+      int32_t* toindex,
+      const int32_t* fromindex,
+      const int64_t* fromcarry,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencarry);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_getitem_carry_64(
+      uint32_t* toindex,
+      const uint32_t* fromindex,
+      const int64_t* fromcarry,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencarry);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_getitem_carry_64(
+      int64_t* toindex,
+      const int64_t* fromindex,
+      const int64_t* fromcarry,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencarry);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray8_32_regular_index(int32_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_U32_regular_index(uint32_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_64_regular_index(int64_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_32_regular_index(
+      int32_t* toindex,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_U32_regular_index(
+      uint32_t* toindex,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_64_regular_index(
+      int64_t* toindex,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray8_32_project_64(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const int32_t* fromindex, int64_t indexoffset, int64_t length, int64_t which);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_U32_project_64(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const uint32_t* fromindex, int64_t indexoffset, int64_t length, int64_t which);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_64_project_64(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const int64_t* fromindex, int64_t indexoffset, int64_t length, int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_32_project_64(
+      int64_t* lenout,
+      int64_t* tocarry,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_U32_project_64(
+      int64_t* lenout,
+      int64_t* tocarry,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_64_project_64(
+      int64_t* lenout,
+      int64_t* tocarry,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t which);
 
-  EXPORT_SYMBOL struct Error awkward_missing_repeat_64(int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t indexlength, int64_t repetitions, int64_t regularsize);
+  EXPORT_SYMBOL struct Error
+    awkward_missing_repeat_64(
+      int64_t* outindex,
+      const int64_t* index,
+      int64_t indexoffset,
+      int64_t indexlength,
+      int64_t repetitions,
+      int64_t regularsize);
 
-  EXPORT_SYMBOL struct Error awkward_regulararray_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t regularsize, int64_t regularlength);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_getitem_jagged_expand_64(
+      int64_t* multistarts,
+      int64_t* multistops,
+      const int64_t* singleoffsets,
+      int64_t regularsize,
+      int64_t regularlength);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_jagged_expand_64(
+      int64_t* multistarts,
+      int64_t* multistops,
+      const int64_t* singleoffsets,
+      int64_t* tocarry,
+      const int32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t jaggedsize,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_jagged_expand_64(
+      int64_t* multistarts,
+      int64_t* multistops,
+      const int64_t* singleoffsets,
+      int64_t* tocarry,
+      const uint32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const uint32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t jaggedsize,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_jagged_expand_64(
+      int64_t* multistarts,
+      int64_t* multistops,
+      const int64_t* singleoffsets,
+      int64_t* tocarry,
+      const int64_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int64_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t jaggedsize,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listarray_getitem_jagged_carrylen_64(int64_t* carrylen, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray_getitem_jagged_carrylen_64(
+      int64_t* carrylen,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_jagged_apply_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset, int64_t contentlen);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_jagged_apply_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset, int64_t contentlen);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_jagged_apply_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset, int64_t contentlen);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_jagged_apply_64(
+      int64_t* tooffsets,
+      int64_t* tocarry,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int64_t* sliceindex,
+      int64_t sliceindexoffset,
+      int64_t sliceinnerlen,
+      const int32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t contentlen);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_jagged_apply_64(
+      int64_t* tooffsets,
+      int64_t* tocarry,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int64_t* sliceindex,
+      int64_t sliceindexoffset,
+      int64_t sliceinnerlen,
+      const uint32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const uint32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t contentlen);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_jagged_apply_64(
+      int64_t* tooffsets,
+      int64_t* tocarry,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int64_t* sliceindex,
+      int64_t sliceindexoffset,
+      int64_t sliceinnerlen,
+      const int64_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int64_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t contentlen);
 
-  EXPORT_SYMBOL struct Error awkward_listarray_getitem_jagged_numvalid_64(int64_t* numvalid, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t length, const int64_t* missing, int64_t missingoffset, int64_t missinglength);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray_getitem_jagged_numvalid_64(
+      int64_t* numvalid,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t length,
+      const int64_t* missing,
+      int64_t missingoffset,
+      int64_t missinglength);
 
-  EXPORT_SYMBOL struct Error awkward_listarray_getitem_jagged_shrink_64(int64_t* tocarry, int64_t* tosmalloffsets, int64_t* tolargeoffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t length, const int64_t* missing, int64_t missingoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray_getitem_jagged_shrink_64(
+      int64_t* tocarry,
+      int64_t* tosmalloffsets,
+      int64_t* tolargeoffsets,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t length,
+      const int64_t* missing,
+      int64_t missingoffset);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_getitem_jagged_descend_64(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_getitem_jagged_descend_64(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset);
-  EXPORT_SYMBOL struct Error awkward_listarray64_getitem_jagged_descend_64(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_getitem_jagged_descend_64(
+      int64_t* tooffsets,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int32_t* fromstops,
+      int64_t fromstopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_getitem_jagged_descend_64(
+      int64_t* tooffsets,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const uint32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const uint32_t* fromstops,
+      int64_t fromstopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_getitem_jagged_descend_64(
+      int64_t* tooffsets,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int64_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int64_t* fromstops,
+      int64_t fromstopsoffset);
 
-  EXPORT_SYMBOL int8_t awkward_index8_getitem_at_nowrap(const int8_t* ptr, int64_t offset, int64_t at);
-  EXPORT_SYMBOL uint8_t awkward_indexU8_getitem_at_nowrap(const uint8_t* ptr, int64_t offset, int64_t at);
-  EXPORT_SYMBOL int32_t awkward_index32_getitem_at_nowrap(const int32_t* ptr, int64_t offset, int64_t at);
-  EXPORT_SYMBOL uint32_t awkward_indexU32_getitem_at_nowrap(const uint32_t* ptr, int64_t offset, int64_t at);
-  EXPORT_SYMBOL int64_t awkward_index64_getitem_at_nowrap(const int64_t* ptr, int64_t offset, int64_t at);
+  EXPORT_SYMBOL int8_t
+    awkward_index8_getitem_at_nowrap(
+      const int8_t* ptr,
+      int64_t offset,
+      int64_t at);
+  EXPORT_SYMBOL uint8_t
+    awkward_indexU8_getitem_at_nowrap(
+      const uint8_t* ptr,
+      int64_t offset,
+      int64_t at);
+  EXPORT_SYMBOL int32_t
+    awkward_index32_getitem_at_nowrap(
+      const int32_t* ptr,
+      int64_t offset,
+      int64_t at);
+  EXPORT_SYMBOL uint32_t
+    awkward_indexU32_getitem_at_nowrap(
+      const uint32_t* ptr,
+      int64_t offset,
+      int64_t at);
+  EXPORT_SYMBOL int64_t
+    awkward_index64_getitem_at_nowrap(
+      const int64_t* ptr,
+      int64_t offset,
+      int64_t at);
 
-  EXPORT_SYMBOL void awkward_index8_setitem_at_nowrap(int8_t* ptr, int64_t offset, int64_t at, int8_t value);
-  EXPORT_SYMBOL void awkward_indexU8_setitem_at_nowrap(uint8_t* ptr, int64_t offset, int64_t at, uint8_t value);
-  EXPORT_SYMBOL void awkward_index32_setitem_at_nowrap(int32_t* ptr, int64_t offset, int64_t at, int32_t value);
-  EXPORT_SYMBOL void awkward_indexU32_setitem_at_nowrap(uint32_t* ptr, int64_t offset, int64_t at, uint32_t value);
-  EXPORT_SYMBOL void awkward_index64_setitem_at_nowrap(int64_t* ptr, int64_t offset, int64_t at, int64_t value);
+  EXPORT_SYMBOL void
+    awkward_index8_setitem_at_nowrap(
+      int8_t* ptr,
+      int64_t offset,
+      int64_t at,
+      int8_t value);
+  EXPORT_SYMBOL void
+    awkward_indexU8_setitem_at_nowrap(
+      uint8_t* ptr,
+      int64_t offset,
+      int64_t at,
+      uint8_t value);
+  EXPORT_SYMBOL void
+    awkward_index32_setitem_at_nowrap(
+      int32_t* ptr,
+      int64_t offset,
+      int64_t at,
+      int32_t value);
+  EXPORT_SYMBOL void
+    awkward_indexU32_setitem_at_nowrap(
+      uint32_t* ptr,
+      int64_t offset,
+      int64_t at,
+      uint32_t value);
+  EXPORT_SYMBOL void
+    awkward_index64_setitem_at_nowrap(
+      int64_t* ptr,
+      int64_t offset,
+      int64_t at,
+      int64_t value);
 
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_getitem_carry_64(int8_t* tomask, const int8_t* frommask, int64_t frommaskoffset, int64_t lenmask, const int64_t* fromcarry, int64_t lencarry);
+  EXPORT_SYMBOL struct Error
+    awkward_bytemaskedarray_getitem_carry_64(
+      int8_t* tomask,
+      const int8_t* frommask,
+      int64_t frommaskoffset,
+      int64_t lenmask,
+      const int64_t* fromcarry,
+      int64_t lencarry);
 
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_numnull(int64_t* numnull, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen);
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_getitem_nextcarry_64(int64_t* tocarry, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen);
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_getitem_nextcarry_outindex_64(int64_t* tocarry, int64_t* outindex, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen);
+  EXPORT_SYMBOL struct Error
+    awkward_bytemaskedarray_numnull(
+      int64_t* numnull,
+      const int8_t* mask,
+      int64_t maskoffset,
+      int64_t length,
+      bool validwhen);
+  EXPORT_SYMBOL struct Error
+    awkward_bytemaskedarray_getitem_nextcarry_64(
+      int64_t* tocarry,
+      const int8_t* mask,
+      int64_t maskoffset,
+      int64_t length,
+      bool validwhen);
+  EXPORT_SYMBOL struct Error
+    awkward_bytemaskedarray_getitem_nextcarry_outindex_64(
+      int64_t* tocarry,
+      int64_t* outindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      int64_t length,
+      bool validwhen);
 
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_toindexedarray_64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen);
+  EXPORT_SYMBOL struct Error
+    awkward_bytemaskedarray_toindexedarray_64(
+      int64_t* toindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      int64_t length,
+      bool validwhen);
 
 }
 

--- a/include/awkward/cpu-kernels/identities.h
+++ b/include/awkward/cpu-kernels/identities.h
@@ -6,44 +6,347 @@
 #include "awkward/cpu-kernels/util.h"
 
 extern "C" {
-  EXPORT_SYMBOL struct Error awkward_new_identities32(int32_t* toptr, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_new_identities64(int64_t* toptr, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_new_identities32(
+      int32_t* toptr,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_new_identities64(
+      int64_t* toptr,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_identities32_to_identities64(int64_t* toptr, const int32_t* fromptr, int64_t length, int64_t width);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_to_identities64(
+      int64_t* toptr,
+      const int32_t* fromptr,
+      int64_t length,
+      int64_t width);
 
-  EXPORT_SYMBOL struct Error awkward_identities32_from_listoffsetarray32(int32_t* toptr, const int32_t* fromptr, const int32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities32_from_listoffsetarrayU32(int32_t* toptr, const int32_t* fromptr, const uint32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities32_from_listoffsetarray64(int32_t* toptr, const int32_t* fromptr, const int64_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_listoffsetarray32(int64_t* toptr, const int64_t* fromptr, const int32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_listoffsetarrayU32(int64_t* toptr, const int64_t* fromptr, const uint32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_listoffsetarray64(int64_t* toptr, const int64_t* fromptr, const int64_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_listoffsetarray32(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int32_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_listoffsetarrayU32(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const uint32_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_listoffsetarray64(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int64_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_listoffsetarray32(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int32_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_listoffsetarrayU32(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const uint32_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_listoffsetarray64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int64_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
 
-  EXPORT_SYMBOL struct Error awkward_identities32_from_listarray32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int32_t* fromstarts, const int32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities32_from_listarrayU32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities32_from_listarray64(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int64_t* fromstarts, const int64_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_listarray32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int32_t* fromstarts, const int32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_listarrayU32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_listarray64(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int64_t* fromstarts, const int64_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_listarray32(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_listarrayU32(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_listarray64(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_listarray32(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_listarrayU32(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_listarray64(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
 
-  EXPORT_SYMBOL struct Error awkward_identities32_from_regulararray(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, int64_t size, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_regulararray(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, int64_t size, int64_t tolength, int64_t fromlength, int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_regulararray(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      int64_t size,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_regulararray(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      int64_t size,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
 
-  EXPORT_SYMBOL struct Error awkward_identities32_from_indexedarray32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities32_from_indexedarrayU32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const uint32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities32_from_indexedarray64(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int64_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_indexedarray32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_indexedarrayU32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const uint32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_indexedarray64(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int64_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_indexedarray32(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_indexedarrayU32(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const uint32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_indexedarray64(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int64_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_indexedarray32(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_indexedarrayU32(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const uint32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_indexedarray64(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int64_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth);
 
-  EXPORT_SYMBOL struct Error awkward_identities32_from_unionarray8_32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const int32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which);
-  EXPORT_SYMBOL struct Error awkward_identities32_from_unionarray8_U32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const uint32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which);
-  EXPORT_SYMBOL struct Error awkward_identities32_from_unionarray8_64(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const int64_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_unionarray8_32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const int32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_unionarray8_U32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const uint32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which);
-  EXPORT_SYMBOL struct Error awkward_identities64_from_unionarray8_64(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const int64_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_unionarray8_32(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int8_t* fromtags,
+      const int32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_unionarray8_U32(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int8_t* fromtags,
+      const uint32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_from_unionarray8_64(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int8_t* fromtags,
+      const int64_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_unionarray8_32(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int8_t* fromtags,
+      const int32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_unionarray8_U32(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int8_t* fromtags,
+      const uint32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_from_unionarray8_64(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int8_t* fromtags,
+      const int64_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which);
 
-  EXPORT_SYMBOL struct Error awkward_identities32_extend(int32_t* toptr, const int32_t* fromptr, int64_t fromoffset, int64_t fromlength, int64_t tolength);
-  EXPORT_SYMBOL struct Error awkward_identities64_extend(int64_t* toptr, const int64_t* fromptr, int64_t fromoffset, int64_t fromlength, int64_t tolength);
+  EXPORT_SYMBOL struct Error
+    awkward_identities32_extend(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromoffset,
+      int64_t fromlength,
+      int64_t tolength);
+  EXPORT_SYMBOL struct Error
+    awkward_identities64_extend(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromoffset,
+      int64_t fromlength,
+      int64_t tolength);
 
 }
 

--- a/include/awkward/cpu-kernels/operations.h
+++ b/include/awkward/cpu-kernels/operations.h
@@ -6,208 +6,1325 @@
 #include "awkward/cpu-kernels/util.h"
 
 extern "C" {
-  EXPORT_SYMBOL struct Error awkward_listarray32_num_64(int64_t* tonum, const int32_t* fromstarts, int64_t startsoffset, const int32_t* fromstops, int64_t stopsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_num_64(int64_t* tonum, const uint32_t* fromstarts, int64_t startsoffset, const uint32_t* fromstops, int64_t stopsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarray64_num_64(int64_t* tonum, const int64_t* fromstarts, int64_t startsoffset, const int64_t* fromstops, int64_t stopsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_num_64(
+      int64_t* tonum,
+      const int32_t* fromstarts,
+      int64_t startsoffset,
+      const int32_t* fromstops,
+      int64_t stopsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_num_64(
+      int64_t* tonum,
+      const uint32_t* fromstarts,
+      int64_t startsoffset,
+      const uint32_t* fromstops,
+      int64_t stopsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_num_64(
+      int64_t* tonum,
+      const int64_t* fromstarts,
+      int64_t startsoffset,
+      const int64_t* fromstops,
+      int64_t stopsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray32_count_64(int64_t* tocount, const int32_t* fromoffsets, int64_t lenoffsets);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarrayU32_count_64(int64_t* tocount, const uint32_t* fromoffsets, int64_t lenoffsets);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray64_count_64(int64_t* tocount, const int64_t* fromoffsets, int64_t lenoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray32_count_64(
+      int64_t* tocount,
+      const int32_t* fromoffsets,
+      int64_t lenoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarrayU32_count_64(
+      int64_t* tocount,
+      const uint32_t* fromoffsets,
+      int64_t lenoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray64_count_64(
+      int64_t* tocount,
+      const int64_t* fromoffsets,
+      int64_t lenoffsets);
 
-  EXPORT_SYMBOL struct Error awkward_regulararray_num_64(int64_t* tonum, int64_t size, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_num_64(
+      int64_t* tonum,
+      int64_t size,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray32_flatten_offsets_64(int64_t* tooffsets, const int32_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarrayU32_flatten_offsets_64(int64_t* tooffsets, const uint32_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray64_flatten_offsets_64(int64_t* tooffsets, const int64_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray32_flatten_offsets_64(
+      int64_t* tooffsets,
+      const int32_t* outeroffsets,
+      int64_t outeroffsetsoffset,
+      int64_t outeroffsetslen,
+      const int64_t* inneroffsets,
+      int64_t inneroffsetsoffset,
+      int64_t inneroffsetslen);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarrayU32_flatten_offsets_64(
+      int64_t* tooffsets,
+      const uint32_t* outeroffsets,
+      int64_t outeroffsetsoffset,
+      int64_t outeroffsetslen,
+      const int64_t* inneroffsets,
+      int64_t inneroffsetsoffset,
+      int64_t inneroffsetslen);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray64_flatten_offsets_64(
+      int64_t* tooffsets,
+      const int64_t* outeroffsets,
+      int64_t outeroffsetsoffset,
+      int64_t outeroffsetslen,
+      const int64_t* inneroffsets,
+      int64_t inneroffsetsoffset,
+      int64_t inneroffsetslen);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_flatten_none2empty_64(int64_t* outoffsets, const int32_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_flatten_none2empty_64(int64_t* outoffsets, const uint32_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_flatten_none2empty_64(int64_t* outoffsets, const int64_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_flatten_none2empty_64(
+      int64_t* outoffsets,
+      const int32_t* outindex,
+      int64_t outindexoffset,
+      int64_t outindexlength,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_flatten_none2empty_64(
+      int64_t* outoffsets,
+      const uint32_t* outindex,
+      int64_t outindexoffset,
+      int64_t outindexlength,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_flatten_none2empty_64(
+      int64_t* outoffsets,
+      const int64_t* outindex,
+      int64_t outindexoffset,
+      int64_t outindexlength,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray32_flatten_length_64(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets);
-  EXPORT_SYMBOL struct Error awkward_unionarrayU32_flatten_length_64(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets);
-  EXPORT_SYMBOL struct Error awkward_unionarray64_flatten_length_64(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray32_flatten_length_64(
+      int64_t* total_length,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarrayU32_flatten_length_64(
+      int64_t* total_length,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const uint32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray64_flatten_length_64(
+      int64_t* total_length,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray32_flatten_combine_64(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets);
-  EXPORT_SYMBOL struct Error awkward_unionarrayU32_flatten_combine_64(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets);
-  EXPORT_SYMBOL struct Error awkward_unionarray64_flatten_combine_64(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray32_flatten_combine_64(
+      int8_t* totags,
+      int64_t* toindex,
+      int64_t* tooffsets,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarrayU32_flatten_combine_64(
+      int8_t* totags,
+      int64_t* toindex,
+      int64_t* tooffsets,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const uint32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray64_flatten_combine_64(
+      int8_t* totags,
+      int64_t* toindex,
+      int64_t* tooffsets,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_flatten_nextcarry_64(int64_t* tocarry, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_flatten_nextcarry_64(int64_t* tocarry, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_flatten_nextcarry_64(int64_t* tocarry, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_flatten_nextcarry_64(
+      int64_t* tocarry,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_flatten_nextcarry_64(
+      int64_t* tocarry,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_flatten_nextcarry_64(
+      int64_t* tocarry,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_overlay_mask8_to64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const int32_t* fromindex, int64_t indexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_overlay_mask8_to64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const uint32_t* fromindex, int64_t indexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_overlay_mask8_to64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const int64_t* fromindex, int64_t indexoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_overlay_mask8_to64(
+      int64_t* toindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_overlay_mask8_to64(
+      int64_t* toindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_overlay_mask8_to64(
+      int64_t* toindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_mask8(int8_t* tomask, const int32_t* fromindex, int64_t indexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_mask8(int8_t* tomask, const uint32_t* fromindex, int64_t indexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_mask8(int8_t* tomask, const int64_t* fromindex, int64_t indexoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_mask8(
+      int8_t* tomask,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_mask8(
+      int8_t* tomask,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_mask8(
+      int8_t* tomask,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_mask8(int8_t* tomask, const int8_t* frommask, int64_t maskoffset, int64_t length, bool validwhen);
+  EXPORT_SYMBOL struct Error
+    awkward_bytemaskedarray_mask8(
+      int8_t* tomask,
+      const int8_t* frommask,
+      int64_t maskoffset,
+      int64_t length,
+      bool validwhen);
 
-  EXPORT_SYMBOL struct Error awkward_zero_mask8(int8_t* tomask, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_zero_mask8(
+      int8_t* tomask,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_simplify32_to64(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength);
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_simplifyU32_to64(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength);
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_simplify64_to64(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_simplify32_to64(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_simplifyU32_to64(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_simplify64_to64(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_simplify32_to64(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_simplifyU32_to64(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_simplify64_to64(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_simplify32_to64(
+      int64_t* toindex,
+      const int32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_simplifyU32_to64(
+      int64_t* toindex,
+      const int32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const uint32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_simplify64_to64(
+      int64_t* toindex,
+      const int32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int64_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_simplify32_to64(
+      int64_t* toindex,
+      const uint32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_simplifyU32_to64(
+      int64_t* toindex,
+      const uint32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const uint32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_simplify64_to64(
+      int64_t* toindex,
+      const uint32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int64_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_simplify32_to64(
+      int64_t* toindex,
+      const int64_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_simplifyU32_to64(
+      int64_t* toindex,
+      const int64_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const uint32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_simplify64_to64(
+      int64_t* toindex,
+      const int64_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int64_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength);
 
-  EXPORT_SYMBOL struct Error awkward_regulararray_compact_offsets64(int64_t* tooffsets, int64_t length, int64_t size);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_compact_offsets64(
+      int64_t* tooffsets,
+      int64_t length,
+      int64_t size);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_compact_offsets64(int64_t* tooffsets, const int32_t* fromstarts, const int32_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_compact_offsets64(int64_t* tooffsets, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarray64_compact_offsets64(int64_t* tooffsets, const int64_t* fromstarts, const int64_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_compact_offsets64(
+      int64_t* tooffsets,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_compact_offsets64(
+      int64_t* tooffsets,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_compact_offsets64(
+      int64_t* tooffsets,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray32_compact_offsets64(int64_t* tooffsets, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarrayU32_compact_offsets64(int64_t* tooffsets, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray64_compact_offsets64(int64_t* tooffsets, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray32_compact_offsets64(
+      int64_t* tooffsets,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarrayU32_compact_offsets64(
+      int64_t* tooffsets,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray64_compact_offsets64(
+      int64_t* tooffsets,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_broadcast_tooffsets64(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const int32_t* fromstarts, int64_t startsoffset, const int32_t* fromstops, int64_t stopsoffset, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_broadcast_tooffsets64(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const uint32_t* fromstarts, int64_t startsoffset, const uint32_t* fromstops, int64_t stopsoffset, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_listarray64_broadcast_tooffsets64(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const int64_t* fromstarts, int64_t startsoffset, const int64_t* fromstops, int64_t stopsoffset, int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_broadcast_tooffsets64(
+      int64_t* tocarry,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength,
+      const int32_t* fromstarts,
+      int64_t startsoffset,
+      const int32_t* fromstops,
+      int64_t stopsoffset,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_broadcast_tooffsets64(
+      int64_t* tocarry,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength,
+      const uint32_t* fromstarts,
+      int64_t startsoffset,
+      const uint32_t* fromstops,
+      int64_t stopsoffset,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_broadcast_tooffsets64(
+      int64_t* tocarry,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength,
+      const int64_t* fromstarts,
+      int64_t startsoffset,
+      const int64_t* fromstops,
+      int64_t stopsoffset,
+      int64_t lencontent);
 
-  EXPORT_SYMBOL struct Error awkward_regulararray_broadcast_tooffsets64(const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, int64_t size);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_broadcast_tooffsets64(
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength,
+      int64_t size);
 
-  EXPORT_SYMBOL struct Error awkward_regulararray_broadcast_tooffsets64_size1(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_broadcast_tooffsets64_size1(
+      int64_t* tocarry,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength);
 
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray32_toRegularArray(int64_t* size, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarrayU32_toRegularArray(int64_t* size, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray64_toRegularArray(int64_t* size, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray32_toRegularArray(
+      int64_t* size,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarrayU32_toRegularArray(
+      int64_t* size,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray64_toRegularArray(
+      int64_t* size,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength);
 
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_fromdouble(double* toptr, int64_t tooffset, const double* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_fromfloat(double* toptr, int64_t tooffset, const float* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_from64(double* toptr, int64_t tooffset, const int64_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_fromU64(double* toptr, int64_t tooffset, const uint64_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_from32(double* toptr, int64_t tooffset, const int32_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_fromU32(double* toptr, int64_t tooffset, const uint32_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_from16(double* toptr, int64_t tooffset, const int16_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_fromU16(double* toptr, int64_t tooffset, const uint16_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_from8(double* toptr, int64_t tooffset, const int8_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_fromU8(double* toptr, int64_t tooffset, const uint8_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_todouble_frombool(double* toptr, int64_t tooffset, const bool* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_toU64_fromU64(uint64_t* toptr, int64_t tooffset, const uint64_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_from64(int64_t* toptr, int64_t tooffset, const int64_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_fromU64(int64_t* toptr, int64_t tooffset, const uint64_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_from32(int64_t* toptr, int64_t tooffset, const int32_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_fromU32(int64_t* toptr, int64_t tooffset, const uint32_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_from16(int64_t* toptr, int64_t tooffset, const int16_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_fromU16(int64_t* toptr, int64_t tooffset, const uint16_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_from8(int64_t* toptr, int64_t tooffset, const int8_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_fromU8(int64_t* toptr, int64_t tooffset, const uint8_t* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_to64_frombool(int64_t* toptr, int64_t tooffset, const bool* fromptr, int64_t fromoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_numpyarray_fill_tobool_frombool(bool* toptr, int64_t tooffset, const bool* fromptr, int64_t fromoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_fromdouble(
+      double* toptr,
+      int64_t tooffset,
+      const double* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_fromfloat(
+      double* toptr,
+      int64_t tooffset,
+      const float* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_from64(
+      double* toptr,
+      int64_t tooffset,
+      const int64_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_fromU64(
+      double* toptr,
+      int64_t tooffset,
+      const uint64_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_from32(
+      double* toptr,
+      int64_t tooffset,
+      const int32_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_fromU32(
+      double* toptr,
+      int64_t tooffset,
+      const uint32_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_from16(
+      double* toptr,
+      int64_t tooffset,
+      const int16_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_fromU16(
+      double* toptr,
+      int64_t tooffset,
+      const uint16_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_from8(
+      double* toptr,
+      int64_t tooffset,
+      const int8_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_fromU8(
+      double* toptr,
+      int64_t tooffset,
+      const uint8_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_todouble_frombool(
+      double* toptr,
+      int64_t tooffset,
+      const bool* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_toU64_fromU64(
+      uint64_t* toptr,
+      int64_t tooffset,
+      const uint64_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_from64(
+      int64_t* toptr,
+      int64_t tooffset,
+      const int64_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_fromU64(
+      int64_t* toptr,
+      int64_t tooffset,
+      const uint64_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_from32(
+      int64_t* toptr,
+      int64_t tooffset,
+      const int32_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_fromU32(
+      int64_t* toptr,
+      int64_t tooffset,
+      const uint32_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_from16(
+      int64_t* toptr,
+      int64_t tooffset,
+      const int16_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_fromU16(
+      int64_t* toptr,
+      int64_t tooffset,
+      const uint16_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_from8(
+      int64_t* toptr,
+      int64_t tooffset,
+      const int8_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_fromU8(
+      int64_t* toptr,
+      int64_t tooffset,
+      const uint8_t* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_to64_frombool(
+      int64_t* toptr,
+      int64_t tooffset,
+      const bool* fromptr,
+      int64_t fromoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_fill_tobool_frombool(
+      bool* toptr,
+      int64_t tooffset,
+      const bool* fromptr,
+      int64_t fromoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listarray_fill_to64_from32(int64_t* tostarts, int64_t tostartsoffset, int64_t* tostops, int64_t tostopsoffset, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_listarray_fill_to64_fromU32(int64_t* tostarts, int64_t tostartsoffset, int64_t* tostops, int64_t tostopsoffset, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_listarray_fill_to64_from64(int64_t* tostarts, int64_t tostartsoffset, int64_t* tostops, int64_t tostopsoffset, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset, int64_t length, int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray_fill_to64_from32(
+      int64_t* tostarts,
+      int64_t tostartsoffset,
+      int64_t* tostops,
+      int64_t tostopsoffset,
+      const int32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray_fill_to64_fromU32(
+      int64_t* tostarts,
+      int64_t tostartsoffset,
+      int64_t* tostops,
+      int64_t tostopsoffset,
+      const uint32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const uint32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray_fill_to64_from64(
+      int64_t* tostarts,
+      int64_t tostartsoffset,
+      int64_t* tostops,
+      int64_t tostopsoffset,
+      const int64_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int64_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t length,
+      int64_t base);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray_fill_to64_from32(int64_t* toindex, int64_t toindexoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_indexedarray_fill_to64_fromU32(int64_t* toindex, int64_t toindexoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_indexedarray_fill_to64_from64(int64_t* toindex, int64_t toindexoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray_fill_to64_from32(
+      int64_t* toindex,
+      int64_t toindexoffset,
+      const int32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray_fill_to64_fromU32(
+      int64_t* toindex,
+      int64_t toindexoffset,
+      const uint32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray_fill_to64_from64(
+      int64_t* toindex,
+      int64_t toindexoffset,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t base);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray_fill_to64_count(int64_t* toindex, int64_t toindexoffset, int64_t length, int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray_fill_to64_count(
+      int64_t* toindex,
+      int64_t toindexoffset,
+      int64_t length,
+      int64_t base);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray_filltags_to8_from8(int8_t* totags, int64_t totagsoffset, const int8_t* fromtags, int64_t fromtagsoffset, int64_t length, int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray_filltags_to8_from8(
+      int8_t* totags,
+      int64_t totagsoffset,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      int64_t length,
+      int64_t base);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray_fillindex_to64_from32(int64_t* toindex, int64_t toindexoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_unionarray_fillindex_to64_fromU32(int64_t* toindex, int64_t toindexoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_unionarray_fillindex_to64_from64(int64_t* toindex, int64_t toindexoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray_fillindex_to64_from32(
+      int64_t* toindex,
+      int64_t toindexoffset,
+      const int32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray_fillindex_to64_fromU32(
+      int64_t* toindex,
+      int64_t toindexoffset,
+      const uint32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray_fillindex_to64_from64(
+      int64_t* toindex,
+      int64_t toindexoffset,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray_filltags_to8_const(int8_t* totags, int64_t totagsoffset, int64_t length, int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray_filltags_to8_const(
+      int8_t* totags,
+      int64_t totagsoffset,
+      int64_t length,
+      int64_t base);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray_fillindex_to64_count(int64_t* toindex, int64_t toindexoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray_fillindex_to64_count(
+      int64_t* toindex,
+      int64_t toindexoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray8_32_simplify8_32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_32_simplify8_U32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_32_simplify8_64_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_U32_simplify8_32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_U32_simplify8_U32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_U32_simplify8_64_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_64_simplify8_32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_64_simplify8_U32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_64_simplify8_64_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_32_simplify8_32_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_32_simplify8_U32_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const uint32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_32_simplify8_64_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int64_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_U32_simplify8_32_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const uint32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_U32_simplify8_U32_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const uint32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const uint32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_U32_simplify8_64_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const uint32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int64_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_64_simplify8_32_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int64_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_64_simplify8_U32_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int64_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const uint32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_64_simplify8_64_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int64_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int64_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray8_32_simplify_one_to8_64(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_U32_simplify_one_to8_64(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_64_simplify_one_to8_64(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_32_simplify_one_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t towhich,
+      int64_t fromwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_U32_simplify_one_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const uint32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t towhich,
+      int64_t fromwhich,
+      int64_t length,
+      int64_t base);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_64_simplify_one_to8_64(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t towhich,
+      int64_t fromwhich,
+      int64_t length,
+      int64_t base);
 
-  EXPORT_SYMBOL struct Error awkward_UnionArray_fillna_from32_to64(int64_t* toindex, const int32_t* fromindex, int64_t offset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_UnionArray_fillna_fromU32_to64(int64_t* toindex, const uint32_t* fromindex, int64_t offset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_UnionArray_fillna_from64_to64(int64_t* toindex, const int64_t* fromindex, int64_t offset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_UnionArray_fillna_from32_to64(
+      int64_t* toindex,
+      const int32_t* fromindex,
+      int64_t offset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_UnionArray_fillna_fromU32_to64(
+      int64_t* toindex,
+      const uint32_t* fromindex,
+      int64_t offset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_UnionArray_fillna_from64_to64(
+      int64_t* toindex,
+      const int64_t* fromindex,
+      int64_t offset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(int64_t* toindex, const int8_t* frommask, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
+      int64_t* toindex,
+      const int8_t* frommask,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_index_rpad_and_clip_axis0_64(int64_t* toindex, int64_t target, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_index_rpad_and_clip_axis1_64(int64_t* tostarts, int64_t* tostops, int64_t target, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index_rpad_and_clip_axis0_64(
+      int64_t* toindex,
+      int64_t target,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_index_rpad_and_clip_axis1_64(
+      int64_t* tostarts,
+      int64_t* tostops,
+      int64_t target,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_RegularArray_rpad_and_clip_axis1_64(int64_t* toindex, int64_t target, int64_t size, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_RegularArray_rpad_and_clip_axis1_64(
+      int64_t* toindex,
+      int64_t target,
+      int64_t size,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_ListArray32_min_range(int64_t* tomin, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset);
-  EXPORT_SYMBOL struct Error awkward_ListArrayU32_min_range(int64_t* tomin, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset);
-  EXPORT_SYMBOL struct Error awkward_ListArray64_min_range(int64_t* tomin, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArray32_min_range(
+      int64_t* tomin,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArrayU32_min_range(
+      int64_t* tomin,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArray64_min_range(
+      int64_t* tomin,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset);
 
-  EXPORT_SYMBOL struct Error awkward_ListArray32_rpad_and_clip_length_axis1(int64_t* tomin, const int32_t* fromstarts, const int32_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset);
-  EXPORT_SYMBOL struct Error awkward_ListArrayU32_rpad_and_clip_length_axis1(int64_t* tomin, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset);
-  EXPORT_SYMBOL struct Error awkward_ListArray64_rpad_and_clip_length_axis1(int64_t* tomin, const int64_t* fromstarts, const int64_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArray32_rpad_and_clip_length_axis1(
+      int64_t* tomin,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t target,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArrayU32_rpad_and_clip_length_axis1(
+      int64_t* tomin,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t target,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArray64_rpad_and_clip_length_axis1(
+      int64_t* tomin,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t target,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset);
 
-  EXPORT_SYMBOL struct Error awkward_ListArray32_rpad_axis1_64(int64_t* toindex, const int32_t* fromstarts, const int32_t* fromstops, int32_t* tostarts, int32_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset);
-  EXPORT_SYMBOL struct Error awkward_ListArrayU32_rpad_axis1_64(int64_t* toindex, const uint32_t* fromstarts, const uint32_t* fromstops, uint32_t* tostarts, uint32_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset);
-  EXPORT_SYMBOL struct Error awkward_ListArray64_rpad_axis1_64(int64_t* toindex, const int64_t* fromstarts, const int64_t* fromstops, int64_t* tostarts, int64_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArray32_rpad_axis1_64(
+      int64_t* toindex,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int32_t* tostarts,
+      int32_t* tostops,
+      int64_t target,
+      int64_t length,
+      int64_t startsoffset,
+      int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArrayU32_rpad_axis1_64(
+      int64_t* toindex,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      uint32_t* tostarts,
+      uint32_t* tostops,
+      int64_t target,
+      int64_t length,
+      int64_t startsoffset,
+      int64_t stopsoffset);
+  EXPORT_SYMBOL struct Error
+    awkward_ListArray64_rpad_axis1_64(
+      int64_t* toindex,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t* tostarts,
+      int64_t* tostops,
+      int64_t target,
+      int64_t length,
+      int64_t startsoffset,
+      int64_t stopsoffset);
 
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArray32_rpad_and_clip_axis1_64(int64_t* toindex, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target);
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArrayU32_rpad_and_clip_axis1_64(int64_t* toindex, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target);
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArray64_rpad_and_clip_axis1_64(int64_t* toindex, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArray32_rpad_and_clip_axis1_64(
+      int64_t* toindex,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      int64_t target);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArrayU32_rpad_and_clip_axis1_64(
+      int64_t* toindex,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      int64_t target);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArray64_rpad_and_clip_axis1_64(
+      int64_t* toindex,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      int64_t target);
 
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArray32_rpad_length_axis1(int32_t* tooffsets, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target, int64_t* tolength);
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArrayU32_rpad_length_axis1(uint32_t* tooffsets, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target, int64_t* tolength);
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArray64_rpad_length_axis1(int64_t* tooffsets, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target, int64_t* tolength);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArray32_rpad_length_axis1(
+      int32_t* tooffsets,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target,
+      int64_t* tolength);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArrayU32_rpad_length_axis1(
+      uint32_t* tooffsets,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target,
+      int64_t* tolength);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArray64_rpad_length_axis1(
+      int64_t* tooffsets,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target,
+      int64_t* tolength);
 
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArray32_rpad_axis1_64(int64_t* toindex, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target);
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArrayU32_rpad_axis1_64(int64_t* toindex, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target);
-  EXPORT_SYMBOL struct Error awkward_ListOffsetArray64_rpad_axis1_64(int64_t* toindex, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArray32_rpad_axis1_64(
+      int64_t* toindex,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArrayU32_rpad_axis1_64(
+      int64_t* toindex,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target);
+  EXPORT_SYMBOL struct Error
+    awkward_ListOffsetArray64_rpad_axis1_64(
+      int64_t* toindex,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_validity(const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_validity(const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent);
-  EXPORT_SYMBOL struct Error awkward_listarray64_validity(const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_validity(
+      const int32_t* starts,
+      int64_t startsoffset,
+      const int32_t* stops,
+      int64_t stopsoffset,
+      int64_t length,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_validity(
+      const uint32_t* starts,
+      int64_t startsoffset,
+      const uint32_t* stops,
+      int64_t stopsoffset,
+      int64_t length,
+      int64_t lencontent);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_validity(
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* stops,
+      int64_t stopsoffset,
+      int64_t length,
+      int64_t lencontent);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_validity(const int32_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_validity(const uint32_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_validity(const int64_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_validity(
+      const int32_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t lencontent,
+      bool isoption);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_validity(
+      const uint32_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t lencontent,
+      bool isoption);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_validity(
+      const int64_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t lencontent,
+      bool isoption);
 
-  EXPORT_SYMBOL struct Error awkward_unionarray8_32_validity(const int8_t* tags, int64_t tagsoffset, const int32_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_U32_validity(const int8_t* tags, int64_t tagsoffset, const uint32_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents);
-  EXPORT_SYMBOL struct Error awkward_unionarray8_64_validity(const int8_t* tags, int64_t tagsoffset, const int64_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_32_validity(
+      const int8_t* tags,
+      int64_t tagsoffset,
+      const int32_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t numcontents,
+      const int64_t* lencontents);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_U32_validity(
+      const int8_t* tags,
+      int64_t tagsoffset,
+      const uint32_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t numcontents,
+      const int64_t* lencontents);
+  EXPORT_SYMBOL struct Error
+    awkward_unionarray8_64_validity(
+      const int8_t* tags,
+      int64_t tagsoffset,
+      const int64_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t numcontents,
+      const int64_t* lencontents);
 
-  EXPORT_SYMBOL struct Error awkward_localindex_64(int64_t* toindex, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_localindex_64(
+      int64_t* toindex,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_localindex_64(int64_t* toindex, const int32_t* offsets, int64_t offsetsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_localindex_64(int64_t* toindex, const uint32_t* offsets, int64_t offsetsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarray64_localindex_64(int64_t* toindex, const int64_t* offsets, int64_t offsetsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_localindex_64(
+      int64_t* toindex,
+      const int32_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_localindex_64(
+      int64_t* toindex,
+      const uint32_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_localindex_64(
+      int64_t* toindex,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_regulararray_localindex_64(int64_t* toindex, int64_t size, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_localindex_64(
+      int64_t* toindex,
+      int64_t size,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_choose_64(int64_t* toindex, int64_t n, bool diagonal, int64_t singlelen);
+  EXPORT_SYMBOL struct Error
+    awkward_choose_64(
+      int64_t* toindex,
+      int64_t n,
+      bool diagonal,
+      int64_t singlelen);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_choose_length_64(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_choose_length_64(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarray64_choose_length_64(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_choose_length_64(
+      int64_t* totallen,
+      int64_t* tooffsets,
+      int64_t n,
+      bool diagonal,
+      const int32_t* starts,
+      int64_t startsoffset,
+      const int32_t* stops,
+      int64_t stopsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_choose_length_64(
+      int64_t* totallen,
+      int64_t* tooffsets,
+      int64_t n,
+      bool diagonal,
+      const uint32_t* starts,
+      int64_t startsoffset,
+      const uint32_t* stops,
+      int64_t stopsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_choose_length_64(
+      int64_t* totallen,
+      int64_t* tooffsets,
+      int64_t n,
+      bool diagonal,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* stops,
+      int64_t stopsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listarray32_choose_64(int64_t** tocarry, int64_t n, bool diagonal, const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarrayU32_choose_64(int64_t** tocarry, int64_t n, bool diagonal, const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listarray64_choose_64(int64_t** tocarry, int64_t n, bool diagonal, const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray32_choose_64(
+      int64_t** tocarry,
+      int64_t n,
+      bool diagonal,
+      const int32_t* starts,
+      int64_t startsoffset,
+      const int32_t* stops,
+      int64_t stopsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarrayU32_choose_64(
+      int64_t** tocarry,
+      int64_t n,
+      bool diagonal,
+      const uint32_t* starts,
+      int64_t startsoffset,
+      const uint32_t* stops,
+      int64_t stopsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listarray64_choose_64(
+      int64_t** tocarry,
+      int64_t n,
+      bool diagonal,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* stops,
+      int64_t stopsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_regulararray_choose_64(int64_t** tocarry, int64_t n, bool diagonal, int64_t size, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_regulararray_choose_64(
+      int64_t** tocarry,
+      int64_t n,
+      bool diagonal,
+      int64_t size,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_overlay_mask8(int8_t* tomask, const int8_t* theirmask, int64_t theirmaskoffset, const int8_t* mymask, int64_t mymaskoffset, int64_t length, bool validwhen);
+  EXPORT_SYMBOL struct Error
+    awkward_bytemaskedarray_overlay_mask8(
+      int8_t* tomask,
+      const int8_t* theirmask,
+      int64_t theirmaskoffset,
+      const int8_t* mymask,
+      int64_t mymaskoffset,
+      int64_t length,
+      bool validwhen);
 
-  EXPORT_SYMBOL struct Error awkward_bitmaskedarray_to_bytemaskedarray(int8_t* tobytemask, const uint8_t* frombitmask, int64_t bitmaskoffset, int64_t bitmasklength, bool validwhen, bool lsb_order);
-  EXPORT_SYMBOL struct Error awkward_bitmaskedarray_to_indexedoptionarray_64(int64_t* toindex, const uint8_t* frombitmask, int64_t bitmaskoffset, int64_t bitmasklength, bool validwhen, bool lsb_order);
+  EXPORT_SYMBOL struct Error
+    awkward_bitmaskedarray_to_bytemaskedarray(
+      int8_t* tobytemask,
+      const uint8_t* frombitmask,
+      int64_t bitmaskoffset,
+      int64_t bitmasklength,
+      bool validwhen,
+      bool lsb_order);
+  EXPORT_SYMBOL struct Error
+    awkward_bitmaskedarray_to_indexedoptionarray_64(
+      int64_t* toindex,
+      const uint8_t* frombitmask,
+      int64_t bitmaskoffset,
+      int64_t bitmasklength,
+      bool validwhen,
+      bool lsb_order);
 
 }
 

--- a/include/awkward/cpu-kernels/reducers.h
+++ b/include/awkward/cpu-kernels/reducers.h
@@ -6,149 +6,1211 @@
 #include "awkward/cpu-kernels/util.h"
 
 extern "C" {
-  EXPORT_SYMBOL struct Error awkward_reduce_count_64(int64_t* toptr, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_count_64(
+      int64_t* toptr,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_uint8_64(int64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_uint16_64(int64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_uint32_64(int64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_uint64_64(int64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_float32_64(int64_t* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_countnonzero_float64_64(int64_t* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_bool_64(
+      int64_t* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_int8_64(
+      int64_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_uint8_64(
+      int64_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_int16_64(
+      int64_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_uint16_64(
+      int64_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_int32_64(
+      int64_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_uint32_64(
+      int64_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_int64_64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_uint64_64(
+      int64_t* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_float32_64(
+      int64_t* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_countnonzero_float64_64(
+      int64_t* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int64_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int64_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_uint64_uint8_64(uint64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int64_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_uint64_uint16_64(uint64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int64_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_uint64_uint32_64(uint64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int64_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_uint64_uint64_64(uint64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_float32_float32_64(float* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_float64_float64_64(double* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int32_bool_64(int32_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int32_int8_64(int32_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_uint32_uint8_64(uint32_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int32_int16_64(int32_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_uint32_uint16_64(uint32_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_int32_int32_64(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_uint32_uint32_64(uint32_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int64_bool_64(
+      int64_t* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int64_int8_64(
+      int64_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_uint64_uint8_64(
+      uint64_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int64_int16_64(
+      int64_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_uint64_uint16_64(
+      uint64_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int64_int32_64(
+      int64_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_uint64_uint32_64(
+      uint64_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int64_int64_64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_uint64_uint64_64(
+      uint64_t* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_float32_float32_64(
+      float* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_float64_float64_64(
+      double* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int32_bool_64(
+      int32_t* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int32_int8_64(
+      int32_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_uint32_uint8_64(
+      uint32_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int32_int16_64(
+      int32_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_uint32_uint16_64(
+      uint32_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_int32_int32_64(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_uint32_uint32_64(
+      uint32_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_bool_64(bool* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_int8_64(bool* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_uint8_64(bool* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_int16_64(bool* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_uint16_64(bool* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_int32_64(bool* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_uint32_64(bool* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_int64_64(bool* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_uint64_64(bool* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_float32_64(bool* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_sum_bool_float64_64(bool* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_bool_64(
+      bool* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_int8_64(
+      bool* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_uint8_64(
+      bool* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_int16_64(
+      bool* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_uint16_64(
+      bool* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_int32_64(
+      bool* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_uint32_64(
+      bool* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_int64_64(
+      bool* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_uint64_64(
+      bool* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_float32_64(
+      bool* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_sum_bool_float64_64(
+      bool* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int64_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int64_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_uint64_uint8_64(uint64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int64_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_uint64_uint16_64(uint64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int64_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_uint64_uint32_64(uint64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int64_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_uint64_uint64_64(uint64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_float32_float32_64(float* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_float64_float64_64(double* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int32_bool_64(int32_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int32_int8_64(int32_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_uint32_uint8_64(uint32_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int32_int16_64(int32_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_uint32_uint16_64(uint32_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_int32_int32_64(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_uint32_uint32_64(uint32_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int64_bool_64(
+      int64_t* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int64_int8_64(
+      int64_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_uint64_uint8_64(
+      uint64_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int64_int16_64(
+      int64_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_uint64_uint16_64(
+      uint64_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int64_int32_64(
+      int64_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_uint64_uint32_64(
+      uint64_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int64_int64_64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_uint64_uint64_64(
+      uint64_t* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_float32_float32_64(
+      float* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_float64_float64_64(
+      double* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int32_bool_64(
+      int32_t* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int32_int8_64(
+      int32_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_uint32_uint8_64(
+      uint32_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int32_int16_64(
+      int32_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_uint32_uint16_64(
+      uint32_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_int32_int32_64(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_uint32_uint32_64(
+      uint32_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_bool_64(bool* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_int8_64(bool* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_uint8_64(bool* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_int16_64(bool* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_uint16_64(bool* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_int32_64(bool* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_uint32_64(bool* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_int64_64(bool* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_uint64_64(bool* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_float32_64(bool* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_prod_bool_float64_64(bool* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_bool_64(
+      bool* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_int8_64(
+      bool* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_uint8_64(
+      bool* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_int16_64(
+      bool* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_uint16_64(
+      bool* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_int32_64(
+      bool* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_uint32_64(
+      bool* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_int64_64(
+      bool* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_uint64_64(
+      bool* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_float32_64(
+      bool* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_prod_bool_float64_64(
+      bool* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_min_int8_int8_64(int8_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int8_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_uint8_uint8_64(uint8_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint8_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_int16_int16_64(int16_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int16_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_uint16_uint16_64(uint16_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint16_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_int32_int32_64(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int32_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_uint32_uint32_64(uint32_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint32_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_int64_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int64_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_uint64_uint64_64(uint64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint64_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_float32_float32_64(float* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, float identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_min_float64_float64_64(double* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, double identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_int8_int8_64(
+      int8_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      int8_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_uint8_uint8_64(
+      uint8_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      uint8_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_int16_int16_64(
+      int16_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      int16_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_uint16_uint16_64(
+      uint16_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      uint16_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_int32_int32_64(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      int32_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_uint32_uint32_64(
+      uint32_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      uint32_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_int64_int64_64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      int64_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_uint64_uint64_64(
+      uint64_t* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      uint64_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_float32_float32_64(
+      float* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      float identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_min_float64_float64_64(
+      double* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      double identity);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_max_int8_int8_64(int8_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int8_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_uint8_uint8_64(uint8_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint8_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_int16_int16_64(int16_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int16_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_uint16_uint16_64(uint16_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint16_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_int32_int32_64(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int32_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_uint32_uint32_64(uint32_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint32_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_int64_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int64_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_uint64_uint64_64(uint64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint64_t identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_float32_float32_64(float* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, float identity);
-  EXPORT_SYMBOL struct Error awkward_reduce_max_float64_float64_64(double* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, double identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_int8_int8_64(
+      int8_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      int8_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_uint8_uint8_64(
+      uint8_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      uint8_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_int16_int16_64(
+      int16_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      int16_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_uint16_uint16_64(
+      uint16_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      uint16_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_int32_int32_64(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      int32_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_uint32_uint32_64(
+      uint32_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      uint32_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_int64_int64_64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      int64_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_uint64_uint64_64(
+      uint64_t* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      uint64_t identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_float32_float32_64(
+      float* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      float identity);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_max_float64_float64_64(
+      double* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength,
+      double identity);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_uint8_64(int64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_uint16_64(int64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_uint32_64(int64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_uint64_64(int64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_float32_64(int64_t* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmin_float64_64(int64_t* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_bool_64(
+      int64_t* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_int8_64(
+      int64_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_uint8_64(
+      int64_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_int16_64(
+      int64_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_uint16_64(
+      int64_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_int32_64(
+      int64_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_uint32_64(
+      int64_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_int64_64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_uint64_64(
+      int64_t* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_float32_64(
+      int64_t* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmin_float64_64(
+      int64_t* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_uint8_64(int64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_uint16_64(int64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_uint32_64(int64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_uint64_64(int64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_float32_64(int64_t* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
-  EXPORT_SYMBOL struct Error awkward_reduce_argmax_float64_64(int64_t* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_bool_64(
+      int64_t* toptr,
+      const bool* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_int8_64(
+      int64_t* toptr,
+      const int8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_uint8_64(
+      int64_t* toptr,
+      const uint8_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_int16_64(
+      int64_t* toptr,
+      const int16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_uint16_64(
+      int64_t* toptr,
+      const uint16_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_int32_64(
+      int64_t* toptr,
+      const int32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_uint32_64(
+      int64_t* toptr,
+      const uint32_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_int64_64(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_uint64_64(
+      int64_t* toptr,
+      const uint64_t* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_float32_64(
+      int64_t* toptr,
+      const float* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_reduce_argmax_float64_64(
+      int64_t* toptr,
+      const double* fromptr,
+      int64_t fromptroffset,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_content_reduce_zeroparents_64(int64_t* toparents, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_global_startstop_64(int64_t* globalstart, int64_t* globalstop, const int64_t* offsets, int64_t offsetsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_content_reduce_zeroparents_64(
+      int64_t* toparents,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_reduce_global_startstop_64(
+      int64_t* globalstart,
+      int64_t* globalstop,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_nonlocal_maxcount_offsetscopy_64(int64_t* maxcount, int64_t* offsetscopy, const int64_t* offsets, int64_t offsetsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_nonlocal_preparenext_64(int64_t* nextcarry, int64_t* nextparents, int64_t nextlen, int64_t* maxnextparents, int64_t* distincts, int64_t distinctslen, int64_t* offsetscopy, const int64_t* offsets, int64_t offsetsoffset, int64_t length, const int64_t* parents, int64_t parentsoffset, int64_t maxcount);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_nonlocal_nextstarts_64(int64_t* nextstarts, const int64_t* nextparents, int64_t nextlen);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_nonlocal_findgaps_64(int64_t* gaps, const int64_t* parents, int64_t parentsoffset, int64_t lenparents);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_nonlocal_outstartsstops_64(int64_t* outstarts, int64_t* outstops, const int64_t* distincts, int64_t lendistincts, const int64_t* gaps);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_reduce_nonlocal_maxcount_offsetscopy_64(
+      int64_t* maxcount,
+      int64_t* offsetscopy,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_reduce_nonlocal_preparenext_64(
+      int64_t* nextcarry,
+      int64_t* nextparents,
+      int64_t nextlen,
+      int64_t* maxnextparents,
+      int64_t* distincts,
+      int64_t distinctslen,
+      int64_t* offsetscopy,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t maxcount);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_reduce_nonlocal_nextstarts_64(
+      int64_t* nextstarts,
+      const int64_t* nextparents,
+      int64_t nextlen);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_reduce_nonlocal_findgaps_64(
+      int64_t* gaps,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_reduce_nonlocal_outstartsstops_64(
+      int64_t* outstarts,
+      int64_t* outstops,
+      const int64_t* distincts,
+      int64_t lendistincts,
+      const int64_t* gaps);
 
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_local_nextparents_64(int64_t* nextparents, const int64_t* offsets, int64_t offsetsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_listoffsetarray_reduce_local_outoffsets_64(int64_t* outoffsets, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_reduce_local_nextparents_64(
+      int64_t* nextparents,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_listoffsetarray_reduce_local_outoffsets_64(
+      int64_t* outoffsets,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexedarrayU32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
-  EXPORT_SYMBOL struct Error awkward_indexedarray64_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray32_reduce_next_64(
+      int64_t* nextcarry,
+      int64_t* nextparents,
+      int64_t* outindex,
+      const int32_t* index,
+      int64_t indexoffset,
+      int64_t* parents,
+      int64_t parentsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarrayU32_reduce_next_64(
+      int64_t* nextcarry,
+      int64_t* nextparents,
+      int64_t* outindex,
+      const uint32_t* index,
+      int64_t indexoffset,
+      int64_t* parents,
+      int64_t parentsoffset,
+      int64_t length);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray64_reduce_next_64(
+      int64_t* nextcarry,
+      int64_t* nextparents,
+      int64_t* outindex,
+      const int64_t* index,
+      int64_t indexoffset,
+      int64_t* parents,
+      int64_t parentsoffset,
+      int64_t length);
 
-  EXPORT_SYMBOL struct Error awkward_indexedarray_reduce_next_fix_offsets_64(int64_t* outoffsets, const int64_t* starts, int64_t startsoffset, int64_t startslength, int64_t outindexlength);
+  EXPORT_SYMBOL struct Error
+    awkward_indexedarray_reduce_next_fix_offsets_64(
+      int64_t* outoffsets,
+      const int64_t* starts,
+      int64_t startsoffset,
+      int64_t startslength,
+      int64_t outindexlength);
 
-  EXPORT_SYMBOL struct Error awkward_numpyarray_reduce_mask_bytemaskedarray(int8_t* toptr, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength);
+  EXPORT_SYMBOL struct Error
+    awkward_numpyarray_reduce_mask_bytemaskedarray(
+      int8_t* toptr,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t lenparents,
+      int64_t outlength);
 
-  EXPORT_SYMBOL struct Error awkward_bytemaskedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int8_t* mask, int64_t maskoffset, const int64_t* parents, int64_t parentsoffset, int64_t length, bool validwhen);
+  EXPORT_SYMBOL struct Error
+    awkward_bytemaskedarray_reduce_next_64(
+      int64_t* nextcarry,
+      int64_t* nextparents,
+      int64_t* outindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      const int64_t* parents,
+      int64_t parentsoffset,
+      int64_t length,
+      bool validwhen);
 
 }
 

--- a/include/awkward/cpu-kernels/util.h
+++ b/include/awkward/cpu-kernels/util.h
@@ -37,15 +37,17 @@ extern "C" {
     int64_t attempt;
     int64_t extra;
   };
-  EXPORT_SYMBOL struct Error success();
-  EXPORT_SYMBOL struct Error failure(const char* str, int64_t identity, int64_t attempt);
+  EXPORT_SYMBOL struct Error
+    success();
+  EXPORT_SYMBOL struct Error
+    failure(const char* str, int64_t identity, int64_t attempt);
 
   const int8_t   kMaxInt8   =                 127;   // 2**7  - 1
   const uint8_t  kMaxUInt8  =                 255;   // 2**8  - 1
   const int32_t  kMaxInt32  =          2147483647;   // 2**31 - 1
   const uint32_t kMaxUInt32 =          4294967295;   // 2**32 - 1
   const int64_t  kMaxInt64  = 9223372036854775806;   // 2**63 - 2: see below
-  const int64_t  kSliceNone = kMaxInt64 + 1;         // reserved for Slice::none()
+  const int64_t  kSliceNone = kMaxInt64 + 1;         // for Slice::none()
 }
 
 #endif // AWKWARDCPU_UTIL_H_

--- a/include/awkward/io/json.h
+++ b/include/awkward/io/json.h
@@ -13,38 +13,63 @@
 namespace awkward {
   class Content;
 
-  EXPORT_SYMBOL const ContentPtr FromJsonString(const char* source, const ArrayBuilderOptions& options);
-  EXPORT_SYMBOL const ContentPtr FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize);
+  EXPORT_SYMBOL const ContentPtr
+    FromJsonString(const char* source, const ArrayBuilderOptions& options);
+  EXPORT_SYMBOL const ContentPtr
+    FromJsonFile(FILE* source,
+                 const ArrayBuilderOptions& options,
+                 int64_t buffersize);
 
   class EXPORT_SYMBOL ToJson {
   public:
-    virtual void null() = 0;
-    virtual void boolean(bool x) = 0;
-    virtual void integer(int64_t x) = 0;
-    virtual void real(double x) = 0;
-    virtual void string(const char* x, int64_t length) = 0;
-    virtual void beginlist() = 0;
-    virtual void endlist() = 0;
-    virtual void beginrecord() = 0;
-    virtual void field(const char* x) = 0;
-    virtual void endrecord() = 0;
+    virtual void
+      null() = 0;
+    virtual void
+      boolean(bool x) = 0;
+    virtual void
+      integer(int64_t x) = 0;
+    virtual void
+      real(double x) = 0;
+    virtual void
+      string(const char* x, int64_t length) = 0;
+    virtual void
+      beginlist() = 0;
+    virtual void
+      endlist() = 0;
+    virtual void
+      beginrecord() = 0;
+    virtual void
+      field(const char* x) = 0;
+    virtual void
+      endrecord() = 0;
   };
 
   class EXPORT_SYMBOL ToJsonString: public ToJson {
   public:
     ToJsonString(int64_t maxdecimals);
     ~ToJsonString();
-    void null() override;
-    void boolean(bool x) override;
-    void integer(int64_t x) override;
-    void real(double x) override;
-    void string(const char* x, int64_t length) override;
-    void beginlist() override;
-    void endlist() override;
-    void beginrecord() override;
-    void field(const char* x) override;
-    void endrecord() override;
-    const std::string tostring();
+    void
+      null() override;
+    void
+      boolean(bool x) override;
+    void
+      integer(int64_t x) override;
+    void
+      real(double x) override;
+    void
+      string(const char* x, int64_t length) override;
+    void
+      beginlist() override;
+    void
+      endlist() override;
+    void
+      beginrecord() override;
+    void
+      field(const char* x) override;
+    void
+      endrecord() override;
+    const std::string
+      tostring();
   private:
     class Impl;
     Impl* impl_;
@@ -54,17 +79,28 @@ namespace awkward {
   public:
     ToJsonPrettyString(int64_t maxdecimals);
     ~ToJsonPrettyString();
-    void null() override;
-    void boolean(bool x) override;
-    void integer(int64_t x) override;
-    void real(double x) override;
-    void string(const char* x, int64_t length) override;
-    void beginlist() override;
-    void endlist() override;
-    void beginrecord() override;
-    void field(const char* x) override;
-    void endrecord() override;
-    const std::string tostring();
+    void
+      null() override;
+    void
+      boolean(bool x) override;
+    void
+      integer(int64_t x) override;
+    void
+      real(double x) override;
+    void
+      string(const char* x, int64_t length) override;
+    void
+      beginlist() override;
+    void
+      endlist() override;
+    void
+      beginrecord() override;
+    void
+      field(const char* x) override;
+    void
+      endrecord() override;
+    const std::string
+      tostring();
   private:
     class Impl;
     Impl* impl_;
@@ -74,16 +110,26 @@ namespace awkward {
   public:
     ToJsonFile(FILE* destination, int64_t maxdecimals, int64_t buffersize);
     ~ToJsonFile();
-    void null() override;
-    void boolean(bool x) override;
-    void integer(int64_t x) override;
-    void real(double x) override;
-    void string(const char* x, int64_t length) override;
-    void beginlist() override;
-    void endlist() override;
-    void beginrecord() override;
-    void field(const char* x) override;
-    void endrecord() override;
+    void
+      null() override;
+    void
+      boolean(bool x) override;
+    void
+      integer(int64_t x) override;
+    void
+      real(double x) override;
+    void
+      string(const char* x, int64_t length) override;
+    void
+      beginlist() override;
+    void
+      endlist() override;
+    void
+      beginrecord() override;
+    void
+      field(const char* x) override;
+    void
+      endrecord() override;
   private:
     class Impl;
     Impl* impl_;
@@ -91,18 +137,30 @@ namespace awkward {
 
   class EXPORT_SYMBOL ToJsonPrettyFile: public ToJson {
   public:
-    ToJsonPrettyFile(FILE* destination, int64_t maxdecimals, int64_t buffersize);
+    ToJsonPrettyFile(FILE* destination,
+                     int64_t maxdecimals,
+                     int64_t buffersize);
     ~ToJsonPrettyFile();
-    void null() override;
-    void boolean(bool x) override;
-    void integer(int64_t x) override;
-    void real(double x) override;
-    void string(const char* x, int64_t length) override;
-    void beginlist() override;
-    void endlist() override;
-    void beginrecord() override;
-    void field(const char* x) override;
-    void endrecord() override;
+    void
+      null() override;
+    void
+      boolean(bool x) override;
+    void
+      integer(int64_t x) override;
+    void
+      real(double x) override;
+    void
+      string(const char* x, int64_t length) override;
+    void
+      beginlist() override;
+    void
+      endlist() override;
+    void
+      beginrecord() override;
+    void
+      field(const char* x) override;
+    void
+      endrecord() override;
   private:
     class Impl;
     Impl* impl_;

--- a/include/awkward/io/json.h
+++ b/include/awkward/io/json.h
@@ -13,8 +13,8 @@
 namespace awkward {
   class Content;
 
-  EXPORT_SYMBOL ContentPtr FromJsonString(const char* source, const ArrayBuilderOptions& options);
-  EXPORT_SYMBOL ContentPtr FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize);
+  EXPORT_SYMBOL const ContentPtr FromJsonString(const char* source, const ArrayBuilderOptions& options);
+  EXPORT_SYMBOL const ContentPtr FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize);
 
   class EXPORT_SYMBOL ToJson {
   public:

--- a/include/awkward/io/json.h
+++ b/include/awkward/io/json.h
@@ -13,8 +13,8 @@
 namespace awkward {
   class Content;
 
-  EXPORT_SYMBOL const std::shared_ptr<Content> FromJsonString(const char* source, const ArrayBuilderOptions& options);
-  EXPORT_SYMBOL const std::shared_ptr<Content> FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize);
+  EXPORT_SYMBOL ContentPtr FromJsonString(const char* source, const ArrayBuilderOptions& options);
+  EXPORT_SYMBOL ContentPtr FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize);
 
   class EXPORT_SYMBOL ToJson {
   public:

--- a/include/awkward/io/root.h
+++ b/include/awkward/io/root.h
@@ -14,7 +14,7 @@
 #include "awkward/array/NumpyArray.h"
 
 namespace awkward {
-  EXPORT_SYMBOL const std::shared_ptr<Content> FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options);
+  EXPORT_SYMBOL ContentPtr FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options);
 }
 
 #endif // AWKWARD_IO_ROOT_H_

--- a/include/awkward/io/root.h
+++ b/include/awkward/io/root.h
@@ -14,7 +14,7 @@
 #include "awkward/array/NumpyArray.h"
 
 namespace awkward {
-  EXPORT_SYMBOL ContentPtr FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options);
+  EXPORT_SYMBOL const ContentPtr FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options);
 }
 
 #endif // AWKWARD_IO_ROOT_H_

--- a/include/awkward/io/root.h
+++ b/include/awkward/io/root.h
@@ -14,7 +14,13 @@
 #include "awkward/array/NumpyArray.h"
 
 namespace awkward {
-  EXPORT_SYMBOL const ContentPtr FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options);
+  EXPORT_SYMBOL const ContentPtr
+    FromROOT_nestedvector(const Index64& byteoffsets,
+                          const NumpyArray& rawdata,
+                          int64_t depth,
+                          int64_t itemsize,
+                          std::string format,
+                          const ArrayBuilderOptions& options);
 }
 
 #endif // AWKWARD_IO_ROOT_H_

--- a/include/awkward/python/content.h
+++ b/include/awkward/python/content.h
@@ -26,50 +26,83 @@
 namespace py = pybind11;
 namespace ak = awkward;
 
-ak::Slice toslice(py::object obj);
+ak::Slice
+  toslice(py::object obj);
 
-py::class_<ak::ArrayBuilder> make_ArrayBuilder(const py::handle& m, const std::string& name);
+py::class_<ak::ArrayBuilder>
+  make_ArrayBuilder(const py::handle& m, const std::string& name);
 
-py::class_<ak::Iterator, std::shared_ptr<ak::Iterator>> make_Iterator(const py::handle& m, const std::string& name);
+py::class_<ak::Iterator, std::shared_ptr<ak::Iterator>>
+  make_Iterator(const py::handle& m, const std::string& name);
 
 class PersistentSharedPtr {
 public:
   PersistentSharedPtr(const std::shared_ptr<ak::Content>& ptr);
-  py::object layout() const;
-  size_t ptr() const;
+  py::object
+    layout() const;
+  size_t
+    ptr() const;
 
 private:
   const std::shared_ptr<ak::Content> ptr_;
 };
 
-py::class_<PersistentSharedPtr> make_PersistentSharedPtr(const py::handle& m, const std::string& name);
+py::class_<PersistentSharedPtr>
+  make_PersistentSharedPtr(const py::handle& m, const std::string& name);
 
-py::class_<ak::Content, std::shared_ptr<ak::Content>> make_Content(const py::handle& m, const std::string& name);
+py::class_<ak::Content, std::shared_ptr<ak::Content>>
+  make_Content(const py::handle& m, const std::string& name);
 
-py::class_<ak::EmptyArray, std::shared_ptr<ak::EmptyArray>, ak::Content> make_EmptyArray(const py::handle& m, const std::string& name);
+py::class_<ak::EmptyArray, std::shared_ptr<ak::EmptyArray>, ak::Content>
+  make_EmptyArray(const py::handle& m, const std::string& name);
 
 template <typename T, bool ISOPTION>
-py::class_<ak::IndexedArrayOf<T, ISOPTION>, std::shared_ptr<ak::IndexedArrayOf<T, ISOPTION>>, ak::Content> make_IndexedArrayOf(const py::handle& m, const std::string& name);
+py::class_<ak::IndexedArrayOf<T, ISOPTION>,
+           std::shared_ptr<ak::IndexedArrayOf<T, ISOPTION>>,
+           ak::Content>
+  make_IndexedArrayOf(const py::handle& m, const std::string& name);
 
-py::class_<ak::ByteMaskedArray, std::shared_ptr<ak::ByteMaskedArray>, ak::Content> make_ByteMaskedArray(const py::handle& m, const std::string& name);
-py::class_<ak::BitMaskedArray,  std::shared_ptr<ak::BitMaskedArray>,  ak::Content> make_BitMaskedArray( const py::handle& m, const std::string& name);
-py::class_<ak::UnmaskedArray,   std::shared_ptr<ak::UnmaskedArray>,   ak::Content> make_UnmaskedArray(  const py::handle& m, const std::string& name);
+py::class_<ak::ByteMaskedArray,
+           std::shared_ptr<ak::ByteMaskedArray>,
+           ak::Content>
+  make_ByteMaskedArray(const py::handle& m, const std::string& name);
+py::class_<ak::BitMaskedArray,
+           std::shared_ptr<ak::BitMaskedArray>,
+           ak::Content>
+  make_BitMaskedArray(const py::handle& m, const std::string& name);
+py::class_<ak::UnmaskedArray,
+           std::shared_ptr<ak::UnmaskedArray>,
+           ak::Content>
+  make_UnmaskedArray(const py::handle& m, const std::string& name);
 
 template <typename T>
-py::class_<ak::ListArrayOf<T>, std::shared_ptr<ak::ListArrayOf<T>>, ak::Content> make_ListArrayOf(const py::handle& m, const std::string& name);
+py::class_<ak::ListArrayOf<T>,
+           std::shared_ptr<ak::ListArrayOf<T>>,
+           ak::Content>
+  make_ListArrayOf(const py::handle& m, const std::string& name);
 
 template <typename T>
-py::class_<ak::ListOffsetArrayOf<T>, std::shared_ptr<ak::ListOffsetArrayOf<T>>, ak::Content> make_ListOffsetArrayOf(const py::handle& m, const std::string& name);
+py::class_<ak::ListOffsetArrayOf<T>,
+           std::shared_ptr<ak::ListOffsetArrayOf<T>>,
+           ak::Content>
+  make_ListOffsetArrayOf(const py::handle& m, const std::string& name);
 
-py::class_<ak::NumpyArray, std::shared_ptr<ak::NumpyArray>, ak::Content> make_NumpyArray(const py::handle& m, const std::string& name);
+py::class_<ak::NumpyArray, std::shared_ptr<ak::NumpyArray>, ak::Content>
+  make_NumpyArray(const py::handle& m, const std::string& name);
 
-py::class_<ak::Record, std::shared_ptr<ak::Record>> make_Record(const py::handle& m, const std::string& name);
+py::class_<ak::Record, std::shared_ptr<ak::Record>>
+  make_Record(const py::handle& m, const std::string& name);
 
-py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content> make_RecordArray(const py::handle& m, const std::string& name);
+py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content>
+  make_RecordArray(const py::handle& m, const std::string& name);
 
-py::class_<ak::RegularArray, std::shared_ptr<ak::RegularArray>, ak::Content> make_RegularArray(const py::handle& m, const std::string& name);
+py::class_<ak::RegularArray, std::shared_ptr<ak::RegularArray>, ak::Content>
+  make_RegularArray(const py::handle& m, const std::string& name);
 
 template <typename T, typename I>
-py::class_<ak::UnionArrayOf<T, I>, std::shared_ptr<ak::UnionArrayOf<T, I>>, ak::Content> make_UnionArrayOf(const py::handle& m, const std::string& name);
+py::class_<ak::UnionArrayOf<T, I>,
+           std::shared_ptr<ak::UnionArrayOf<T, I>>,
+           ak::Content>
+  make_UnionArrayOf(const py::handle& m, const std::string& name);
 
 #endif // AWKWARDPY_CONTENT_H_

--- a/include/awkward/python/identities.h
+++ b/include/awkward/python/identities.h
@@ -10,9 +10,11 @@ namespace py = pybind11;
 namespace ak = awkward;
 
 template <typename T>
-py::tuple identity(const T& self);
+py::tuple
+  identity(const T& self);
 
 template <typename T>
-py::class_<ak::IdentitiesOf<T>> make_IdentitiesOf(const py::handle& m, const std::string& name);
+py::class_<ak::IdentitiesOf<T>>
+  make_IdentitiesOf(const py::handle& m, const std::string& name);
 
 #endif // AWKWARDPY_IDENTITIES_H_

--- a/include/awkward/python/index.h
+++ b/include/awkward/python/index.h
@@ -13,6 +13,7 @@ namespace py = pybind11;
 namespace ak = awkward;
 
 template <typename T>
-py::class_<ak::IndexOf<T>> make_IndexOf(const py::handle& m, const std::string& name);
+py::class_<ak::IndexOf<T>>
+  make_IndexOf(const py::handle& m, const std::string& name);
 
 #endif // AWKWARDPY_INDEX_H_

--- a/include/awkward/type/ArrayType.h
+++ b/include/awkward/type/ArrayType.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    const std::shared_ptr<Content> empty() const override;
+    ContentPtr empty() const override;
 
     const std::shared_ptr<Type> type() const;
     int64_t length() const;

--- a/include/awkward/type/ArrayType.h
+++ b/include/awkward/type/ArrayType.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    ContentPtr empty() const override;
+    const ContentPtr empty() const override;
 
     const std::shared_ptr<Type> type() const;
     int64_t length() const;

--- a/include/awkward/type/ArrayType.h
+++ b/include/awkward/type/ArrayType.h
@@ -8,20 +8,45 @@
 namespace awkward {
   class EXPORT_SYMBOL ArrayType: public Type {
   public:
-    ArrayType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type, int64_t length);
+    ArrayType(const util::Parameters& parameters,
+              const std::string& typestr,
+              const TypePtr& type,
+              int64_t length);
 
-    std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr shallow_copy() const override;
-    bool equal(const TypePtr& other, bool check_parameters) const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
-    const ContentPtr empty() const override;
+    std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
 
-    const TypePtr type() const;
-    int64_t length() const;
+    const TypePtr
+      shallow_copy() const override;
+
+    bool
+      equal(const TypePtr& other, bool check_parameters) const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
+
+    const ContentPtr
+      empty() const override;
+
+    const TypePtr
+      type() const;
+
+    int64_t
+      length() const;
 
   private:
     TypePtr type_;

--- a/include/awkward/type/ArrayType.h
+++ b/include/awkward/type/ArrayType.h
@@ -8,11 +8,11 @@
 namespace awkward {
   class EXPORT_SYMBOL ArrayType: public Type {
   public:
-    ArrayType(const util::Parameters& parameters, const std::string& typestr, const std::shared_ptr<Type>& type, int64_t length);
+    ArrayType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type, int64_t length);
 
     std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> shallow_copy() const override;
-    bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const override;
+    const TypePtr shallow_copy() const override;
+    bool equal(const TypePtr& other, bool check_parameters) const override;
     int64_t numfields() const override;
     int64_t fieldindex(const std::string& key) const override;
     const std::string key(int64_t fieldindex) const override;
@@ -20,11 +20,11 @@ namespace awkward {
     const std::vector<std::string> keys() const override;
     const ContentPtr empty() const override;
 
-    const std::shared_ptr<Type> type() const;
+    const TypePtr type() const;
     int64_t length() const;
 
   private:
-    std::shared_ptr<Type> type_;
+    TypePtr type_;
     int64_t length_;
   };
 }

--- a/include/awkward/type/ListType.h
+++ b/include/awkward/type/ListType.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    ContentPtr empty() const override;
+    const ContentPtr empty() const override;
 
   const std::shared_ptr<Type> type() const;
 

--- a/include/awkward/type/ListType.h
+++ b/include/awkward/type/ListType.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    const std::shared_ptr<Content> empty() const override;
+    ContentPtr empty() const override;
 
   const std::shared_ptr<Type> type() const;
 

--- a/include/awkward/type/ListType.h
+++ b/include/awkward/type/ListType.h
@@ -8,11 +8,11 @@
 namespace awkward {
   class EXPORT_SYMBOL ListType: public Type {
   public:
-    ListType(const util::Parameters& parameters, const std::string& typestr, const std::shared_ptr<Type>& type);
+    ListType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type);
 
     std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> shallow_copy() const override;
-    bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const override;
+    const TypePtr shallow_copy() const override;
+    bool equal(const TypePtr& other, bool check_parameters) const override;
     int64_t numfields() const override;
     int64_t fieldindex(const std::string& key) const override;
     const std::string key(int64_t fieldindex) const override;
@@ -20,10 +20,10 @@ namespace awkward {
     const std::vector<std::string> keys() const override;
     const ContentPtr empty() const override;
 
-  const std::shared_ptr<Type> type() const;
+  const TypePtr type() const;
 
   private:
-    const std::shared_ptr<Type> type_;
+    const TypePtr type_;
   };
 }
 

--- a/include/awkward/type/ListType.h
+++ b/include/awkward/type/ListType.h
@@ -8,19 +8,41 @@
 namespace awkward {
   class EXPORT_SYMBOL ListType: public Type {
   public:
-    ListType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type);
+    ListType(const util::Parameters& parameters,
+             const std::string& typestr,
+             const TypePtr& type);
 
-    std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr shallow_copy() const override;
-    bool equal(const TypePtr& other, bool check_parameters) const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
-    const ContentPtr empty() const override;
+    std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
 
-  const TypePtr type() const;
+    const TypePtr
+      shallow_copy() const override;
+
+    bool
+      equal(const TypePtr& other, bool check_parameters) const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
+
+    const ContentPtr
+      empty() const override;
+
+  const TypePtr
+    type() const;
 
   private:
     const TypePtr type_;

--- a/include/awkward/type/OptionType.h
+++ b/include/awkward/type/OptionType.h
@@ -8,19 +8,41 @@
 namespace awkward {
   class EXPORT_SYMBOL OptionType: public Type {
   public:
-    OptionType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type);
+    OptionType(const util::Parameters& parameters,
+               const std::string& typestr,
+               const TypePtr& type);
 
-    std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr shallow_copy() const override;
-    bool equal(const TypePtr& other, bool check_parameters) const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
-    const ContentPtr empty() const override;
+    std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
 
-  const TypePtr type() const;
+    const TypePtr
+      shallow_copy() const override;
+
+    bool
+      equal(const TypePtr& other, bool check_parameters) const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
+
+    const ContentPtr
+      empty() const override;
+
+    const TypePtr
+      type() const;
 
   private:
     const TypePtr type_;

--- a/include/awkward/type/OptionType.h
+++ b/include/awkward/type/OptionType.h
@@ -8,11 +8,11 @@
 namespace awkward {
   class EXPORT_SYMBOL OptionType: public Type {
   public:
-    OptionType(const util::Parameters& parameters, const std::string& typestr, const std::shared_ptr<Type>& type);
+    OptionType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type);
 
     std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> shallow_copy() const override;
-    bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const override;
+    const TypePtr shallow_copy() const override;
+    bool equal(const TypePtr& other, bool check_parameters) const override;
     int64_t numfields() const override;
     int64_t fieldindex(const std::string& key) const override;
     const std::string key(int64_t fieldindex) const override;
@@ -20,10 +20,10 @@ namespace awkward {
     const std::vector<std::string> keys() const override;
     const ContentPtr empty() const override;
 
-  const std::shared_ptr<Type> type() const;
+  const TypePtr type() const;
 
   private:
-    const std::shared_ptr<Type> type_;
+    const TypePtr type_;
   };
 }
 

--- a/include/awkward/type/OptionType.h
+++ b/include/awkward/type/OptionType.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    ContentPtr empty() const override;
+    const ContentPtr empty() const override;
 
   const std::shared_ptr<Type> type() const;
 

--- a/include/awkward/type/OptionType.h
+++ b/include/awkward/type/OptionType.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    const std::shared_ptr<Content> empty() const override;
+    ContentPtr empty() const override;
 
   const std::shared_ptr<Type> type() const;
 

--- a/include/awkward/type/PrimitiveType.h
+++ b/include/awkward/type/PrimitiveType.h
@@ -23,23 +23,45 @@ namespace awkward {
       numtypes
     };
 
-    PrimitiveType(const util::Parameters& parameters, const std::string& typestr, DType dtype);
+    PrimitiveType(const util::Parameters& parameters,
+                  const std::string& typestr, DType dtype);
 
-    std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr shallow_copy() const override;
-    bool equal(const TypePtr& other, bool check_parameters) const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
-    const ContentPtr empty() const override;
+    std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
 
-  const DType dtype() const;
+    const TypePtr
+      shallow_copy() const override;
+
+    bool
+      equal(const TypePtr& other, bool check_parameters) const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
+
+    const ContentPtr
+      empty() const override;
+
+  const DType
+    dtype() const;
 
   private:
     const DType dtype_;
   };
+
 }
 
 #endif // AWKWARD_PRIMITIVETYPE_H_

--- a/include/awkward/type/PrimitiveType.h
+++ b/include/awkward/type/PrimitiveType.h
@@ -33,7 +33,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    ContentPtr empty() const override;
+    const ContentPtr empty() const override;
 
   const DType dtype() const;
 

--- a/include/awkward/type/PrimitiveType.h
+++ b/include/awkward/type/PrimitiveType.h
@@ -26,8 +26,8 @@ namespace awkward {
     PrimitiveType(const util::Parameters& parameters, const std::string& typestr, DType dtype);
 
     std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> shallow_copy() const override;
-    bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const override;
+    const TypePtr shallow_copy() const override;
+    bool equal(const TypePtr& other, bool check_parameters) const override;
     int64_t numfields() const override;
     int64_t fieldindex(const std::string& key) const override;
     const std::string key(int64_t fieldindex) const override;

--- a/include/awkward/type/PrimitiveType.h
+++ b/include/awkward/type/PrimitiveType.h
@@ -33,7 +33,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    const std::shared_ptr<Content> empty() const override;
+    ContentPtr empty() const override;
 
   const DType dtype() const;
 

--- a/include/awkward/type/RecordType.h
+++ b/include/awkward/type/RecordType.h
@@ -29,7 +29,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    ContentPtr empty() const override;
+    const ContentPtr empty() const override;
 
     const std::shared_ptr<Type> field(int64_t fieldindex) const;
     const std::shared_ptr<Type> field(const std::string& key) const;

--- a/include/awkward/type/RecordType.h
+++ b/include/awkward/type/RecordType.h
@@ -29,7 +29,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    const std::shared_ptr<Content> empty() const override;
+    ContentPtr empty() const override;
 
     const std::shared_ptr<Type> field(int64_t fieldindex) const;
     const std::shared_ptr<Type> field(const std::string& key) const;

--- a/include/awkward/type/RecordType.h
+++ b/include/awkward/type/RecordType.h
@@ -14,28 +14,67 @@
 namespace awkward {
   class EXPORT_SYMBOL RecordType: public Type {
   public:
-    RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types, const util::RecordLookupPtr& recordlookup);
-    RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types);
+    RecordType(const util::Parameters& parameters,
+               const std::string& typestr,
+               const std::vector<TypePtr>& types,
+               const util::RecordLookupPtr& recordlookup);
 
-    const std::vector<TypePtr> types() const;
-    const util::RecordLookupPtr recordlookup() const;
-    bool istuple() const;
+    RecordType(const util::Parameters& parameters,
+               const std::string& typestr,
+               const std::vector<TypePtr>& types);
 
-    std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr shallow_copy() const override;
-    bool equal(const TypePtr& other, bool check_parameters) const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
-    const ContentPtr empty() const override;
+    const std::vector<TypePtr>
+      types() const;
 
-    const TypePtr field(int64_t fieldindex) const;
-    const TypePtr field(const std::string& key) const;
-    const std::vector<TypePtr> fields() const;
-    const std::vector<std::pair<std::string, TypePtr>> fielditems() const;
-    const TypePtr astuple() const;
+    const util::RecordLookupPtr
+      recordlookup() const;
+
+    bool
+      istuple() const;
+
+    std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
+
+    const TypePtr
+      shallow_copy() const override;
+
+    bool
+      equal(const TypePtr& other, bool check_parameters) const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
+
+    const ContentPtr
+      empty() const override;
+
+    const TypePtr
+      field(int64_t fieldindex) const;
+
+    const TypePtr
+      field(const std::string& key) const;
+
+    const std::vector<TypePtr>
+      fields() const;
+
+    const std::vector<std::pair<std::string, TypePtr>>
+      fielditems() const;
+
+    const TypePtr
+      astuple() const;
 
   private:
     const std::vector<TypePtr> types_;

--- a/include/awkward/type/RecordType.h
+++ b/include/awkward/type/RecordType.h
@@ -14,16 +14,16 @@
 namespace awkward {
   class EXPORT_SYMBOL RecordType: public Type {
   public:
-    RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<std::shared_ptr<Type>>& types, const std::shared_ptr<util::RecordLookup>& recordlookup);
-    RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<std::shared_ptr<Type>>& types);
+    RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types, const util::RecordLookupPtr& recordlookup);
+    RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types);
 
-    const std::vector<std::shared_ptr<Type>> types() const;
-    const std::shared_ptr<util::RecordLookup> recordlookup() const;
+    const std::vector<TypePtr> types() const;
+    const util::RecordLookupPtr recordlookup() const;
     bool istuple() const;
 
     std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> shallow_copy() const override;
-    bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const override;
+    const TypePtr shallow_copy() const override;
+    bool equal(const TypePtr& other, bool check_parameters) const override;
     int64_t numfields() const override;
     int64_t fieldindex(const std::string& key) const override;
     const std::string key(int64_t fieldindex) const override;
@@ -31,15 +31,15 @@ namespace awkward {
     const std::vector<std::string> keys() const override;
     const ContentPtr empty() const override;
 
-    const std::shared_ptr<Type> field(int64_t fieldindex) const;
-    const std::shared_ptr<Type> field(const std::string& key) const;
-    const std::vector<std::shared_ptr<Type>> fields() const;
-    const std::vector<std::pair<std::string, std::shared_ptr<Type>>> fielditems() const;
-    const std::shared_ptr<Type> astuple() const;
+    const TypePtr field(int64_t fieldindex) const;
+    const TypePtr field(const std::string& key) const;
+    const std::vector<TypePtr> fields() const;
+    const std::vector<std::pair<std::string, TypePtr>> fielditems() const;
+    const TypePtr astuple() const;
 
   private:
-    const std::vector<std::shared_ptr<Type>> types_;
-    const std::shared_ptr<util::RecordLookup> recordlookup_;
+    const std::vector<TypePtr> types_;
+    const util::RecordLookupPtr recordlookup_;
   };
 }
 

--- a/include/awkward/type/RegularType.h
+++ b/include/awkward/type/RegularType.h
@@ -20,7 +20,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    ContentPtr empty() const override;
+    const ContentPtr empty() const override;
 
     const std::shared_ptr<Type> type() const;
     int64_t size() const;

--- a/include/awkward/type/RegularType.h
+++ b/include/awkward/type/RegularType.h
@@ -10,20 +10,45 @@
 namespace awkward {
   class EXPORT_SYMBOL RegularType: public Type {
   public:
-    RegularType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type, int64_t size);
+    RegularType(const util::Parameters& parameters,
+                const std::string& typestr,
+                const TypePtr& type,
+                int64_t size);
 
-    std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr shallow_copy() const override;
-    bool equal(const TypePtr& other, bool check_parameters) const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
-    const ContentPtr empty() const override;
+    std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
 
-    const TypePtr type() const;
-    int64_t size() const;
+    const TypePtr
+      shallow_copy() const override;
+
+    bool
+      equal(const TypePtr& other, bool check_parameters) const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
+
+    const ContentPtr
+      empty() const override;
+
+    const TypePtr
+      type() const;
+
+    int64_t
+      size() const;
 
   private:
     const TypePtr type_;

--- a/include/awkward/type/RegularType.h
+++ b/include/awkward/type/RegularType.h
@@ -10,11 +10,11 @@
 namespace awkward {
   class EXPORT_SYMBOL RegularType: public Type {
   public:
-    RegularType(const util::Parameters& parameters, const std::string& typestr, const std::shared_ptr<Type>& type, int64_t size);
+    RegularType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type, int64_t size);
 
     std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> shallow_copy() const override;
-    bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const override;
+    const TypePtr shallow_copy() const override;
+    bool equal(const TypePtr& other, bool check_parameters) const override;
     int64_t numfields() const override;
     int64_t fieldindex(const std::string& key) const override;
     const std::string key(int64_t fieldindex) const override;
@@ -22,11 +22,11 @@ namespace awkward {
     const std::vector<std::string> keys() const override;
     const ContentPtr empty() const override;
 
-    const std::shared_ptr<Type> type() const;
+    const TypePtr type() const;
     int64_t size() const;
 
   private:
-    const std::shared_ptr<Type> type_;
+    const TypePtr type_;
     const int64_t size_;
   };
 }

--- a/include/awkward/type/RegularType.h
+++ b/include/awkward/type/RegularType.h
@@ -20,7 +20,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    const std::shared_ptr<Content> empty() const override;
+    ContentPtr empty() const override;
 
     const std::shared_ptr<Type> type() const;
     int64_t size() const;

--- a/include/awkward/type/Type.h
+++ b/include/awkward/type/Type.h
@@ -11,8 +11,7 @@
 
 namespace awkward {
   class Content;
-  typedef const std::shared_ptr<Content> ContentPtr;
-  typedef std::vector<std::shared_ptr<Content>> ContentPtrVec;
+  typedef std::shared_ptr<Content> ContentPtr;
 
   class EXPORT_SYMBOL Type {
   public:
@@ -29,7 +28,7 @@ namespace awkward {
     virtual const std::string key(int64_t fieldindex) const = 0;
     virtual bool haskey(const std::string& key) const = 0;
     virtual const std::vector<std::string> keys() const = 0;
-    virtual ContentPtr empty() const = 0;
+    virtual const ContentPtr empty() const = 0;
 
     const util::Parameters parameters() const;
     void setparameters(const util::Parameters& parameters);

--- a/include/awkward/type/Type.h
+++ b/include/awkward/type/Type.h
@@ -12,6 +12,7 @@
 namespace awkward {
   class Content;
   using ContentPtr = std::shared_ptr<Content>;
+
   class Type;
   using TypePtr = std::shared_ptr<Type>;
 
@@ -20,32 +21,71 @@ namespace awkward {
     static TypePtr none();
 
     Type(const util::Parameters& parameters, const std::string& typestr);
+
     virtual ~Type();
 
-    virtual std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const = 0;
-    virtual const TypePtr shallow_copy() const = 0;
-    virtual bool equal(const TypePtr& other, bool check_parameters) const = 0;
-    virtual int64_t numfields() const = 0;
-    virtual int64_t fieldindex(const std::string& key) const = 0;
-    virtual const std::string key(int64_t fieldindex) const = 0;
-    virtual bool haskey(const std::string& key) const = 0;
-    virtual const std::vector<std::string> keys() const = 0;
-    virtual const ContentPtr empty() const = 0;
+    virtual std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const = 0;
 
-    const util::Parameters parameters() const;
-    void setparameters(const util::Parameters& parameters);
-    const std::string parameter(const std::string& key) const;
-    void setparameter(const std::string& key, const std::string& value);
-    bool parameter_equals(const std::string& key, const std::string& value) const;
-    bool parameters_equal(const util::Parameters& other) const;
-    const std::string tostring() const;
-    const std::string compare(TypePtr supertype);
+    virtual const TypePtr
+      shallow_copy() const = 0;
 
-    const std::string typestr() const;
+    virtual bool
+      equal(const TypePtr& other, bool check_parameters) const = 0;
+
+    virtual int64_t
+      numfields() const = 0;
+
+    virtual int64_t
+      fieldindex(const std::string& key) const = 0;
+
+    virtual const std::string
+      key(int64_t fieldindex) const = 0;
+
+    virtual bool
+      haskey(const std::string& key) const = 0;
+
+    virtual const std::vector<std::string>
+      keys() const = 0;
+
+    virtual const ContentPtr
+      empty() const = 0;
+
+    const util::Parameters
+      parameters() const;
+
+    void
+      setparameters(const util::Parameters& parameters);
+
+    const std::string
+      parameter(const std::string& key) const;
+
+    void
+      setparameter(const std::string& key, const std::string& value);
+
+    bool
+      parameter_equals(const std::string& key, const std::string& value) const;
+
+    bool
+      parameters_equal(const util::Parameters& other) const;
+
+    const std::string
+      tostring() const;
+
+    const std::string
+      compare(TypePtr supertype);
+
+    const std::string
+      typestr() const;
 
   protected:
-    bool get_typestr(std::string& output) const;
-    const std::string string_parameters() const;
+    bool
+      get_typestr(std::string& output) const;
+
+    const std::string
+      string_parameters() const;
 
     util::Parameters parameters_;
     const std::string typestr_;

--- a/include/awkward/type/Type.h
+++ b/include/awkward/type/Type.h
@@ -11,9 +11,9 @@
 
 namespace awkward {
   class Content;
-  typedef std::shared_ptr<Content> ContentPtr;
+  using ContentPtr = std::shared_ptr<Content>;
   class Type;
-  typedef std::shared_ptr<Type> TypePtr;
+  using TypePtr = std::shared_ptr<Type>;
 
   class EXPORT_SYMBOL Type {
   public:

--- a/include/awkward/type/Type.h
+++ b/include/awkward/type/Type.h
@@ -11,6 +11,8 @@
 
 namespace awkward {
   class Content;
+  typedef const std::shared_ptr<Content> ContentPtr;
+  typedef std::vector<std::shared_ptr<Content>> ContentPtrVec;
 
   class EXPORT_SYMBOL Type {
   public:
@@ -27,7 +29,7 @@ namespace awkward {
     virtual const std::string key(int64_t fieldindex) const = 0;
     virtual bool haskey(const std::string& key) const = 0;
     virtual const std::vector<std::string> keys() const = 0;
-    virtual const std::shared_ptr<Content> empty() const = 0;
+    virtual ContentPtr empty() const = 0;
 
     const util::Parameters parameters() const;
     void setparameters(const util::Parameters& parameters);

--- a/include/awkward/type/Type.h
+++ b/include/awkward/type/Type.h
@@ -12,17 +12,19 @@
 namespace awkward {
   class Content;
   typedef std::shared_ptr<Content> ContentPtr;
+  class Type;
+  typedef std::shared_ptr<Type> TypePtr;
 
   class EXPORT_SYMBOL Type {
   public:
-    static std::shared_ptr<Type> none();
+    static TypePtr none();
 
     Type(const util::Parameters& parameters, const std::string& typestr);
     virtual ~Type();
 
     virtual std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const = 0;
-    virtual const std::shared_ptr<Type> shallow_copy() const = 0;
-    virtual bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const = 0;
+    virtual const TypePtr shallow_copy() const = 0;
+    virtual bool equal(const TypePtr& other, bool check_parameters) const = 0;
     virtual int64_t numfields() const = 0;
     virtual int64_t fieldindex(const std::string& key) const = 0;
     virtual const std::string key(int64_t fieldindex) const = 0;
@@ -37,7 +39,7 @@ namespace awkward {
     bool parameter_equals(const std::string& key, const std::string& value) const;
     bool parameters_equal(const util::Parameters& other) const;
     const std::string tostring() const;
-    const std::string compare(std::shared_ptr<Type> supertype);
+    const std::string compare(TypePtr supertype);
 
     const std::string typestr() const;
 

--- a/include/awkward/type/UnionType.h
+++ b/include/awkward/type/UnionType.h
@@ -20,7 +20,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    ContentPtr empty() const override;
+    const ContentPtr empty() const override;
 
     int64_t numtypes() const;
     const std::vector<std::shared_ptr<Type>> types() const;

--- a/include/awkward/type/UnionType.h
+++ b/include/awkward/type/UnionType.h
@@ -20,7 +20,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    const std::shared_ptr<Content> empty() const override;
+    ContentPtr empty() const override;
 
     int64_t numtypes() const;
     const std::vector<std::shared_ptr<Type>> types() const;

--- a/include/awkward/type/UnionType.h
+++ b/include/awkward/type/UnionType.h
@@ -10,21 +10,47 @@
 namespace awkward {
   class EXPORT_SYMBOL UnionType: public Type {
   public:
-    UnionType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types);
+    UnionType(const util::Parameters& parameters,
+              const std::string& typestr,
+              const std::vector<TypePtr>& types);
 
-    std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr shallow_copy() const override;
-    bool equal(const TypePtr& other, bool check_parameters) const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
-    const ContentPtr empty() const override;
+    std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
 
-    int64_t numtypes() const;
-    const std::vector<TypePtr> types() const;
-    const TypePtr type(int64_t index) const;
+    const TypePtr
+      shallow_copy() const override;
+
+    bool
+      equal(const TypePtr& other, bool check_parameters) const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
+
+    const ContentPtr
+      empty() const override;
+
+    int64_t
+      numtypes() const;
+
+    const std::vector<TypePtr>
+      types() const;
+
+    const TypePtr
+      type(int64_t index) const;
 
   private:
     const std::vector<TypePtr> types_;

--- a/include/awkward/type/UnionType.h
+++ b/include/awkward/type/UnionType.h
@@ -10,11 +10,11 @@
 namespace awkward {
   class EXPORT_SYMBOL UnionType: public Type {
   public:
-    UnionType(const util::Parameters& parameters, const std::string& typestr, const std::vector<std::shared_ptr<Type>>& types);
+    UnionType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types);
 
     std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> shallow_copy() const override;
-    bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const override;
+    const TypePtr shallow_copy() const override;
+    bool equal(const TypePtr& other, bool check_parameters) const override;
     int64_t numfields() const override;
     int64_t fieldindex(const std::string& key) const override;
     const std::string key(int64_t fieldindex) const override;
@@ -23,11 +23,11 @@ namespace awkward {
     const ContentPtr empty() const override;
 
     int64_t numtypes() const;
-    const std::vector<std::shared_ptr<Type>> types() const;
-    const std::shared_ptr<Type> type(int64_t index) const;
+    const std::vector<TypePtr> types() const;
+    const TypePtr type(int64_t index) const;
 
   private:
-    const std::vector<std::shared_ptr<Type>> types_;
+    const std::vector<TypePtr> types_;
   };
 }
 

--- a/include/awkward/type/UnknownType.h
+++ b/include/awkward/type/UnknownType.h
@@ -11,8 +11,8 @@ namespace awkward {
     UnknownType(const util::Parameters& parameters, const std::string& typestr);
 
     std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const std::shared_ptr<Type> shallow_copy() const override;
-    bool equal(const std::shared_ptr<Type>& other, bool check_parameters) const override;
+    const TypePtr shallow_copy() const override;
+    bool equal(const TypePtr& other, bool check_parameters) const override;
     int64_t numfields() const override;
     int64_t fieldindex(const std::string& key) const override;
     const std::string key(int64_t fieldindex) const override;

--- a/include/awkward/type/UnknownType.h
+++ b/include/awkward/type/UnknownType.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    const std::shared_ptr<Content> empty() const override;
+    ContentPtr empty() const override;
 
   private:
   };

--- a/include/awkward/type/UnknownType.h
+++ b/include/awkward/type/UnknownType.h
@@ -18,7 +18,7 @@ namespace awkward {
     const std::string key(int64_t fieldindex) const override;
     bool haskey(const std::string& key) const override;
     const std::vector<std::string> keys() const override;
-    ContentPtr empty() const override;
+    const ContentPtr empty() const override;
 
   private:
   };

--- a/include/awkward/type/UnknownType.h
+++ b/include/awkward/type/UnknownType.h
@@ -8,19 +8,37 @@
 namespace awkward {
   class EXPORT_SYMBOL UnknownType: public Type {
   public:
-    UnknownType(const util::Parameters& parameters, const std::string& typestr);
+    UnknownType(const util::Parameters& parameters,
+                const std::string& typestr);
 
-    std::string tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const override;
-    const TypePtr shallow_copy() const override;
-    bool equal(const TypePtr& other, bool check_parameters) const override;
-    int64_t numfields() const override;
-    int64_t fieldindex(const std::string& key) const override;
-    const std::string key(int64_t fieldindex) const override;
-    bool haskey(const std::string& key) const override;
-    const std::vector<std::string> keys() const override;
-    const ContentPtr empty() const override;
+    std::string
+      tostring_part(const std::string& indent,
+                    const std::string& pre,
+                    const std::string& post) const override;
 
-  private:
+    const TypePtr
+      shallow_copy() const override;
+
+    bool
+      equal(const TypePtr& other, bool check_parameters) const override;
+
+    int64_t
+      numfields() const override;
+
+    int64_t
+      fieldindex(const std::string& key) const override;
+
+    const std::string
+      key(int64_t fieldindex) const override;
+
+    bool
+      haskey(const std::string& key) const override;
+
+    const std::vector<std::string>
+      keys() const override;
+
+    const ContentPtr
+      empty() const override;
   };
 }
 

--- a/include/awkward/util.h
+++ b/include/awkward/util.h
@@ -80,10 +80,11 @@ namespace awkward {
     bool
       parameters_equal(const Parameters& self, const Parameters& other);
 
+    using TypeStrs = std::map<std::string, std::string>;
+
     std::string
       gettypestr(const Parameters& parameters,
-                 const std::map<std::string,
-                 std::string>& typestrs);
+                 const TypeStrs& typestrs);
 
     template <typename T>
     ERROR

--- a/include/awkward/util.h
+++ b/include/awkward/util.h
@@ -30,156 +30,831 @@ namespace awkward {
       void operator()(T const *p) { }
     };
 
-    std::string quote(const std::string& x, bool doublequote);
+    std::string
+      quote(const std::string& x, bool doublequote);
 
-    void handle_error(const struct Error& err, const std::string& classname, const Identities* id);
+    void
+      handle_error(const struct Error& err,
+                   const std::string& classname,
+                   const Identities* id);
 
     template <typename T>
-    IndexOf<T> make_starts(const IndexOf<T>& offsets);
+    IndexOf<T>
+      make_starts(const IndexOf<T>& offsets);
+
     template <typename T>
-    IndexOf<T> make_stops(const IndexOf<T>& offsets);
+    IndexOf<T>
+      make_stops(const IndexOf<T>& offsets);
 
     using RecordLookup    = std::vector<std::string>;
     using RecordLookupPtr = std::shared_ptr<RecordLookup>;
-    RecordLookupPtr init_recordlookup(int64_t numfields);
-    int64_t fieldindex(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields);
-    const std::string key(const RecordLookupPtr& recordlookup, int64_t fieldindex, int64_t numfields);
-    bool haskey(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields);
-    const std::vector<std::string> keys(const RecordLookupPtr& recordlookup, int64_t numfields);
+
+    RecordLookupPtr
+      init_recordlookup(int64_t numfields);
+
+    int64_t
+      fieldindex(const RecordLookupPtr& recordlookup,
+                 const std::string& key,
+                 int64_t numfields);
+
+    const std::string
+      key(const RecordLookupPtr& recordlookup,
+          int64_t fieldindex,
+          int64_t numfields);
+
+    bool
+      haskey(const RecordLookupPtr& recordlookup,
+             const std::string& key,
+             int64_t numfields);
+
+    const std::vector<std::string>
+      keys(const RecordLookupPtr& recordlookup, int64_t numfields);
 
     using Parameters = std::map<std::string, std::string>;
-    bool parameter_equals(const Parameters& parameters, const std::string& key, const std::string& value);
-    bool parameters_equal(const Parameters& self, const Parameters& other);
 
-    std::string gettypestr(const Parameters& parameters, const std::map<std::string, std::string>& typestrs);
+    bool
+      parameter_equals(const Parameters& parameters,
+                       const std::string& key,
+                       const std::string& value);
 
-    template <typename T>
-    ERROR awkward_identities32_from_listoffsetarray(int32_t* toptr, const int32_t* fromptr, const T* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-    template <typename T>
-    ERROR awkward_identities64_from_listoffsetarray(int64_t* toptr, const int64_t* fromptr, const T* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-    template <typename T>
-    ERROR awkward_identities32_from_listarray(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const T* fromstarts, const T* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-    template <typename T>
-    ERROR awkward_identities64_from_listarray(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const T* fromstarts, const T* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-    template <typename T>
-    ERROR awkward_identities32_from_indexedarray(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const T* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-    template <typename T>
-    ERROR awkward_identities64_from_indexedarray(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const T* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth);
-    template <typename T, typename I>
-    ERROR awkward_identities32_from_unionarray(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const T* fromtags, const I* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which);
-    template <typename T, typename I>
-    ERROR awkward_identities64_from_unionarray(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const T* fromtags, const I* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which);
-    template <typename T>
-    ERROR awkward_index_carry_64(T* toindex, const T* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length);
-    template <typename T>
-    ERROR awkward_index_carry_nocheck_64(T* toindex, const T* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length);
-    template <typename T>
-    ERROR awkward_listarray_getitem_next_at_64(int64_t* tocarry, const T* fromstarts, const T* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at);
-    template <typename T>
-    ERROR awkward_listarray_getitem_next_range_carrylength(int64_t* carrylength, const T* fromstarts, const T* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step);
-    template <typename T>
-    ERROR awkward_listarray_getitem_next_range_64(T* tooffsets, int64_t* tocarry, const T* fromstarts, const T* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step);
-    template <typename T>
-    ERROR awkward_listarray_getitem_next_range_counts_64(int64_t* total, const T* fromoffsets, int64_t lenstarts);
-    template <typename T>
-    ERROR awkward_listarray_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, const T* fromoffsets, int64_t lenstarts);
-    template <typename T>
-    ERROR awkward_listarray_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const T* fromstarts, const T* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent);
-    template <typename T>
-    ERROR awkward_listarray_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const T* fromstarts, const T* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent);
-    template <typename T>
-    ERROR awkward_listarray_getitem_carry_64(T* tostarts, T* tostops, const T* fromstarts, const T* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry);
-    template <typename T>
-    ERROR awkward_listarray_num_64(int64_t* tonum, const T* fromstarts, int64_t startsoffset, const T* fromstops, int64_t stopsoffset, int64_t length);
-    template <typename T>
-    ERROR awkward_listoffsetarray_flatten_offsets_64(int64_t* tooffsets, const T* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen);
-    template <typename T>
-    ERROR awkward_indexedarray_flatten_none2empty_64(int64_t* outoffsets, const T* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_flatten_length_64(int64_t* total_length, const T* fromtags, int64_t fromtagsoffset, const I* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_flatten_combine_64(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const T* fromtags, int64_t fromtagsoffset, const I* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets);
-    template <typename T>
-    ERROR awkward_indexedarray_flatten_nextcarry_64(int64_t* tocarry, const T* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-    template <typename T>
-    ERROR awkward_indexedarray_numnull(int64_t* numnull, const T* fromindex, int64_t indexoffset, int64_t lenindex);
-    template <typename T>
-    ERROR awkward_indexedarray_getitem_nextcarry_outindex_64(int64_t* tocarry, T* toindex, const T* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-    template <typename T>
-    ERROR awkward_indexedarray_getitem_nextcarry_outindex_mask_64(int64_t* tocarry, int64_t* toindex, const T* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-    template <typename T>
-    ERROR awkward_indexedarray_getitem_nextcarry_64(int64_t* tocarry, const T* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent);
-    template <typename T>
-    ERROR awkward_indexedarray_getitem_carry_64(T* toindex, const T* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry);
-    template <typename T>
-    ERROR awkward_indexedarray_overlay_mask8_to64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const T* fromindex, int64_t indexoffset, int64_t length);
-    template <typename T>
-    ERROR awkward_indexedarray_mask8(int8_t* tomask, const T* fromindex, int64_t indexoffset, int64_t length);
-    template <typename T>
-    ERROR awkward_indexedarray_simplify32_to64(int64_t* toindex, const T* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength);
-    template <typename T>
-    ERROR awkward_indexedarray_simplifyU32_to64(int64_t* toindex, const T* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength);
-    template <typename T>
-    ERROR awkward_indexedarray_simplify64_to64(int64_t* toindex, const T* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_regular_index(I* toindex, const T* fromtags, int64_t tagsoffset, int64_t length);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_project_64(int64_t* lenout, int64_t* tocarry, const T* fromtags, int64_t tagsoffset, const I* fromindex, int64_t indexoffset, int64_t length, int64_t which);
-    template <typename T>
-    ERROR awkward_listarray_compact_offsets64(int64_t* tooffsets, const T* fromstarts, const T* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length);
-    template <typename T>
-    ERROR awkward_listoffsetarray_compact_offsets64(int64_t* tooffsets, const T* fromoffsets, int64_t offsetsoffset, int64_t length);
-    template <typename T>
-    ERROR awkward_listarray_broadcast_tooffsets64(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const T* fromstarts, int64_t startsoffset, const T* fromstops, int64_t stopsoffset, int64_t lencontent);
-    template <typename T>
-    ERROR awkward_listoffsetarray_toRegularArray(int64_t* size, const T* fromoffsets, int64_t offsetsoffset, int64_t offsetslength);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_simplify8_32_to8_64(int8_t* totags, int64_t* toindex, const T* outertags, int64_t outertagsoffset, const I* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_simplify8_U32_to8_64(int8_t* totags, int64_t* toindex, const T* outertags, int64_t outertagsoffset, const I* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_simplify8_64_to8_64(int8_t* totags, int64_t* toindex, const T* outertags, int64_t outertagsoffset, const I* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_simplify_one_to8_64(int8_t* totags, int64_t* toindex, const T* fromtags, int64_t fromtagsoffset, const I* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base);
-    template <typename T>
-    ERROR awkward_listarray_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const T* fromstarts, int64_t fromstartsoffset, const T* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length);
-    template <typename T>
-    ERROR awkward_listarray_getitem_jagged_apply_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const T* fromstarts, int64_t fromstartsoffset, const T* fromstops, int64_t fromstopsoffset, int64_t contentlen);
-    template <typename T>
-    ERROR awkward_listarray_getitem_jagged_descend_64(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const T* fromstarts, int64_t fromstartsoffset, const T* fromstops, int64_t fromstopsoffset);
-    template <typename T>
-    ERROR awkward_indexedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const T* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length);
-    template <typename T>
-    ERROR awkward_UnionArray_fillna_64(int64_t* toindex, const T* fromindex, int64_t offset, int64_t length);
+    bool
+      parameters_equal(const Parameters& self, const Parameters& other);
+
+    std::string
+      gettypestr(const Parameters& parameters,
+                 const std::map<std::string,
+                 std::string>& typestrs);
 
     template <typename T>
-    ERROR awkward_ListArray_min_range(int64_t* tomin, const T* fromstarts, const T* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset);
+    ERROR
+      awkward_identities32_from_listoffsetarray(
+        int32_t* toptr,
+        const int32_t* fromptr,
+        const T* fromoffsets,
+        int64_t fromptroffset,
+        int64_t offsetsoffset,
+        int64_t tolength,
+        int64_t fromlength,
+        int64_t fromwidth);
+
     template <typename T>
-    ERROR awkward_ListArray_rpad_axis1_64(int64_t* toindex, const T* fromstarts, const T* fromstops, T* tostarts, T* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset);
+    ERROR
+      awkward_identities64_from_listoffsetarray(
+        int64_t* toptr,
+        const int64_t* fromptr,
+        const T* fromoffsets,
+        int64_t fromptroffset,
+        int64_t offsetsoffset,
+        int64_t tolength,
+        int64_t fromlength,
+        int64_t fromwidth);
+
+    
     template <typename T>
-    ERROR awkward_ListArray_rpad_and_clip_length_axis1(int64_t* tolength, const T* fromstarts, const T* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset);
+    ERROR
+      awkward_identities32_from_listarray(
+        bool* uniquecontents,
+        int32_t* toptr,
+        const int32_t* fromptr,
+        const T* fromstarts,
+        const T* fromstops,
+        int64_t fromptroffset,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t tolength,
+        int64_t fromlength,
+        int64_t fromwidth);
+
+    
     template <typename T>
-    ERROR awkward_ListOffsetArray_rpad_length_axis1(T* tooffsets, const T* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target, int64_t* tolength);
+    ERROR
+      awkward_identities64_from_listarray(
+        bool* uniquecontents,
+        int64_t* toptr,
+        const int64_t* fromptr,
+        const T* fromstarts,
+        const T* fromstops,
+        int64_t fromptroffset,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t tolength,
+        int64_t fromlength,
+        int64_t fromwidth);
+
+    
     template <typename T>
-    ERROR awkward_ListOffsetArray_rpad_axis1_64(int64_t* toindex, const T* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target);
+    ERROR
+      awkward_identities32_from_indexedarray(
+        bool* uniquecontents,
+        int32_t* toptr,
+        const int32_t* fromptr,
+        const T* fromindex,
+        int64_t fromptroffset,
+        int64_t indexoffset,
+        int64_t tolength,
+        int64_t fromlength,
+        int64_t fromwidth);
+
+    
     template <typename T>
-    ERROR awkward_ListOffsetArray_rpad_and_clip_axis1_64(int64_t* toindex, const T* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target);
+    ERROR
+      awkward_identities64_from_indexedarray(
+        bool* uniquecontents,
+        int64_t* toptr,
+        const int64_t* fromptr,
+        const T* fromindex,
+        int64_t fromptroffset,
+        int64_t indexoffset,
+        int64_t tolength,
+        int64_t fromlength,
+        int64_t fromwidth);
+
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_identities32_from_unionarray(
+        bool* uniquecontents,
+        int32_t* toptr,
+        const int32_t* fromptr,
+        const T* fromtags,
+        const I* fromindex,
+        int64_t fromptroffset,
+        int64_t tagsoffset,
+        int64_t indexoffset,
+        int64_t tolength,
+        int64_t fromlength,
+        int64_t fromwidth,
+        int64_t which);
+
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_identities64_from_unionarray(
+        bool* uniquecontents,
+        int64_t* toptr,
+        const int64_t* fromptr,
+        const T* fromtags,
+        const I* fromindex,
+        int64_t fromptroffset,
+        int64_t tagsoffset,
+        int64_t indexoffset,
+        int64_t tolength,
+        int64_t fromlength,
+        int64_t fromwidth,
+        int64_t which);
+
+    
     template <typename T>
-    ERROR awkward_listarray_validity(const T* starts, int64_t startsoffset, const T* stops, int64_t stopsoffset, int64_t length, int64_t lencontent);
+    ERROR
+      awkward_index_carry_64(
+        T* toindex,
+        const T* fromindex,
+        const int64_t* carry,
+        int64_t fromindexoffset,
+        int64_t lenfromindex,
+        int64_t length);
+
+    
     template <typename T>
-    ERROR awkward_indexedarray_validity(const T* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption);
-    template <typename T, typename I>
-    ERROR awkward_unionarray_validity(const T* tags, int64_t tagsoffset, const I* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents);
+    ERROR
+      awkward_index_carry_nocheck_64(
+        T* toindex,
+        const T* fromindex,
+        const int64_t* carry,
+        int64_t fromindexoffset,
+        int64_t length);
+
+    
     template <typename T>
-    ERROR awkward_listarray_localindex_64(int64_t* toindex, const T* offsets, int64_t offsetsoffset, int64_t length);
+    ERROR
+      awkward_listarray_getitem_next_at_64(
+        int64_t* tocarry,
+        const T* fromstarts,
+        const T* fromstops,
+        int64_t lenstarts,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t at);
+
+    
     template <typename T>
-    ERROR awkward_listarray_choose_length_64(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const T* starts, int64_t startsoffset, const T* stops, int64_t stopsoffset, int64_t length);
+    ERROR
+      awkward_listarray_getitem_next_range_carrylength(
+        int64_t* carrylength,
+        const T* fromstarts,
+        const T* fromstops,
+        int64_t lenstarts,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t start,
+        int64_t stop,
+        int64_t step);
+
+    
     template <typename T>
-    ERROR awkward_listarray_choose_64(int64_t** tocarry, int64_t n, bool diagonal, const T* starts, int64_t startsoffset, const T* stops, int64_t stopsoffset, int64_t length);
+    ERROR
+      awkward_listarray_getitem_next_range_64(
+        T* tooffsets,
+        int64_t* tocarry,
+        const T* fromstarts,
+        const T* fromstops,
+        int64_t lenstarts,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t start,
+        int64_t stop,
+        int64_t step);
+
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_getitem_next_range_counts_64(
+        int64_t* total,
+        const T* fromoffsets,
+        int64_t lenstarts);
+
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_getitem_next_range_spreadadvanced_64(
+        int64_t* toadvanced,
+        const int64_t* fromadvanced,
+        const T* fromoffsets,
+        int64_t lenstarts);
+
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_getitem_next_array_64(
+        int64_t* tocarry,
+        int64_t* toadvanced,
+        const T* fromstarts,
+        const T* fromstops,
+        const int64_t* fromarray,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t lenstarts,
+        int64_t lenarray,
+        int64_t lencontent);
+
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_getitem_next_array_advanced_64(
+        int64_t* tocarry,
+        int64_t* toadvanced,
+        const T* fromstarts,
+        const T* fromstops,
+        const int64_t* fromarray,
+        const int64_t* fromadvanced,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t lenstarts,
+        int64_t lenarray,
+        int64_t lencontent);
+
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_getitem_carry_64(
+        T* tostarts,
+        T* tostops,
+        const T* fromstarts,
+        const T* fromstops,
+        const int64_t* fromcarry,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t lenstarts,
+        int64_t lencarry);
+
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_num_64(
+        int64_t* tonum,
+        const T* fromstarts,
+        int64_t startsoffset,
+        const T* fromstops,
+        int64_t stopsoffset,
+        int64_t length);
+
+    
+    template <typename T>
+    ERROR
+      awkward_listoffsetarray_flatten_offsets_64(
+        int64_t* tooffsets,
+        const T* outeroffsets,
+        int64_t outeroffsetsoffset,
+        int64_t outeroffsetslen,
+        const int64_t* inneroffsets,
+        int64_t inneroffsetsoffset,
+        int64_t inneroffsetslen);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_flatten_none2empty_64(
+        int64_t* outoffsets,
+        const T* outindex,
+        int64_t outindexoffset,
+        int64_t outindexlength,
+        const int64_t* offsets,
+        int64_t offsetsoffset,
+        int64_t offsetslength);
+
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_flatten_length_64(
+        int64_t* total_length,
+        const T* fromtags,
+        int64_t fromtagsoffset,
+        const I* fromindex,
+        int64_t fromindexoffset,
+        int64_t length,
+        int64_t** offsetsraws,
+        int64_t* offsetsoffsets);
+
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_flatten_combine_64(
+        int8_t* totags,
+        int64_t* toindex,
+        int64_t* tooffsets,
+        const T* fromtags,
+        int64_t fromtagsoffset,
+        const I* fromindex,
+        int64_t fromindexoffset,
+        int64_t length,
+        int64_t** offsetsraws,
+        int64_t* offsetsoffsets);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_flatten_nextcarry_64(
+        int64_t* tocarry,
+        const T* fromindex,
+        int64_t indexoffset,
+        int64_t lenindex,
+        int64_t lencontent);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_numnull(
+        int64_t* numnull,
+        const T* fromindex,
+        int64_t indexoffset,
+        int64_t lenindex);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_getitem_nextcarry_outindex_64(
+        int64_t* tocarry,
+        T* toindex,
+        const T* fromindex,
+        int64_t indexoffset,
+        int64_t lenindex,
+        int64_t lencontent);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_getitem_nextcarry_outindex_mask_64(
+        int64_t* tocarry,
+        int64_t* toindex,
+        const T* fromindex,
+        int64_t indexoffset,
+        int64_t lenindex,
+        int64_t lencontent);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_getitem_nextcarry_64(
+        int64_t* tocarry,
+        const T* fromindex,
+        int64_t indexoffset,
+        int64_t lenindex,
+        int64_t lencontent);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_getitem_carry_64(
+        T* toindex,
+        const T* fromindex,
+        const int64_t* fromcarry,
+        int64_t indexoffset,
+        int64_t lenindex,
+        int64_t lencarry);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_overlay_mask8_to64(
+        int64_t* toindex,
+        const int8_t* mask,
+        int64_t maskoffset,
+        const T* fromindex,
+        int64_t indexoffset,
+        int64_t length);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_mask8(
+        int8_t* tomask,
+        const T* fromindex,
+        int64_t indexoffset,
+        int64_t length);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_simplify32_to64(
+        int64_t* toindex,
+        const T* outerindex,
+        int64_t outeroffset,
+        int64_t outerlength,
+        const int32_t* innerindex,
+        int64_t inneroffset,
+        int64_t innerlength);
+
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_simplifyU32_to64(
+        int64_t* toindex,
+        const T* outerindex,
+        int64_t outeroffset,
+        int64_t outerlength,
+        const uint32_t* innerindex,
+        int64_t inneroffset,
+        int64_t innerlength);
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_simplify64_to64(
+        int64_t* toindex,
+        const T* outerindex,
+        int64_t outeroffset,
+        int64_t outerlength,
+        const int64_t* innerindex,
+        int64_t inneroffset,
+        int64_t innerlength);
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_regular_index(
+        I* toindex,
+        const T* fromtags,
+        int64_t tagsoffset,
+        int64_t length);
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_project_64(
+        int64_t* lenout,
+        int64_t* tocarry,
+        const T* fromtags,
+        int64_t tagsoffset,
+        const I* fromindex,
+        int64_t indexoffset,
+        int64_t length,
+        int64_t which);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_compact_offsets64(
+        int64_t* tooffsets,
+        const T* fromstarts,
+        const T* fromstops,
+        int64_t startsoffset,
+        int64_t stopsoffset,
+        int64_t length);
+    
+    template <typename T>
+    ERROR
+      awkward_listoffsetarray_compact_offsets64(
+        int64_t* tooffsets,
+        const T* fromoffsets,
+        int64_t offsetsoffset,
+        int64_t length);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_broadcast_tooffsets64(
+        int64_t* tocarry,
+        const int64_t* fromoffsets,
+        int64_t offsetsoffset,
+        int64_t offsetslength,
+        const T* fromstarts,
+        int64_t startsoffset,
+        const T* fromstops,
+        int64_t stopsoffset,
+        int64_t lencontent);
+    
+    template <typename T>
+    ERROR
+      awkward_listoffsetarray_toRegularArray(
+        int64_t* size,
+        const T* fromoffsets,
+        int64_t offsetsoffset,
+        int64_t offsetslength);
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_simplify8_32_to8_64(
+        int8_t* totags,
+        int64_t* toindex,
+        const T* outertags,
+        int64_t outertagsoffset,
+        const I* outerindex,
+        int64_t outerindexoffset,
+        const int8_t* innertags,
+        int64_t innertagsoffset,
+        const int32_t* innerindex,
+        int64_t innerindexoffset,
+        int64_t towhich,
+        int64_t innerwhich,
+        int64_t outerwhich,
+        int64_t length,
+        int64_t base);
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_simplify8_U32_to8_64(
+        int8_t* totags,
+        int64_t* toindex,
+        const T* outertags,
+        int64_t outertagsoffset,
+        const I* outerindex,
+        int64_t outerindexoffset,
+        const int8_t* innertags,
+        int64_t innertagsoffset,
+        const uint32_t* innerindex,
+        int64_t innerindexoffset,
+        int64_t towhich,
+        int64_t innerwhich,
+        int64_t outerwhich,
+        int64_t length,
+        int64_t base);
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_simplify8_64_to8_64(
+        int8_t* totags,
+        int64_t* toindex,
+        const T* outertags,
+        int64_t outertagsoffset,
+        const I* outerindex,
+        int64_t outerindexoffset,
+        const int8_t* innertags,
+        int64_t innertagsoffset,
+        const int64_t* innerindex,
+        int64_t innerindexoffset,
+        int64_t towhich,
+        int64_t innerwhich,
+        int64_t outerwhich,
+        int64_t length,
+        int64_t base);
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_simplify_one_to8_64(
+        int8_t* totags,
+        int64_t* toindex,
+        const T* fromtags,
+        int64_t fromtagsoffset,
+        const I* fromindex,
+        int64_t fromindexoffset,
+        int64_t towhich,
+        int64_t fromwhich,
+        int64_t length,
+        int64_t base);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_getitem_jagged_expand_64(
+        int64_t* multistarts,
+        int64_t* multistops,
+        const int64_t* singleoffsets,
+        int64_t* tocarry,
+        const T* fromstarts,
+        int64_t fromstartsoffset,
+        const T* fromstops,
+        int64_t fromstopsoffset,
+        int64_t jaggedsize,
+        int64_t length);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_getitem_jagged_apply_64(
+        int64_t* tooffsets,
+        int64_t* tocarry,
+        const int64_t* slicestarts,
+        int64_t slicestartsoffset,
+        const int64_t* slicestops,
+        int64_t slicestopsoffset,
+        int64_t sliceouterlen,
+        const int64_t* sliceindex,
+        int64_t sliceindexoffset,
+        int64_t sliceinnerlen,
+        const T* fromstarts,
+        int64_t fromstartsoffset,
+        const T* fromstops,
+        int64_t fromstopsoffset,
+        int64_t contentlen);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_getitem_jagged_descend_64(
+        int64_t* tooffsets,
+        const int64_t* slicestarts,
+        int64_t slicestartsoffset,
+        const int64_t* slicestops,
+        int64_t slicestopsoffset,
+        int64_t sliceouterlen,
+        const T* fromstarts,
+        int64_t fromstartsoffset,
+        const T* fromstops,
+        int64_t fromstopsoffset);
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_reduce_next_64(
+        int64_t* nextcarry,
+        int64_t* nextparents,
+        int64_t* outindex,
+        const T* index,
+        int64_t indexoffset,
+        int64_t* parents,
+        int64_t parentsoffset,
+        int64_t length);
+    
+    template <typename T>
+    ERROR
+      awkward_UnionArray_fillna_64(
+        int64_t* toindex,
+        const T* fromindex,
+        int64_t offset,
+        int64_t length);
+
+    
+    template <typename T>
+    ERROR
+      awkward_ListArray_min_range(
+        int64_t* tomin,
+        const T* fromstarts,
+        const T* fromstops,
+        int64_t lenstarts,
+        int64_t startsoffset,
+        int64_t stopsoffset);
+    
+    template <typename T>
+    ERROR
+      awkward_ListArray_rpad_axis1_64(
+        int64_t* toindex,
+        const T* fromstarts,
+        const T* fromstops,
+        T* tostarts,
+        T* tostops,
+        int64_t target,
+        int64_t length,
+        int64_t startsoffset,
+        int64_t stopsoffset);
+    
+    template <typename T>
+    ERROR
+      awkward_ListArray_rpad_and_clip_length_axis1(
+        int64_t* tolength,
+        const T* fromstarts,
+        const T* fromstops,
+        int64_t target,
+        int64_t lenstarts,
+        int64_t startsoffset,
+        int64_t stopsoffset);
+    
+    template <typename T>
+    ERROR
+      awkward_ListOffsetArray_rpad_length_axis1(
+        T* tooffsets,
+        const T* fromoffsets,
+        int64_t offsetsoffset,
+        int64_t fromlength,
+        int64_t target,
+        int64_t* tolength);
+    
+    template <typename T>
+    ERROR
+      awkward_ListOffsetArray_rpad_axis1_64(
+        int64_t* toindex,
+        const T* fromoffsets,
+        int64_t offsetsoffset,
+        int64_t fromlength,
+        int64_t target);
+    
+    template <typename T>
+    ERROR
+      awkward_ListOffsetArray_rpad_and_clip_axis1_64(
+        int64_t* toindex,
+        const T* fromoffsets,
+        int64_t offsetsoffset,
+        int64_t length,
+        int64_t target);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_validity(
+        const T* starts,
+        int64_t startsoffset,
+        const T* stops,
+        int64_t stopsoffset,
+        int64_t length,
+        int64_t lencontent);
+    
+    template <typename T>
+    ERROR
+      awkward_indexedarray_validity(
+        const T* index,
+        int64_t indexoffset,
+        int64_t length,
+        int64_t lencontent,
+        bool isoption);
+    
+    template <typename T,
+              typename I>
+    ERROR
+      awkward_unionarray_validity(
+        const T* tags,
+        int64_t tagsoffset,
+        const I* index,
+        int64_t indexoffset,
+        int64_t length,
+        int64_t numcontents,
+        const int64_t* lencontents);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_localindex_64(
+        int64_t* toindex,
+        const T* offsets,
+        int64_t offsetsoffset,
+        int64_t length);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_choose_length_64(
+        int64_t* totallen,
+        int64_t* tooffsets,
+        int64_t n,
+        bool diagonal,
+        const T* starts,
+        int64_t startsoffset,
+        const T* stops,
+        int64_t stopsoffset,
+        int64_t length);
+    
+    template <typename T>
+    ERROR
+      awkward_listarray_choose_64(
+        int64_t** tocarry,
+        int64_t n,
+        bool diagonal,
+        const T* starts,
+        int64_t startsoffset,
+        const T* stops,
+        int64_t stopsoffset,
+        int64_t length);
+    
     template<typename T>
-    T awkward_index_getitem_at_nowrap(const T* ptr, int64_t offset, int64_t at);
+    T
+      awkward_index_getitem_at_nowrap(
+        const T* ptr,
+        int64_t offset,
+        int64_t at);
+    
     template<typename T>
-    void awkward_index_setitem_at_nowrap(T* ptr, int64_t offset, int64_t at, T value);
+    void
+      awkward_index_setitem_at_nowrap(
+        T* ptr,
+        int64_t offset,
+        int64_t at,
+        T value);
   }
 }
 

--- a/include/awkward/util.h
+++ b/include/awkward/util.h
@@ -40,11 +40,12 @@ namespace awkward {
     IndexOf<T> make_stops(const IndexOf<T>& offsets);
 
     typedef std::vector<std::string> RecordLookup;
-    std::shared_ptr<RecordLookup> init_recordlookup(int64_t numfields);
-    int64_t fieldindex(const std::shared_ptr<RecordLookup>& recordlookup, const std::string& key, int64_t numfields);
-    const std::string key(const std::shared_ptr<RecordLookup>& recordlookup, int64_t fieldindex, int64_t numfields);
-    bool haskey(const std::shared_ptr<RecordLookup>& recordlookup, const std::string& key, int64_t numfields);
-    const std::vector<std::string> keys(const std::shared_ptr<RecordLookup>& recordlookup, int64_t numfields);
+    typedef std::shared_ptr<RecordLookup> RecordLookupPtr;
+    RecordLookupPtr init_recordlookup(int64_t numfields);
+    int64_t fieldindex(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields);
+    const std::string key(const RecordLookupPtr& recordlookup, int64_t fieldindex, int64_t numfields);
+    bool haskey(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields);
+    const std::vector<std::string> keys(const RecordLookupPtr& recordlookup, int64_t numfields);
 
     typedef std::map<std::string, std::string> Parameters;
     bool parameter_equals(const Parameters& parameters, const std::string& key, const std::string& value);

--- a/include/awkward/util.h
+++ b/include/awkward/util.h
@@ -39,15 +39,15 @@ namespace awkward {
     template <typename T>
     IndexOf<T> make_stops(const IndexOf<T>& offsets);
 
-    typedef std::vector<std::string> RecordLookup;
-    typedef std::shared_ptr<RecordLookup> RecordLookupPtr;
+    using RecordLookup    = std::vector<std::string>;
+    using RecordLookupPtr = std::shared_ptr<RecordLookup>;
     RecordLookupPtr init_recordlookup(int64_t numfields);
     int64_t fieldindex(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields);
     const std::string key(const RecordLookupPtr& recordlookup, int64_t fieldindex, int64_t numfields);
     bool haskey(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields);
     const std::vector<std::string> keys(const RecordLookupPtr& recordlookup, int64_t numfields);
 
-    typedef std::map<std::string, std::string> Parameters;
+    using Parameters = std::map<std::string, std::string>;
     bool parameter_equals(const Parameters& parameters, const std::string& key, const std::string& value);
     bool parameters_equal(const Parameters& self, const Parameters& other);
 

--- a/src/awkward1/__init__.py
+++ b/src/awkward1/__init__.py
@@ -4,11 +4,12 @@ from __future__ import absolute_import
 
 import distutils.version
 
-# NumPy 1.13.1 introduced NEP13, without which Awkward ufuncs won't work,
-# which would be worse than lacking a feature: it would cause unexpected output.
+# NumPy 1.13.1 introduced NEP13, without which Awkward ufuncs won't work, which
+# would be worse than lacking a feature: it would cause unexpected output.
 # NumPy 1.17.0 introduced NEP18, which is optional (use ak.* instead of np.*).
 import numpy
-if distutils.version.LooseVersion(numpy.__version__) < distutils.version.LooseVersion("1.13.1"):
+if (distutils.version.LooseVersion(numpy.__version__) <
+    distutils.version.LooseVersion("1.13.1")):
     raise ImportError("Numpy 1.13.1 or later required")
 
 # C++ modules
@@ -51,4 +52,5 @@ autograd.elementwise_grad = awkward1._connect._autograd.elementwise_grad
 # version
 __version__ = awkward1.layout.__version__
 
-__all__ = [x for x in list(globals()) if not x.startswith("_") and x not in ("distutils", "numpy")]
+__all__ = [x for x in list(globals())
+             if not x.startswith("_") and x not in ("distutils", "numpy")]

--- a/src/awkward1/_connect/_autograd.py
+++ b/src/awkward1/_connect/_autograd.py
@@ -16,44 +16,65 @@ def register():
     global NEP13Box
 
     if NEP13Box is None:
-        class NEP13Box(autograd.extend.Box, awkward1._connect._numpy.NDArrayOperatorsMixin):
+        class NEP13Box(autograd.extend.Box,
+                       awkward1._connect._numpy.NDArrayOperatorsMixin):
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
                 import autograd
 
-                if method != "__call__" or len(inputs) == 0 or "out" in kwargs or ufunc.__class__.__module__ != "numpy":
+                if (method != "__call__" or
+                    len(inputs) == 0 or
+                    "out" in kwargs or
+                    ufunc.__class__.__module__ != "numpy"):
                     return NotImplemented
 
                 nextinputs = []
                 for x in inputs:
                     if isinstance(x, NEP13Box):
-                        nextinputs.append(autograd.numpy.numpy_boxes.ArrayBox(numpy.asarray(x._value), x._trace, x._node))
+                        nextinputs.append(
+                            autograd.numpy.numpy_boxes.ArrayBox(
+                              numpy.asarray(x._value), x._trace, x._node))
                     else:
                         nextinputs.append(x)
 
-                out = getattr(autograd.numpy, ufunc.__name__)(*nextinputs, **kwargs)
-                return NEP13Box(awkward1.layout.NumpyArray(out._value), out._trace, out._node)
+                out = getattr(autograd.numpy, ufunc.__name__)(*nextinputs,
+                                                              **kwargs)
+                return NEP13Box(awkward1.layout.NumpyArray(out._value),
+                                out._trace,
+                                out._node)
 
         NEP13Box.register(awkward1.layout.NumpyArray)
 
-        autograd.extend.VSpace.register(awkward1.layout.NumpyArray, lambda x: autograd.numpy.numpy_vspaces.ArrayVSpace(numpy.asarray(x)))
+        autograd.extend.VSpace.register(
+            awkward1.layout.NumpyArray,
+            lambda x: autograd.numpy.numpy_vspaces.ArrayVSpace(
+                        numpy.asarray(x)))
 
 def elementwise_grad(fun, argnum=0, *nary_op_args, **nary_op_kwargs):
     import autograd
     register()
 
-    gradfun = autograd.elementwise_grad(fun, argnum, *nary_op_args, **nary_op_kwargs)
+    gradfun = autograd.elementwise_grad(fun,
+                                        argnum,
+                                        *nary_op_args,
+                                        **nary_op_kwargs)
 
     def broadcast(*args, **kwargs):
-        nextargs = [awkward1.operations.convert.tolayout(x, allowrecord=True, allowother=True) for x in args]
+        nextargs = [awkward1.operations.convert.tolayout(x,
+                                                         allowrecord=True,
+                                                         allowother=True)
+                    for x in args]
 
         def getfunction(inputs, depth):
-            if all(isinstance(x, awkward1.layout.NumpyArray) or not isinstance(x, awkward1.layout.Content) for x in inputs):
+            if all(isinstance(x, awkward1.layout.NumpyArray) or
+                   not isinstance(x, awkward1.layout.Content) for x in inputs):
                 return lambda: (awkward1.layout.NumpyArray(gradfun(*inputs)),)
             else:
                 return None
 
         behavior = awkward1._util.behaviorof(*args)
-        out = awkward1._util.broadcast_and_apply(nextargs, getfunction, behavior)
+        out = awkward1._util.broadcast_and_apply(nextargs,
+                                                 getfunction,
+                                                 behavior)
         assert isinstance(out, tuple) and len(out) == 1
         return awkward1._util.wrap(out[0], behavior)
 

--- a/src/awkward1/_connect/_numba/__init__.py
+++ b/src/awkward1/_connect/_numba/__init__.py
@@ -11,23 +11,25 @@ def register():
     import awkward1._connect._numba.layout
     import awkward1._connect._numba.builder
 
-    awkward1.numba.ArrayViewType = awkward1._connect._numba.arrayview.ArrayViewType
-    awkward1.numba.ArrayViewModel = awkward1._connect._numba.arrayview.ArrayViewModel
-    awkward1.numba.RecordViewType = awkward1._connect._numba.arrayview.RecordViewType
-    awkward1.numba.RecordViewModel = awkward1._connect._numba.arrayview.RecordViewModel
-    awkward1.numba.ContentType = awkward1._connect._numba.layout.ContentType
-    awkward1.numba.NumpyArrayType = awkward1._connect._numba.layout.NumpyArrayType
-    awkward1.numba.RegularArrayType = awkward1._connect._numba.layout.RegularArrayType
-    awkward1.numba.ListArrayType = awkward1._connect._numba.layout.ListArrayType
-    awkward1.numba.IndexedArrayType = awkward1._connect._numba.layout.IndexedArrayType
-    awkward1.numba.IndexedOptionArrayType = awkward1._connect._numba.layout.IndexedOptionArrayType
-    awkward1.numba.ByteMaskedArrayType = awkward1._connect._numba.layout.ByteMaskedArrayType
-    awkward1.numba.BitMaskedArrayType = awkward1._connect._numba.layout.BitMaskedArrayType
-    awkward1.numba.UnmaskedArrayType = awkward1._connect._numba.layout.UnmaskedArrayType
-    awkward1.numba.RecordArrayType = awkward1._connect._numba.layout.RecordArrayType
-    awkward1.numba.UnionArrayType = awkward1._connect._numba.layout.UnionArrayType
-    awkward1.numba.ArrayBuilderType = awkward1._connect._numba.builder.ArrayBuilderType
-    awkward1.numba.ArrayBuilderModel = awkward1._connect._numba.builder.ArrayBuilderModel
+    n = awkward1.numba
+    n.ArrayViewType       = awkward1._connect._numba.arrayview.ArrayViewType
+    n.ArrayViewModel      = awkward1._connect._numba.arrayview.ArrayViewModel
+    n.RecordViewType      = awkward1._connect._numba.arrayview.RecordViewType
+    n.RecordViewModel     = awkward1._connect._numba.arrayview.RecordViewModel
+    n.ContentType         = awkward1._connect._numba.layout.ContentType
+    n.NumpyArrayType      = awkward1._connect._numba.layout.NumpyArrayType
+    n.RegularArrayType    = awkward1._connect._numba.layout.RegularArrayType
+    n.ListArrayType       = awkward1._connect._numba.layout.ListArrayType
+    n.IndexedArrayType    = awkward1._connect._numba.layout.IndexedArrayType
+    n.IndexedOptionArrayType = \
+                         awkward1._connect._numba.layout.IndexedOptionArrayType
+    n.ByteMaskedArrayType = awkward1._connect._numba.layout.ByteMaskedArrayType
+    n.BitMaskedArrayType  = awkward1._connect._numba.layout.BitMaskedArrayType
+    n.UnmaskedArrayType   = awkward1._connect._numba.layout.UnmaskedArrayType
+    n.RecordArrayType     = awkward1._connect._numba.layout.RecordArrayType
+    n.UnionArrayType      = awkward1._connect._numba.layout.UnionArrayType
+    n.ArrayBuilderType    = awkward1._connect._numba.builder.ArrayBuilderType
+    n.ArrayBuilderModel   = awkward1._connect._numba.builder.ArrayBuilderModel
 
 try:
     import numba
@@ -62,7 +64,8 @@ def castint(context, builder, fromtype, totype, val):
         elif fromtype.width == 64:
             fromtype = numba.int64
     if not isinstance(fromtype, numba.types.Integer):
-        raise AssertionError("unrecognized integer type: {0}".format(repr(fromtype)))
+        raise AssertionError(
+                "unrecognized integer type: {0}".format(repr(fromtype)))
 
     if fromtype.bitwidth < totype.bitwidth:
         if fromtype.signed:

--- a/src/awkward1/_connect/_numba/arrayview.py
+++ b/src/awkward1/_connect/_numba/arrayview.py
@@ -30,47 +30,73 @@ class Lookup(object):
         self.positions = [find(x) for x in positions]
         self.sharedptrs_hold = sharedptrs
         self.arrays = tuple(arrays)
-        self.arrayptrs = numpy.array([x if isinstance(x, int) else x.ctypes.data for x in positions], dtype=numpy.intp)
-        self.sharedptrs = numpy.array([0 if x is None else x.ptr() for x in sharedptrs], dtype=numpy.intp)
+        self.arrayptrs = numpy.array([x if isinstance(x, int)
+                                        else x.ctypes.data for x in positions],
+                                     dtype=numpy.intp)
+        self.sharedptrs = numpy.array([0 if x is None else x.ptr()
+                                         for x in sharedptrs],
+                                      dtype=numpy.intp)
 
 def tolookup(layout, positions, sharedptrs, arrays):
     import awkward1.layout
 
     if isinstance(layout, awkward1.layout.NumpyArray):
-        return awkward1._connect._numba.layout.NumpyArrayType.tolookup(layout, positions, sharedptrs, arrays)
+        return awkward1._connect._numba.layout.NumpyArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
     elif isinstance(layout, awkward1.layout.RegularArray):
-        return awkward1._connect._numba.layout.RegularArrayType.tolookup(layout, positions, sharedptrs, arrays)
+        return awkward1._connect._numba.layout.RegularArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
-    elif isinstance(layout, (awkward1.layout.ListArray32, awkward1.layout.ListArrayU32, awkward1.layout.ListArray64, awkward1.layout.ListOffsetArray32, awkward1.layout.ListOffsetArrayU32, awkward1.layout.ListOffsetArray64)):
-        return awkward1._connect._numba.layout.ListArrayType.tolookup(layout, positions, sharedptrs, arrays)
+    elif isinstance(layout, (awkward1.layout.ListArray32,
+                             awkward1.layout.ListArrayU32,
+                             awkward1.layout.ListArray64,
+                             awkward1.layout.ListOffsetArray32,
+                             awkward1.layout.ListOffsetArrayU32,
+                             awkward1.layout.ListOffsetArray64)):
+        return awkward1._connect._numba.layout.ListArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
-    elif isinstance(layout, (awkward1.layout.IndexedArray32, awkward1.layout.IndexedArrayU32, awkward1.layout.IndexedArray64)):
-        return awkward1._connect._numba.layout.IndexedArrayType.tolookup(layout, positions, sharedptrs, arrays)
+    elif isinstance(layout, (awkward1.layout.IndexedArray32,
+                             awkward1.layout.IndexedArrayU32,
+                             awkward1.layout.IndexedArray64)):
+        return awkward1._connect._numba.layout.IndexedArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
-    elif isinstance(layout, (awkward1.layout.IndexedOptionArray32, awkward1.layout.IndexedOptionArray64)):
-        return awkward1._connect._numba.layout.IndexedOptionArrayType.tolookup(layout, positions, sharedptrs, arrays)
+    elif isinstance(layout, (awkward1.layout.IndexedOptionArray32,
+                             awkward1.layout.IndexedOptionArray64)):
+        return awkward1._connect._numba.layout.IndexedOptionArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
     elif isinstance(layout, awkward1.layout.ByteMaskedArray):
-        return awkward1._connect._numba.layout.ByteMaskedArrayType.tolookup(layout, positions, sharedptrs, arrays)
+        return awkward1._connect._numba.layout.ByteMaskedArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
     elif isinstance(layout, awkward1.layout.BitMaskedArray):
-        return awkward1._connect._numba.layout.BitMaskedArrayType.tolookup(layout, positions, sharedptrs, arrays)
+        return awkward1._connect._numba.layout.BitMaskedArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
     elif isinstance(layout, awkward1.layout.UnmaskedArray):
-        return awkward1._connect._numba.layout.UnmaskedArrayType.tolookup(layout, positions, sharedptrs, arrays)
+        return awkward1._connect._numba.layout.UnmaskedArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
     elif isinstance(layout, awkward1.layout.RecordArray):
-        return awkward1._connect._numba.layout.RecordArrayType.tolookup(layout, positions, sharedptrs, arrays)
+        return awkward1._connect._numba.layout.RecordArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
     elif isinstance(layout, awkward1.layout.Record):
-        return awkward1._connect._numba.layout.RecordType.tolookup(layout, positions, sharedptrs, arrays)
+        return awkward1._connect._numba.layout.RecordType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
-    elif isinstance(layout, (awkward1.layout.UnionArray8_32, awkward1.layout.UnionArray8_U32, awkward1.layout.UnionArray8_64)):
-        return awkward1._connect._numba.layout.UnionArrayType.tolookup(layout, positions, sharedptrs, arrays)
+    elif isinstance(layout, (awkward1.layout.UnionArray8_32,
+                             awkward1.layout.UnionArray8_U32,
+                             awkward1.layout.UnionArray8_64)):
+        return awkward1._connect._numba.layout.UnionArrayType.tolookup(
+                 layout, positions, sharedptrs, arrays)
 
     else:
-        raise AssertionError("unrecognized layout type: {0}".format(type(layout)))
+        raise AssertionError(
+                "unrecognized layout type: {0}".format(type(layout)))
 
 @numba.extending.typeof_impl.register(Lookup)
 def typeof_Lookup(obj, c):
@@ -95,8 +121,10 @@ def unbox_Lookup(lookuptype, lookupobj, c):
     sharedptrs_obj = c.pyapi.object_getattr_string(lookupobj, "sharedptrs")
 
     proxyout = c.context.make_helper(c.builder, lookuptype)
-    proxyout.arrayptrs = c.pyapi.to_native_value(lookuptype.arraytype, arrayptrs_obj).value
-    proxyout.sharedptrs = c.pyapi.to_native_value(lookuptype.arraytype, sharedptrs_obj).value
+    proxyout.arrayptrs = c.pyapi.to_native_value(lookuptype.arraytype,
+                                                 arrayptrs_obj).value
+    proxyout.sharedptrs = c.pyapi.to_native_value(lookuptype.arraytype,
+                                                  sharedptrs_obj).value
 
     c.pyapi.decref(arrayptrs_obj)
     c.pyapi.decref(sharedptrs_obj)
@@ -108,9 +136,22 @@ class ArrayView(object):
     @classmethod
     def fromarray(self, array):
         behavior = awkward1._util.behaviorof(array)
-        layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False, numpytype=(numpy.number,))
-        layout = awkward1.operations.convert.regularize_numpyarray(layout, allowempty=False, highlevel=False)
-        return ArrayView(numba.typeof(layout), behavior, Lookup(layout), 0, 0, len(layout), ())
+        layout = awkward1.operations.convert.tolayout(
+                   array,
+                   allowrecord=False,
+                   allowother=False,
+                   numpytype=(numpy.number,))
+        layout = awkward1.operations.convert.regularize_numpyarray(
+                   layout,
+                   allowempty=False,
+                   highlevel=False)
+        return ArrayView(numba.typeof(layout),
+                         behavior,
+                         Lookup(layout),
+                         0,
+                         0,
+                         len(layout),
+                         ())
 
     def __init__(self, type, behavior, lookup, pos, start, stop, fields):
         self.type = type
@@ -137,7 +178,11 @@ def wrap(type, viewtype, fields):
 
 class ArrayViewType(numba.types.Type):
     def __init__(self, type, behavior, fields):
-        super(ArrayViewType, self).__init__(name="awkward1.ArrayView({0}, {1}, {2})".format(type.name, awkward1._connect._numba.repr_behavior(behavior), repr(fields)))
+        super(ArrayViewType, self).__init__(
+            name="awkward1.ArrayView({0}, {1}, {2})".format(
+              type.name,
+              awkward1._connect._numba.repr_behavior(behavior),
+              repr(fields)))
         self.type = type
         self.behavior = behavior
         self.fields = fields
@@ -173,8 +218,12 @@ def unbox_ArrayView(viewtype, view_obj, c):
     proxyout.pos        = c.pyapi.number_as_ssize_t(pos_obj)
     proxyout.start      = c.pyapi.number_as_ssize_t(start_obj)
     proxyout.stop       = c.pyapi.number_as_ssize_t(stop_obj)
-    proxyout.arrayptrs  = c.context.make_helper(c.builder, LookupType.arraytype, lookup_proxy.arrayptrs).data
-    proxyout.sharedptrs = c.context.make_helper(c.builder, LookupType.arraytype, lookup_proxy.sharedptrs).data
+    proxyout.arrayptrs  = c.context.make_helper(c.builder,
+                                                LookupType.arraytype,
+                                                lookup_proxy.arrayptrs).data
+    proxyout.sharedptrs = c.context.make_helper(c.builder,
+                                                LookupType.arraytype,
+                                                lookup_proxy.sharedptrs).data
     proxyout.pylookup   = lookup_obj
 
     c.pyapi.decref(lookup_obj)
@@ -208,12 +257,19 @@ def serializable2dict(obj):
         return dict(obj)
 
 def box_ArrayView(viewtype, viewval, c):
-    serializable2dict_obj = c.pyapi.unserialize(c.pyapi.serialize_object(serializable2dict))
-    behavior2_obj = c.pyapi.unserialize(c.pyapi.serialize_object(dict2serializable(viewtype.behavior)))
-    behavior_obj  = c.pyapi.call_function_objargs(serializable2dict_obj, (behavior2_obj,))
-    ArrayView_obj = c.pyapi.unserialize(c.pyapi.serialize_object(ArrayView))
-    type_obj      = c.pyapi.unserialize(c.pyapi.serialize_object(viewtype.type))
-    fields_obj    = c.pyapi.unserialize(c.pyapi.serialize_object(viewtype.fields))
+    serializable2dict_obj = c.pyapi.unserialize(
+                              c.pyapi.serialize_object(serializable2dict))
+    behavior2_obj = c.pyapi.unserialize(
+                      c.pyapi.serialize_object(
+                        dict2serializable(viewtype.behavior)))
+    behavior_obj  = c.pyapi.call_function_objargs(serializable2dict_obj,
+                                                  (behavior2_obj,))
+    ArrayView_obj = c.pyapi.unserialize(
+                      c.pyapi.serialize_object(ArrayView))
+    type_obj      = c.pyapi.unserialize(
+                      c.pyapi.serialize_object(viewtype.type))
+    fields_obj    = c.pyapi.unserialize(
+                      c.pyapi.serialize_object(viewtype.fields))
 
     proxyin = c.context.make_helper(c.builder, viewtype, viewval)
     pos_obj    = c.pyapi.long_from_ssize_t(proxyin.pos)
@@ -221,7 +277,14 @@ def box_ArrayView(viewtype, viewval, c):
     stop_obj   = c.pyapi.long_from_ssize_t(proxyin.stop)
     lookup_obj = proxyin.pylookup
 
-    out = c.pyapi.call_function_objargs(ArrayView_obj, (type_obj, behavior_obj, lookup_obj, pos_obj, start_obj, stop_obj, fields_obj))
+    out = c.pyapi.call_function_objargs(ArrayView_obj,
+                                        (type_obj,
+                                         behavior_obj,
+                                         lookup_obj,
+                                         pos_obj,
+                                         start_obj,
+                                         stop_obj,
+                                         fields_obj))
 
     c.pyapi.decref(serializable2dict_obj)
     c.pyapi.decref(behavior2_obj)
@@ -238,7 +301,8 @@ def box_ArrayView(viewtype, viewval, c):
 @numba.typing.templates.infer_global(len)
 class type_len(numba.typing.templates.AbstractTemplate):
     def generic(self, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], ArrayViewType):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and isinstance(args[0], ArrayViewType)):
             return numba.intp(args[0])
 
 @numba.extending.lower_builtin(len, ArrayViewType)
@@ -249,37 +313,72 @@ def lower_len(context, builder, sig, args):
 @numba.typing.templates.infer_global(operator.getitem)
 class type_getitem(numba.typing.templates.AbstractTemplate):
     def generic(self, args, kwargs):
-        if len(args) == 2 and len(kwargs) == 0 and isinstance(args[0], ArrayViewType):
+        if (len(args) == 2 and
+            len(kwargs) == 0 and
+            isinstance(args[0], ArrayViewType)):
             viewtype, wheretype = args
             if isinstance(wheretype, numba.types.Integer):
-                return viewtype.type.getitem_at_check(viewtype)(viewtype, wheretype)
-            elif isinstance(wheretype, numba.types.SliceType) and not wheretype.has_step:
+                return viewtype.type.getitem_at_check(viewtype)(viewtype,
+                                                                wheretype)
+            elif (isinstance(wheretype, numba.types.SliceType) and
+                  not wheretype.has_step):
                 return viewtype.type.getitem_range(viewtype)(viewtype, wheretype)
             elif isinstance(wheretype, numba.types.StringLiteral):
-                return viewtype.type.getitem_field(viewtype, wheretype.literal_value)(viewtype, wheretype)
+                return viewtype.type.getitem_field(
+                         viewtype, wheretype.literal_value)(viewtype, wheretype)
             else:
-                raise TypeError("only an integer, start:stop range, or a *constant* field name string may be used as awkward1.Array slices in compiled code")
+                raise TypeError(
+                        "only an integer, start:stop range, or a *constant* "
+                        "field name string may be used as awkward1.Array "
+                        "slices in compiled code")
 
-@numba.extending.lower_builtin(operator.getitem, ArrayViewType, numba.types.Integer)
+@numba.extending.lower_builtin(operator.getitem,
+                               ArrayViewType,
+                               numba.types.Integer)
 def lower_getitem_at(context, builder, sig, args):
     rettype, (viewtype, wheretype) = sig.return_type, sig.args
     viewval, whereval = args
     viewproxy = context.make_helper(builder, viewtype, viewval)
-    return viewtype.type.lower_getitem_at_check(context, builder, rettype, viewtype, viewval, viewproxy, wheretype, whereval, True, True)
+    return viewtype.type.lower_getitem_at_check(context,
+                                                builder,
+                                                rettype,
+                                                viewtype,
+                                                viewval,
+                                                viewproxy,
+                                                wheretype,
+                                                whereval,
+                                                True,
+                                                True)
 
-@numba.extending.lower_builtin(operator.getitem, ArrayViewType, numba.types.slice2_type)
+@numba.extending.lower_builtin(operator.getitem,
+                               ArrayViewType,
+                               numba.types.slice2_type)
 def lower_getitem_range(context, builder, sig, args):
     rettype, (viewtype, wheretype) = sig.return_type, sig.args
     viewval, whereval = args
     viewproxy = context.make_helper(builder, viewtype, viewval)
     whereproxy = context.make_helper(builder, wheretype, whereval)
-    return viewtype.type.lower_getitem_range(context, builder, rettype, viewtype, viewval, viewproxy, whereproxy.start, whereproxy.stop, True)
+    return viewtype.type.lower_getitem_range(context,
+                                             builder,
+                                             rettype,
+                                             viewtype,
+                                             viewval,
+                                             viewproxy,
+                                             whereproxy.start,
+                                             whereproxy.stop,
+                                             True)
 
-@numba.extending.lower_builtin(operator.getitem, ArrayViewType, numba.types.StringLiteral)
+@numba.extending.lower_builtin(operator.getitem,
+                               ArrayViewType,
+                               numba.types.StringLiteral)
 def lower_getitem_field(context, builder, sig, args):
     rettype, (viewtype, wheretype) = sig.return_type, sig.args
     viewval, whereval = args
-    return viewtype.type.lower_getitem_field(context, builder, viewtype, viewval, wheretype.literal_value)
+    return viewtype.type.lower_getitem_field(context,
+                                             builder,
+                                             viewtype,
+                                             viewval,
+                                             wheretype.literal_value)
 
 @numba.typing.templates.infer_getattr
 class type_getattr(numba.typing.templates.AttributeTemplate):
@@ -292,11 +391,16 @@ class type_getattr(numba.typing.templates.AttributeTemplate):
 
 @numba.extending.lower_getattr_generic(ArrayViewType)
 def lower_getattr_generic(context, builder, viewtype, viewval, attr):
-    return viewtype.type.lower_getitem_field(context, builder, viewtype, viewval, attr)
+    return viewtype.type.lower_getitem_field(context,
+                                             builder,
+                                             viewtype,
+                                             viewval,
+                                             attr)
 
 class IteratorType(numba.types.common.SimpleIteratorType):
     def __init__(self, viewtype):
-        super(IteratorType, self).__init__("awkward1.Iterator({0})".format(viewtype.name), viewtype.type.getitem_at_check(viewtype))
+        super(IteratorType, self).__init__("awkward1.Iterator({0})".format(
+                viewtype.name), viewtype.type.getitem_at_check(viewtype))
         self.viewtype = viewtype
 
 @numba.typing.templates.infer
@@ -304,7 +408,9 @@ class type_getiter(numba.typing.templates.AbstractTemplate):
     key = "getiter"
 
     def generic(self, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], ArrayViewType):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0], ArrayViewType)):
             return IteratorType(args[0])(args[0])
 
 @numba.datamodel.registry.register_default(IteratorType)
@@ -323,10 +429,14 @@ def lower_getiter(context, builder, sig, args):
     proxyout = context.make_helper(builder, rettype)
     proxyout.view = viewval
     proxyout.length = builder.sub(viewproxy.stop, viewproxy.start)
-    proxyout.at = numba.cgutils.alloca_once_value(builder, context.get_constant(numba.intp, 0))
+    proxyout.at = numba.cgutils.alloca_once_value(
+                    builder, context.get_constant(numba.intp, 0))
     if context.enable_nrt:
         context.nrt.incref(builder, viewtype, viewval)
-    return numba.targets.imputils.impl_ret_new_ref(context, builder, rettype, proxyout._getvalue())
+    return numba.targets.imputils.impl_ret_new_ref(context,
+                                                   builder,
+                                                   rettype,
+                                                   proxyout._getvalue())
 
 @numba.extending.lower_builtin("iternext", IteratorType)
 @numba.targets.imputils.iternext_impl(numba.targets.imputils.RefType.BORROWED)
@@ -340,7 +450,11 @@ def lower_iternext(context, builder, sig, args, result):
     result.set_valid(is_valid)
 
     with builder.if_then(is_valid, likely=True):
-        result.yield_(lower_getitem_at(context, builder, itertype.yield_type(itertype.viewtype, numba.intp), (proxyin.view, at)))
+        result.yield_(lower_getitem_at(
+            context,
+            builder,
+            itertype.yield_type(itertype.viewtype, numba.intp),
+            (proxyin.view, at)))
         nextat = numba.cgutils.increment_index(builder, at)
         builder.store(nextat, proxyin.at)
 
@@ -348,10 +462,21 @@ class RecordView(object):
     @classmethod
     def fromrecord(self, record):
         behavior = awkward1._util.behaviorof(record)
-        layout = awkward1.operations.convert.tolayout(record, allowrecord=True, allowother=False, numpytype=(numpy.number,))
+        layout = awkward1.operations.convert.tolayout(
+                   record,
+                   allowrecord=True,
+                   allowother=False,
+                   numpytype=(numpy.number,))
         assert isinstance(layout, awkward1.layout.Record)
         arraylayout = layout.array
-        return RecordView(ArrayView(numba.typeof(arraylayout), behavior, Lookup(arraylayout), 0, 0, len(arraylayout), ()), layout.at)
+        return RecordView(ArrayView(numba.typeof(arraylayout),
+                                    behavior,
+                                    Lookup(arraylayout),
+                                    0,
+                                    0,
+                                    len(arraylayout),
+                                    ()),
+                          layout.at)
 
     def __init__(self, arrayview, at):
         self.arrayview = arrayview
@@ -359,7 +484,9 @@ class RecordView(object):
 
     def torecord(self):
         arraylayout = self.arrayview.toarray().layout
-        return awkward1._util.wrap(awkward1.layout.Record(arraylayout, self.at), self.arrayview.behavior)
+        return awkward1._util.wrap(
+                 awkward1.layout.Record(arraylayout, self.at),
+                 self.arrayview.behavior)
 
 @numba.extending.typeof_impl.register(RecordView)
 def typeof_RecordView(obj, c):
@@ -367,7 +494,8 @@ def typeof_RecordView(obj, c):
 
 class RecordViewType(numba.types.Type):
     def __init__(self, arrayviewtype):
-        super(RecordViewType, self).__init__(name="RecordViewType({0})".format(arrayviewtype.name))
+        super(RecordViewType, self).__init__(
+            name="RecordViewType({0})".format(arrayviewtype.name))
         self.arrayviewtype = arrayviewtype
 
     @property
@@ -382,7 +510,11 @@ class RecordViewType(numba.types.Type):
         return self.arrayviewtype.type.getitem_field_record(self, key)
 
     def lower_field(self, context, builder, val, key):
-        return self.arrayviewtype.type.lower_getitem_field_record(context, builder, self, val, key)
+        return self.arrayviewtype.type.lower_getitem_field_record(context,
+                                                                  builder,
+                                                                  self,
+                                                                  val,
+                                                                  key)
 
 @numba.extending.register_model(RecordViewType)
 class RecordViewModel(numba.datamodel.models.StructModel):
@@ -397,7 +529,9 @@ def unbox_RecordView(recordviewtype, recordobj, c):
     arrayview_obj  = c.pyapi.object_getattr_string(recordview_obj, "arrayview")
     at_obj         = c.pyapi.object_getattr_string(recordview_obj, "at")
 
-    arrayview_val = unbox_ArrayView(recordviewtype.arrayviewtype, arrayview_obj, c).value
+    arrayview_val = unbox_ArrayView(recordviewtype.arrayviewtype,
+                                    arrayview_obj,
+                                    c).value
 
     proxyout = c.context.make_helper(c.builder, recordviewtype)
     proxyout.arrayview = arrayview_val
@@ -407,7 +541,9 @@ def unbox_RecordView(recordviewtype, recordobj, c):
     c.pyapi.decref(at_obj)
 
     if c.context.enable_nrt:
-        c.context.nrt.decref(c.builder, recordviewtype.arrayviewtype, arrayview_val)
+        c.context.nrt.decref(c.builder,
+                             recordviewtype.arrayviewtype,
+                             arrayview_val)
 
     is_error = numba.cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
     return numba.extending.NativeValue(proxyout._getvalue(), is_error)
@@ -417,10 +553,13 @@ def box_RecordView(recordviewtype, viewval, c):
     RecordView_obj = c.pyapi.unserialize(c.pyapi.serialize_object(RecordView))
 
     proxyin = c.context.make_helper(c.builder, recordviewtype, viewval)
-    arrayview_obj = box_ArrayView(recordviewtype.arrayviewtype, proxyin.arrayview, c)
+    arrayview_obj = box_ArrayView(recordviewtype.arrayviewtype,
+                                  proxyin.arrayview,
+                                  c)
     at_obj        = c.pyapi.long_from_ssize_t(proxyin.at)
 
-    recordview_obj = c.pyapi.call_function_objargs(RecordView_obj, (arrayview_obj, at_obj))
+    recordview_obj = c.pyapi.call_function_objargs(RecordView_obj,
+                                                   (arrayview_obj, at_obj))
 
     out = c.pyapi.call_method(recordview_obj, "torecord", ())
 
@@ -434,25 +573,40 @@ def box_RecordView(recordviewtype, viewval, c):
 @numba.typing.templates.infer_global(operator.getitem)
 class type_getitem_record(numba.typing.templates.AbstractTemplate):
     def generic(self, args, kwargs):
-        if len(args) == 2 and len(kwargs) == 0 and isinstance(args[0], RecordViewType):
+        if (len(args) == 2 and
+            len(kwargs) == 0 and
+            isinstance(args[0], RecordViewType)):
             recordviewtype, wheretype = args
             if isinstance(wheretype, numba.types.StringLiteral):
-                return recordviewtype.arrayviewtype.type.getitem_field_record(recordviewtype, wheretype.literal_value)(recordviewtype, wheretype)
+                return recordviewtype.arrayviewtype.type.getitem_field_record(
+                         recordviewtype,
+                         wheretype.literal_value)(recordviewtype, wheretype)
             else:
-                raise TypeError("only a *constant* field name string may be used as awkward1.Record slices in compiled code")
+                raise TypeError(
+                        "only a *constant* field name string may be used as "
+                        "awkward1.Record slices in compiled code")
 
-@numba.extending.lower_builtin(operator.getitem, RecordViewType, numba.types.StringLiteral)
+@numba.extending.lower_builtin(operator.getitem,
+                               RecordViewType,
+                               numba.types.StringLiteral)
 def lower_getitem_field_record(context, builder, sig, args):
     rettype, (recordviewtype, wheretype) = sig.return_type, sig.args
     recordviewval, whereval = args
-    return recordviewtype.arrayviewtype.type.lower_getitem_field_record(context, builder, recordviewtype, recordviewval, wheretype.literal_value)
+    return recordviewtype.arrayviewtype.type.lower_getitem_field_record(
+             context,
+             builder,
+             recordviewtype,
+             recordviewval,
+             wheretype.literal_value)
 
 @numba.typing.templates.infer_getattr
 class type_getattr_record(numba.typing.templates.AttributeTemplate):
     key = RecordViewType
 
     def generic_resolve(self, recordviewtype, attr):
-        for methodname, typer, lower in awkward1._util.numba_methods(recordviewtype.arrayviewtype.type, recordviewtype.arrayviewtype.behavior):
+        for methodname, typer, lower in awkward1._util.numba_methods(
+                                        recordviewtype.arrayviewtype.type,
+                                        recordviewtype.arrayviewtype.behavior):
             if attr == methodname:
                 class type_method(numba.typing.templates.AbstractTemplate):
                     key = methodname
@@ -460,11 +614,18 @@ class type_getattr_record(numba.typing.templates.AttributeTemplate):
                         if len(kwargs) == 0:
                             sig = typer(recordviewtype, args)
                             sig.recvr = recordviewtype
-                            numba.extending.lower_builtin(methodname, recordviewtype, *[x.literal_type if isinstance(x, numba.types.Literal) else x for x in args])(lower)
+                            numba.extending.lower_builtin(
+                                methodname,
+                                recordviewtype,
+                                *[x.literal_type
+                                    if isinstance(x, numba.types.Literal)
+                                    else x for x in args])(lower)
                             return sig
                 return numba.types.BoundFunction(type_method, recordviewtype)
 
-        for attrname, typer, lower in awkward1._util.numba_attrs(recordviewtype.arrayviewtype.type, recordviewtype.arrayviewtype.behavior):
+        for attrname, typer, lower in awkward1._util.numba_attrs(
+                                      recordviewtype.arrayviewtype.type,
+                                      recordviewtype.arrayviewtype.behavior):
             if attr == attrname:
                 return typer(recordviewtype)
 
@@ -472,12 +633,24 @@ class type_getattr_record(numba.typing.templates.AttributeTemplate):
             return recordviewtype.typer_field(attr)
 
 @numba.extending.lower_getattr_generic(RecordViewType)
-def lower_getattr_generic_record(context, builder, recordviewtype, recordviewval, attr):
-    for attrname, typer, lower in awkward1._util.numba_attrs(recordviewtype.arrayviewtype.type, recordviewtype.arrayviewtype.behavior):
+def lower_getattr_generic_record(context,
+                                 builder,
+                                 recordviewtype,
+                                 recordviewval,
+                                 attr):
+    for attrname, typer, lower in awkward1._util.numba_attrs(
+                                  recordviewtype.arrayviewtype.type,
+                                  recordviewtype.arrayviewtype.behavior):
         if attr == attrname:
-            return lower(context, builder, typer(recordviewtype)(recordviewtype), (recordviewval,))
+            return lower(context,
+                         builder,
+                         typer(recordviewtype)(recordviewtype),
+                         (recordviewval,))
     else:
-        return recordviewtype.lower_field(context, builder, recordviewval, attr)
+        return recordviewtype.lower_field(context,
+                                          builder,
+                                          recordviewval,
+                                          attr)
 
 def register_unary_operator(unaryop):
     @numba.typing.templates.infer_global(unaryop)
@@ -490,11 +663,19 @@ def register_unary_operator(unaryop):
                     left = args[0].arrayviewtype.type
                     behavior = args[0].arrayviewtype.behavior
 
-                for typer, lower in awkward1._util.numba_unaryops(unaryop, left, behavior):
+                for typer, lower in awkward1._util.numba_unaryops(unaryop,
+                                                                  left,
+                                                                  behavior):
                     numba.extending.lower_builtin(unaryop, *args)(lower)
                     return typer(unaryop, args[0])
 
-for unaryop in (abs, operator.inv, operator.invert, operator.neg, operator.not_, operator.pos, operator.truth):
+for unaryop in (abs,
+                operator.inv,
+                operator.invert,
+                operator.neg,
+                operator.not_,
+                operator.pos,
+                operator.truth):
     register_unary_operator(unaryop)
 
 def register_binary_operator(binop):
@@ -513,9 +694,32 @@ def register_binary_operator(binop):
                     if behavior is None:
                         behavior = args[1].arrayviewtype.behavior
 
-                for typer, lower in awkward1._util.numba_binops(binop, left, right, behavior):
+                for typer, lower in awkward1._util.numba_binops(binop,
+                                                                left,
+                                                                right,
+                                                                behavior):
                     numba.extending.lower_builtin(binop, *args)(lower)
                     return typer(binop, args[0], args[1])
 
-for binop in (operator.add, operator.and_, operator.contains, operator.eq, operator.floordiv, operator.ge, operator.gt, operator.le, operator.lshift, operator.lt, operator.mod, operator.mul, operator.ne, operator.or_, operator.pow, operator.rshift, operator.sub, operator.truediv, operator.xor) + (() if not hasattr(operator, "matmul") else (operator.matmul,)):
+for binop in ((operator.add,
+               operator.and_,
+               operator.contains,
+               operator.eq,
+               operator.floordiv,
+               operator.ge,
+               operator.gt,
+               operator.le,
+               operator.lshift,
+               operator.lt,
+               operator.mod,
+               operator.mul,
+               operator.ne,
+               operator.or_,
+               operator.pow,
+               operator.rshift,
+               operator.sub,
+               operator.truediv,
+               operator.xor)
+              + (() if not hasattr(operator, "matmul")
+                    else (operator.matmul,))):
     register_binary_operator(binop)

--- a/src/awkward1/_connect/_numba/arrayview.py
+++ b/src/awkward1/_connect/_numba/arrayview.py
@@ -322,10 +322,12 @@ class type_getitem(numba.typing.templates.AbstractTemplate):
                                                                 wheretype)
             elif (isinstance(wheretype, numba.types.SliceType) and
                   not wheretype.has_step):
-                return viewtype.type.getitem_range(viewtype)(viewtype, wheretype)
+                return viewtype.type.getitem_range(viewtype)(viewtype,
+                                                             wheretype)
             elif isinstance(wheretype, numba.types.StringLiteral):
                 return viewtype.type.getitem_field(
-                         viewtype, wheretype.literal_value)(viewtype, wheretype)
+                         viewtype, wheretype.literal_value)(viewtype,
+                                                            wheretype)
             else:
                 raise TypeError(
                         "only an integer, start:stop range, or a *constant* "

--- a/src/awkward1/_connect/_numba/builder.py
+++ b/src/awkward1/_connect/_numba/builder.py
@@ -17,14 +17,23 @@ dynamic_addrs = {}
 def globalstring(context, builder, pyvalue):
     import llvmlite.ir.types
     if pyvalue not in dynamic_addrs:
-        buf = dynamic_addrs[pyvalue] = numpy.array(pyvalue.encode("utf-8") + b"\x00")
-        context.add_dynamic_addr(builder, buf.ctypes.data, info="str({0})".format(repr(pyvalue)))
-    ptr = context.get_constant(numba.types.uintp, dynamic_addrs[pyvalue].ctypes.data)
-    return builder.inttoptr(ptr, llvmlite.llvmpy.core.Type.pointer(llvmlite.llvmpy.core.Type.int(8)))
+        buf = dynamic_addrs[pyvalue] = numpy.array(pyvalue.encode("utf-8")
+                                                   + b"\x00")
+        context.add_dynamic_addr(builder,
+                                 buf.ctypes.data,
+                                 info="str({0})".format(repr(pyvalue)))
+    ptr = context.get_constant(numba.types.uintp,
+                               dynamic_addrs[pyvalue].ctypes.data)
+    return builder.inttoptr(
+             ptr,
+             llvmlite.llvmpy.core.Type.pointer(
+               llvmlite.llvmpy.core.Type.int(8)))
 
 class ArrayBuilderType(numba.types.Type):
     def __init__(self, behavior):
-        super(ArrayBuilderType, self).__init__(name="awkward1.ArrayBuilderType({0})".format(awkward1._connect._numba.repr_behavior(behavior)))
+        super(ArrayBuilderType, self).__init__(
+            name="awkward1.ArrayBuilderType({0})".format(
+              awkward1._connect._numba.repr_behavior(behavior)))
         self.behavior = behavior
 
 @numba.extending.register_model(ArrayBuilderType)
@@ -52,13 +61,20 @@ def unbox_ArrayBuilder(arraybuildertype, arraybuilderobj, c):
 @numba.extending.box(ArrayBuilderType)
 def box_ArrayBuilder(arraybuildertype, arraybuilderval, c):
     import awkward1.highlevel
-    ArrayBuilder_obj = c.pyapi.unserialize(c.pyapi.serialize_object(awkward1.highlevel.ArrayBuilder))
-    behavior_obj = c.pyapi.unserialize(c.pyapi.serialize_object(arraybuildertype.behavior))
+    ArrayBuilder_obj = c.pyapi.unserialize(
+                         c.pyapi.serialize_object(
+                           awkward1.highlevel.ArrayBuilder))
+    behavior_obj = c.pyapi.unserialize(
+                     c.pyapi.serialize_object(arraybuildertype.behavior))
 
-    proxyin = c.context.make_helper(c.builder, arraybuildertype, arraybuilderval)
+    proxyin = c.context.make_helper(c.builder,
+                                    arraybuildertype,
+                                    arraybuilderval)
     c.pyapi.incref(proxyin.pyptr)
 
-    out = c.pyapi.call_method(ArrayBuilder_obj, "_wrap", (proxyin.pyptr, behavior_obj))
+    out = c.pyapi.call_method(ArrayBuilder_obj,
+                              "_wrap",
+                              (proxyin.pyptr, behavior_obj))
 
     c.pyapi.decref(ArrayBuilder_obj)
     c.pyapi.decref(behavior_obj)
@@ -69,16 +85,23 @@ def box_ArrayBuilder(arraybuildertype, arraybuilderval, c):
 def call(context, builder, fcn, args):
     numbatype = numba.typing.ctypes_utils.make_function_type(fcn)
     fcntype = context.get_function_pointer_type(numbatype)
-    fcnval = context.add_dynamic_addr(builder, numbatype.get_pointer(fcn), info=fcn.name)
+    fcnval = context.add_dynamic_addr(builder,
+                                      numbatype.get_pointer(fcn),
+                                      info=fcn.name)
     fcnptr = builder.bitcast(fcnval, fcntype)
     err = context.call_function_pointer(builder, fcnptr, args)
-    with builder.if_then(builder.icmp_unsigned("!=", err, context.get_constant(numba.uint8, 0)), likely=False):
-        context.call_conv.return_user_exc(builder, ValueError, (fcn.name + " failed",))
+    with builder.if_then(builder.icmp_unsigned(
+           "!=", err, context.get_constant(numba.uint8, 0)), likely=False):
+        context.call_conv.return_user_exc(builder,
+                                          ValueError,
+                                          (fcn.name + " failed",))
 
 @numba.typing.templates.infer_global(len)
 class type_len(numba.typing.templates.AbstractTemplate):
     def generic(self, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], ArrayBuilderType):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0], ArrayBuilderType)):
             return numba.intp(args[0])
 
 @numba.extending.lower_builtin(len, ArrayBuilderType)
@@ -86,9 +109,15 @@ def lower_len(context, builder, sig, args):
     arraybuildertype, = sig.args
     arraybuilderval, = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    result = numba.cgutils.alloca_once(builder, context.get_value_type(numba.int64))
-    call(context, builder, awkward1._libawkward.ArrayBuilder_length, (proxyin.rawptr, result))
-    return awkward1._connect._numba.castint(context, builder, numba.int64, numba.intp, builder.load(result))
+    result = numba.cgutils.alloca_once(builder,
+                                       context.get_value_type(numba.int64))
+    call(context, builder, awkward1._libawkward.ArrayBuilder_length,
+         (proxyin.rawptr, result))
+    return awkward1._connect._numba.castint(context,
+                                            builder,
+                                            numba.int64,
+                                            numba.intp,
+                                            builder.load(result))
 
 @numba.typing.templates.infer_getattr
 class type_methods(numba.typing.templates.AttributeTemplate):
@@ -110,147 +139,235 @@ class type_methods(numba.typing.templates.AttributeTemplate):
 
     @numba.typing.templates.bound_function("boolean")
     def resolve_boolean(self, arraybuildertype, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], numba.types.Boolean):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0], numba.types.Boolean)):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.boolean")
+            raise TypeError(
+                    "wrong number or types of arguments for "
+                    "ArrayBuilder.boolean")
 
     @numba.typing.templates.bound_function("integer")
     def resolve_integer(self, arraybuildertype, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], numba.types.Integer):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0], numba.types.Integer)):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.integer")
+            raise TypeError(
+                    "wrong number or types of arguments for "
+                    "ArrayBuilder.integer")
 
     @numba.typing.templates.bound_function("real")
     def resolve_real(self, arraybuildertype, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], (numba.types.Integer, numba.types.Float)):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0], (numba.types.Integer, numba.types.Float))):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.real")
+            raise TypeError(
+                    "wrong number or types of arguments for ArrayBuilder.real")
 
     @numba.typing.templates.bound_function("beginlist")
     def resolve_beginlist(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.beginlist")
+            raise TypeError(
+                    "wrong number of arguments for ArrayBuilder.beginlist")
 
     @numba.typing.templates.bound_function("endlist")
     def resolve_endlist(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.endlist")
+            raise TypeError(
+                    "wrong number of arguments for ArrayBuilder.endlist")
 
     @numba.typing.templates.bound_function("begintuple")
     def resolve_begintuple(self, arraybuildertype, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], numba.types.Integer):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0], numba.types.Integer)):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.begintuple")
+            raise TypeError(
+                    "wrong number or types of arguments for "
+                    "ArrayBuilder.begintuple")
 
     @numba.typing.templates.bound_function("index")
     def resolve_index(self, arraybuildertype, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], numba.types.Integer):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0], numba.types.Integer)):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.index")
+            raise TypeError(
+                    "wrong number or types of arguments for "
+                    "ArrayBuilder.index")
 
     @numba.typing.templates.bound_function("endtuple")
     def resolve_endtuple(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.endtuple")
+            raise TypeError(
+                    "wrong number of arguments for ArrayBuilder.endtuple")
 
     @numba.typing.templates.bound_function("beginrecord")
     def resolve_beginrecord(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
-        elif len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], numba.types.StringLiteral):
+        elif (len(args) == 1 and
+              len(kwargs) == 0 and
+              isinstance(args[0], numba.types.StringLiteral)):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.beginrecord")
+            raise TypeError(
+                    "wrong number or types of arguments for "
+                    "ArrayBuilder.beginrecord")
 
     @numba.typing.templates.bound_function("field")
     def resolve_field(self, arraybuildertype, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], numba.types.StringLiteral):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0], numba.types.StringLiteral)):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.field")
+            raise TypeError(
+                    "wrong number or types of arguments for "
+                    "ArrayBuilder.field")
 
     @numba.typing.templates.bound_function("endrecord")
     def resolve_endrecord(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.endrecord")
+            raise TypeError(
+                    "wrong number of arguments for ArrayBuilder.endrecord")
 
     @numba.typing.templates.bound_function("append")
     def resolve_append(self, arraybuildertype, args, kwargs):
         import awkward1.highlevel
 
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], (awkward1._connect._numba.arrayview.ArrayViewType, awkward1._connect._numba.arrayview.RecordViewType, numba.types.Boolean, numba.types.Integer, numba.types.Float)):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0],
+                       (awkward1._connect._numba.arrayview.ArrayViewType,
+                        awkward1._connect._numba.arrayview.RecordViewType,
+                        numba.types.Boolean,
+                        numba.types.Integer,
+                        numba.types.Float))):
             return numba.types.none(args[0])
-        elif len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], numba.types.Optional) and isinstance(args[0].type, (numba.types.Boolean, numba.types.Integer, numba.types.Float)):
+        elif (len(args) == 1 and
+              len(kwargs) == 0 and
+              isinstance(args[0], numba.types.Optional) and
+              isinstance(args[0].type, (numba.types.Boolean,
+                                        numba.types.Integer,
+                                        numba.types.Float))):
             return numba.types.none(args[0])
-        elif len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], numba.types.NoneType):
+        elif (len(args) == 1 and
+              len(kwargs) == 0 and
+              isinstance(args[0], numba.types.NoneType)):
             return numba.types.none(args[0])
-        elif len(args) == 2 and len(kwargs) == 0 and isinstance(args[0], awkward1._connect._numba.arrayview.ArrayViewType) and isinstance(args[1], numba.types.Integer):
+        elif (len(args) == 2 and
+              len(kwargs) == 0 and
+              isinstance(args[0],
+                         awkward1._connect._numba.arrayview.ArrayViewType) and
+              isinstance(args[1], numba.types.Integer)):
             return numba.types.none(args[0], args[1])
         else:
             if len(args) == 1 and arraybuildertype.behavior is not None:
                 for key, lower in arraybuildertype.behavior.items():
-                    if isinstance(key, tuple) and len(key) == 3 and key[0] == "__numba_lower__" and key[1] == awkward1.highlevel.ArrayBuilder.append and (args[0] == key[2] or (isinstance(key[2], type) and isinstance(args[0], key[2]))):
-                        numba.extending.lower_builtin("append", ArrayBuilderType, args[0])(lower)
+                    if (isinstance(key, tuple) and
+                        len(key) == 3 and
+                        key[0] == "__numba_lower__" and
+                        key[1] == awkward1.highlevel.ArrayBuilder.append and
+                        (args[0] == key[2] or
+                         (isinstance(key[2], type) and
+                          isinstance(args[0], key[2])))):
+                        numba.extending.lower_builtin(
+                            "append", ArrayBuilderType, args[0])(lower)
                         return numba.types.none(args[0])
 
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.append")
+            raise TypeError(
+                    "wrong number or types of arguments for "
+                    "ArrayBuilder.append")
 
     @numba.typing.templates.bound_function("extend")
     def resolve_extend(self, arraybuildertype, args, kwargs):
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], awkward1._connect._numba.arrayview.ArrayViewType):
+        if (len(args) == 1 and
+            len(kwargs) == 0 and
+            isinstance(args[0],
+                       awkward1._connect._numba.arrayview.ArrayViewType)):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.extend")
+            raise TypeError(
+                "wrong number or types of arguments for ArrayBuilder.extend")
 
-@numba.extending.lower_builtin("clear", ArrayBuilderType)
+@numba.extending.lower_builtin("clear",
+                               ArrayBuilderType)
 def lower_clear(context, builder, sig, args):
     arraybuildertype, = sig.args
     arraybuilderval, = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_clear, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_clear,
+         (proxyin.rawptr,))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("null", ArrayBuilderType)
+@numba.extending.lower_builtin("null",
+                               ArrayBuilderType)
 def lower_null(context, builder, sig, args):
     arraybuildertype, = sig.args
     arraybuilderval, = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_null, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_null,
+         (proxyin.rawptr,))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("boolean", ArrayBuilderType, numba.types.Boolean)
+@numba.extending.lower_builtin("boolean",
+                               ArrayBuilderType,
+                               numba.types.Boolean)
 def lower_boolean(context, builder, sig, args):
     arraybuildertype, xtype = sig.args
     arraybuilderval, xval = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
     x = builder.zext(xval, context.get_value_type(numba.uint8))
-    call(context, builder, awkward1._libawkward.ArrayBuilder_boolean, (proxyin.rawptr, x))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_boolean,
+         (proxyin.rawptr, x))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("integer", ArrayBuilderType, numba.types.Integer)
+@numba.extending.lower_builtin("integer",
+                               ArrayBuilderType,
+                               numba.types.Integer)
 def lower_integer(context, builder, sig, args):
     arraybuildertype, xtype = sig.args
     arraybuilderval, xval = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    x = awkward1._connect._numba.castint(context, builder, xtype, numba.int64, xval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_integer, (proxyin.rawptr, x))
+    x = awkward1._connect._numba.castint(context,
+                                         builder,
+                                         xtype,
+                                         numba.int64,
+                                         xval)
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_integer,
+         (proxyin.rawptr, x))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("real", ArrayBuilderType, numba.types.Integer)
-@numba.extending.lower_builtin("real", ArrayBuilderType, numba.types.Float)
+@numba.extending.lower_builtin("real",
+                               ArrayBuilderType,
+                               numba.types.Integer)
+@numba.extending.lower_builtin("real",
+                               ArrayBuilderType,
+                               numba.types.Float)
 def lower_real(context, builder, sig, args):
     arraybuildertype, xtype = sig.args
     arraybuilderval, xval = args
@@ -265,7 +382,10 @@ def lower_real(context, builder, sig, args):
         x = builder.fptrunc(xval, context.get_value_type(numba.types.float64))
     else:
         x = xval
-    call(context, builder, awkward1._libawkward.ArrayBuilder_real, (proxyin.rawptr, x))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_real,
+         (proxyin.rawptr, x))
     return context.get_dummy_value()
 
 @numba.extending.lower_builtin("beginlist", ArrayBuilderType)
@@ -273,7 +393,10 @@ def lower_beginlist(context, builder, sig, args):
     arraybuildertype, = sig.args
     arraybuilderval, = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_beginlist, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_beginlist,
+         (proxyin.rawptr,))
     return context.get_dummy_value()
 
 @numba.extending.lower_builtin("endlist", ArrayBuilderType)
@@ -281,127 +404,236 @@ def lower_endlist(context, builder, sig, args):
     arraybuildertype, = sig.args
     arraybuilderval, = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_endlist, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_endlist,
+         (proxyin.rawptr,))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("begintuple", ArrayBuilderType, numba.types.Integer)
+@numba.extending.lower_builtin("begintuple",
+                               ArrayBuilderType,
+                               numba.types.Integer)
 def lower_begintuple(context, builder, sig, args):
     arraybuildertype, numfieldstype = sig.args
     arraybuilderval, numfieldsval = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    numfields = awkward1._connect._numba.castint(context, builder, numfieldstype, numba.int64, numfieldsval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_begintuple, (proxyin.rawptr, numfields))
+    numfields = awkward1._connect._numba.castint(context,
+                                                 builder,
+                                                 numfieldstype,
+                                                 numba.int64,
+                                                 numfieldsval)
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_begintuple,
+         (proxyin.rawptr,
+          numfields))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("index", ArrayBuilderType, numba.types.Integer)
+@numba.extending.lower_builtin("index",
+                               ArrayBuilderType,
+                               numba.types.Integer)
 def lower_index(context, builder, sig, args):
     arraybuildertype, indextype = sig.args
     arraybuilderval, indexval = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    index = awkward1._connect._numba.castint(context, builder, indextype, numba.int64, indexval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_index, (proxyin.rawptr, index))
+    index = awkward1._connect._numba.castint(context,
+                                             builder,
+                                             indextype,
+                                             numba.int64,
+                                             indexval)
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_index,
+         (proxyin.rawptr, index))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("endtuple", ArrayBuilderType)
+@numba.extending.lower_builtin("endtuple",
+                               ArrayBuilderType)
 def lower_endtuple(context, builder, sig, args):
     arraybuildertype, = sig.args
     arraybuilderval, = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_endtuple, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_endtuple,
+         (proxyin.rawptr,))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("beginrecord", ArrayBuilderType)
+@numba.extending.lower_builtin("beginrecord",
+                               ArrayBuilderType)
 def lower_beginrecord(context, builder, sig, args):
     arraybuildertype, = sig.args
     arraybuilderval, = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_beginrecord, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_beginrecord,
+         (proxyin.rawptr,))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("beginrecord", ArrayBuilderType, numba.types.StringLiteral)
+@numba.extending.lower_builtin("beginrecord",
+                               ArrayBuilderType,
+                               numba.types.StringLiteral)
 def lower_beginrecord(context, builder, sig, args):
     arraybuildertype, nametype = sig.args
     arraybuilderval, nameval = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
     name = globalstring(context, builder, nametype.literal_value)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_beginrecord_fast, (proxyin.rawptr, name))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_beginrecord_fast,
+         (proxyin.rawptr, name))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("field", ArrayBuilderType, numba.types.StringLiteral)
+@numba.extending.lower_builtin("field",
+                               ArrayBuilderType,
+                               numba.types.StringLiteral)
 def lower_field(context, builder, sig, args):
     arraybuildertype, keytype = sig.args
     arraybuilderval, keyval = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
     key = globalstring(context, builder, keytype.literal_value)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_field_fast, (proxyin.rawptr, key))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_field_fast,
+         (proxyin.rawptr, key))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("endrecord", ArrayBuilderType)
+@numba.extending.lower_builtin("endrecord",
+                               ArrayBuilderType)
 def lower_endrecord(context, builder, sig, args):
     arraybuildertype, = sig.args
     arraybuilderval, = args
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_endrecord, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_endrecord,
+         (proxyin.rawptr,))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("append", ArrayBuilderType, awkward1._connect._numba.arrayview.ArrayViewType, numba.types.Integer)
+@numba.extending.lower_builtin(
+    "append",
+    ArrayBuilderType,
+    awkward1._connect._numba.arrayview.ArrayViewType,
+    numba.types.Integer)
 def lower_append_array_at(context, builder, sig, args):
     arraybuildertype, viewtype, attype = sig.args
     arraybuilderval, viewval, atval = args
 
     viewproxy = context.make_helper(builder, viewtype, viewval)
-    atval = awkward1._connect._numba.layout.regularize_atval(context, builder, viewproxy, attype, atval, True, True)
-    atval = awkward1._connect._numba.castint(context, builder, numba.intp, numba.int64, atval)
+    atval = awkward1._connect._numba.layout.regularize_atval(context,
+                                                             builder,
+                                                             viewproxy,
+                                                             attype,
+                                                             atval,
+                                                             True,
+                                                             True)
+    atval = awkward1._connect._numba.castint(context,
+                                             builder,
+                                             numba.intp,
+                                             numba.int64,
+                                             atval)
 
-    sharedptr = awkward1._connect._numba.layout.getat(context, builder, viewproxy.sharedptrs, viewproxy.pos)
+    sharedptr = awkward1._connect._numba.layout.getat(context,
+                                                      builder,
+                                                      viewproxy.sharedptrs,
+                                                      viewproxy.pos)
 
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_append_nowrap, (proxyin.rawptr, builder.inttoptr(sharedptr, context.get_value_type(numba.types.voidptr)), atval))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_append_nowrap,
+         (proxyin.rawptr,
+          builder.inttoptr(sharedptr,
+                           context.get_value_type(numba.types.voidptr)),
+          atval))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("append", ArrayBuilderType, awkward1._connect._numba.arrayview.ArrayViewType)
+@numba.extending.lower_builtin(
+    "append",
+    ArrayBuilderType,
+    awkward1._connect._numba.arrayview.ArrayViewType)
 def lower_append_array(context, builder, sig, args):
     arraybuildertype, viewtype = sig.args
     arraybuilderval, viewval = args
 
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_beginlist, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_beginlist,
+         (proxyin.rawptr,))
 
     lower_extend_array(context, builder, sig, args)
 
-    call(context, builder, awkward1._libawkward.ArrayBuilder_endlist, (proxyin.rawptr,))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_endlist,
+         (proxyin.rawptr,))
 
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("append", ArrayBuilderType, awkward1._connect._numba.arrayview.RecordViewType)
+@numba.extending.lower_builtin(
+    "append",
+    ArrayBuilderType,
+    awkward1._connect._numba.arrayview.RecordViewType)
 def lower_append_record(context, builder, sig, args):
     arraybuildertype, recordviewtype = sig.args
     arraybuilderval, recordviewval = args
 
-    recordviewproxy = context.make_helper(builder, recordviewtype, recordviewval)
+    recordviewproxy = context.make_helper(builder,
+                                          recordviewtype,
+                                          recordviewval)
 
-    arrayviewproxy = context.make_helper(builder, recordviewtype.arrayviewtype, recordviewproxy.arrayview)
-    atval = awkward1._connect._numba.castint(context, builder, numba.intp, numba.int64, recordviewproxy.at)
+    arrayviewproxy = context.make_helper(builder,
+                                         recordviewtype.arrayviewtype,
+                                         recordviewproxy.arrayview)
+    atval = awkward1._connect._numba.castint(context,
+                                             builder,
+                                             numba.intp,
+                                             numba.int64,
+                                             recordviewproxy.at)
 
-    sharedptr = awkward1._connect._numba.layout.getat(context, builder, arrayviewproxy.sharedptrs, arrayviewproxy.pos)
+    sharedptr = awkward1._connect._numba.layout.getat(
+        context,
+        builder,
+        arrayviewproxy.sharedptrs,
+        arrayviewproxy.pos)
 
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    call(context, builder, awkward1._libawkward.ArrayBuilder_append_nowrap, (proxyin.rawptr, builder.inttoptr(sharedptr, context.get_value_type(numba.types.voidptr)), atval))
+    call(context,
+         builder,
+         awkward1._libawkward.ArrayBuilder_append_nowrap,
+         (proxyin.rawptr,
+          builder.inttoptr(sharedptr,
+                           context.get_value_type(numba.types.voidptr)),
+          atval))
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("append", ArrayBuilderType, numba.types.Boolean)
+@numba.extending.lower_builtin(
+    "append",
+    ArrayBuilderType,
+    numba.types.Boolean)
 def lower_append_bool(context, builder, sig, args):
     return lower_boolean(context, builder, sig, args)
 
-@numba.extending.lower_builtin("append", ArrayBuilderType, numba.types.Integer)
+@numba.extending.lower_builtin(
+    "append",
+    ArrayBuilderType,
+    numba.types.Integer)
 def lower_append_int(context, builder, sig, args):
     return lower_integer(context, builder, sig, args)
 
-@numba.extending.lower_builtin("append", ArrayBuilderType, numba.types.Float)
+@numba.extending.lower_builtin(
+    "append",
+    ArrayBuilderType,
+    numba.types.Float)
 def lower_append_float(context, builder, sig, args):
     return lower_real(context, builder, sig, args)
 
-@numba.extending.lower_builtin("append", ArrayBuilderType, numba.types.Optional)
+@numba.extending.lower_builtin(
+    "append",
+    ArrayBuilderType,
+    numba.types.Optional)
 def lower_append_optional(context, builder, sig, args):
     arraybuildertype, opttype = sig.args
     arraybuilderval, optval = args
@@ -412,35 +644,71 @@ def lower_append_optional(context, builder, sig, args):
     with builder.if_else(validbit) as (is_valid, is_not_valid):
         with is_valid:
             if isinstance(opttype.type, numba.types.Boolean):
-                lower_boolean(context, builder, numba.types.none(arraybuildertype, opttype.type), (arraybuilderval, optproxy.data))
+                lower_boolean(context,
+                              builder,
+                              numba.types.none(arraybuildertype, opttype.type),
+                              (arraybuilderval, optproxy.data))
             elif isinstance(opttype.type, numba.types.Integer):
-                lower_integer(context, builder, numba.types.none(arraybuildertype, opttype.type), (arraybuilderval, optproxy.data))
+                lower_integer(context,
+                              builder,
+                              numba.types.none(arraybuildertype, opttype.type),
+                              (arraybuilderval, optproxy.data))
             elif isinstance(opttype.type, numba.types.Float):
-                lower_real(context, builder, numba.types.none(arraybuildertype, opttype.type), (arraybuilderval, optproxy.data))
+                lower_real(context,
+                           builder,
+                           numba.types.none(arraybuildertype, opttype.type),
+                           (arraybuilderval, optproxy.data))
             else:
                 raise AssertionError(opttype.type)
 
         with is_not_valid:
-            lower_null(context, builder, numba.types.none(arraybuildertype,), (arraybuilderval,))
+            lower_null(context,
+                       builder,
+                       numba.types.none(arraybuildertype,),
+                       (arraybuilderval,))
 
     return context.get_dummy_value()
 
-@numba.extending.lower_builtin("append", ArrayBuilderType, numba.types.NoneType)
+@numba.extending.lower_builtin(
+    "append",
+    ArrayBuilderType,
+    numba.types.NoneType)
 def lower_append_none(context, builder, sig, args):
-    return lower_null(context, builder, sig.return_type(sig.args[0]), (args[0],))
+    return lower_null(context,
+                      builder,
+                      sig.return_type(sig.args[0]),
+                      (args[0],))
 
-@numba.extending.lower_builtin("extend", ArrayBuilderType, awkward1._connect._numba.arrayview.ArrayViewType)
+@numba.extending.lower_builtin(
+    "extend",
+    ArrayBuilderType,
+    awkward1._connect._numba.arrayview.ArrayViewType)
 def lower_extend_array(context, builder, sig, args):
     arraybuildertype, viewtype = sig.args
     arraybuilderval, viewval = args
 
     viewproxy = context.make_helper(builder, viewtype, viewval)
 
-    sharedptr = awkward1._connect._numba.layout.getat(context, builder, viewproxy.sharedptrs, viewproxy.pos)
+    sharedptr = awkward1._connect._numba.layout.getat(context,
+                                                      builder,
+                                                      viewproxy.sharedptrs,
+                                                      viewproxy.pos)
 
     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-    with numba.cgutils.for_range(builder, viewproxy.stop, viewproxy.start) as loop:
-        atval = awkward1._connect._numba.castint(context, builder, numba.intp, numba.int64, loop.index)
-        call(context, builder, awkward1._libawkward.ArrayBuilder_append_nowrap, (proxyin.rawptr, builder.inttoptr(sharedptr, context.get_value_type(numba.types.voidptr)), atval))
+    with numba.cgutils.for_range(builder,
+                                 viewproxy.stop,
+                                 viewproxy.start) as loop:
+        atval = awkward1._connect._numba.castint(context,
+                                                 builder,
+                                                 numba.intp,
+                                                 numba.int64,
+                                                 loop.index)
+        call(context,
+             builder,
+             awkward1._libawkward.ArrayBuilder_append_nowrap,
+             (proxyin.rawptr,
+              builder.inttoptr(sharedptr,
+                               context.get_value_type(numba.types.voidptr)),
+              atval))
 
     return context.get_dummy_value()

--- a/src/awkward1/_connect/_numba/layout.py
+++ b/src/awkward1/_connect/_numba/layout.py
@@ -13,11 +13,16 @@ import awkward1._connect._numba.arrayview
 
 @numba.extending.typeof_impl.register(awkward1.layout.NumpyArray)
 def typeof(obj, c):
-    return NumpyArrayType(numba.typeof(numpy.asarray(obj)), numba.typeof(obj.identities), obj.parameters)
+    return NumpyArrayType(numba.typeof(numpy.asarray(obj)),
+                          numba.typeof(obj.identities),
+                          obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.RegularArray)
 def typeof(obj, c):
-    return RegularArrayType(numba.typeof(obj.content), obj.size, numba.typeof(obj.identities), obj.parameters)
+    return RegularArrayType(numba.typeof(obj.content),
+                            obj.size,
+                            numba.typeof(obj.identities),
+                            obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.ListArray32)
 @numba.extending.typeof_impl.register(awkward1.layout.ListArrayU32)
@@ -26,34 +31,57 @@ def typeof(obj, c):
 @numba.extending.typeof_impl.register(awkward1.layout.ListOffsetArrayU32)
 @numba.extending.typeof_impl.register(awkward1.layout.ListOffsetArray64)
 def typeof(obj, c):
-    return ListArrayType(numba.typeof(numpy.asarray(obj.starts)), numba.typeof(obj.content), numba.typeof(obj.identities), obj.parameters)
+    return ListArrayType(numba.typeof(numpy.asarray(obj.starts)),
+                         numba.typeof(obj.content),
+                         numba.typeof(obj.identities),
+                         obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.IndexedArray32)
 @numba.extending.typeof_impl.register(awkward1.layout.IndexedArrayU32)
 @numba.extending.typeof_impl.register(awkward1.layout.IndexedArray64)
 def typeof(obj, c):
-    return IndexedArrayType(numba.typeof(numpy.asarray(obj.index)), numba.typeof(obj.content), numba.typeof(obj.identities), obj.parameters)
+    return IndexedArrayType(numba.typeof(numpy.asarray(obj.index)),
+                            numba.typeof(obj.content),
+                            numba.typeof(obj.identities),
+                            obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.IndexedOptionArray32)
 @numba.extending.typeof_impl.register(awkward1.layout.IndexedOptionArray64)
 def typeof(obj, c):
-    return IndexedOptionArrayType(numba.typeof(numpy.asarray(obj.index)), numba.typeof(obj.content), numba.typeof(obj.identities), obj.parameters)
+    return IndexedOptionArrayType(numba.typeof(numpy.asarray(obj.index)),
+                                  numba.typeof(obj.content),
+                                  numba.typeof(obj.identities),
+                                  obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.ByteMaskedArray)
 def typeof(obj, c):
-    return ByteMaskedArrayType(numba.typeof(numpy.asarray(obj.mask)), numba.typeof(obj.content), obj.validwhen, numba.typeof(obj.identities), obj.parameters)
+    return ByteMaskedArrayType(numba.typeof(numpy.asarray(obj.mask)),
+                               numba.typeof(obj.content),
+                               obj.validwhen,
+                               numba.typeof(obj.identities),
+                               obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.BitMaskedArray)
 def typeof(obj, c):
-    return BitMaskedArrayType(numba.typeof(numpy.asarray(obj.mask)), numba.typeof(obj.content), obj.validwhen, obj.lsb_order, numba.typeof(obj.identities), obj.parameters)
+    return BitMaskedArrayType(numba.typeof(numpy.asarray(obj.mask)),
+                              numba.typeof(obj.content),
+                              obj.validwhen,
+                              obj.lsb_order,
+                              numba.typeof(obj.identities),
+                              obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.UnmaskedArray)
 def typeof(obj, c):
-    return UnmaskedArrayType(numba.typeof(obj.content), numba.typeof(obj.identities), obj.parameters)
+    return UnmaskedArrayType(numba.typeof(obj.content),
+                             numba.typeof(obj.identities),
+                             obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.RecordArray)
 def typeof(obj, c):
-    return RecordArrayType(tuple(numba.typeof(x) for x in obj.contents), obj.recordlookup, numba.typeof(obj.identities), obj.parameters)
+    return RecordArrayType(tuple(numba.typeof(x) for x in obj.contents),
+                           obj.recordlookup,
+                           numba.typeof(obj.identities),
+                           obj.parameters)
 
 @numba.extending.typeof_impl.register(awkward1.layout.Record)
 def typeof(obj, c):
@@ -63,7 +91,10 @@ def typeof(obj, c):
 @numba.extending.typeof_impl.register(awkward1.layout.UnionArray8_U32)
 @numba.extending.typeof_impl.register(awkward1.layout.UnionArray8_64)
 def typeof(obj, c):
-    return UnionArrayType(numba.typeof(numpy.asarray(obj.tags)), numba.typeof(numpy.asarray(obj.index)), tuple(numba.typeof(x) for x in obj.contents), numba.typeof(obj.identities), obj.parameters)
+    return UnionArrayType(numba.typeof(numpy.asarray(obj.tags)),
+                          numba.typeof(numpy.asarray(obj.index)),
+                          tuple(numba.typeof(x) for x in obj.contents),
+                          numba.typeof(obj.identities), obj.parameters)
 
 class ContentType(numba.types.Type):
     @classmethod
@@ -88,10 +119,12 @@ class ContentType(numba.types.Type):
         elif arraytype.dtype.bitwidth == 64 and arraytype.dtype.signed:
             return awkward1.layout.Index64
         else:
-            raise AssertionError("no Index* type for array: {0}".format(arraytype))
+            raise AssertionError(
+                    "no Index* type for array: {0}".format(arraytype))
 
     def getitem_at_check(self, viewtype):
-        typer = awkward1._util.numba_array_typer(viewtype.type, viewtype.behavior)
+        typer = awkward1._util.numba_array_typer(viewtype.type,
+                                                 viewtype.behavior)
         if typer is None:
             return self.getitem_at(viewtype)
         else:
@@ -102,44 +135,98 @@ class ContentType(numba.types.Type):
 
     def getitem_field(self, viewtype, key):
         if self.hasfield(key):
-            return awkward1._connect._numba.arrayview.wrap(self, viewtype, viewtype.fields + (key,))
+            return awkward1._connect._numba.arrayview.wrap(
+                     self, viewtype, viewtype.fields + (key,))
         else:
-            raise TypeError("array does not have a field with key {0}".format(repr(key)))
+            raise TypeError(
+                    "array does not have a field with key {0}".format(
+                                                                  repr(key)))
 
-    def lower_getitem_at_check(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
-        lower = awkward1._util.numba_array_lower(viewtype.type, viewtype.behavior)
+    def lower_getitem_at_check(self,
+                               context,
+                               builder,
+                               rettype,
+                               viewtype,
+                               viewval,
+                               viewproxy,
+                               attype,
+                               atval,
+                               wrapneg,
+                               checkbounds):
+        lower = awkward1._util.numba_array_lower(viewtype.type,
+                                                 viewtype.behavior)
         if lower is not None:
-            atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
-            return lower(context, builder, rettype, viewtype, viewval, viewproxy, attype, atval)
+            atval = regularize_atval(context,
+                                     builder,
+                                     viewproxy,
+                                     attype,
+                                     atval,
+                                     wrapneg,
+                                     checkbounds)
+            return lower(context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval)
         else:
-            return self.lower_getitem_at(context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds)
+            return self.lower_getitem_at(context,
+                                         builder,
+                                         rettype,
+                                         viewtype,
+                                         viewval,
+                                         viewproxy,
+                                         attype,
+                                         atval,
+                                         wrapneg,
+                                         checkbounds)
 
-    def lower_getitem_range(self, context, builder, rettype, viewtype, viewval, viewproxy, start, stop, wrapneg):
+    def lower_getitem_range(self,
+                            context,
+                            builder,
+                            rettype,
+                            viewtype,
+                            viewval,
+                            viewproxy,
+                            start,
+                            stop,
+                            wrapneg):
         length = builder.sub(viewproxy.stop, viewproxy.start)
 
         regular_start = numba.cgutils.alloca_once_value(builder, start)
         regular_stop = numba.cgutils.alloca_once_value(builder, stop)
 
         if wrapneg:
-            with builder.if_then(builder.icmp_signed("<", start, context.get_constant(numba.intp, 0))):
+            with builder.if_then(builder.icmp_signed(
+                   "<", start, context.get_constant(numba.intp, 0))):
                 builder.store(builder.add(start, length), regular_start)
-            with builder.if_then(builder.icmp_signed("<", stop, context.get_constant(numba.intp, 0))):
+            with builder.if_then(builder.icmp_signed(
+                   "<", stop, context.get_constant(numba.intp, 0))):
                 builder.store(builder.add(stop, length), regular_stop)
 
-        with builder.if_then(builder.icmp_signed("<", builder.load(regular_start), context.get_constant(numba.intp, 0))):
+        with builder.if_then(builder.icmp_signed(
+               "<", builder.load(regular_start),
+                    context.get_constant(numba.intp, 0))):
             builder.store(context.get_constant(numba.intp, 0), regular_start)
-        with builder.if_then(builder.icmp_signed(">", builder.load(regular_start), length)):
+        with builder.if_then(builder.icmp_signed(
+               ">", builder.load(regular_start), length)):
             builder.store(length, regular_start)
 
-        with builder.if_then(builder.icmp_signed("<", builder.load(regular_stop), builder.load(regular_start))):
+        with builder.if_then(builder.icmp_signed(
+               "<", builder.load(regular_stop), builder.load(regular_start))):
             builder.store(builder.load(regular_start), regular_stop)
-        with builder.if_then(builder.icmp_signed(">", builder.load(regular_stop), length)):
+        with builder.if_then(builder.icmp_signed(
+               ">", builder.load(regular_stop), length)):
             builder.store(length, regular_stop)
 
         proxyout = context.make_helper(builder, rettype)
         proxyout.pos        = viewproxy.pos
-        proxyout.start      = builder.add(viewproxy.start, builder.load(regular_start))
-        proxyout.stop       = builder.add(viewproxy.start, builder.load(regular_stop))
+        proxyout.start      = builder.add(viewproxy.start,
+                                          builder.load(regular_start))
+        proxyout.stop       = builder.add(viewproxy.start,
+                                          builder.load(regular_stop))
         proxyout.arrayptrs  = viewproxy.arrayptrs
         proxyout.sharedptrs = viewproxy.sharedptrs
         proxyout.pylookup   = viewproxy.pylookup
@@ -158,11 +245,25 @@ def getat(context, builder, baseptr, offset, rettype=None):
         bitwidth = rettype.bitwidth
     else:
         bitwidth = numba.intp.bitwidth
-    byteoffset = builder.mul(offset, context.get_constant(numba.intp, bitwidth // 8))
-    return builder.load(numba.cgutils.pointer_add(builder, baseptr, byteoffset, ptrtype))
+    byteoffset = builder.mul(offset,
+                             context.get_constant(numba.intp, bitwidth // 8))
+    return builder.load(numba.cgutils.pointer_add(builder,
+                                                  baseptr,
+                                                  byteoffset,
+                                                  ptrtype))
 
-def regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds):
-    atval = awkward1._connect._numba.castint(context, builder, attype, numba.intp, atval)
+def regularize_atval(context,
+                     builder,
+                     viewproxy,
+                     attype,
+                     atval,
+                     wrapneg,
+                     checkbounds):
+    atval = awkward1._connect._numba.castint(context,
+                                             builder,
+                                             attype,
+                                             numba.intp,
+                                             atval)
 
     if not attype.signed:
         wrapneg = False
@@ -172,16 +273,25 @@ def regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkb
 
         if wrapneg:
             regular_atval = numba.cgutils.alloca_once_value(builder, atval)
-            with builder.if_then(builder.icmp_signed("<", atval, context.get_constant(numba.intp, 0))):
+            with builder.if_then(builder.icmp_signed(
+                   "<", atval, context.get_constant(numba.intp, 0))):
                 builder.store(builder.add(atval, length), regular_atval)
             atval = builder.load(regular_atval)
 
         if checkbounds:
-            with builder.if_then(builder.or_(builder.icmp_signed("<", atval, context.get_constant(numba.intp, 0)),
-                                             builder.icmp_signed(">=", atval, length))):
-                context.call_conv.return_user_exc(builder, ValueError, ("slice index out of bounds",))
+            with builder.if_then(
+                   builder.or_(
+                     builder.icmp_signed(
+                       "<", atval, context.get_constant(numba.intp, 0)),
+                     builder.icmp_signed(">=", atval, length))):
+                context.call_conv.return_user_exc(
+                    builder, ValueError, ("slice index out of bounds",))
 
-    return awkward1._connect._numba.castint(context, builder, atval.type, numba.intp, atval)
+    return awkward1._connect._numba.castint(context,
+                                            builder,
+                                            atval.type,
+                                            numba.intp,
+                                            atval)
 
 class NumpyArrayType(ContentType):
     IDENTITIES = 0
@@ -200,14 +310,18 @@ class NumpyArrayType(ContentType):
         return pos
 
     def __init__(self, arraytype, identitiestype, parameters):
-        super(NumpyArrayType, self).__init__(name="awkward1.NumpyArrayType({0}, {1}, {2})".format(arraytype.name, identitiestype.name, json.dumps(parameters)))
+        super(NumpyArrayType, self).__init__(
+            name="awkward1.NumpyArrayType({0}, {1}, {2})".format(
+              arraytype.name, identitiestype.name, json.dumps(parameters)))
         self.arraytype = arraytype
         self.identitiestype = identitiestype
         self.parameters = parameters
 
     def tolayout(self, lookup, pos, fields):
         assert fields == ()
-        return awkward1.layout.NumpyArray(lookup.arrays[lookup.positions[pos + self.ARRAY]], parameters=self.parameters)
+        return awkward1.layout.NumpyArray(
+                 lookup.arrays[lookup.positions[pos + self.ARRAY]],
+                 parameters=self.parameters)
 
     def hasfield(self, key):
         return False
@@ -215,10 +329,26 @@ class NumpyArrayType(ContentType):
     def getitem_at(self, viewtype):
         return self.arraytype.dtype
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
         whichpos = posat(context, builder, viewproxy.pos, self.ARRAY)
         arrayptr = getat(context, builder, viewproxy.arrayptrs, whichpos)
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
         arraypos = builder.add(viewproxy.start, atval)
         return getat(context, builder, arrayptr, arraypos, rettype)
 
@@ -233,31 +363,61 @@ class RegularArrayType(ContentType):
         sharedptrs[-1] = layout._persistent_shared_ptr
         positions.append(None)
         sharedptrs.append(None)
-        positions[pos + cls.CONTENT] = awkward1._connect._numba.arrayview.tolookup(layout.content, positions, sharedptrs, arrays)
+        positions[pos + cls.CONTENT] = \
+          awkward1._connect._numba.arrayview.tolookup(layout.content,
+                                                      positions,
+                                                      sharedptrs,
+                                                      arrays)
         return pos
 
     def __init__(self, contenttype, size, identitiestype, parameters):
-        super(RegularArrayType, self).__init__(name="awkward1.RegularArrayType({0}, {1}, {2}, {3})".format(contenttype.name, size, identitiestype.name, json.dumps(parameters)))
+        super(RegularArrayType, self).__init__(
+            name="awkward1.RegularArrayType({0}, {1}, {2}, {3})".format(
+            contenttype.name,
+            size,
+            identitiestype.name,
+            json.dumps(parameters)))
         self.contenttype = contenttype
         self.size = size
         self.identitiestype = identitiestype
         self.parameters = parameters
 
     def tolayout(self, lookup, pos, fields):
-        content = self.contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENT], fields)
-        return awkward1.layout.RegularArray(content, self.size, parameters=self.parameters)
+        content = self.contenttype.tolayout(
+                    lookup, lookup.positions[pos + self.CONTENT], fields)
+        return awkward1.layout.RegularArray(content,
+                                            self.size,
+                                            parameters=self.parameters)
 
     def hasfield(self, key):
         return self.contenttype.hasfield(key)
 
     def getitem_at(self, viewtype):
-        return awkward1._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+        return awkward1._connect._numba.arrayview.wrap(self.contenttype,
+                                                       viewtype,
+                                                       None)
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
         whichpos = posat(context, builder, viewproxy.pos, self.CONTENT)
         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
 
         size = context.get_constant(numba.intp, self.size)
         start = builder.mul(builder.add(viewproxy.start, atval), size)
@@ -280,10 +440,14 @@ class ListArrayType(ContentType):
 
     @classmethod
     def tolookup(cls, layout, positions, sharedptrs, arrays):
-        if isinstance(layout, (awkward1.layout.ListArray32, awkward1.layout.ListArrayU32, awkward1.layout.ListArray64)):
+        if isinstance(layout, (awkward1.layout.ListArray32,
+                               awkward1.layout.ListArrayU32,
+                               awkward1.layout.ListArray64)):
             starts = numpy.asarray(layout.starts)
             stops = numpy.asarray(layout.stops)
-        elif isinstance(layout, (awkward1.layout.ListOffsetArray32, awkward1.layout.ListOffsetArrayU32, awkward1.layout.ListOffsetArray64)):
+        elif isinstance(layout, (awkward1.layout.ListOffsetArray32,
+                                 awkward1.layout.ListOffsetArrayU32,
+                                 awkward1.layout.ListOffsetArray64)):
             offsets = numpy.asarray(layout.offsets)
             starts = offsets[:-1]
             stops = offsets[1:]
@@ -299,11 +463,20 @@ class ListArrayType(ContentType):
         arrays.append(stops)
         positions.append(None)
         sharedptrs.append(None)
-        positions[pos + cls.CONTENT] = awkward1._connect._numba.arrayview.tolookup(layout.content, positions, sharedptrs, arrays)
+        positions[pos + cls.CONTENT] = \
+          awkward1._connect._numba.arrayview.tolookup(layout.content,
+                                                      positions,
+                                                      sharedptrs,
+                                                      arrays)
         return pos
 
     def __init__(self, indextype, contenttype, identitiestype, parameters):
-        super(ListArrayType, self).__init__(name="awkward1.ListArrayType({0}, {1}, {2}, {3})".format(indextype.name, contenttype.name, identitiestype.name, json.dumps(parameters)))
+        super(ListArrayType, self).__init__(
+            name="awkward1.ListArrayType({0}, {1}, {2}, {3})".format(
+              indextype.name,
+              contenttype.name,
+              identitiestype.name,
+              json.dumps(parameters)))
         self.indextype = indextype
         self.contenttype = contenttype
         self.identitiestype = identitiestype
@@ -314,43 +487,89 @@ class ListArrayType(ContentType):
             return awkward1.layout.ListArray32
         elif self.indextype.dtype.bitwidth == 32:
             return awkward1.layout.ListArrayU32
-        elif self.indextype.dtype.bitwidth == 64 and self.indextype.dtype.signed:
+        elif (self.indextype.dtype.bitwidth == 64 and
+              self.indextype.dtype.signed):
             return awkward1.layout.ListArray64
         else:
-            raise AssertionError("no ListArray* type for array: {0}".format(indextype))
+            raise AssertionError(
+                    "no ListArray* type for array: {0}".format(indextype))
 
     def tolayout(self, lookup, pos, fields):
-        starts = self.IndexOf(self.indextype)(lookup.arrays[lookup.positions[pos + self.STARTS]])
-        stops = self.IndexOf(self.indextype)(lookup.arrays[lookup.positions[pos + self.STOPS]])
-        content = self.contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENT], fields)
-        return self.ListArrayOf()(starts, stops, content, parameters=self.parameters)
+        starts = self.IndexOf(self.indextype)(
+                   lookup.arrays[lookup.positions[pos + self.STARTS]])
+        stops = self.IndexOf(self.indextype)(
+                   lookup.arrays[lookup.positions[pos + self.STOPS]])
+        content = self.contenttype.tolayout(
+                   lookup,
+                   lookup.positions[pos + self.CONTENT],
+                   fields)
+        return self.ListArrayOf()(starts,
+                                  stops,
+                                  content,
+                                  parameters=self.parameters)
 
     def hasfield(self, key):
         return self.contenttype.hasfield(key)
 
     def getitem_at(self, viewtype):
-        return awkward1._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+        return awkward1._connect._numba.arrayview.wrap(self.contenttype,
+                                                       viewtype,
+                                                       None)
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
         whichpos = posat(context, builder, viewproxy.pos, self.CONTENT)
         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
 
         startspos = posat(context, builder, viewproxy.pos, self.STARTS)
         startsptr = getat(context, builder, viewproxy.arrayptrs, startspos)
         startsarraypos = builder.add(viewproxy.start, atval)
-        start = getat(context, builder, startsptr, startsarraypos, self.indextype.dtype)
+        start = getat(context,
+                      builder,
+                      startsptr,
+                      startsarraypos,
+                      self.indextype.dtype)
 
         stopspos = posat(context, builder, viewproxy.pos, self.STOPS)
         stopsptr = getat(context, builder, viewproxy.arrayptrs, stopspos)
         stopsarraypos = builder.add(viewproxy.start, atval)
-        stop = getat(context, builder, stopsptr, stopsarraypos, self.indextype.dtype)
+        stop = getat(context,
+                     builder,
+                     stopsptr,
+                     stopsarraypos,
+                     self.indextype.dtype)
 
         proxyout = context.make_helper(builder, rettype)
         proxyout.pos        = nextpos
-        proxyout.start      = awkward1._connect._numba.castint(context, builder, self.indextype.dtype, numba.intp, start)
-        proxyout.stop       = awkward1._connect._numba.castint(context, builder, self.indextype.dtype, numba.intp, stop)
+        proxyout.start      = awkward1._connect._numba.castint(
+                                context,
+                                builder,
+                                self.indextype.dtype,
+                                numba.intp,
+                                start)
+        proxyout.stop       = awkward1._connect._numba.castint(
+                                context,
+                                builder,
+                                self.indextype.dtype,
+                                numba.intp,
+                                stop)
         proxyout.arrayptrs  = viewproxy.arrayptrs
         proxyout.sharedptrs = viewproxy.sharedptrs
         proxyout.pylookup   = viewproxy.pylookup
@@ -371,11 +590,20 @@ class IndexedArrayType(ContentType):
         sharedptrs.append(None)
         positions.append(None)
         sharedptrs.append(None)
-        positions[pos + cls.CONTENT] = awkward1._connect._numba.arrayview.tolookup(layout.content, positions, sharedptrs, arrays)
+        positions[pos + cls.CONTENT] = \
+          awkward1._connect._numba.arrayview.tolookup(layout.content,
+                                                      positions,
+                                                      sharedptrs,
+                                                      arrays)
         return pos
 
     def __init__(self, indextype, contenttype, identitiestype, parameters):
-        super(IndexedArrayType, self).__init__(name="awkward1.IndexedArrayType({0}, {1}, {2}, {3})".format(indextype.name, contenttype.name, identitiestype.name, json.dumps(parameters)))
+        super(IndexedArrayType, self).__init__(
+            name="awkward1.IndexedArrayType({0}, {1}, {2}, {3})".format(
+              indextype.name,
+              contenttype.name,
+              identitiestype.name,
+              json.dumps(parameters)))
         self.indextype = indextype
         self.contenttype = contenttype
         self.identitiestype = identitiestype
@@ -386,15 +614,22 @@ class IndexedArrayType(ContentType):
             return awkward1.layout.IndexedArray32
         elif self.indextype.dtype.bitwidth == 32:
             return awkward1.layout.IndexedArrayU32
-        elif self.indextype.dtype.bitwidth == 64 and self.indextype.dtype.signed:
+        elif (self.indextype.dtype.bitwidth == 64 and
+              self.indextype.dtype.signed):
             return awkward1.layout.IndexedArray64
         else:
-            raise AssertionError("no IndexedArray* type for array: {0}".format(self.indextype))
+            raise AssertionError(
+                    "no IndexedArray* type for array: {0}".format(
+                      self.indextype))
 
     def tolayout(self, lookup, pos, fields):
-        index = self.IndexOf(self.indextype)(lookup.arrays[lookup.positions[pos + self.INDEX]])
-        content = self.contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENT], fields)
-        return self.IndexedArrayOf()(index, content, parameters=self.parameters)
+        index = self.IndexOf(self.indextype)(
+                  lookup.arrays[lookup.positions[pos + self.INDEX]])
+        content = self.contenttype.tolayout(
+                    lookup, lookup.positions[pos + self.CONTENT], fields)
+        return self.IndexedArrayOf()(index,
+                                     content,
+                                     parameters=self.parameters)
 
     def hasfield(self, key):
         return self.contenttype.hasfield(key)
@@ -402,27 +637,66 @@ class IndexedArrayType(ContentType):
     def getitem_at(self, viewtype):
         return self.contenttype.getitem_at_check(viewtype)
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
         whichpos = posat(context, builder, viewproxy.pos, self.CONTENT)
         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
 
         indexpos = posat(context, builder, viewproxy.pos, self.INDEX)
         indexptr = getat(context, builder, viewproxy.arrayptrs, indexpos)
         indexarraypos = builder.add(viewproxy.start, atval)
-        nextat = getat(context, builder, indexptr, indexarraypos, self.indextype.dtype)
+        nextat = getat(context,
+                       builder,
+                       indexptr,
+                       indexarraypos,
+                       self.indextype.dtype)
 
-        nextviewtype = awkward1._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+        nextviewtype = awkward1._connect._numba.arrayview.wrap(
+                         self.contenttype, viewtype, None)
         proxynext = context.make_helper(builder, nextviewtype)
         proxynext.pos        = nextpos
         proxynext.start      = viewproxy.start
-        proxynext.stop       = builder.add(awkward1._connect._numba.castint(context, builder, self.indextype.dtype, numba.intp, nextat), builder.add(viewproxy.start, context.get_constant(numba.intp, 1)))
+        proxynext.stop       = builder.add(
+                                 awkward1._connect._numba.castint(
+                                   context,
+                                   builder,
+                                   self.indextype.dtype,
+                                   numba.intp,
+                                   nextat),
+                                 builder.add(viewproxy.start,
+                                             context.get_constant(
+                                               numba.intp, 1)))
         proxynext.arrayptrs  = viewproxy.arrayptrs
         proxynext.sharedptrs = viewproxy.sharedptrs
         proxynext.pylookup   = viewproxy.pylookup
 
-        return self.contenttype.lower_getitem_at_check(context, builder, rettype, nextviewtype, proxynext._getvalue(), proxynext, numba.intp, nextat, False, False)
+        return self.contenttype.lower_getitem_at_check(context,
+                                                       builder,
+                                                       rettype,
+                                                       nextviewtype,
+                                                       proxynext._getvalue(),
+                                                       proxynext,
+                                                       numba.intp,
+                                                       nextat,
+                                                       False,
+                                                       False)
 
 class IndexedOptionArrayType(ContentType):
     IDENTITIES = 0
@@ -439,11 +713,20 @@ class IndexedOptionArrayType(ContentType):
         sharedptrs.append(None)
         positions.append(None)
         sharedptrs.append(None)
-        positions[pos + cls.CONTENT] = awkward1._connect._numba.arrayview.tolookup(layout.content, positions, sharedptrs, arrays)
+        positions[pos + cls.CONTENT] = \
+          awkward1._connect._numba.arrayview.tolookup(layout.content,
+                                                      positions,
+                                                      sharedptrs,
+                                                      arrays)
         return pos
 
     def __init__(self, indextype, contenttype, identitiestype, parameters):
-        super(IndexedOptionArrayType, self).__init__(name="awkward1.IndexedOptionArrayType({0}, {1}, {2}, {3})".format(indextype.name, contenttype.name, identitiestype.name, json.dumps(parameters)))
+        super(IndexedOptionArrayType, self).__init__(
+            name="awkward1.IndexedOptionArrayType({0}, {1}, {2}, {3})".format(
+              indextype.name,
+              contenttype.name,
+              identitiestype.name,
+              json.dumps(parameters)))
         self.indextype = indextype
         self.contenttype = contenttype
         self.identitiestype = identitiestype
@@ -452,51 +735,103 @@ class IndexedOptionArrayType(ContentType):
     def IndexedOptionArrayOf(self):
         if self.indextype.dtype.bitwidth == 32 and self.indextype.dtype.signed:
             return awkward1.layout.IndexedOptionArray32
-        elif self.indextype.dtype.bitwidth == 64 and self.indextype.dtype.signed:
+        elif (self.indextype.dtype.bitwidth == 64 and
+              self.indextype.dtype.signed):
             return awkward1.layout.IndexedOptionArray64
         else:
-            raise AssertionError("no IndexedOptionArray* type for array: {0}".format(self.indextype))
+            raise AssertionError(
+                    "no IndexedOptionArray* type for array: {0}".format(
+                      self.indextype))
 
     def tolayout(self, lookup, pos, fields):
-        index = self.IndexOf(self.indextype)(lookup.arrays[lookup.positions[pos + self.INDEX]])
-        content = self.contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENT], fields)
-        return self.IndexedOptionArrayOf()(index, content, parameters=self.parameters)
+        index = self.IndexOf(self.indextype)(
+            lookup.arrays[lookup.positions[pos + self.INDEX]])
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields)
+        return self.IndexedOptionArrayOf()(index,
+                                           content,
+                                           parameters=self.parameters)
 
     def hasfield(self, key):
         return self.contenttype.hasfield(key)
 
     def getitem_at(self, viewtype):
-        return numba.types.optional(self.contenttype.getitem_at_check(viewtype))
+        return numba.types.optional(
+                 self.contenttype.getitem_at_check(viewtype))
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
         whichpos = posat(context, builder, viewproxy.pos, self.CONTENT)
         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
 
         indexpos = posat(context, builder, viewproxy.pos, self.INDEX)
         indexptr = getat(context, builder, viewproxy.arrayptrs, indexpos)
         indexarraypos = builder.add(viewproxy.start, atval)
-        nextat = getat(context, builder, indexptr, indexarraypos, self.indextype.dtype)
+        nextat = getat(context,
+                       builder,
+                       indexptr,
+                       indexarraypos,
+                       self.indextype.dtype)
 
         output = context.make_helper(builder, rettype)
 
-        with builder.if_else(builder.icmp_signed("<", nextat, context.get_constant(self.indextype.dtype, 0))) as (isnone, isvalid):
+        with builder.if_else(builder.icmp_signed(
+               "<",
+               nextat,
+               context.get_constant(self.indextype.dtype, 0))) as (isnone,
+                                                                   isvalid):
             with isnone:
                 output.valid = numba.cgutils.false_bit
                 output.data = numba.cgutils.get_null_value(output.data.type)
 
             with isvalid:
-                nextviewtype = awkward1._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+                nextviewtype = awkward1._connect._numba.arrayview.wrap(
+                                 self.contenttype, viewtype, None)
                 proxynext = context.make_helper(builder, nextviewtype)
                 proxynext.pos        = nextpos
                 proxynext.start      = viewproxy.start
-                proxynext.stop       = builder.add(awkward1._connect._numba.castint(context, builder, self.indextype.dtype, numba.intp, nextat), builder.add(viewproxy.start, context.get_constant(numba.intp, 1)))
+                proxynext.stop       = builder.add(
+                                         awkward1._connect._numba.castint(
+                                           context,
+                                           builder,
+                                           self.indextype.dtype,
+                                           numba.intp,
+                                           nextat),
+                                         builder.add(viewproxy.start,
+                                                     context.get_constant(
+                                                       numba.intp, 1)))
                 proxynext.arrayptrs  = viewproxy.arrayptrs
                 proxynext.sharedptrs = viewproxy.sharedptrs
                 proxynext.pylookup   = viewproxy.pylookup
 
-                outdata = self.contenttype.lower_getitem_at_check(context, builder, rettype.type, nextviewtype, proxynext._getvalue(), proxynext, numba.intp, nextat, False, False)
+                outdata = self.contenttype.lower_getitem_at_check(
+                            context,
+                            builder,
+                            rettype.type,
+                            nextviewtype,
+                            proxynext._getvalue(),
+                            proxynext,
+                            numba.intp,
+                            nextat,
+                            False,
+                            False)
 
                 output.valid = numba.cgutils.true_bit
                 output.data = outdata
@@ -518,11 +853,26 @@ class ByteMaskedArrayType(ContentType):
         sharedptrs.append(None)
         positions.append(None)
         sharedptrs.append(None)
-        positions[pos + cls.CONTENT] = awkward1._connect._numba.arrayview.tolookup(layout.content, positions, sharedptrs, arrays)
+        positions[pos + cls.CONTENT] = \
+          awkward1._connect._numba.arrayview.tolookup(layout.content,
+                                                      positions,
+                                                      sharedptrs,
+                                                      arrays)
         return pos
 
-    def __init__(self, masktype, contenttype, validwhen, identitiestype, parameters):
-        super(ByteMaskedArrayType, self).__init__(name="awkward1.ByteMaskedArrayType({0}, {1}, {2}, {3}, {4})".format(masktype.name, contenttype.name, validwhen, identitiestype.name, json.dumps(parameters)))
+    def __init__(self,
+                 masktype,
+                 contenttype,
+                 validwhen,
+                 identitiestype,
+                 parameters):
+        super(ByteMaskedArrayType, self).__init__(
+            name="awkward1.ByteMaskedArrayType({0}, {1}, {2}, {3}, "
+            "{4})".format(masktype.name,
+                          contenttype.name,
+                          validwhen,
+                          identitiestype.name,
+                          json.dumps(parameters)))
         self.masktype = masktype
         self.contenttype = contenttype
         self.validwhen = validwhen
@@ -530,32 +880,66 @@ class ByteMaskedArrayType(ContentType):
         self.parameters = parameters
 
     def tolayout(self, lookup, pos, fields):
-        mask = self.IndexOf(self.masktype)(lookup.arrays[lookup.positions[pos + self.MASK]])
-        content = self.contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENT], fields)
-        return awkward1.layout.ByteMaskedArray(mask, content, self.validwhen, parameters=self.parameters)
+        mask = self.IndexOf(self.masktype)(
+            lookup.arrays[lookup.positions[pos + self.MASK]])
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields)
+        return awkward1.layout.ByteMaskedArray(mask,
+                                               content,
+                                               self.validwhen,
+                                               parameters=self.parameters)
 
     def hasfield(self, key):
         return self.contenttype.hasfield(key)
 
     def getitem_at(self, viewtype):
-        return numba.types.optional(self.contenttype.getitem_at_check(viewtype))
+        return numba.types.optional(
+                 self.contenttype.getitem_at_check(viewtype))
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
         whichpos = posat(context, builder, viewproxy.pos, self.CONTENT)
         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
 
         maskpos = posat(context, builder, viewproxy.pos, self.MASK)
         maskptr = getat(context, builder, viewproxy.arrayptrs, maskpos)
         maskarraypos = builder.add(viewproxy.start, atval)
-        byte = getat(context, builder, maskptr, maskarraypos, self.masktype.dtype)
+        byte = getat(context,
+                     builder,
+                     maskptr,
+                     maskarraypos,
+                     self.masktype.dtype)
 
         output = context.make_helper(builder, rettype)
 
-        with builder.if_else(builder.icmp_signed("==", builder.icmp_signed("!=", byte, context.get_constant(numba.int8, 0)), context.get_constant(numba.int8, int(self.validwhen)))) as (isvalid, isnone):
+        with builder.if_else(
+               builder.icmp_signed("==",
+                 builder.icmp_signed("!=",
+                                     byte,
+                                     context.get_constant(numba.int8, 0)),
+                                   context.get_constant(numba.int8,
+                                                        int(self.validwhen)
+                          ))) as (isvalid, isnone):
             with isvalid:
-                nextviewtype = awkward1._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+                nextviewtype = awkward1._connect._numba.arrayview.wrap(
+                                 self.contenttype, viewtype, None)
                 proxynext = context.make_helper(builder, nextviewtype)
                 proxynext.pos        = nextpos
                 proxynext.start      = viewproxy.start
@@ -564,7 +948,17 @@ class ByteMaskedArrayType(ContentType):
                 proxynext.sharedptrs = viewproxy.sharedptrs
                 proxynext.pylookup   = viewproxy.pylookup
 
-                outdata = self.contenttype.lower_getitem_at_check(context, builder, rettype.type, nextviewtype, proxynext._getvalue(), proxynext, numba.intp, atval, False, False)
+                outdata = self.contenttype.lower_getitem_at_check(
+                            context,
+                            builder,
+                            rettype.type,
+                            nextviewtype,
+                            proxynext._getvalue(),
+                            proxynext,
+                            numba.intp,
+                            atval,
+                            False,
+                            False)
 
                 output.valid = numba.cgutils.true_bit
                 output.data = outdata
@@ -590,11 +984,28 @@ class BitMaskedArrayType(ContentType):
         sharedptrs.append(None)
         positions.append(None)
         sharedptrs.append(None)
-        positions[pos + cls.CONTENT] = awkward1._connect._numba.arrayview.tolookup(layout.content, positions, sharedptrs, arrays)
+        positions[pos + cls.CONTENT] = \
+          awkward1._connect._numba.arrayview.tolookup(layout.content,
+                                                      positions,
+                                                      sharedptrs,
+                                                      arrays)
         return pos
 
-    def __init__(self, masktype, contenttype, validwhen, lsb_order, identitiestype, parameters):
-        super(BitMaskedArrayType, self).__init__(name="awkward1.BitMaskedArrayType({0}, {1}, {2}, {3}, {4}, {5})".format(masktype.name, contenttype.name, validwhen, lsb_order, identitiestype.name, json.dumps(parameters)))
+    def __init__(self,
+                 masktype,
+                 contenttype,
+                 validwhen,
+                 lsb_order,
+                 identitiestype,
+                 parameters):
+        super(BitMaskedArrayType, self).__init__(
+            name="awkward1.BitMaskedArrayType({0}, {1}, {2}, {3}, {4}, "
+            "{5})".format(masktype.name,
+                          contenttype.name,
+                          validwhen,
+                          lsb_order,
+                          identitiestype.name,
+                          json.dumps(parameters)))
         self.masktype = masktype
         self.contenttype = contenttype
         self.validwhen = validwhen
@@ -603,40 +1014,85 @@ class BitMaskedArrayType(ContentType):
         self.parameters = parameters
 
     def tolayout(self, lookup, pos, fields):
-        mask = self.IndexOf(self.masktype)(lookup.arrays[lookup.positions[pos + self.MASK]])
-        content = self.contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENT], fields)
-        return awkward1.layout.BitMaskedArray(mask, content, self.validwhen, len(content), self.lsb_order, parameters=self.parameters)
+        mask = self.IndexOf(self.masktype)(
+            lookup.arrays[lookup.positions[pos + self.MASK]])
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields)
+        return awkward1.layout.BitMaskedArray(mask,
+                                              content,
+                                              self.validwhen,
+                                              len(content),
+                                              self.lsb_order,
+                                              parameters=self.parameters)
 
     def hasfield(self, key):
         return self.contenttype.hasfield(key)
 
     def getitem_at(self, viewtype):
-        return numba.types.optional(self.contenttype.getitem_at_check(viewtype))
+        return numba.types.optional(
+                 self.contenttype.getitem_at_check(viewtype))
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
         whichpos = posat(context, builder, viewproxy.pos, self.CONTENT)
         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
         bitatval = builder.sdiv(atval, context.get_constant(numba.intp, 8))
-        shiftval = awkward1._connect._numba.castint(context, builder, numba.intp, numba.uint8, builder.srem(atval, context.get_constant(numba.intp, 8)))
+        shiftval = awkward1._connect._numba.castint(
+                     context,
+                     builder,
+                     numba.intp,
+                     numba.uint8,
+                     builder.srem(atval, context.get_constant(numba.intp, 8)))
 
         maskpos = posat(context, builder, viewproxy.pos, self.MASK)
         maskptr = getat(context, builder, viewproxy.arrayptrs, maskpos)
         maskarraypos = builder.add(viewproxy.start, bitatval)
-        byte = getat(context, builder, maskptr, maskarraypos, self.masktype.dtype)
+        byte = getat(context,
+                     builder,
+                     maskptr,
+                     maskarraypos,
+                     self.masktype.dtype)
         if self.lsb_order:
             # ((byte >> ((uint8_t)shift)) & ((uint8_t)1))
-            asbool = builder.and_(builder.lshr(byte, shiftval), context.get_constant(numba.uint8, 1))
+            asbool = builder.and_(
+                       builder.lshr(byte, shiftval),
+                       context.get_constant(numba.uint8, 1))
         else:
             # ((byte << ((uint8_t)shift)) & ((uint8_t)128))
-            asbool = builder.and_(builder.shl(byte, shiftval), context.get_constant(numba.uint8, 128))
+            asbool = builder.and_(
+                       builder.shl(byte, shiftval),
+                       context.get_constant(numba.uint8, 128))
 
         output = context.make_helper(builder, rettype)
 
-        with builder.if_else(builder.icmp_signed("==", builder.icmp_signed("!=", asbool, context.get_constant(numba.uint8, 0)), context.get_constant(numba.uint8, int(self.validwhen)))) as (isvalid, isnone):
+        with builder.if_else(
+               builder.icmp_signed("==",
+                 builder.icmp_signed("!=",
+                                     asbool,
+                                     context.get_constant(numba.uint8, 0)),
+                                   context.get_constant(numba.uint8,
+                                                        int(self.validwhen)
+                          ))) as (isvalid, isnone):
             with isvalid:
-                nextviewtype = awkward1._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+                nextviewtype = awkward1._connect._numba.arrayview.wrap(
+                                 self.contenttype, viewtype, None)
                 proxynext = context.make_helper(builder, nextviewtype)
                 proxynext.pos        = nextpos
                 proxynext.start      = viewproxy.start
@@ -645,7 +1101,17 @@ class BitMaskedArrayType(ContentType):
                 proxynext.sharedptrs = viewproxy.sharedptrs
                 proxynext.pylookup   = viewproxy.pylookup
 
-                outdata = self.contenttype.lower_getitem_at_check(context, builder, rettype.type, nextviewtype, proxynext._getvalue(), proxynext, numba.intp, atval, False, False)
+                outdata = self.contenttype.lower_getitem_at_check(
+                            context,
+                            builder,
+                            rettype.type,
+                            nextviewtype,
+                            proxynext._getvalue(),
+                            proxynext,
+                            numba.intp,
+                            atval,
+                            False,
+                            False)
 
                 output.valid = numba.cgutils.true_bit
                 output.data = outdata
@@ -667,34 +1133,62 @@ class UnmaskedArrayType(ContentType):
         sharedptrs[-1] = layout._persistent_shared_ptr
         positions.append(None)
         sharedptrs.append(None)
-        positions[pos + cls.CONTENT] = awkward1._connect._numba.arrayview.tolookup(layout.content, positions, sharedptrs, arrays)
+        positions[pos + cls.CONTENT] = \
+          awkward1._connect._numba.arrayview.tolookup(layout.content,
+                                                      positions,
+                                                      sharedptrs,
+                                                      arrays)
         return pos
 
     def __init__(self, contenttype, identitiestype, parameters):
-        super(UnmaskedArrayType, self).__init__(name="awkward1.UnmaskedArrayType({0}, {1}, {2})".format(contenttype.name, identitiestype.name, json.dumps(parameters)))
+        super(UnmaskedArrayType, self).__init__(
+            name="awkward1.UnmaskedArrayType({0}, {1}, {2})".format(
+              contenttype.name,
+              identitiestype.name,
+              json.dumps(parameters)))
         self.contenttype = contenttype
         self.identitiestype = identitiestype
         self.parameters = parameters
 
     def tolayout(self, lookup, pos, fields):
-        content = self.contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENT], fields)
-        return awkward1.layout.UnmaskedArray(content, parameters=self.parameters)
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields)
+        return awkward1.layout.UnmaskedArray(content,
+                                             parameters=self.parameters)
 
     def hasfield(self, key):
         return self.contenttype.hasfield(key)
 
     def getitem_at(self, viewtype):
-        return numba.types.optional(self.contenttype.getitem_at_check(viewtype))
+        return numba.types.optional(
+                 self.contenttype.getitem_at_check(viewtype))
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
         whichpos = posat(context, builder, viewproxy.pos, self.CONTENT)
         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
 
         output = context.make_helper(builder, rettype)
 
-        nextviewtype = awkward1._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+        nextviewtype = awkward1._connect._numba.arrayview.wrap(
+                         self.contenttype, viewtype, None)
         proxynext = context.make_helper(builder, nextviewtype)
         proxynext.pos        = nextpos
         proxynext.start      = viewproxy.start
@@ -703,7 +1197,17 @@ class UnmaskedArrayType(ContentType):
         proxynext.sharedptrs = viewproxy.sharedptrs
         proxynext.pylookup   = viewproxy.pylookup
 
-        outdata = self.contenttype.lower_getitem_at_check(context, builder, rettype.type, nextviewtype, proxynext._getvalue(), proxynext, numba.intp, atval, False, False)
+        outdata = self.contenttype.lower_getitem_at_check(
+                    context,
+                    builder,
+                    rettype.type,
+                    nextviewtype,
+                    proxynext._getvalue(),
+                    proxynext,
+                    numba.intp,
+                    atval,
+                    False,
+                    False)
 
         output.valid = numba.cgutils.true_bit
         output.data = outdata
@@ -722,11 +1226,21 @@ class RecordArrayType(ContentType):
         positions.extend([None] * layout.numfields)
         sharedptrs.extend([None] * layout.numfields)
         for i, content in enumerate(layout.contents):
-            positions[pos + cls.CONTENTS + i] = awkward1._connect._numba.arrayview.tolookup(content, positions, sharedptrs, arrays)
+            positions[pos + cls.CONTENTS + i] = \
+              awkward1._connect._numba.arrayview.tolookup(content,
+                                                          positions,
+                                                          sharedptrs,
+                                                          arrays)
         return pos
 
     def __init__(self, contenttypes, recordlookup, identitiestype, parameters):
-        super(RecordArrayType, self).__init__(name="awkward1.RecordArrayType(({0}{1}), ({2}), {3}, {4})".format(", ".join(x.name for x in contenttypes), "," if len(contenttypes) == 1 else "", "None" if recordlookup is None else repr(tuple(recordlookup)), identitiestype.name, json.dumps(parameters)))
+        super(RecordArrayType, self).__init__(
+            name="awkward1.RecordArrayType(({0}{1}), ({2}), {3}, {4})".format(
+              ", ".join(x.name for x in contenttypes),
+              "," if len(contenttypes) == 1 else "",
+              "None" if recordlookup is None else repr(tuple(recordlookup)),
+              identitiestype.name,
+              json.dumps(parameters)))
         self.contenttypes = contenttypes
         self.recordlookup = recordlookup
         self.identitiestype = identitiestype
@@ -752,16 +1266,28 @@ class RecordArrayType(ContentType):
         if len(fields) > 0:
             index = self.fieldindex(fields[0])
             assert index is not None
-            return self.contenttypes[index].tolayout(lookup, lookup.positions[pos + self.CONTENTS + index], fields[1:])
+            return self.contenttypes[index].tolayout(
+                     lookup,
+                     lookup.positions[pos + self.CONTENTS + index],
+                     fields[1:])
         else:
             contents = []
             for i, contenttype in enumerate(self.contenttypes):
-                layout = contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENTS + i], fields)
+                layout = contenttype.tolayout(
+                           lookup,
+                           lookup.positions[pos + self.CONTENTS + i],
+                           fields)
                 contents.append(layout)
             if len(contents) == 0:
-                return awkward1.layout.RecordArray(contents, self.recordlookup, numpy.iinfo(numpy.int64).max, parameters=self.parameters)
+                return awkward1.layout.RecordArray(
+                         contents,
+                         self.recordlookup,
+                         numpy.iinfo(numpy.int64).max,
+                         parameters=self.parameters)
             else:
-                return awkward1.layout.RecordArray(contents, self.recordlookup, parameters=self.parameters)
+                return awkward1.layout.RecordArray(contents,
+                                                   self.recordlookup,
+                                                   parameters=self.parameters)
 
     def hasfield(self, key):
         return self.fieldindex(key) is not None
@@ -769,7 +1295,8 @@ class RecordArrayType(ContentType):
     def getitem_at_check(self, viewtype):
         out = self.getitem_at(viewtype)
         if isinstance(out, awkward1._connect._numba.arrayview.RecordViewType):
-            typer = awkward1._util.numba_record_typer(out.arrayviewtype.type, out.arrayviewtype.behavior)
+            typer = awkward1._util.numba_record_typer(
+                      out.arrayviewtype.type, out.arrayviewtype.behavior)
             if typer is not None:
                 return typer(out)
         return out
@@ -782,49 +1309,111 @@ class RecordArrayType(ContentType):
             index = self.fieldindex(key)
             if index is None:
                 if self.recordlookup is None:
-                    raise ValueError("no field {0} in tuples with {1} fields".format(repr(key), len(self.contenttypes)))
+                    raise ValueError(
+                            "no field {0} in tuples with {1} fields".format(
+                              repr(key), len(self.contenttypes)))
                 else:
-                    raise ValueError("no field {0} in records with fields: [{1}]".format(repr(key), ", ".join(repr(x) for x in self.recordlookup)))
+                    raise ValueError(
+                            "no field {0} in records with "
+                            "fields: [{1}]".format(
+                              repr(key),
+                              ", ".join(repr(x) for x in self.recordlookup)))
             contenttype = self.contenttypes[index]
-            subviewtype = awkward1._connect._numba.arrayview.wrap(contenttype, viewtype, viewtype.fields[1:])
+            subviewtype = awkward1._connect._numba.arrayview.wrap(
+                            contenttype, viewtype, viewtype.fields[1:])
             return contenttype.getitem_at_check(subviewtype)
 
     def getitem_field(self, viewtype, key):
         index = self.fieldindex(key)
         if index is None:
             if self.recordlookup is None:
-                raise ValueError("no field {0} in tuples with {1} fields".format(repr(key), len(self.contenttypes)))
+                raise ValueError(
+                        "no field {0} in tuples with {1} fields".format(
+                        repr(key), len(self.contenttypes)))
             else:
-                raise ValueError("no field {0} in records with fields: [{1}]".format(repr(key), ", ".join(repr(x) for x in self.recordlookup)))
+                raise ValueError(
+                        "no field {0} in records with fields: [{1}]".format(
+                          repr(key),
+                          ", ".join(repr(x) for x in self.recordlookup)))
         contenttype = self.contenttypes[index]
-        subviewtype = awkward1._connect._numba.arrayview.wrap(contenttype, viewtype, None)
+        subviewtype = awkward1._connect._numba.arrayview.wrap(contenttype,
+                                                              viewtype,
+                                                              None)
         return contenttype.getitem_range(subviewtype)
 
     def getitem_field_record(self, recordviewtype, key):
         index = self.fieldindex(key)
         if index is None:
             if self.recordlookup is None:
-                raise ValueError("no field {0} in tuple with {1} fields".format(repr(key), len(self.contenttypes)))
+                raise ValueError(
+                        "no field {0} in tuple with {1} fields".format(
+                        repr(key), len(self.contenttypes)))
             else:
-                raise ValueError("no field {0} in record with fields: [{1}]".format(repr(key), ", ".join(repr(x) for x in self.recordlookup)))
+                raise ValueError(
+                        "no field {0} in record with fields: [{1}]".format(
+                        repr(key),
+                        ", ".join(repr(x) for x in self.recordlookup)))
         contenttype = self.contenttypes[index]
-        subviewtype = awkward1._connect._numba.arrayview.wrap(contenttype, recordviewtype, None)
+        subviewtype = awkward1._connect._numba.arrayview.wrap(contenttype,
+                                                              recordviewtype,
+                                                              None)
         return contenttype.getitem_at_check(subviewtype)
 
-    def lower_getitem_at_check(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
-        out = self.lower_getitem_at(context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds)
+    def lower_getitem_at_check(self,
+                               context,
+                               builder,
+                               rettype,
+                               viewtype,
+                               viewval,
+                               viewproxy,
+                               attype,
+                               atval,
+                               wrapneg,
+                               checkbounds):
+        out = self.lower_getitem_at(context,
+                                    builder,
+                                    rettype,
+                                    viewtype,
+                                    viewval,
+                                    viewproxy,
+                                    attype,
+                                    atval,
+                                    wrapneg,
+                                    checkbounds)
         baretype = self.getitem_at(viewtype)
-        if isinstance(baretype, awkward1._connect._numba.arrayview.RecordViewType):
-            lower = awkward1._util.numba_record_lower(baretype.arrayviewtype.type, baretype.arrayviewtype.behavior)
+        if isinstance(baretype,
+                      awkward1._connect._numba.arrayview.RecordViewType):
+            lower = awkward1._util.numba_record_lower(
+                      baretype.arrayviewtype.type,
+                      baretype.arrayviewtype.behavior)
             if lower is not None:
                 return lower(context, builder, rettype(baretype), (out,))
         return out
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
-        atval = regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds)
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
+        atval = regularize_atval(context,
+                                 builder,
+                                 viewproxy,
+                                 attype,
+                                 atval,
+                                 wrapneg,
+                                 checkbounds)
 
         if len(viewtype.fields) == 0:
-            proxyout = context.make_helper(builder, awkward1._connect._numba.arrayview.RecordViewType(viewtype))
+            proxyout = context.make_helper(
+                         builder,
+                         awkward1._connect._numba.arrayview.RecordViewType(
+                           viewtype))
             proxyout.arrayview = viewval
             proxyout.at        = atval
             return proxyout._getvalue()
@@ -833,19 +1422,35 @@ class RecordArrayType(ContentType):
             index = self.fieldindex(viewtype.fields[0])
             contenttype = self.contenttypes[index]
 
-            whichpos = posat(context, builder, viewproxy.pos, self.CONTENTS + index)
+            whichpos = posat(context,
+                             builder,
+                             viewproxy.pos,
+                             self.CONTENTS + index)
             nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-            nextviewtype = awkward1._connect._numba.arrayview.wrap(contenttype, viewtype, viewtype.fields[1:])
+            nextviewtype = awkward1._connect._numba.arrayview.wrap(
+                             contenttype, viewtype, viewtype.fields[1:])
             proxynext = context.make_helper(builder, nextviewtype)
             proxynext.pos        = nextpos
             proxynext.start      = viewproxy.start
-            proxynext.stop       = builder.add(atval, builder.add(viewproxy.start, context.get_constant(numba.intp, 1)))
+            proxynext.stop       = builder.add(atval,
+                                     builder.add(
+                                       viewproxy.start,
+                                       context.get_constant(numba.intp, 1)))
             proxynext.arrayptrs  = viewproxy.arrayptrs
             proxynext.sharedptrs = viewproxy.sharedptrs
             proxynext.pylookup   = viewproxy.pylookup
 
-            return contenttype.lower_getitem_at_check(context, builder, rettype, nextviewtype, proxynext._getvalue(), proxynext, numba.intp, atval, False, False)
+            return contenttype.lower_getitem_at_check(context,
+                                                      builder,
+                                                      rettype,
+                                                      nextviewtype,
+                                                      proxynext._getvalue(),
+                                                      proxynext,
+                                                      numba.intp,
+                                                      atval,
+                                                      False,
+                                                      False)
 
     def lower_getitem_field(self, context, builder, viewtype, viewval, key):
         viewproxy = context.make_helper(builder, viewtype, viewval)
@@ -853,10 +1458,14 @@ class RecordArrayType(ContentType):
         index = self.fieldindex(key)
         contenttype = self.contenttypes[index]
 
-        whichpos = posat(context, builder, viewproxy.pos, self.CONTENTS + index)
+        whichpos = posat(context,
+                         builder,
+                         viewproxy.pos,
+                         self.CONTENTS + index)
         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-        proxynext = context.make_helper(builder, contenttype.getitem_range(viewtype))
+        proxynext = context.make_helper(builder,
+                                        contenttype.getitem_range(viewtype))
         proxynext.pos        = nextpos
         proxynext.start      = viewproxy.start
         proxynext.stop       = viewproxy.stop
@@ -866,31 +1475,59 @@ class RecordArrayType(ContentType):
 
         return proxynext._getvalue()
 
-    def lower_getitem_field_record(self, context, builder, recordviewtype, recordviewval, key):
+    def lower_getitem_field_record(self,
+                                   context,
+                                   builder,
+                                   recordviewtype,
+                                   recordviewval,
+                                   key):
         arrayviewtype = recordviewtype.arrayviewtype
-        recordviewproxy = context.make_helper(builder, recordviewtype, recordviewval)
+        recordviewproxy = context.make_helper(builder,
+                                              recordviewtype,
+                                              recordviewval)
         arrayviewval = recordviewproxy.arrayview
-        arrayviewproxy = context.make_helper(builder, arrayviewtype, arrayviewval)
+        arrayviewproxy = context.make_helper(builder,
+                                             arrayviewtype,
+                                             arrayviewval)
 
         index = self.fieldindex(key)
         contenttype = self.contenttypes[index]
 
-        whichpos = posat(context, builder, arrayviewproxy.pos, self.CONTENTS + index)
+        whichpos = posat(context,
+                         builder,
+                         arrayviewproxy.pos,
+                         self.CONTENTS + index)
         nextpos = getat(context, builder, arrayviewproxy.arrayptrs, whichpos)
 
-        proxynext = context.make_helper(builder, contenttype.getitem_range(arrayviewtype))
+        proxynext = context.make_helper(
+                      builder, contenttype.getitem_range(arrayviewtype))
         proxynext.pos        = nextpos
         proxynext.start      = arrayviewproxy.start
-        proxynext.stop       = builder.add(recordviewproxy.at, builder.add(arrayviewproxy.start, context.get_constant(numba.intp, 1)))
+        proxynext.stop       = builder.add(
+                                 recordviewproxy.at,
+                                 builder.add(
+                                   arrayviewproxy.start,
+                                   context.get_constant(numba.intp, 1)))
         proxynext.arrayptrs  = arrayviewproxy.arrayptrs
         proxynext.sharedptrs = arrayviewproxy.sharedptrs
         proxynext.pylookup   = arrayviewproxy.pylookup
 
-        nextviewtype = awkward1._connect._numba.arrayview.wrap(contenttype, arrayviewtype, None)
+        nextviewtype = awkward1._connect._numba.arrayview.wrap(contenttype,
+                                                               arrayviewtype,
+                                                               None)
 
         rettype = self.getitem_field_record(recordviewtype, key)
 
-        return contenttype.lower_getitem_at_check(context, builder, rettype, nextviewtype, proxynext._getvalue(), proxynext, numba.intp, recordviewproxy.at, False, False)
+        return contenttype.lower_getitem_at_check(context,
+                                                  builder,
+                                                  rettype,
+                                                  nextviewtype,
+                                                  proxynext._getvalue(),
+                                                  proxynext,
+                                                  numba.intp,
+                                                  recordviewproxy.at,
+                                                  False,
+                                                  False)
 
 class UnionArrayType(ContentType):
     IDENTITIES = 0
@@ -912,11 +1549,26 @@ class UnionArrayType(ContentType):
         positions.extend([None] * layout.numcontents)
         sharedptrs.extend([None] * layout.numcontents)
         for i, content in enumerate(layout.contents):
-            positions[pos + cls.CONTENTS + i] = awkward1._connect._numba.arrayview.tolookup(content, positions, sharedptrs, arrays)
+            positions[pos + cls.CONTENTS + i] = \
+              awkward1._connect._numba.arrayview.tolookup(content,
+                                                          positions,
+                                                          sharedptrs,
+                                                          arrays)
         return pos
 
-    def __init__(self, tagstype, indextype, contenttypes, identitiestype, parameters):
-        super(UnionArrayType, self).__init__(name="awkward1.UnionArrayType({0}, {1}, ({2}{3}), {4}, {5})".format(tagstype.name, indextype.name, ", ".join(x.name for x in contenttypes), "," if len(contenttypes) == 1 else "", identitiestype.name, json.dumps(parameters)))
+    def __init__(self,
+                 tagstype,
+                 indextype,
+                 contenttypes,
+                 identitiestype,
+                 parameters):
+        super(UnionArrayType, self).__init__(
+            name="awkward1.UnionArrayType({0}, {1}, ({2}{3}), {4}, "
+            "{5})".format(tagstype.name,
+                          indextype.name,
+                          ", ".join(x.name for x in contenttypes),
+                          "," if len(contenttypes) == 1 else "",
+                          identitiestype.name, json.dumps(parameters)))
         self.tagstype = tagstype
         self.indextype = indextype
         self.contenttypes = contenttypes
@@ -925,25 +1577,39 @@ class UnionArrayType(ContentType):
 
     def UnionArrayOf(self):
         if self.tagstype.dtype.bitwidth == 8 and self.tagstype.dtype.signed:
-            if self.indextype.dtype.bitwidth == 32 and self.indextype.dtype.signed:
+            if (self.indextype.dtype.bitwidth == 32 and
+                self.indextype.dtype.signed):
                 return awkward1.layout.UnionArray8_32
             elif self.indextype.dtype.bitwidth == 32:
                 return awkward1.layout.UnionArray8_U32
-            elif self.indextype.dtype.bitwidth == 64 and self.indextype.dtype.signed:
+            elif (self.indextype.dtype.bitwidth == 64 and
+                  self.indextype.dtype.signed):
                 return awkward1.layout.UnionArray8_64
             else:
-                raise AssertionError("no UnionArray* type for index array: {0}".format(self.indextype))
+                raise AssertionError(
+                        "no UnionArray* type for index array: {0}".format(
+                          self.indextype))
         else:
-            raise AssertionError("no UnionArray* type for tags array: {0}".format(self.tagstype))
+            raise AssertionError(
+                    "no UnionArray* type for tags array: {0}".format(
+                      self.tagstype))
 
     def tolayout(self, lookup, pos, fields):
-        tags = self.IndexOf(self.tagstype)(lookup.arrays[lookup.positions[pos + self.TAGS]])
-        index = self.IndexOf(self.indextype)(lookup.arrays[lookup.positions[pos + self.INDEX]])
+        tags = self.IndexOf(self.tagstype)(
+                 lookup.arrays[lookup.positions[pos + self.TAGS]])
+        index = self.IndexOf(self.indextype)(
+                  lookup.arrays[lookup.positions[pos + self.INDEX]])
         contents = []
         for i, contenttype in enumerate(self.contenttypes):
-            layout = contenttype.tolayout(lookup, lookup.positions[pos + self.CONTENTS + i], fields)
+            layout = contenttype.tolayout(
+                       lookup,
+                       lookup.positions[pos + self.CONTENTS + i],
+                       fields)
             contents.append(layout)
-        return self.UnionArrayOf()(tags, index, contents, parameters=self.parameters)
+        return self.UnionArrayOf()(tags,
+                                   index,
+                                   contents,
+                                   parameters=self.parameters)
 
     def hasfield(self, key):
         return any(x.hasfield(key) for x in self.contenttypes)
@@ -960,11 +1626,39 @@ class UnionArrayType(ContentType):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
             raise TypeError("union types cannot be accessed in Numba")
 
-    def lower_getitem_at(self, context, builder, rettype, viewtype, viewval, viewproxy, attype, atval, wrapneg, checkbounds):
-        raise NotImplementedError(type(self).__name__ + ".lower_getitem_at not implemented")
+    def lower_getitem_at(self,
+                         context,
+                         builder,
+                         rettype,
+                         viewtype,
+                         viewval,
+                         viewproxy,
+                         attype,
+                         atval,
+                         wrapneg,
+                         checkbounds):
+        raise NotImplementedError(
+            type(self).__name__ + ".lower_getitem_at not implemented")
 
-    def lower_getitem_range(self, context, builder, rettype, viewtype, viewval, viewproxy, start, stop, wrapneg):
-        raise NotImplementedError(type(self).__name__ + ".lower_getitem_range not implemented")
+    def lower_getitem_range(self,
+                            context,
+                            builder,
+                            rettype,
+                            viewtype,
+                            viewval,
+                            viewproxy,
+                            start,
+                            stop,
+                            wrapneg):
+        raise NotImplementedError(
+            type(self).__name__ + ".lower_getitem_range not implemented")
 
-    def lower_getitem_field(self, context, builder, viewtype, viewval, viewproxy, key):
-        raise NotImplementedError(type(self).__name__ + ".lower_getitem_field not implemented")
+    def lower_getitem_field(self,
+                            context,
+                            builder,
+                            viewtype,
+                            viewval,
+                            viewproxy,
+                            key):
+        raise NotImplementedError(
+            type(self).__name__ + ".lower_getitem_field not implemented")

--- a/src/awkward1/_connect/_pandas.py
+++ b/src/awkward1/_connect/_pandas.py
@@ -11,7 +11,6 @@ import awkward1._util
 import awkward1.operations.convert
 import awkward1.operations.structure
 
-# Don't import 'pandas' until an Awkward Array is used in Pandas or register() is called.
 def register():
     global AwkwardDtype
     try:
@@ -29,8 +28,11 @@ def get_pandas():
     import pandas
     global checked_version
     if not checked_version:
-        if distutils.version.LooseVersion(pandas.__version__) < distutils.version.LooseVersion("0.24.0"):
-            raise ImportError("cannot use Awkward Array with Pandas version {0} (at least 0.24.0 is required)".format(pandas.__version__))
+        if (distutils.version.LooseVersion(pandas.__version__) <
+            distutils.version.LooseVersion("0.24.0")):
+            raise ImportError(
+                    "cannot use Awkward Array with Pandas version {0} (at "
+                    "least 0.24.0 is required)".format(pandas.__version__))
         checked_version = True
     return pandas
 
@@ -54,7 +56,8 @@ def get_dtype():
                 if string == cls.name:
                     return cls()
                 else:
-                    raise TypeError("cannot construct a {0} from {1}".format(cls, string))
+                    raise TypeError(
+                        "cannot construct a {0} from {1}".format(cls, string))
 
             @classmethod
             def construct_array_type(cls):
@@ -150,26 +153,37 @@ class PandasMixin(PandasNotImportedYet):
             indices = numpy.asarray(indices, dtype=numpy.int64)
             if fill_value is None:
                 index = awkward1.layout.Index64(indices)
-                layout = awkward1.layout.IndexedOptionArray64(index, self.layout, parameters=self.layout.parameters)
-                return awkward1._util.wrap(layout, awkward1._util.behaviorof(self))
+                layout = awkward1.layout.IndexedOptionArray64(
+                           index,
+                           self.layout,
+                           parameters=self.layout.parameters)
+                return awkward1._util.wrap(layout,
+                                           awkward1._util.behaviorof(self))
 
             else:
                 tags = (indices >= 0).view(numpy.int8)
                 index = indices.copy()
                 index[~tags] = 0
-                content0 = awkward1.operations.convert.fromiter([fill_value], highlevel=False)
+                content0 = awkward1.operations.convert.fromiter(
+                             [fill_value], highlevel=False)
                 content1 = self.layout
                 tags = awkward1.layout.Index8(tags)
                 index = awkward1.layout.Index64(index)
-                layout = awkward1.layout.UnionArray8_64(tags, index, [content0, content1])
-                return awkward1._util.wrap(layout, awkward1._util.behaviorof(self))
+                layout = awkward1.layout.UnionArray8_64(tags,
+                                                        index,
+                                                        [content0, content1])
+                return awkward1._util.wrap(layout,
+                                           awkward1._util.behaviorof(self))
 
         else:
             return self[indices]
 
     def copy(self):
         # https://pandas.pydata.org/pandas-docs/version/1.0.0/reference/api/pandas.api.extensions.ExtensionArray.copy.html
-        return awkward1._util.wrap(self._layout.deep_copy(copyarrays=True, copyindexes=True, copyidentities=True), awkward1._util.behaviorof(self))
+        return awkward1._util.wrap(self._layout.deep_copy(copyarrays=True,
+                                                          copyindexes=True,
+                                                          copyidentities=True),
+                                   awkward1._util.behaviorof(self))
 
     @classmethod
     def _concat_same_type(cls, to_concat):
@@ -236,7 +250,10 @@ class PandasMixin(PandasNotImportedYet):
     #     register()
     #     raise NotImplementedError
 
-def df(array, how="inner", levelname=lambda i: "sub"*i + "entry", anonymous="values"):
+def df(array,
+       how="inner",
+       levelname=lambda i: "sub"*i + "entry",
+       anonymous="values"):
     register()
     pandas = get_pandas()
     out = None
@@ -244,10 +261,16 @@ def df(array, how="inner", levelname=lambda i: "sub"*i + "entry", anonymous="val
         if out is None:
             out = df
         else:
-            out = pandas.merge(out, df, how=how, left_index=True, right_index=True)
+            out = pandas.merge(out,
+                               df,
+                               how=how,
+                               left_index=True,
+                               right_index=True)
     return out
 
-def dfs(array, levelname=lambda i: "sub"*i + "entry", anonymous="values"):
+def dfs(array,
+        levelname=lambda i: "sub"*i + "entry",
+        anonymous="values"):
     register()
     pandas = get_pandas()
 
@@ -260,23 +283,31 @@ def dfs(array, levelname=lambda i: "sub"*i + "entry", anonymous="values"):
             if awkward1._util.win:
                 counts = counts.astype(numpy.int32)
             if len(row_arrays) == 0:
-                newrows = [numpy.repeat(numpy.arange(len(counts), dtype=counts.dtype), counts)]
+                newrows = [numpy.repeat(numpy.arange(len(counts),
+                                                     dtype=counts.dtype),
+                                        counts)]
             else:
                 newrows = [numpy.repeat(x, counts) for x in row_arrays]
-            newrows.append(numpy.arange(offsets[-1], dtype=counts.dtype) - numpy.repeat(starts, counts))
+            newrows.append(numpy.arange(offsets[-1], dtype=counts.dtype) -
+                           numpy.repeat(starts, counts))
             return recurse(flattened, newrows, col_names)
 
         elif isinstance(layout, awkward1.layout.RecordArray):
-            return sum([recurse(layout.field(n), row_arrays, col_names + (n,)) for n in layout.keys()], [])
+            return sum([recurse(layout.field(n), row_arrays, col_names + (n,))
+                          for n in layout.keys()], [])
 
         else:
             try:
-                return [(awkward1.operations.convert.tonumpy(layout), row_arrays, col_names)]
+                return [(awkward1.operations.convert.tonumpy(layout),
+                         row_arrays,
+                         col_names)]
             except:
                 return [(layout, row_arrays, col_names)]
 
     behavior = awkward1._util.behaviorof(array)
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=True, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=True,
+                                                  allowother=False)
     if isinstance(layout, awkward1.layout.Record):
         layout2 = layout.array[layout.at : layout.at + 1]
     else:
@@ -286,30 +317,42 @@ def dfs(array, levelname=lambda i: "sub"*i + "entry", anonymous="values"):
     last_row_arrays = None
     for column, row_arrays, col_names in recurse(layout2, [], ()):
         if isinstance(layout, awkward1.layout.Record):
-            row_arrays = row_arrays[1:]   # this Record was presented as a RecordArray of one element
+            row_arrays = row_arrays[1:]   # Record --> one-element RecordArray
 
         if len(col_names) == 0:
             columns = [anonymous]
         else:
             columns = pandas.MultiIndex.from_tuples([col_names])
 
-        if last_row_arrays is not None and len(last_row_arrays) == len(row_arrays) and all(numpy.array_equal(x, y) for x, y in zip(last_row_arrays, row_arrays)):
+        if (last_row_arrays is not None and
+            len(last_row_arrays) == len(row_arrays) and
+            all(numpy.array_equal(x, y)
+                  for x, y in zip(last_row_arrays, row_arrays))):
             oldcolumns = tables[-1].columns
             numold = len(oldcolumns.levels)
             numnew = len(columns.levels)
             maxnum = max(numold, numnew)
             if numold != maxnum:
-                oldcolumns = pandas.MultiIndex.from_tuples([x + ("",)*(maxnum - numold) for x in oldcolumns])
+                oldcolumns = pandas.MultiIndex.from_tuples(
+                               [x + ("",)*(maxnum - numold)
+                                  for x in oldcolumns])
                 tables[-1].columns = oldcolumns
             if numnew != maxnum:
-                columns = pandas.MultiIndex.from_tuples([x + ("",)*(maxnum - numold) for x in columns])
+                columns = pandas.MultiIndex.from_tuples(
+                            [x + ("",)*(maxnum - numold)
+                               for x in columns])
 
-            newframe = pandas.DataFrame(data=column, index=tables[-1].index, columns=columns)
+            newframe = pandas.DataFrame(data=column,
+                                        index=tables[-1].index,
+                                        columns=columns)
             tables[-1] = pandas.concat([tables[-1], newframe], axis=1)
 
         else:
-            index = pandas.MultiIndex.from_arrays(row_arrays, names=[levelname(i) for i in range(len(row_arrays))])
-            tables.append(pandas.DataFrame(data=column, index=index, columns=columns))
+            index = pandas.MultiIndex.from_arrays(
+                      row_arrays,
+                      names=[levelname(i) for i in range(len(row_arrays))])
+            tables.append(pandas.DataFrame(data=column,
+                                           index=index, columns=columns))
 
         last_row_arrays = row_arrays
 

--- a/src/awkward1/_libawkward.py
+++ b/src/awkward1/_libawkward.py
@@ -20,10 +20,12 @@ libpath = pkg_resources.resource_filename("awkward1", name)
 
 lib = ctypes.cdll.LoadLibrary(libpath)
 
-# bool awkward_ArrayBuilder_length(void* fillablearray, int64_t* result);
+# bool awkward_ArrayBuilder_length(void* fillablearray,
+#                                  int64_t* result);
 ArrayBuilder_length = lib.awkward_ArrayBuilder_length
 ArrayBuilder_length.name = "ArrayBuilder.length"
-ArrayBuilder_length.argtypes  = [ctypes.c_voidp, ctypes.POINTER(ctypes.c_int64)]
+ArrayBuilder_length.argtypes  = [ctypes.c_voidp,
+                                 ctypes.POINTER(ctypes.c_int64)]
 ArrayBuilder_length.restype   = ctypes.c_uint8
 
 # bool awkward_ArrayBuilder_clear(void* fillablearray);
@@ -38,19 +40,22 @@ ArrayBuilder_null.name = "ArrayBuilder.null"
 ArrayBuilder_null.argtypes  = [ctypes.c_voidp]
 ArrayBuilder_null.restype   = ctypes.c_uint8
 
-# bool awkward_ArrayBuilder_boolean(void* fillablearray, bool x);
+# bool awkward_ArrayBuilder_boolean(void* fillablearray,
+#                                   bool x);
 ArrayBuilder_boolean = lib.awkward_ArrayBuilder_boolean
 ArrayBuilder_boolean.name = "ArrayBuilder.boolean"
 ArrayBuilder_boolean.argtypes  = [ctypes.c_voidp, ctypes.c_uint8]
 ArrayBuilder_boolean.restype   = ctypes.c_uint8
 
-# bool awkward_ArrayBuilder_integer(void* fillablearray, int64_t x);
+# bool awkward_ArrayBuilder_integer(void* fillablearray,
+#                                   int64_t x);
 ArrayBuilder_integer = lib.awkward_ArrayBuilder_integer
 ArrayBuilder_integer.name = "ArrayBuilder.integer"
 ArrayBuilder_integer.argtypes  = [ctypes.c_voidp, ctypes.c_int64]
 ArrayBuilder_integer.restype   = ctypes.c_uint8
 
-# bool awkward_ArrayBuilder_real(void* fillablearray, double x);
+# bool awkward_ArrayBuilder_real(void* fillablearray,
+#                                double x);
 ArrayBuilder_real = lib.awkward_ArrayBuilder_real
 ArrayBuilder_real.name = "ArrayBuilder.real"
 ArrayBuilder_real.argtypes  = [ctypes.c_voidp, ctypes.c_double]
@@ -68,13 +73,15 @@ ArrayBuilder_endlist.name = "ArrayBuilder.endlist"
 ArrayBuilder_endlist.argtypes  = [ctypes.c_voidp]
 ArrayBuilder_endlist.restype   = ctypes.c_uint8
 
-# uint8_t awkward_ArrayBuilder_begintuple(void* fillablearray, int64_t numfields);
+# uint8_t awkward_ArrayBuilder_begintuple(void* fillablearray,
+#                                         int64_t numfields);
 ArrayBuilder_begintuple = lib.awkward_ArrayBuilder_begintuple
 ArrayBuilder_begintuple.name = "ArrayBuilder.begintuple"
 ArrayBuilder_begintuple.argtypes  = [ctypes.c_voidp, ctypes.c_int64]
 ArrayBuilder_begintuple.restype   = ctypes.c_uint8
 
-# uint8_t awkward_ArrayBuilder_index(void* fillablearray, int64_t index);
+# uint8_t awkward_ArrayBuilder_index(void* fillablearray,
+#                                    int64_t index);
 ArrayBuilder_index = lib.awkward_ArrayBuilder_index
 ArrayBuilder_index.name = "ArrayBuilder.index"
 ArrayBuilder_index.argtypes  = [ctypes.c_voidp, ctypes.c_int64]
@@ -92,25 +99,29 @@ ArrayBuilder_beginrecord.name = "ArrayBuilder.beginrecord"
 ArrayBuilder_beginrecord.argtypes  = [ctypes.c_voidp]
 ArrayBuilder_beginrecord.restype   = ctypes.c_uint8
 
-# uint8_t awkward_ArrayBuilder_beginrecord_fast(void* fillablearray, const char* name);
+# uint8_t awkward_ArrayBuilder_beginrecord_fast(void* fillablearray,
+#                                               const char* name);
 ArrayBuilder_beginrecord_fast = lib.awkward_ArrayBuilder_beginrecord_fast
 ArrayBuilder_beginrecord_fast.name = "ArrayBuilder.beginrecord_fast"
 ArrayBuilder_beginrecord_fast.argtypes  = [ctypes.c_voidp, ctypes.c_voidp]
 ArrayBuilder_beginrecord_fast.restype   = ctypes.c_uint8
 
-# uint8_t awkward_ArrayBuilder_beginrecord_check(void* fillablearray, const char* name);
+# uint8_t awkward_ArrayBuilder_beginrecord_check(void* fillablearray,
+#                                                const char* name);
 ArrayBuilder_beginrecord_check = lib.awkward_ArrayBuilder_beginrecord_check
 ArrayBuilder_beginrecord_check.name = "ArrayBuilder.beginrecord_check"
 ArrayBuilder_beginrecord_check.argtypes  = [ctypes.c_voidp, ctypes.c_voidp]
 ArrayBuilder_beginrecord_check.restype   = ctypes.c_uint8
 
-# uint8_t awkward_ArrayBuilder_field_fast(void* fillablearray, const char* key);
+# uint8_t awkward_ArrayBuilder_field_fast(void* fillablearray,
+#                                         const char* key);
 ArrayBuilder_field_fast = lib.awkward_ArrayBuilder_field_fast
 ArrayBuilder_field_fast.name = "ArrayBuilder.field_fast"
 ArrayBuilder_field_fast.argtypes  = [ctypes.c_voidp, ctypes.c_voidp]
 ArrayBuilder_field_fast.restype   = ctypes.c_uint8
 
-# uint8_t awkward_ArrayBuilder_field_check(void* fillablearray, const char* key);
+# uint8_t awkward_ArrayBuilder_field_check(void* fillablearray,
+#                                          const char* key);
 ArrayBuilder_field_check = lib.awkward_ArrayBuilder_field_check
 ArrayBuilder_field_check.name = "ArrayBuilder.field_check"
 ArrayBuilder_field_check.argtypes  = [ctypes.c_voidp, ctypes.c_voidp]
@@ -122,8 +133,12 @@ ArrayBuilder_endrecord.name = "ArrayBuilder.endrecord"
 ArrayBuilder_endrecord.argtypes  = [ctypes.c_voidp]
 ArrayBuilder_endrecord.restype   = ctypes.c_uint8
 
-# uint8_t awkward_ArrayBuilder_append_nowrap(void* fillablearray, const void* shared_ptr_ptr, int64_t at);
+# uint8_t awkward_ArrayBuilder_append_nowrap(void* fillablearray,
+#                                            const void* shared_ptr_ptr,
+#                                            int64_t at);
 ArrayBuilder_append_nowrap = lib.awkward_ArrayBuilder_append_nowrap
 ArrayBuilder_append_nowrap.name = "ArrayBuilder.append_nowrap"
-ArrayBuilder_append_nowrap.argtypes  = [ctypes.c_voidp, ctypes.c_voidp, ctypes.c_int64]
+ArrayBuilder_append_nowrap.argtypes  = [ctypes.c_voidp,
+                                        ctypes.c_voidp,
+                                        ctypes.c_int64]
 ArrayBuilder_append_nowrap.restype   = ctypes.c_uint8

--- a/src/awkward1/_util.py
+++ b/src/awkward1/_util.py
@@ -21,13 +21,27 @@ win  = (os.name == "nt")
 
 unknowntypes = (awkward1.layout.EmptyArray,)
 
-indexedtypes = (awkward1.layout.IndexedArray32, awkward1.layout.IndexedArrayU32, awkward1.layout.IndexedArray64)
+indexedtypes = (awkward1.layout.IndexedArray32,
+                awkward1.layout.IndexedArrayU32,
+                awkward1.layout.IndexedArray64)
 
-uniontypes = (awkward1.layout.UnionArray8_32, awkward1.layout.UnionArray8_U32, awkward1.layout.UnionArray8_64)
+uniontypes = (awkward1.layout.UnionArray8_32,
+              awkward1.layout.UnionArray8_U32,
+              awkward1.layout.UnionArray8_64)
 
-optiontypes = (awkward1.layout.IndexedOptionArray32, awkward1.layout.IndexedOptionArray64, awkward1.layout.ByteMaskedArray, awkward1.layout.BitMaskedArray, awkward1.layout.UnmaskedArray)
+optiontypes = (awkward1.layout.IndexedOptionArray32,
+               awkward1.layout.IndexedOptionArray64,
+               awkward1.layout.ByteMaskedArray,
+               awkward1.layout.BitMaskedArray,
+               awkward1.layout.UnmaskedArray)
 
-listtypes = (awkward1.layout.RegularArray, awkward1.layout.ListArray32, awkward1.layout.ListArrayU32, awkward1.layout.ListArray64, awkward1.layout.ListOffsetArray32, awkward1.layout.ListOffsetArrayU32, awkward1.layout.ListOffsetArray64)
+listtypes = (awkward1.layout.RegularArray,
+             awkward1.layout.ListArray32,
+             awkward1.layout.ListArrayU32,
+             awkward1.layout.ListArray64,
+             awkward1.layout.ListOffsetArray32,
+             awkward1.layout.ListOffsetArrayU32,
+             awkward1.layout.ListOffsetArray64)
 
 recordtypes = (awkward1.layout.RecordArray,)
 
@@ -92,7 +106,9 @@ def custom_broadcast(layout, behavior):
         custom = layout.purelist_parameter("__record__")
     if (isinstance(custom, str) or (py27 and isinstance(custom, unicode))):
         for key, fcn in behavior.items():
-            if isinstance(key, tuple) and len(key) == 2 and key[0] == "__broadcast__" and key[1] == custom:
+            if (isinstance(key, tuple) and
+                len(key) == 2 and
+                key[0] == "__broadcast__" and key[1] == custom):
                 return fcn
     return None
 
@@ -142,7 +158,8 @@ def recordclass(layout, behavior):
     rec = layout.parameter("__record__")
     if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
         cls = behavior[rec]
-        if isinstance(cls, type) and issubclass(cls, awkward1.highlevel.Record):
+        if (isinstance(cls, type) and
+            issubclass(cls, awkward1.highlevel.Record)):
             return cls
     return awkward1.highlevel.Record
 
@@ -151,7 +168,13 @@ def typestrs(behavior):
     behavior = Behavior(awkward1.behavior, behavior)
     out = {}
     for key, typestr in behavior.items():
-        if isinstance(key, tuple) and len(key) == 2 and key[0] == "__typestr__" and (isinstance(key[1], str) or (py27 and isinstance(key[1], unicode))) and (isinstance(typestr, str) or (py27 and isinstance(typestr, unicode))):
+        if (isinstance(key, tuple) and
+            len(key) == 2 and
+            key[0] == "__typestr__" and
+            (isinstance(key[1], str) or
+             (py27 and isinstance(key[1], unicode))) and
+            (isinstance(typestr, str) or
+             (py27 and isinstance(typestr, unicode)))):
             out[key[1]] = typestr
     return out
     
@@ -186,7 +209,10 @@ def numba_attrs(layouttype, behavior):
     rec = layouttype.parameters.get("__record__")
     if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
         for key, typer in behavior.items():
-            if isinstance(key, tuple) and len(key) == 3 and key[0] == "__numba_typer__" and key[1] == rec:
+            if (isinstance(key, tuple) and
+                len(key) == 3 and
+                key[0] == "__numba_typer__" and
+                key[1] == rec):
                 lower = behavior["__numba_lower__", key[1], key[2]]
                 yield key[2], typer, lower
 
@@ -196,7 +222,11 @@ def numba_methods(layouttype, behavior):
     rec = layouttype.parameters.get("__record__")
     if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
         for key, typer in behavior.items():
-            if isinstance(key, tuple) and len(key) == 4 and key[0] == "__numba_typer__" and key[1] == rec and key[3] == ():
+            if (isinstance(key, tuple) and
+                len(key) == 4 and
+                key[0] == "__numba_typer__" and
+                key[1] == rec and
+                key[3] == ()):
                 lower = behavior["__numba_lower__", key[1], key[2], ()]
                 yield key[2], typer, lower
 
@@ -213,7 +243,11 @@ def numba_unaryops(unaryop, left, behavior):
 
     if not done:
         for key, typer in behavior.items():
-            if isinstance(key, tuple) and len(key) == 3 and key[0] == "__numba_typer__" and key[1] == unaryop and key[2] == left:
+            if (isinstance(key, tuple) and
+                len(key) == 3 and
+                key[0] == "__numba_typer__" and
+                key[1] == unaryop and
+                key[2] == left):
                 lower = behavior["__numba_lower__", key[1], key[2]]
                 yield typer, lower
 
@@ -230,19 +264,28 @@ def numba_binops(binop, left, right, behavior):
 
     if isinstance(right, awkward1._connect._numba.layout.ContentType):
         right = right.parameters.get("__record__")
-        if not (isinstance(right, str) or (py27 and isinstance(right, unicode))):
+        if (not isinstance(right, str) and
+            not (py27 and isinstance(right, unicode))):
             done = True
 
     if not done:
         for key, typer in behavior.items():
-            if isinstance(key, tuple) and len(key) == 4 and key[0] == "__numba_typer__" and key[1] == left and key[2] == binop and key[3] == right:
+            if (isinstance(key, tuple) and
+                len(key) == 4 and
+                key[0] == "__numba_typer__" and
+                key[1] == left and
+                key[2] == binop and
+                key[3] == right):
                 lower = behavior["__numba_lower__", key[1], key[2], key[3]]
                 yield typer, lower
 
 def behaviorof(*arrays):
     behavior = None
     for x in arrays[::-1]:
-        if isinstance(x, (awkward1.highlevel.Array, awkward1.highlevel.Record, awkward1.highlevel.ArrayBuilder)) and x.behavior is not None:
+        if (isinstance(x, (awkward1.highlevel.Array,
+                           awkward1.highlevel.Record,
+                           awkward1.highlevel.ArrayBuilder)) and
+            x.behavior is not None):
             if behavior is None:
                 behavior = dict(x.behavior)
             else:
@@ -277,7 +320,8 @@ def called_by_module(modulename):
     frame = inspect.currentframe()
     while frame is not None:
         name = getattr(inspect.getmodule(frame), "__name__", None)
-        if name is not None and (name == modulename or name.startswith(modulename + ".")):
+        if (name is not None and
+            (name == modulename or name.startswith(modulename + "."))):
             return True
         frame = frame.f_back
     return True
@@ -332,20 +376,30 @@ def completely_flatten(array):
         return (numpy.asarray(array),)
 
     else:
-        raise RuntimeError("cannot completely flatten: {0}".format(type(array)))
+        raise RuntimeError(
+                "cannot completely flatten: {0}".format(type(array)))
 
 def broadcast_and_apply(inputs, getfunction, behavior):
     def checklength(inputs):
         length = len(inputs[0])
         for x in inputs[1:]:
             if len(x) != length:
-                raise ValueError("cannot broadcast {0} of length {1} with {2} of length {3}".format(type(inputs[0]).__name__, length, type(x).__name__, len(x)))
+                raise ValueError(
+                        "cannot broadcast {0} of length {1} with {2} of "
+                        "length {3}".format(type(inputs[0]).__name__,
+                                            length,
+                                            type(x).__name__,
+                                            len(x)))
 
     def apply(inputs, depth):
         # handle implicit right-broadcasting (i.e. NumPy-like)
         if any(isinstance(x, listtypes) for x in inputs):
-            maxdepth = max(x.purelist_depth for x in inputs if isinstance(x, awkward1.layout.Content))
-            if maxdepth > 0 and all(x.purelist_isregular for x in inputs if isinstance(x, awkward1.layout.Content)):
+            maxdepth = max(x.purelist_depth
+                           for x in inputs
+                           if isinstance(x, awkward1.layout.Content))
+            if maxdepth > 0 and all(x.purelist_isregular
+                                    for x in inputs
+                                    if isinstance(x, awkward1.layout.Content)):
                 nextinputs = []
                 for x in inputs:
                     if isinstance(x, awkward1.layout.Content):
@@ -356,7 +410,8 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                     return apply(nextinputs, depth)
 
         # now all lengths must agree
-        checklength([x for x in inputs if isinstance(x, awkward1.layout.Content)])
+        checklength([x for x in inputs
+                       if isinstance(x, awkward1.layout.Content)])
 
         function = getfunction(inputs, depth)
 
@@ -365,13 +420,22 @@ def broadcast_and_apply(inputs, getfunction, behavior):
             return function()
 
         elif any(isinstance(x, unknowntypes) for x in inputs):
-            return apply([x if not isinstance(x, unknowntypes) else awkward1.layout.NumpyArray(numpy.array([], dtype=numpy.bool_)) for x in inputs], depth)
+            return apply([x if not isinstance(x, unknowntypes)
+                            else awkward1.layout.NumpyArray(
+                                   numpy.array([], dtype=numpy.bool_))
+                            for x in inputs],
+                         depth)
 
-        elif any(isinstance(x, awkward1.layout.NumpyArray) and x.ndim > 1 for x in inputs):
-            return apply([x if not (isinstance(x, awkward1.layout.NumpyArray) and x.ndim > 1) else x.toRegularArray() for x in inputs], depth)
+        elif any(isinstance(x, awkward1.layout.NumpyArray) and x.ndim > 1
+                 for x in inputs):
+            return apply([x if not (isinstance(x, awkward1.layout.NumpyArray)
+                                    and x.ndim > 1)
+                            else x.toRegularArray() for x in inputs], depth)
 
         elif any(isinstance(x, indexedtypes) for x in inputs):
-            return apply([x if not isinstance(x, indexedtypes) else x.project() for x in inputs], depth)
+            return apply([x if not isinstance(x, indexedtypes) else x.project()
+                            for x in inputs],
+                         depth)
 
         elif any(isinstance(x, uniontypes) for x in inputs):
             tagslist = []
@@ -382,10 +446,16 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                     if length is None:
                         length = len(tagslist[-1])
                     elif length != len(tagslist[-1]):
-                        raise ValueError("cannot broadcast UnionArray of length {0} with UnionArray of length {1}".format(length, len(tagslist[-1])))
+                        raise ValueError(
+                                "cannot broadcast UnionArray of length {0} "
+                                "with UnionArray of length {1}".format(
+                                  length,
+                                  len(tagslist[-1])))
 
             combos = numpy.stack(tagslist, axis=-1)
-            combos = combos.view([(str(i), combos.dtype) for i in range(len(tagslist))]).reshape(length)
+            combos = combos.view([(str(i), combos.dtype)
+                                    for i in range(len(tagslist))
+                                 ]).reshape(length)
 
             tags = numpy.empty(length, dtype=numpy.int8)
             index = numpy.empty(length, dtype=numpy.int64)
@@ -411,12 +481,16 @@ def broadcast_and_apply(inputs, getfunction, behavior):
 
             tags = awkward1.layout.Index8(tags)
             index = awkward1.layout.Index64(index)
-            return tuple(awkward1.layout.UnionArray8_64(tags, index, [x[i] for x in outcontents]).simplify() for i in range(numoutputs))
+            return tuple(awkward1.layout.UnionArray8_64(
+                           tags,
+                           index,
+                           [x[i] for x in outcontents]).simplify()
+                         for i in range(numoutputs))
 
         elif any(isinstance(x, optiontypes) for x in inputs):
             mask = None
             for x in inputs:
-                if isinstance(x, (awkward1.layout.IndexedOptionArray32, awkward1.layout.IndexedOptionArray64, awkward1.layout.ByteMaskedArray, awkward1.layout.BitMaskedArray, awkward1.layout.UnmaskedArray)):
+                if isinstance(x, optiontypes):
                     m = numpy.asarray(x.bytemask()).view(numpy.bool_)
                     if mask is None:
                         mask = m
@@ -425,7 +499,8 @@ def broadcast_and_apply(inputs, getfunction, behavior):
 
             nextmask = awkward1.layout.Index8(mask.view(numpy.int8))
             index = numpy.full(len(mask), -1, dtype=numpy.int64)
-            index[~mask] = numpy.arange(len(mask) - numpy.count_nonzero(mask), dtype=numpy.int64)
+            index[~mask] = numpy.arange(len(mask) - numpy.count_nonzero(mask),
+                                        dtype=numpy.int64)
             index = awkward1.layout.Index64(index)
             if any(not isinstance(x, optiontypes) for x in inputs):
                 nextindex = numpy.arange(len(mask), dtype=numpy.int64)
@@ -437,47 +512,70 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                 if isinstance(x, optiontypes):
                     nextinputs.append(x.project(nextmask))
                 elif isinstance(x, awkward1.layout.Content):
-                    nextinputs.append(awkward1.layout.IndexedOptionArray64(nextindex, x).project(nextmask))
+                    nextinputs.append(
+                        awkward1.layout.IndexedOptionArray64(nextindex, x)
+                                                        .project(nextmask))
                 else:
                     nextinputs.append(x)
 
             outcontent = apply(nextinputs, depth)
             assert isinstance(outcontent, tuple)
-            return tuple(awkward1.layout.IndexedOptionArray64(index, x).simplify() for x in outcontent)
+            return tuple(awkward1.layout.IndexedOptionArray64(index, x)
+                                                            .simplify()
+                         for x in outcontent)
 
         elif any(isinstance(x, listtypes) for x in inputs):
-            if all(isinstance(x, awkward1.layout.RegularArray) or not isinstance(x, listtypes) for x in inputs):
-                maxsize = max([x.size for x in inputs if isinstance(x, awkward1.layout.RegularArray)])
+            if all(isinstance(x, awkward1.layout.RegularArray) or
+                   not isinstance(x, listtypes) for x in inputs):
+                maxsize = max([x.size
+                               for x in inputs
+                               if isinstance(x, awkward1.layout.RegularArray)])
                 for x in inputs:
                     if isinstance(x, awkward1.layout.RegularArray):
                         if maxsize > 1 and x.size == 1:
-                            tmpindex = awkward1.layout.Index64(numpy.repeat(numpy.arange(len(x), dtype=numpy.int64), maxsize))
+                            tmpindex = awkward1.layout.Index64(
+                                numpy.repeat(numpy.arange(len(x),
+                                                          dtype=numpy.int64),
+                                             maxsize))
                 nextinputs = []
                 for x in inputs:
                     if isinstance(x, awkward1.layout.RegularArray):
                         if maxsize > 1 and x.size == 1:
-                            nextinputs.append(awkward1.layout.IndexedArray64(tmpindex, x.content[:len(x)*x.size]).project())
+                            nextinputs.append(
+                                awkward1.layout.IndexedArray64(
+                                  tmpindex,
+                                  x.content[:len(x)*x.size]).project())
                         elif x.size == maxsize:
                             nextinputs.append(x.content[:len(x)*x.size])
                         else:
-                            raise ValueError("cannot broadcast RegularArray of size {0} with RegularArray of size {1}".format(x.size, maxsize))
+                            raise ValueError(
+                                    "cannot broadcast RegularArray of size "
+                                    "{0} with RegularArray of size {1}".format(
+                                                              x.size, maxsize))
                     else:
                         nextinputs.append(x)
                 outcontent = apply(nextinputs, depth + 1)
                 assert isinstance(outcontent, tuple)
-                return tuple(awkward1.layout.RegularArray(x, maxsize) for x in outcontent)
+                return tuple(awkward1.layout.RegularArray(x, maxsize)
+                             for x in outcontent)
 
             else:
-                fcns = [custom_broadcast(x, behavior) if isinstance(x, awkward1.layout.Content) else None for x in inputs]
+                fcns = [custom_broadcast(x, behavior)
+                          if isinstance(x, awkward1.layout.Content)
+                          else None
+                        for x in inputs]
                 first, secondround = None, False
                 for x, fcn in zip(inputs, fcns):
-                    if isinstance(x, listtypes) and not isinstance(x, awkward1.layout.RegularArray) and fcn is None:
+                    if (isinstance(x, listtypes) and
+                        not isinstance(x, awkward1.layout.RegularArray) and
+                        fcn is None):
                         first = x
                         break
                 if first is None:
                     secondround = True
                     for x in inputs:
-                        if isinstance(x, listtypes) and not isinstance(x, awkward1.layout.RegularArray):
+                        if (isinstance(x, listtypes) and
+                            not isinstance(x, awkward1.layout.RegularArray)):
                             first = x
                             break
 
@@ -486,18 +584,24 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                 nextinputs = []
                 for x, fcn in zip(inputs, fcns):
                     if callable(fcn) and not secondround:
-                        nextinputs.append(fcn(x, offsets))
+                        nextinputs.append(
+                            fcn(x, offsets))
                     elif isinstance(x, listtypes):
-                        nextinputs.append(x.broadcast_tooffsets64(offsets).content)
+                        nextinputs.append(
+                            x.broadcast_tooffsets64(offsets).content)
                     # handle implicit left-broadcasting (unlike NumPy)
                     elif isinstance(x, awkward1.layout.Content):
-                        nextinputs.append(awkward1.layout.RegularArray(x, 1).broadcast_tooffsets64(offsets).content)
+                        nextinputs.append(
+                            awkward1.layout.RegularArray(x, 1)
+                                .broadcast_tooffsets64(offsets)
+                                .content)
                     else:
                         nextinputs.append(x)
 
                 outcontent = apply(nextinputs, depth + 1)
                 assert isinstance(outcontent, tuple)
-                return tuple(awkward1.layout.ListOffsetArray64(offsets, x) for x in outcontent)
+                return tuple(awkward1.layout.ListOffsetArray64(offsets, x)
+                               for x in outcontent)
 
         elif any(isinstance(x, recordtypes) for x in inputs):
             keys = None
@@ -508,26 +612,41 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                     if keys is None:
                         keys = x.keys()
                     elif set(keys) != set(x.keys()):
-                        raise ValueError("cannot broadcast records because keys don't match:\n    {0}\n    {1}".format(", ".join(sorted(keys)), ", ".join(sorted(x.keys()))))
+                        raise ValueError(
+                                "cannot broadcast records because keys don't "
+                                "match:\n    {0}\n    {1}".format(
+                                  ", ".join(sorted(keys)),
+                                  ", ".join(sorted(x.keys()))))
                     if length is None:
                         length = len(x)
                     elif length != len(x):
-                        raise ValueError("cannot broadcast RecordArray of length {0} with RecordArray of length {1}".format(length, len(x)))
+                        raise ValueError(
+                                "cannot broadcast RecordArray of length {0} "
+                                "with RecordArray of length {1}".format(
+                                  length, len(x)))
                     if not x.istuple:
                         istuple = False
 
             outcontents = []
             numoutputs = None
             for key in keys:
-                outcontents.append(apply([x if not isinstance(x, recordtypes) else x[key] for x in inputs], depth))
+                outcontents.append(apply([x if not isinstance(x, recordtypes)
+                                            else x[key]
+                                            for x in inputs], depth))
                 assert isinstance(outcontents[-1], tuple)
                 if numoutputs is not None:
                     assert numoutputs == len(outcontents[-1])
                 numoutputs = len(outcontents[-1])
-            return tuple(awkward1.layout.RecordArray([x[i] for x in outcontents], None if istuple else keys, length) for i in range(numoutputs))
+            return tuple(awkward1.layout.RecordArray(
+                           [x[i] for x in outcontents],
+                           None if istuple else keys,
+                           length)
+                         for i in range(numoutputs))
 
         else:
-            raise ValueError("cannot broadcast: {0}".format(", ".join(repr(type(x)) for x in inputs)))
+            raise ValueError(
+                "cannot broadcast: {0}".format(
+                  ", ".join(repr(type(x)) for x in inputs)))
 
     isscalar = []
     out = apply(broadcast_pack(inputs, isscalar), 0)
@@ -545,7 +664,8 @@ def broadcast_pack(inputs, isscalar):
     for x in inputs:
         if isinstance(x, awkward1.layout.Record):
             index = numpy.full(maxlen, x.at, dtype=numpy.int64)
-            nextinputs.append(awkward1.layout.RegularArray(x.array[index], maxlen))
+            nextinputs.append(awkward1.layout.RegularArray(x.array[index],
+                                                           maxlen))
             isscalar.append(True)
         elif isinstance(x, awkward1.layout.Content):
             nextinputs.append(awkward1.layout.RegularArray(x, len(x)))
@@ -579,67 +699,160 @@ def recursively_apply(layout, getfunction, args=(), depth=1):
         return layout
 
     elif isinstance(layout, awkward1.layout.RegularArray):
-        return awkward1.layout.RegularArray(recursively_apply(layout.content, getfunction, args, depth + 1), layout.size, layout.identities, layout.parameters)
+        return awkward1.layout.RegularArray(
+            recursively_apply(layout.content, getfunction, args, depth + 1),
+            layout.size,
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.ListArray32):
-        return awkward1.layout.ListArray32(layout.starts, layout.stops, recursively_apply(layout.content, getfunction, args, depth + 1), layout.identities, layout.parameters)
+        return awkward1.layout.ListArray32(
+            layout.starts,
+            layout.stops,
+            recursively_apply(layout.content, getfunction, args, depth + 1),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.ListArrayU32):
-        return awkward1.layout.ListArrayU32(layout.starts, layout.stops, recursively_apply(layout.content, getfunction, args, depth + 1), layout.identities, layout.parameters)
+        return awkward1.layout.ListArrayU32(
+            layout.starts,
+            layout.stops,
+            recursively_apply(layout.content, getfunction, args, depth + 1),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.ListArray64):
-        return awkward1.layout.ListArray64(layout.starts, layout.stops, recursively_apply(layout.content, getfunction, args, depth + 1), layout.identities, layout.parameters)
+        return awkward1.layout.ListArray64(
+            layout.starts,
+            layout.stops,
+            recursively_apply(layout.content, getfunction, args, depth + 1),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.ListOffsetArray32):
-        return awkward1.layout.ListOffsetArray32(layout.offsets, recursively_apply(layout.content, getfunction, args, depth + 1), layout.identities, layout.parameters)
+        return awkward1.layout.ListOffsetArray32(
+            layout.offsets,
+            recursively_apply(layout.content, getfunction, args, depth + 1),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.ListOffsetArrayU32):
-        return awkward1.layout.ListOffsetArrayU32(layout.offsets, recursively_apply(layout.content, getfunction, args, depth + 1), layout.identities, layout.parameters)
+        return awkward1.layout.ListOffsetArrayU32(
+            layout.offsets,
+            recursively_apply(layout.content, getfunction, args, depth + 1),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.ListOffsetArray64):
-        return awkward1.layout.ListOffsetArray64(layout.offsets, recursively_apply(layout.content, getfunction, args, depth + 1), layout.identities, layout.parameters)
+        return awkward1.layout.ListOffsetArray64(
+            layout.offsets,
+            recursively_apply(layout.content, getfunction, args, depth + 1),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.IndexedArray32):
-        return awkward1.layout.IndexedArray32(layout.index, recursively_apply(layout.content, getfunction, args, depth), layout.identities, layout.parameters)
+        return awkward1.layout.IndexedArray32(
+            layout.index,
+            recursively_apply(layout.content, getfunction, args, depth),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.IndexedArrayU32):
-        return awkward1.layout.IndexedArrayU32(layout.index, recursively_apply(layout.content, getfunction, args, depth), layout.identities, layout.parameters)
+        return awkward1.layout.IndexedArrayU32(
+            layout.index,
+            recursively_apply(layout.content, getfunction, args, depth),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.IndexedArray64):
-        return awkward1.layout.IndexedArray64(layout.index, recursively_apply(layout.content, getfunction, args, depth), layout.identities, layout.parameters)
+        return awkward1.layout.IndexedArray64(
+            layout.index,
+            recursively_apply(layout.content, getfunction, args, depth),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.IndexedOptionArray32):
-        return awkward1.layout.IndexedOptionArray32(layout.index, recursively_apply(layout.content, getfunction, args, depth), layout.identities, layout.parameters)
+        return awkward1.layout.IndexedOptionArray32(
+            layout.index,
+            recursively_apply(layout.content, getfunction, args, depth),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.IndexedOptionArray64):
-        return awkward1.layout.IndexedOptionArray64(layout.index, recursively_apply(layout.content, getfunction, args, depth), layout.identities, layout.parameters)
+        return awkward1.layout.IndexedOptionArray64(
+            layout.index,
+            recursively_apply(layout.content, getfunction, args, depth),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.ByteMaskedArray):
-        return awkward1.layout.ByteMaskedArray(layout.mask, recursively_apply(layout.content, getfunction, args, depth), layout.validwhen, layout.identities, layout.parameters)
+        return awkward1.layout.ByteMaskedArray(
+            layout.mask,
+            recursively_apply(layout.content, getfunction, args, depth),
+            layout.validwhen,
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.BitMaskedArray):
-        return awkward1.layout.BitMaskedArray(layout.mask, recursively_apply(layout.content, getfunction, args, depth), layout.validwhen, len(layout), layout.lsb_order, layout.identities, layout.parameters)
+        return awkward1.layout.BitMaskedArray(
+            layout.mask,
+            recursively_apply(layout.content, getfunction, args, depth),
+            layout.validwhen,
+            len(layout),
+            layout.lsb_order,
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.UnmaskedArray):
-        return awkward1.layout.UnmaskedArray(recursively_apply(layout.content, getfunction, args, depth), layout.identities, layout.parameters)
+        return awkward1.layout.UnmaskedArray(
+            recursively_apply(layout.content, getfunction, args, depth),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.RecordArray):
-        return awkward1.layout.RecordArray([recursively_apply(x, getfunction, args, depth) for x in layout.contents], layout.recordlookup, len(layout), layout.identities, layout.parameters)
+        return awkward1.layout.RecordArray(
+            [recursively_apply(x, getfunction, args, depth)
+               for x in layout.contents],
+            layout.recordlookup,
+            len(layout),
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.Record):
-        return awkward1.layout.Record(recursively_apply(layout.array, getfunction, args, depth), layout.at)
+        return awkward1.layout.Record(
+            recursively_apply(layout.array, getfunction, args, depth),
+            layout.at)
 
     elif isinstance(layout, awkward1.layout.UnionArray8_32):
-        return awkward1.layout.UnionArray8_32(layout.tags, layout.index, [recursively_apply(x, getfunction, args, depth) for x in layout.contents], layout.identities, layout.parameters)
+        return awkward1.layout.UnionArray8_32(
+            layout.tags,
+            layout.index,
+            [recursively_apply(x, getfunction, args, depth)
+               for x in layout.contents],
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.UnionArray8_U32):
-        return awkward1.layout.UnionArray8_U32(layout.tags, layout.index, [recursively_apply(x, getfunction, args, depth) for x in layout.contents], layout.identities, layout.parameters)
+        return awkward1.layout.UnionArray8_U32(
+            layout.tags,
+            layout.index,
+            [recursively_apply(x, getfunction, args, depth)
+               for x in layout.contents],
+            layout.identities,
+            layout.parameters)
 
     elif isinstance(layout, awkward1.layout.UnionArray8_64):
-        return awkward1.layout.UnionArray8_64(layout.tags, layout.index, [recursively_apply(x, getfunction, args, depth) for x in layout.contents], layout.identities, layout.parameters)
+        return awkward1.layout.UnionArray8_64(
+            layout.tags,
+            layout.index,
+            [recursively_apply(x, getfunction, args, depth)
+               for x in layout.contents],
+            layout.identities,
+            layout.parameters)
 
     else:
-        raise AssertionError("unrecognized Content type: {0}".format(type(layout)))
+        raise AssertionError(
+                "unrecognized Content type: {0}".format(type(layout)))
 
 def minimally_touching_string(limit_length, layout, behavior):
     import awkward1.layout
@@ -770,19 +983,23 @@ def minimally_touching_string(limit_length, layout, behavior):
     halfway = len(layout) // 2
     left, right = ["["], ["]"]
     leftlen, rightlen = 1, 1
-    leftgen = forever(forward(layout[:halfway], "", brackets=False, wrap=False))
-    rightgen = forever(backward(layout[halfway:], "", brackets=False, wrap=False))
+    leftgen = \
+      forever(forward(layout[:halfway], "", brackets=False, wrap=False))
+    rightgen = \
+      forever(backward(layout[halfway:], "", brackets=False, wrap=False))
     while True:
         l = next(leftgen)
         if l is not None:
-            if leftlen + rightlen + len(l) + (2 if l is None and r is None else 6) > limit_length:
+            if (leftlen + rightlen + len(l)
+                + (2 if l is None and r is None else 6) > limit_length):
                 break
             left.append(l)
             leftlen += len(l)
 
         r = next(rightgen)
         if r is not None:
-            if leftlen + rightlen + len(r) + (2 if l is None and r is None else 6) > limit_length:
+            if (leftlen + rightlen + len(r)
+                + (2 if l is None and r is None else 6) > limit_length):
                 break
             right.append(r)
             rightlen += len(r)
@@ -790,21 +1007,31 @@ def minimally_touching_string(limit_length, layout, behavior):
         if l is None and r is None:
             break
 
-    while len(left) > 1 and (left[-1] == "[" or left[-1] == ", [" or left[-1] == "{" or left[-1] == ", {" or left[-1] == ", "):
+    while len(left) > 1 and (left[-1] == "[" or
+                             left[-1] == ", [" or
+                             left[-1] == "{" or
+                             left[-1] == ", {" or
+                             left[-1] == ", "):
         left.pop()
         l = ""
-    while len(right) > 1 and (right[-1] == "]" or right[-1] == "], " or right[-1] == "}" or right[-1] == "}, " or right[-1] == ", "):
+    while len(right) > 1 and (right[-1] == "]" or
+                              right[-1] == "], " or
+                              right[-1] == "}" or
+                              right[-1] == "}, " or
+                              right[-1] == ", "):
         right.pop()
         r = ""
     if l is None and r is None:
         if left == ["["]:
             return "[" + "".join(reversed(right)).lstrip(" ")
         else:
-            return "".join(left).rstrip(" ") + ", " + "".join(reversed(right)).lstrip(" ")
+            return ("".join(left).rstrip(" ")
+                    + ", " + "".join(reversed(right)).lstrip(" "))
     else:
         if left == ["["] and right == ["]"]:
             return "[...]"
         elif left == ["["]:
             return "[... " + "".join(reversed(right)).lstrip(" ")
         else:
-            return "".join(left).rstrip(" ") + ", ... " + "".join(reversed(right)).lstrip(" ")
+            return ("".join(left).rstrip(" ") + ", ... "
+                    + "".join(reversed(right)).lstrip(" "))

--- a/src/awkward1/highlevel.py
+++ b/src/awkward1/highlevel.py
@@ -20,20 +20,27 @@ import awkward1.operations.convert
 
 _dir_pattern = re.compile(r"^[a-zA-Z_]\w*$")
 
-class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._pandas.PandasMixin, Sequence):
+class Array(awkward1._connect._numpy.NDArrayOperatorsMixin,
+            awkward1._connect._pandas.PandasMixin, Sequence):
     def __init__(self, data, behavior=None, checkvalid=False):
         if isinstance(data, awkward1.layout.Content):
             layout = data
         elif isinstance(data, Array):
             layout = data.layout
         elif isinstance(data, numpy.ndarray):
-            layout = awkward1.operations.convert.fromnumpy(data, highlevel=False)
+            layout = awkward1.operations.convert.fromnumpy(data,
+                                                           highlevel=False)
         elif isinstance(data, str):
-            layout = awkward1.operations.convert.fromjson(data, highlevel=False)
+            layout = awkward1.operations.convert.fromjson(data,
+                                                          highlevel=False)
         elif isinstance(data, dict):
-            raise TypeError("could not convert dict into an awkward1.Array; try awkward1.Record")
+            raise TypeError(
+                    "could not convert dict into an awkward1.Array; "
+                    "try awkward1.Record")
         else:
-            layout = awkward1.operations.convert.fromiter(data, highlevel=False, allowrecord=False)
+            layout = awkward1.operations.convert.fromiter(data,
+                                                          highlevel=False,
+                                                          allowrecord=False)
         if not isinstance(layout, awkward1.layout.Content):
             raise TypeError("could not convert data into an awkward1.Array")
 
@@ -55,7 +62,8 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
             self._layout = layout
             self._numbaview = None
         else:
-            raise TypeError("layout must be a subclass of awkward1.layout.Content")
+            raise TypeError(
+                    "layout must be a subclass of awkward1.layout.Content")
 
     @property
     def behavior(self):
@@ -70,7 +78,9 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
 
     @property
     def type(self):
-        return awkward1.types.ArrayType(self._layout.type(awkward1._util.typestrs(self._behavior)), len(self._layout))
+        return awkward1.types.ArrayType(
+                 self._layout.type(awkward1._util.typestrs(self._behavior)),
+                 len(self._layout))
 
     def __len__(self):
         return len(self._layout)
@@ -84,8 +94,11 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
 
     def __setitem__(self, where, what):
         if not isinstance(where, str):
-            raise ValueError("only fields may be assigned in-place (by field name)")
-        self._layout = awkward1.operations.structure.withfield(self._layout, what, where).layout
+            raise ValueError(
+                    "only fields may be assigned in-place (by field name)")
+        self._layout = awkward1.operations.structure.withfield(self._layout,
+                                                               what,
+                                                               where).layout
         self._numbaview = None
 
     def __getattr__(self, where):
@@ -96,12 +109,19 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
                 try:
                     return self[where]
                 except Exception as err:
-                    raise AttributeError("while trying to get field {0}, an exception occurred:\n{1}: {2}".format(repr(where), type(err), str(err)))
+                    raise AttributeError(
+                            "while trying to get field {0}, an exception "
+                            "occurred:\n{1}: {2}".format(repr(where),
+                                                         type(err),
+                                                         str(err)))
             else:
                 raise AttributeError("no field named {0}".format(repr(where)))
 
     def __dir__(self):
-        return sorted(set(dir(super(Array, self)) + [x for x in self._layout.keys() if _dir_pattern.match(x) and not keyword.iskeyword(x)]))
+        return sorted(set(dir(super(Array, self))
+                          + [x for x in self._layout.keys()
+                               if _dir_pattern.match(x) and
+                                  not keyword.iskeyword(x)]))
 
     @property
     def i0(self):
@@ -135,10 +155,14 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
         return self["9"]
 
     def __str__(self, limit_value=85):
-        return awkward1._util.minimally_touching_string(limit_value, self._layout, self._behavior)
+        return awkward1._util.minimally_touching_string(limit_value,
+                                                        self._layout,
+                                                        self._behavior)
 
     def __repr__(self, limit_value=40, limit_total=85):
-        value = awkward1._util.minimally_touching_string(limit_value, self._layout, self._behavior)
+        value = awkward1._util.minimally_touching_string(limit_value,
+                                                         self._layout,
+                                                         self._behavior)
 
         limit_type = limit_total - len(value) - len("<Array  type=>")
         type = repr(str(self.type))
@@ -150,20 +174,31 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
     def __array__(self, *args, **kwargs):
         if awkward1._util.called_by_module("pandas"):
             try:
-                return awkward1._connect._numpy.convert_to_array(self._layout, args, kwargs)
+                return awkward1._connect._numpy.convert_to_array(self._layout,
+                                                                 args,
+                                                                 kwargs)
             except:
                 out = numpy.empty(len(self._layout), dtype="O")
                 for i, x in enumerate(self._layout):
                     out[i] = awkward1._util.wrap(x, self._behavior)
                 return out
         else:
-            return awkward1._connect._numpy.convert_to_array(self._layout, args, kwargs)
+            return awkward1._connect._numpy.convert_to_array(self._layout,
+                                                             args,
+                                                             kwargs)
 
     def __array_function__(self, func, types, args, kwargs):
-        return awkward1._connect._numpy.array_function(func, types, args, kwargs)
+        return awkward1._connect._numpy.array_function(func,
+                                                       types,
+                                                       args,
+                                                       kwargs)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        return awkward1._connect._numpy.array_ufunc(ufunc, method, inputs, kwargs, self._behavior)
+        return awkward1._connect._numpy.array_ufunc(ufunc,
+                                                    method,
+                                                    inputs,
+                                                    kwargs,
+                                                    self._behavior)
 
     @property
     def numbatype(self):
@@ -171,7 +206,8 @@ class Array(awkward1._connect._numpy.NDArrayOperatorsMixin, awkward1._connect._p
         import awkward1._connect._numba
         awkward1._connect._numba.register()
         if self._numbaview is None:
-            self._numbaview = awkward1._connect._numba.arrayview.ArrayView.fromarray(self)
+            self._numbaview = \
+              awkward1._connect._numba.arrayview.ArrayView.fromarray(self)
         return numba.typeof(self._numbaview)
 
 class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
@@ -181,11 +217,14 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
         elif isinstance(data, Record):
             layout = data.layout
         elif isinstance(data, str):
-            layout = awkward1.operations.convert.fromjson(data, highlevel=False)
+            layout = awkward1.operations.convert.fromjson(data,
+                                                          highlevel=False)
         elif isinstance(data, dict):
-            layout = awkward1.operations.convert.fromiter([data], highlevel=False)[0]
+            layout = awkward1.operations.convert.fromiter([data],
+                                                          highlevel=False)[0]
         elif isinstance(data, Iterable):
-            raise TypeError("could not convert non-dict into an awkward1.Record; try awkward1.Array")
+            raise TypeError("could not convert non-dict into an "
+                            "awkward1.Record; try awkward1.Array")
         else:
             layout = None
         if not isinstance(layout, awkward1.layout.Record):
@@ -209,7 +248,8 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
             self._layout = layout
             self._numbaview = None
         else:
-            raise TypeError("layout must be a subclass of awkward1.layout.Record")
+            raise TypeError(
+                    "layout must be a subclass of awkward1.layout.Record")
 
     @property
     def behavior(self):
@@ -231,8 +271,11 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
 
     def __setitem__(self, where, what):
         if not isinstance(where, str):
-            raise ValueError("only fields may be assigned in-place (by field name)")
-        self._layout = awkward1.operations.structure.withfield(self._layout, what, where).layout
+            raise ValueError(
+                    "only fields may be assigned in-place (by field name)")
+        self._layout = awkward1.operations.structure.withfield(self._layout,
+                                                               what,
+                                                               where).layout
         self._numbaview = None
 
     def __getattr__(self, where):
@@ -243,12 +286,19 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
                 try:
                     return self[where]
                 except Exception as err:
-                    raise AttributeError("while trying to get field {0}, an exception occurred:\n{1}: {2}".format(repr(where), type(err), str(err)))
+                    raise AttributeError(
+                            "while trying to get field {0}, an exception "
+                            "occurred:\n{1}: {2}".format(repr(where),
+                                                         type(err),
+                                                         str(err)))
             else:
                 raise AttributeError("no field named {0}".format(repr(where)))
 
     def __dir__(self):
-        return sorted(set(dir(super(Array, self)) + [x for x in self._layout.keys() if _dir_pattern.match(x) and not keyword.iskeyword(x)]))
+        return sorted(set(dir(super(Array, self))
+                          + [x for x in self._layout.keys()
+                               if _dir_pattern.match(x) and
+                               not keyword.iskeyword(x)]))
 
     @property
     def i0(self):
@@ -282,10 +332,14 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
         return self["9"]
 
     def __str__(self, limit_value=85):
-        return awkward1._util.minimally_touching_string(limit_value + 2, self._layout, self._behavior)[1:-1]
+        return awkward1._util.minimally_touching_string(limit_value + 2,
+                                                        self._layout,
+                                                        self._behavior)[1:-1]
 
     def __repr__(self, limit_value=40, limit_total=85):
-        value = awkward1._util.minimally_touching_string(limit_value + 2, self._layout, self._behavior)[1:-1]
+        value = awkward1._util.minimally_touching_string(limit_value + 2,
+                                                         self._layout,
+                                                         self._behavior)[1:-1]
 
         limit_type = limit_total - len(value) - len("<Record  type=>")
         type = repr(str(self.type))
@@ -295,7 +349,11 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
         return "<Record {0} type={1}>".format(value, type)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        return awkward1._connect._numpy.array_ufunc(ufunc, method, inputs, kwargs, self._behavior)
+        return awkward1._connect._numpy.array_ufunc(ufunc,
+                                                    method,
+                                                    inputs,
+                                                    kwargs,
+                                                    self._behavior)
 
     @property
     def numbatype(self):
@@ -303,7 +361,8 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
         import awkward1._connect._numba
         awkward1._connect._numba.register()
         if self._numbaview is None:
-            self._numbaview = awkward1._connect._numba.arrayview.RecordView.fromrecord(self)
+            self._numbaview = \
+              awkward1._connect._numba.arrayview.RecordView.fromrecord(self)
         return numba.typeof(self._numbaview)
 
 class ArrayBuilder(Sequence):
@@ -333,7 +392,8 @@ class ArrayBuilder(Sequence):
     @property
     def type(self):
         tmp = self._layout.snapshot()
-        return awkward1.types.ArrayType(tmp.type(awkward1._util.typestrs(self._behavior)), len(tmp))
+        return awkward1.types.ArrayType(
+                 tmp.type(awkward1._util.typestrs(self._behavior)), len(tmp))
 
     def __len__(self):
         return len(self._layout)
@@ -362,20 +422,29 @@ class ArrayBuilder(Sequence):
         return "<ArrayBuilder {0} type={1}>".format(value, type)
 
     def __array__(self, *args, **kwargs):
-        return awkward1._connect._numpy.convert_to_array(self._layout.snapshot(), args, kwargs)
+        return awkward1._connect._numpy.convert_to_array(
+                 self._layout.snapshot(), args, kwargs)
 
     def __array_function__(self, func, types, args, kwargs):
-        return awkward1._connect._numpy.array_function(func, types, args, kwargs)
+        return awkward1._connect._numpy.array_function(func,
+                                                       types,
+                                                       args,
+                                                       kwargs)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        return awkward1._connect._numpy.array_ufunc(ufunc, method, inputs, kwargs, self._behavior)
+        return awkward1._connect._numpy.array_ufunc(ufunc,
+                                                    method,
+                                                    inputs,
+                                                    kwargs,
+                                                    self._behavior)
 
     @property
     def numbatype(self):
         import numba
         import awkward1._connect._numba.builder
         awkward1._connect._numba.register()
-        return awkward1._connect._numba.builder.ArrayBuilderType(self._behavior)
+        return awkward1._connect._numba.builder.ArrayBuilderType(
+                 self._behavior)
 
     def snapshot(self):
         return awkward1._util.wrap(self._layout.snapshot(), self._behavior)
@@ -435,7 +504,9 @@ class ArrayBuilder(Sequence):
             if isinstance(obj, Array):
                 self._layout.append(obj.layout, at)
             else:
-                raise TypeError("'append' method can only be used with 'at' when 'obj' is an ak.Array")
+                raise TypeError(
+                        "'append' method can only be used with 'at' when "
+                        "'obj' is an ak.Array")
 
     def extend(self, obj):
         if isinstance(obj, Array):

--- a/src/awkward1/highlevel.py
+++ b/src/awkward1/highlevel.py
@@ -415,7 +415,8 @@ class ArrayBuilder(Sequence):
         value = self.__str__(limit_value=limit_value, snapshot=snapshot)
 
         limit_type = limit_total - len(value) - len("<ArrayBuilder  type=>")
-        type = repr(str(snapshot.type(awkward1._util.typestrs(self._behavior))))
+        typestrs = awkward1._util.typestrs(self._behavior)
+        type = repr(str(snapshot.type(typestrs)))
         if len(type) > limit_type:
             type = type[:(limit_type - 4)] + "..." + type[-1]
 

--- a/src/awkward1/operations/describe.py
+++ b/src/awkward1/operations/describe.py
@@ -9,7 +9,9 @@ import numpy
 import awkward1.layout
 
 def keys(array):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=True, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=True,
+                                                  allowother=False)
     return layout.keys()
 
 def parameters(array):
@@ -41,10 +43,23 @@ def typeof(array):
     elif isinstance(array, numbers.Real):
         return awkward1.types.PrimitiveType("float64")
 
-    elif isinstance(array, (numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float32, numpy.float64)):
-        return awkward1.types.PrimitiveType(typeof.dtype2primitive[array.dtype.type])
+    elif isinstance(array,
+                    (numpy.int8,
+                     numpy.int16,
+                     numpy.int32,
+                     numpy.int64,
+                     numpy.uint8,
+                     numpy.uint16,
+                     numpy.uint32,
+                     numpy.uint64,
+                     numpy.float32,
+                     numpy.float64)):
+        return awkward1.types.PrimitiveType(
+                 typeof.dtype2primitive[array.dtype.type])
 
-    elif isinstance(array, (awkward1.highlevel.Array, awkward1.highlevel.Record, awkward1.highlevel.ArrayBuilder)):
+    elif isinstance(array, (awkward1.highlevel.Array,
+                            awkward1.highlevel.Record,
+                            awkward1.highlevel.ArrayBuilder)):
         return array.type
 
     elif isinstance(array, awkward1.layout.Record):
@@ -54,7 +69,8 @@ def typeof(array):
         if len(array.shape) == 0:
             return typeof(array.reshape((1,))[0])
         else:
-            out = awkward1.types.PrimitiveType(typeof.dtype2primitive[array.dtype.type])
+            out = awkward1.types.PrimitiveType(
+                    typeof.dtype2primitive[array.dtype.type])
             for x in array.shape[-1:0:-1]:
                 out = awkward1.types.RegularType(out, x)
             return awkward1.types.ArrayType(out, array.shape[0])
@@ -82,7 +98,8 @@ typeof.dtype2primitive = {
 }
 
 def validityerror(array, exception=False):
-    if isinstance(array, (awkward1.highlevel.Array, awkward1.highlevel.Record)):
+    if isinstance(array, (awkward1.highlevel.Array,
+                          awkward1.highlevel.Record)):
         return validityerror(array.layout, exception=exception)
 
     elif isinstance(array, awkward1.highlevel.ArrayBuilder):
@@ -105,4 +122,6 @@ def isvalid(array, exception=False):
     out = validityerror(array, exception=exception)
     return out is None
 
-__all__ = [x for x in list(globals()) if not x.startswith("_") and x not in ("numbers", "numpy", "awkward1")]
+__all__ = [x for x in list(globals())
+             if not x.startswith("_") and
+             x not in ("numbers", "numpy", "awkward1")]

--- a/src/awkward1/operations/describe.py
+++ b/src/awkward1/operations/describe.py
@@ -15,10 +15,12 @@ def keys(array):
     return layout.keys()
 
 def parameters(array):
-    if isinstance(array, (awkward1.highlevel.Array, awkward1.highlevel.Record)):
+    if isinstance(array, (awkward1.highlevel.Array,
+                          awkward1.highlevel.Record)):
         return array.layout.parameters
 
-    elif isinstance(array, (awkward1.layout.Content, awkward1.layout.Record)):
+    elif isinstance(array, (awkward1.layout.Content,
+                            awkward1.layout.Record)):
         return array.parameters
 
     elif isinstance(array, awkward1.highlevel.ArrayBuilder):

--- a/src/awkward1/operations/reducers.py
+++ b/src/awkward1/operations/reducers.py
@@ -10,91 +10,129 @@ import awkward1.layout
 import awkward1.operations.convert
 
 def count(array, axis=None, keepdims=False, maskidentity=False):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         def reduce(xs):
             if len(xs) == 1:
                 return xs[0]
             else:
                 return xs[0] + reduce(xs[1:])
-        return reduce([numpy.size(x) for x in awkward1._util.completely_flatten(layout)])
+        return reduce([numpy.size(x)
+                         for x in awkward1._util.completely_flatten(layout)])
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.count(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.count(axis=axis,
+                                                mask=maskidentity,
+                                                keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.count_nonzero)
 def count_nonzero(array, axis=None, keepdims=False, maskidentity=False):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         def reduce(xs):
             if len(xs) == 1:
                 return xs[0]
             else:
                 return xs[0] + reduce(xs[1:])
-        return reduce([numpy.count_nonzero(x) for x in awkward1._util.completely_flatten(layout)])
+        return reduce([numpy.count_nonzero(x)
+                         for x in awkward1._util.completely_flatten(layout)])
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.count_nonzero(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.count_nonzero(axis=axis,
+                                                        mask=maskidentity,
+                                                        keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.sum)
 def sum(array, axis=None, keepdims=False, maskidentity=False):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         def reduce(xs):
             if len(xs) == 1:
                 return xs[0]
             else:
                 return xs[0] + reduce(xs[1:])
-        return reduce([numpy.sum(x) for x in awkward1._util.completely_flatten(layout)])
+        return reduce([numpy.sum(x)
+                         for x in awkward1._util.completely_flatten(layout)])
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.sum(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.sum(axis=axis,
+                                              mask=maskidentity,
+                                              keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.prod)
 def prod(array, axis=None, keepdims=False, maskidentity=False):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         def reduce(xs):
             if len(xs) == 1:
                 return xs[0]
             else:
                 return xs[0] * reduce(xs[1:])
-        return reduce([numpy.prod(x) for x in awkward1._util.completely_flatten(layout)])
+        return reduce([numpy.prod(x)
+                         for x in awkward1._util.completely_flatten(layout)])
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.prod(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.prod(axis=axis,
+                                               mask=maskidentity,
+                                               keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.any)
 def any(array, axis=None, keepdims=False, maskidentity=False):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         def reduce(xs):
             if len(xs) == 1:
                 return xs[0]
             else:
                 return xs[0] or reduce(xs[1:])
-        return reduce([numpy.any(x) for x in awkward1._util.completely_flatten(layout)])
+        return reduce([numpy.any(x)
+                         for x in awkward1._util.completely_flatten(layout)])
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.any(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.any(axis=axis,
+                                              mask=maskidentity,
+                                              keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.all)
 def all(array, axis=None, keepdims=False, maskidentity=False):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         def reduce(xs):
             if len(xs) == 1:
                 return xs[0]
             else:
                 return xs[0] and reduce(xs[1:])
-        return reduce([numpy.all(x) for x in awkward1._util.completely_flatten(layout)])
+        return reduce([numpy.all(x)
+                         for x in awkward1._util.completely_flatten(layout)])
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.all(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.all(axis=axis,
+                                              mask=maskidentity,
+                                              keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.min)
 def min(array, axis=None, keepdims=False, maskidentity=True):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         def reduce(xs):
             if len(xs) == 0:
@@ -108,11 +146,16 @@ def min(array, axis=None, keepdims=False, maskidentity=True):
         return reduce([numpy.min(x) for x in tmp if len(x) > 0])
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.min(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.min(axis=axis,
+                                              mask=maskidentity,
+                                              keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.max)
 def max(array, axis=None, keepdims=False, maskidentity=True):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         def reduce(xs):
             if len(xs) == 0:
@@ -126,29 +169,43 @@ def max(array, axis=None, keepdims=False, maskidentity=True):
         return reduce([numpy.max(x) for x in tmp if len(x) > 0])
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.max(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.max(axis=axis,
+                                              mask=maskidentity,
+                                              keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.argmin)
 def argmin(array, axis=None, keepdims=False, maskidentity=True):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         tmp = awkward1._util.completely_flatten(layout)
         return numpy.argmin(tmp, axis=None)
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.argmin(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.argmin(axis=axis,
+                                                 mask=maskidentity,
+                                                 keepdims=keepdims),
+                                   behavior)
 
 @awkward1._connect._numpy.implements(numpy.argmax)
 def argmax(array, axis=None, keepdims=False, maskidentity=True):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if axis is None:
         tmp = awkward1._util.completely_flatten(layout)
         return numpy.argmax(tmp, axis=None)
     else:
         behavior = awkward1._util.behaviorof(array)
-        return awkward1._util.wrap(layout.argmax(axis=axis, mask=maskidentity, keepdims=keepdims), behavior)
+        return awkward1._util.wrap(layout.argmax(axis=axis,
+                                                 mask=maskidentity,
+                                                 keepdims=keepdims),
+                                   behavior)
 
-### The following are not strictly reducers, but are defined in terms of reducers and ufuncs.
+# The following are not strictly reducers, but are defined in terms of
+# reducers and ufuncs.
 
 def moment(x, n, weight=None, axis=None, keepdims=False):
     with numpy.errstate(invalid="ignore"):
@@ -182,14 +239,19 @@ def var(x, weight=None, ddof=0, axis=None, keepdims=False):
             sumw   = sum(x*0 + weight, axis=axis, keepdims=keepdims)
             sumwxx = sum((x - xmean)**2 * weight, axis=axis, keepdims=keepdims)
         if ddof != 0:
-            return numpy.true_divide(sumwxx, sumw) * numpy.true_divide(sumw, sumw - ddof)
+            return (numpy.true_divide(sumwxx, sumw) *
+                    numpy.true_divide(sumw, sumw - ddof))
         else:
             return numpy.true_divide(sumwxx, sumw)
 
 @awkward1._connect._numpy.implements(numpy.std)
 def std(x, weight=None, ddof=0, axis=None, keepdims=False):
     with numpy.errstate(invalid="ignore"):
-        return numpy.sqrt(var(x, weight=weight, ddof=ddof, axis=axis, keepdims=keepdims))
+        return numpy.sqrt(var(x,
+                              weight=weight,
+                              ddof=ddof,
+                              axis=axis,
+                              keepdims=keepdims))
 
 def covar(x, y, weight=None, axis=None, keepdims=False):
     with numpy.errstate(invalid="ignore"):
@@ -200,7 +262,9 @@ def covar(x, y, weight=None, axis=None, keepdims=False):
             sumwxy = sum((x - xmean)*(y - ymean), axis=axis, keepdims=keepdims)
         else:
             sumw = sum(x*0 + weight, axis=axis, keepdims=keepdims)
-            sumwxy = sum((x - xmean)*(y - ymean)*weight, axis=axis, keepdims=keepdims)
+            sumwxy = sum((x - xmean)*(y - ymean)*weight,
+                         axis=axis,
+                         keepdims=keepdims)
         return numpy.true_divide(sumwxy, sumw)
 
 def corr(x, y, weight=None, axis=None, keepdims=False):
@@ -234,28 +298,50 @@ def linearfit(x, y, weight=None, axis=None, keepdims=False):
             sumwxx = sum((x**2)*weight, axis=axis, keepdims=keepdims)
             sumwxy = sum(x*y*weight, axis=axis, keepdims=keepdims)
         delta           = (sumw*sumwxx) - (sumwx*sumwx)
-        intercept       = numpy.true_divide(((sumwxx*sumwy) - (sumwx*sumwxy)), delta)
-        slope           = numpy.true_divide(((sumw*sumwxy) - (sumwx*sumwy)), delta)
+        intercept       = numpy.true_divide(((sumwxx*sumwy) - (sumwx*sumwxy)),
+                                            delta)
+        slope           = numpy.true_divide(((sumw*sumwxy) - (sumwx*sumwy)),
+                                            delta)
         intercept_error = numpy.sqrt(numpy.true_divide(sumwxx, delta))
         slope_error     = numpy.sqrt(numpy.true_divide(sumw, delta))
 
-        intercept       = awkward1.operations.convert.tolayout(intercept, allowrecord=True, allowother=True)
-        slope           = awkward1.operations.convert.tolayout(slope, allowrecord=True, allowother=True)
-        intercept_error = awkward1.operations.convert.tolayout(intercept_error, allowrecord=True, allowother=True)
-        slope_error     = awkward1.operations.convert.tolayout(slope_error, allowrecord=True, allowother=True)
+        intercept       = awkward1.operations.convert.tolayout(
+                            intercept, allowrecord=True, allowother=True)
+        slope           = awkward1.operations.convert.tolayout(
+                            slope, allowrecord=True, allowother=True)
+        intercept_error = awkward1.operations.convert.tolayout(
+                            intercept_error, allowrecord=True, allowother=True)
+        slope_error     = awkward1.operations.convert.tolayout(
+                            slope_error, allowrecord=True, allowother=True)
 
-        scalar = not isinstance(intercept, awkward1.layout.Content) and not isinstance(slope, awkward1.layout.Content) and not isinstance(intercept_error, awkward1.layout.Content) and not isinstance(slope_error, awkward1.layout.Content)
+        scalar = (not isinstance(intercept, awkward1.layout.Content) and
+                  not isinstance(slope, awkward1.layout.Content) and
+                  not isinstance(intercept_error, awkward1.layout.Content) and
+                  not isinstance(slope_error, awkward1.layout.Content))
 
-        if not isinstance(intercept, (awkward1.layout.Content, awkward1.layout.Record)):
+        if not isinstance(intercept, (awkward1.layout.Content,
+                                      awkward1.layout.Record)):
             intercept = awkward1.layout.NumpyArray(numpy.array([intercept]))
-        if not isinstance(slope, (awkward1.layout.Content, awkward1.layout.Record)):
+        if not isinstance(slope, (awkward1.layout.Content,
+                                  awkward1.layout.Record)):
             slope = awkward1.layout.NumpyArray(numpy.array([slope]))
-        if not isinstance(intercept_error, (awkward1.layout.Content, awkward1.layout.Record)):
-            intercept_error = awkward1.layout.NumpyArray(numpy.array([intercept_error]))
-        if not isinstance(slope_error, (awkward1.layout.Content, awkward1.layout.Record)):
-            slope_error = awkward1.layout.NumpyArray(numpy.array([slope_error]))
+        if not isinstance(intercept_error, (awkward1.layout.Content,
+                                            awkward1.layout.Record)):
+            intercept_error = awkward1.layout.NumpyArray(
+                                numpy.array([intercept_error]))
+        if not isinstance(slope_error, (awkward1.layout.Content,
+                                        awkward1.layout.Record)):
+            slope_error = awkward1.layout.NumpyArray(
+                            numpy.array([slope_error]))
 
-        out = awkward1.layout.RecordArray([intercept, slope, intercept_error, slope_error], ["intercept", "slope", "intercept_error", "slope_error"])
+        out = awkward1.layout.RecordArray([intercept,
+                                           slope,
+                                           intercept_error,
+                                           slope_error],
+                                          ["intercept",
+                                           "slope",
+                                           "intercept_error",
+                                           "slope_error"])
         out.setparameter("__record__", "LinearFit")
         if scalar:
             out = out[0]
@@ -268,4 +354,6 @@ def softmax(x, axis=None, keepdims=False):
         denom = sum(expx, axis=axis, keepdims=keepdims)
         return numpy.true_divide(expx, denom)
 
-__all__ = [x for x in list(globals()) if not x.startswith("_") and x not in ("collections", "numpy", "awkward1")]
+__all__ = [x for x in list(globals())
+             if not x.startswith("_") and
+             x not in ("collections", "numpy", "awkward1")]

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -15,20 +15,27 @@ import awkward1._connect._numpy
 import awkward1.operations.convert
 
 def withfield(base, what, where=None, highlevel=True):
-    base = awkward1.operations.convert.tolayout(base, allowrecord=True, allowother=False)
-    what = awkward1.operations.convert.tolayout(what, allowrecord=True, allowother=True)
+    base = awkward1.operations.convert.tolayout(base,
+                                                allowrecord=True,
+                                                allowother=False)
+    what = awkward1.operations.convert.tolayout(what,
+                                                allowrecord=True,
+                                                allowother=True)
 
     def getfunction(inputs, depth):
         base, what = inputs
         if isinstance(base, awkward1.layout.RecordArray):
             if not isinstance(what, awkward1.layout.Content):
-                what = awkward1.layout.NumpyArray(numpy.lib.stride_tricks.as_strided([what], shape=(len(base),), strides=(0,)))
+                what = awkward1.layout.NumpyArray(
+                    numpy.lib.stride_tricks.as_strided(
+                      [what], shape=(len(base),), strides=(0,)))
             return lambda: (base.setitem_field(where, what),)
         else:
             return None
 
     behavior = awkward1._util.behaviorof(base, what)
-    out = awkward1._util.broadcast_and_apply([base, what], getfunction, behavior)
+    out = awkward1._util.broadcast_and_apply(
+            [base, what], getfunction, behavior)
     assert isinstance(out, tuple) and len(out) == 1
     if highlevel:
         return awkward1._util.wrap(out[0], behavior=behavior)
@@ -44,7 +51,8 @@ def isna(array, highlevel=True):
             return apply(layout.project())
 
         elif isinstance(layout, awkward1._util.uniontypes):
-            contents = [apply(layout.project(i)) for i in range(layout.numcontents)]
+            contents = [apply(layout.project(i))
+                          for i in range(layout.numcontents)]
             out = numpy.empty(len(layout), dtype=numpy.bool_)
             tags = numpy.asarray(layout.tags)
             for tag, content in enumerate(contents):
@@ -60,7 +68,8 @@ def isna(array, highlevel=True):
 
     out = apply(awkward1.operations.convert.tolayout(array, allowrecord=False))
     if highlevel:
-        return awkward1._util.wrap(out, behavior=awkward1._util.behaviorof(array))
+        return awkward1._util.wrap(out,
+                                   behavior=awkward1._util.behaviorof(array))
     else:
         return out
 
@@ -68,10 +77,13 @@ def notna(array, highlevel=True):
     return ~isna(array, highlevel=highlevel)
 
 def num(array, axis=1, highlevel=True):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     out = layout.num(axis=axis)
     if highlevel:
-        return awkward1._util.wrap(out, behavior=awkward1._util.behaviorof(array))
+        return awkward1._util.wrap(out,
+                                   behavior=awkward1._util.behaviorof(array))
     else:
         return out
 
@@ -93,7 +105,9 @@ def size(array, axis=None):
                 if compare is None:
                     compare = inner
                 elif compare != inner:
-                    raise ValueError("ak.size is ambiguous due to union of different sizes")
+                    raise ValueError(
+                            "ak.size is ambiguous due to union of different "
+                            "sizes")
             sizes.extend(compare)
         elif isinstance(layout, awkward1._util.optiontypes):
             return recurse(layout.content, axis, sizes)
@@ -114,7 +128,9 @@ def size(array, axis=None):
                 if compare is None:
                     compare = inner
                 elif compare != inner:
-                    raise ValueError("ak.size is ambiguous due to record of different sizes")
+                    raise ValueError(
+                            "ak.size is ambiguous due to record of different "
+                            "sizes")
             sizes.extend(compare)
         elif isinstance(layout, awkward1.layout.NumpyArray):
             if axis is None:
@@ -134,26 +150,35 @@ def size(array, axis=None):
         out = 1
         for size in sizes:
             if size is None:
-                raise ValueError("ak.size is ambiguous due to variable-length arrays (try ak.flatten to remove structure or ak.tonumpy to force regularity, if possible)")
+                raise ValueError(
+                        "ak.size is ambiguous due to variable-length arrays "
+                        "(try ak.flatten to remove structure or ak.tonumpy to "
+                        "force regularity, if possible)")
             else:
                 out *= size
         return out
     else:
         if sizes[-1] is None:
-            raise ValueError("ak.size is ambiguous due to variable-length arrays at axis {0} (try ak.flatten to remove structure or ak.tonumpy to force regularity, if possible)".format(axis))
+            raise ValueError(
+                    "ak.size is ambiguous due to variable-length arrays at "
+                    "axis {0} (try ak.flatten to remove structure or "
+                    "ak.tonumpy to force regularity, if possible)".format(
+                                                                        axis))
         else:
             return sizes[-1]
 
 @awkward1._connect._numpy.implements(numpy.atleast_1d)
 def atleast_1d(*arrays):
-    return numpy.atleast_1d(*[awkward1.operations.convert.tonumpy(x) for x in arrays])
+    return numpy.atleast_1d(*[awkward1.operations.convert.tonumpy(x)
+                                for x in arrays])
 
 @awkward1._connect._numpy.implements(numpy.concatenate)
 def concatenate(arrays, axis=0, mergebool=True, highlevel=True):
     if axis != 0:
         raise NotImplementedError("axis={0}".format(axis))
 
-    contents = [awkward1.operations.convert.tolayout(x, allowrecord=False) for x in arrays]
+    contents = [awkward1.operations.convert.tolayout(x, allowrecord=False)
+                  for x in arrays]
 
     if len(contents) == 0:
         raise ValueError("need at least one array to concatenate")
@@ -167,7 +192,8 @@ def concatenate(arrays, axis=0, mergebool=True, highlevel=True):
             out = out.simplify(mergebool=mergebool)
 
     if highlevel:
-        return awkward1._util.wrap(out, behavior=awkward1._util.behaviorof(*arrays))
+        return awkward1._util.wrap(out,
+                                   behavior=awkward1._util.behaviorof(*arrays))
     else:
         return out
 
@@ -176,7 +202,10 @@ def broadcast_arrays(*arrays, **kwargs):
     highlevel, = awkward1._util.extra((), kwargs, [
         ("highlevel", True)])
 
-    inputs = [awkward1.operations.convert.tolayout(x, allowrecord=True, allowother=False) for x in arrays]
+    inputs = [awkward1.operations.convert.tolayout(x,
+                                                   allowrecord=True,
+                                                   allowother=False)
+                for x in arrays]
 
     def getfunction(inputs, depth):
         if all(isinstance(x, awkward1.layout.NumpyArray) for x in inputs):
@@ -203,7 +232,10 @@ def where(condition, *args, **kwargs):
     if len(args) == 0:
         out = numpy.nonzero(npcondition)
         if highlevel:
-            return tuple(awkward1._util.wrap(awkward1.layout.NumpyArray(x), awkward1._util.behaviorof(condition)) for x in out)
+            return tuple(
+                awkward1._util.wrap(awkward1.layout.NumpyArray(x),
+                                    awkward1._util.behaviorof(condition))
+                  for x in out)
         else:
             return tuple(awkward1.layout.NumpyArray(x) for x in out)
 
@@ -212,7 +244,8 @@ def where(condition, *args, **kwargs):
 
     elif len(args) == 2:
         if len(npcondition.shape) != 1:
-            raise NotImplementedError("FIXME: ak.where(condition, x, y) where condition is not 1-d")
+            raise NotImplementedError(
+                "FIXME: ak.where(condition, x, y) where condition is not 1-d")
 
         x = awkward1.operations.convert.tolayout(args[0], allowrecord=False)
         y = awkward1.operations.convert.tolayout(args[1], allowrecord=False)
@@ -227,13 +260,19 @@ def where(condition, *args, **kwargs):
         tmp = awkward1.layout.UnionArray8_64(tags, index, [x, y])
         out = tmp.simplify(mergebool=mergebool)
 
-        return awkward1._util.wrap(out, behavior=awkward1._util.behaviorof(*((npcondition,) + args)))
+        return awkward1._util.wrap(
+                 out, behavior=awkward1._util.behaviorof(*((npcondition,)
+                                                           + args)))
 
     else:
-        raise TypeError("where() takes from 1 to 3 positional arguments but {0} were given".format(len(args) + 1))
+        raise TypeError(
+                "where() takes from 1 to 3 positional arguments but {0} were "
+                "given".format(len(args) + 1))
 
 def flatten(array, axis=1, highlevel=True):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     out = layout.flatten(axis)
     if highlevel:
         return awkward1._util.wrap(out, awkward1._util.behaviorof(array))
@@ -241,7 +280,9 @@ def flatten(array, axis=1, highlevel=True):
         return out
 
 def rpad(array, length, axis=1, clip=False, highlevel=True):
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
+    layout = awkward1.operations.convert.tolayout(array,
+                                                  allowrecord=False,
+                                                  allowother=False)
     if clip:
         out = layout.rpad_and_clip(length, axis)
     else:
@@ -252,18 +293,27 @@ def rpad(array, length, axis=1, clip=False, highlevel=True):
         return out
 
 def fillna(array, value, highlevel=True):
-    arraylayout = awkward1.operations.convert.tolayout(array, allowrecord=True, allowother=False)
+    arraylayout = awkward1.operations.convert.tolayout(array,
+                                                       allowrecord=True,
+                                                       allowother=False)
     if isinstance(value, Iterable):
-        valuelayout = awkward1.operations.convert.tolayout(value, allowrecord=True, allowother=False)
+        valuelayout = awkward1.operations.convert.tolayout(value,
+                                                           allowrecord=True,
+                                                           allowother=False)
         if isinstance(valuelayout, awkward1.layout.Record):
-            valuelayout = valuelayout.array[valuelayout.at : valuelayout.at + 1]
+            valuelayout = valuelayout.array[valuelayout.at:valuelayout.at + 1]
         elif len(valuelayout) == 0:
-            offsets = awkward1.layout.Index64(numpy.array([0, 0], dtype=numpy.int64))
-            valuelayout = awkward1.layout.ListOffsetArray64(offsets, valuelayout)
+            offsets = awkward1.layout.Index64(numpy.array([0, 0],
+                                                          dtype=numpy.int64))
+            valuelayout = awkward1.layout.ListOffsetArray64(offsets,
+                                                            valuelayout)
         else:
-            valuelayout = awkward1.layout.RegularArray(valuelayout, len(valuelayout))
+            valuelayout = awkward1.layout.RegularArray(valuelayout,
+                                                       len(valuelayout))
     else:
-        valuelayout = awkward1.operations.convert.tolayout([value], allowrecord=True, allowother=False)
+        valuelayout = awkward1.operations.convert.tolayout([value],
+                                                           allowrecord=True,
+                                                           allowother=False)
 
     out = arraylayout.fillna(valuelayout)
     if highlevel:
@@ -280,16 +330,27 @@ def zip(arrays, depthlimit=None, parameters=None, highlevel=True):
         layouts = []
         for n, x in arrays.items():
             recordlookup.append(n)
-            layouts.append(awkward1.operations.convert.tolayout(x, allowrecord=False, allowother=False))
+            layouts.append(
+                awkward1.operations.convert.tolayout(x,
+                                                     allowrecord=False,
+                                                     allowother=False))
     else:
         recordlookup = None
         layouts = []
         for x in arrays:
-            layouts.append(awkward1.operations.convert.tolayout(x, allowrecord=False, allowother=False))
+            layouts.append(
+                awkward1.operations.convert.tolayout(x,
+                                                     allowrecord=False,
+                                                     allowother=False))
 
     def getfunction(inputs, depth):
-        if (depthlimit is None and any(x.purelist_depth == 1 for x in inputs)) or (depthlimit == depth):
-            return lambda: (awkward1.layout.RecordArray(inputs, recordlookup, parameters=parameters),)
+        if ((depthlimit is None and
+             any(x.purelist_depth == 1 for x in inputs)) or
+            (depthlimit == depth)):
+            return lambda: (
+                awkward1.layout.RecordArray(inputs,
+                                            recordlookup,
+                                            parameters=parameters),)
         else:
             return None
 
@@ -314,14 +375,25 @@ def argcross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
 
     else:
         if isinstance(arrays, dict):
-            layouts = dict((n, awkward1.operations.convert.tolayout(x, allowrecord=False, allowother=False).localindex(axis)) for n, x in arrays.items())
+            layouts = dict((n, awkward1.operations.convert.tolayout(
+                                 x, allowrecord=False, allowother=False)
+                               .localindex(axis))
+                           for n, x in arrays.items())
         else:
-            layouts = [awkward1.operations.convert.tolayout(x, allowrecord=False, allowother=False).localindex(axis) for x in arrays]
+            layouts = [awkward1.operations.convert.tolayout(
+                         x,
+                         allowrecord=False,
+                         allowother=False).localindex(axis) for x in arrays]
 
-        result = cross(layouts, axis=axis, nested=nested, parameters=parameters, highlevel=False)
+        result = cross(layouts,
+                       axis=axis,
+                       nested=nested,
+                       parameters=parameters,
+                       highlevel=False)
 
         if highlevel:
-            return awkward1._util.wrap(result, awkward1._util.behaviorof(*arrays))
+            return awkward1._util.wrap(result,
+                                       awkward1._util.behaviorof(*arrays))
         else:
             return result
 
@@ -337,15 +409,19 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
 
         if isinstance(arrays, dict):
             if nested is True:
-                nested = list(arrays.keys())   # includes the last key, but it's ignored below
+                nested = list(arrays.keys())   # last key is ignored below
             if any(not (isinstance(n, str) and n in arrays) for x in nested):
-                raise ValueError("cross's 'nested' must be dict keys for a dict of arrays")
+                raise ValueError(
+                    "cross's 'nested' must be dict keys for a dict of arrays")
             recordlookup = []
             layouts = []
             tonested = []
             for i, (n, x) in enumerate(arrays.items()):
                 recordlookup.append(n)
-                layouts.append(awkward1.operations.convert.tolayout(x, allowrecord=False, allowother=False))
+                layouts.append(
+                    awkward1.operations.convert.tolayout(x,
+                                                         allowrecord=False,
+                                                         allowother=False))
                 if n in nested:
                     tonested.append(i)
             nested = tonested
@@ -353,20 +429,35 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
         else:
             if nested is True:
                 nested = list(range(len(arrays) - 1))
-            if any(not (isinstance(x, int) and 0 <= x < len(arrays) - 1) for x in nested):
-                raise ValueError("cross's 'nested' must be integers in [0, len(arrays) - 1) for an iterable of arrays")
+            if any(not (isinstance(x, int) and 0 <= x < len(arrays) - 1)
+                     for x in nested):
+                raise ValueError(
+                    "cross's 'nested' must be integers in [0, len(arrays) - 1)"
+                    " for an iterable of arrays")
             recordlookup = None
             layouts = []
             for x in arrays:
-                layouts.append(awkward1.operations.convert.tolayout(x, allowrecord=False, allowother=False))
+                layouts.append(
+                    awkward1.operations.convert.tolayout(x,
+                                                         allowrecord=False,
+                                                         allowother=False))
 
-        indexes = [awkward1.layout.Index64(x.reshape(-1)) for x in numpy.meshgrid(*[numpy.arange(len(x), dtype=numpy.int64) for x in layouts], indexing="ij")]
-        outs = [awkward1.layout.IndexedArray64(x, y) for x, y in __builtins__["zip"](indexes, layouts)]
+        indexes = [awkward1.layout.Index64(x.reshape(-1))
+                     for x in numpy.meshgrid(*[numpy.arange(
+                                               len(x),
+                                               dtype=numpy.int64)
+                                               for x in layouts],
+                                             indexing="ij")]
+        outs = [awkward1.layout.IndexedArray64(x, y)
+                  for x, y in __builtins__["zip"](indexes, layouts)]
 
-        result = awkward1.layout.RecordArray(outs, recordlookup, parameters=parameters)
+        result = awkward1.layout.RecordArray(outs,
+                                             recordlookup,
+                                             parameters=parameters)
         for i in range(len(arrays) - 1, -1, -1):
             if i in nested:
-                result = awkward1.layout.RegularArray(result, len(layouts[i + 1]))
+                result = awkward1.layout.RegularArray(result,
+                                                      len(layouts[i + 1]))
 
     else:
         def newaxis(layout, i):
@@ -385,12 +476,20 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
             if depth == axis:
                 inside = len(arrays) - i - 1
                 outside = i
-                return lambda: newaxis(awkward1._util.recursively_apply(layout, getfunction1, args=(inside,)), outside)
+                return lambda: newaxis(
+                    awkward1._util.recursively_apply(layout,
+                                                     getfunction1,
+                                                     args=(inside,)), outside)
             else:
                 return None
 
         def apply(x, i):
-            return awkward1._util.recursively_apply(awkward1.operations.convert.tolayout(x, allowrecord=False, allowother=False), getfunction2, args=(i,))
+            return awkward1._util.recursively_apply(
+                awkward1.operations.convert.tolayout(x,
+                                                     allowrecord=False,
+                                                     allowother=False),
+                getfunction2,
+                args=(i,))
 
         toflatten = []
         if nested is None or nested is False:
@@ -398,9 +497,10 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
 
         if isinstance(arrays, dict):
             if nested is True:
-                nested = list(arrays.keys())   # includes the last key, but it's ignored below
+                nested = list(arrays.keys())   # last key is ignored below
             if any(not (isinstance(n, str) and n in arrays) for x in nested):
-                raise ValueError("cross's 'nested' must be dict keys for a dict of arrays")
+                raise ValueError(
+                    "cross's 'nested' must be dict keys for a dict of arrays")
             recordlookup = []
             layouts = []
             for i, (n, x) in enumerate(arrays.items()):
@@ -412,8 +512,11 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
         else:
             if nested is True:
                 nested = list(range(len(arrays) - 1))
-            if any(not (isinstance(x, int) and 0 <= x < len(arrays) - 1) for x in nested):
-                raise ValueError("cross's 'nested' must be integers in [0, len(arrays) - 1) for an iterable of arrays")
+            if any(not (isinstance(x, int) and 0 <= x < len(arrays) - 1)
+                   for x in nested):
+                raise ValueError(
+                    "cross's 'nested' must be integers in [0, len(arrays) - 1)"
+                    " for an iterable of arrays")
             recordlookup = None
             layouts = []
             for i, x in enumerate(arrays):
@@ -423,11 +526,16 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
 
         def getfunction3(inputs, depth):
             if depth == axis + len(arrays):
-                return lambda: (awkward1.layout.RecordArray(inputs, recordlookup, parameters=parameters),)
+                return lambda: (
+                    awkward1.layout.RecordArray(inputs,
+                                                recordlookup,
+                                                parameters=parameters),)
             else:
                 return None
 
-        out = awkward1._util.broadcast_and_apply(layouts, getfunction3, behavior)
+        out = awkward1._util.broadcast_and_apply(layouts,
+                                                 getfunction3,
+                                                 behavior)
         assert isinstance(out, tuple) and len(out) == 1
         result = out[0]
 
@@ -440,26 +548,50 @@ def cross(arrays, axis=1, nested=None, parameters=None, highlevel=True):
     else:
         return result
 
-def argchoose(array, n, diagonal=False, axis=1, keys=None, parameters=None, highlevel=True):
+def argchoose(array,
+              n,
+              diagonal=False,
+              axis=1,
+              keys=None,
+              parameters=None,
+              highlevel=True):
     if parameters is None:
         parameters = {}
     if axis < 0:
         raise ValueError("argchoose's 'axis' must be non-negative")
     else:
-        layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False).localindex(axis)
-        out = layout.choose(n, diagonal=diagonal, keys=keys, parameters=parameters, axis=axis)
+        layout = awkward1.operations.convert.tolayout(
+                   array, allowrecord=False, allowother=False).localindex(axis)
+        out = layout.choose(n,
+                            diagonal=diagonal,
+                            keys=keys,
+                            parameters=parameters,
+                            axis=axis)
         if highlevel:
-            return awkward1._util.wrap(out, behavior=awkward1._util.behaviorof(array))
+            return awkward1._util.wrap(
+                out, behavior=awkward1._util.behaviorof(array))
         else:
             return out
 
-def choose(array, n, diagonal=False, axis=1, keys=None, parameters=None, highlevel=True):
+def choose(array,
+           n,
+           diagonal=False,
+           axis=1,
+           keys=None,
+           parameters=None,
+           highlevel=True):
     if parameters is None:
         parameters = {}
-    layout = awkward1.operations.convert.tolayout(array, allowrecord=False, allowother=False)
-    out = layout.choose(n, diagonal=diagonal, keys=keys, parameters=parameters, axis=axis)
+    layout = awkward1.operations.convert.tolayout(
+               array, allowrecord=False, allowother=False)
+    out = layout.choose(n,
+                        diagonal=diagonal,
+                        keys=keys,
+                        parameters=parameters,
+                        axis=axis)
     if highlevel:
-        return awkward1._util.wrap(out, behavior=awkward1._util.behaviorof(array))
+        return awkward1._util.wrap(
+                 out, behavior=awkward1._util.behaviorof(array))
     else:
         return out
 
@@ -469,21 +601,33 @@ def tomask(array, mask, validwhen=True, highlevel=True):
         if isinstance(layoutmask, awkward1.layout.NumpyArray):
             m = numpy.asarray(layoutmask)
             if not issubclass(m.dtype.type, (numpy.bool, numpy.bool_)):
-                raise ValueError("mask must have boolean type, not {0}".format(repr(m.dtype)))
+                raise ValueError(
+                    "mask must have boolean type, not "
+                    "{0}".format(repr(m.dtype)))
             bytemask = awkward1.layout.Index8(m.view(numpy.int8))
-            return lambda: (awkward1.layout.ByteMaskedArray(bytemask, layoutarray, validwhen=validwhen),)
+            return lambda: (
+                awkward1.layout.ByteMaskedArray(bytemask,
+                                                layoutarray,
+                                                validwhen=validwhen),)
         else:
             return None
 
-    layoutarray = awkward1.operations.convert.tolayout(array, allowrecord=True, allowother=False)
-    layoutmask = awkward1.operations.convert.tolayout(mask, allowrecord=True, allowother=False)
+    layoutarray = awkward1.operations.convert.tolayout(array,
+                                                       allowrecord=True,
+                                                       allowother=False)
+    layoutmask = awkward1.operations.convert.tolayout(mask,
+                                                      allowrecord=True,
+                                                      allowother=False)
 
     behavior = awkward1._util.behaviorof(array, mask)
-    out = awkward1._util.broadcast_and_apply([layoutarray, layoutmask], getfunction, behavior)
+    out = awkward1._util.broadcast_and_apply([layoutarray, layoutmask],
+                                             getfunction,
+                                             behavior)
     assert isinstance(out, tuple) and len(out) == 1
     if highlevel:
         return awkward1._util.wrap(out[0], behavior)
     else:
         return out[0]
 
-__all__ = [x for x in list(globals()) if not x.startswith("_") and x not in ("numpy", "awkward1")]
+__all__ = [x for x in list(globals()) if not x.startswith("_") and
+                                         x not in ("numpy", "awkward1")]

--- a/src/cpu-kernels/getitem.cpp
+++ b/src/cpu-kernels/getitem.cpp
@@ -5,7 +5,13 @@
 
 #include "awkward/cpu-kernels/getitem.h"
 
-void awkward_regularize_rangeslice(int64_t* start, int64_t* stop, bool posstep, bool hasstart, bool hasstop, int64_t length) {
+void awkward_regularize_rangeslice(
+  int64_t* start,
+  int64_t* stop,
+  bool posstep,
+  bool hasstart,
+  bool hasstop,
+  int64_t length) {
   if (posstep) {
     if (!hasstart)           *start = 0;
     else if (*start < 0)     *start += length;
@@ -34,7 +40,10 @@ void awkward_regularize_rangeslice(int64_t* start, int64_t* stop, bool posstep, 
 }
 
 template <typename T>
-ERROR awkward_regularize_arrayslice(T* flatheadptr, int64_t lenflathead, int64_t length) {
+ERROR awkward_regularize_arrayslice(
+  T* flatheadptr,
+  int64_t lenflathead,
+  int64_t length) {
   for (int64_t i = 0;  i < lenflathead;  i++) {
     T original = flatheadptr[i];
     if (flatheadptr[i] < 0) {
@@ -46,29 +55,47 @@ ERROR awkward_regularize_arrayslice(T* flatheadptr, int64_t lenflathead, int64_t
   }
   return success();
 }
-ERROR awkward_regularize_arrayslice_64(int64_t* flatheadptr, int64_t lenflathead, int64_t length) {
-  return awkward_regularize_arrayslice<int64_t>(flatheadptr, lenflathead, length);
+ERROR awkward_regularize_arrayslice_64(
+  int64_t* flatheadptr,
+  int64_t lenflathead,
+  int64_t length) {
+  return awkward_regularize_arrayslice<int64_t>(
+    flatheadptr,
+    lenflathead,
+    length);
 }
 
-ERROR awkward_index8_to_index64(int64_t* toptr, const int8_t* fromptr, int64_t length) {
+ERROR awkward_index8_to_index64(
+  int64_t* toptr,
+  const int8_t* fromptr,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toptr[i]= (int64_t)fromptr[i];
   }
   return success();
 }
-ERROR awkward_indexU8_to_index64(int64_t* toptr, const uint8_t* fromptr, int64_t length) {
+ERROR awkward_indexU8_to_index64(
+  int64_t* toptr,
+  const uint8_t* fromptr,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toptr[i]= (int64_t)fromptr[i];
   }
   return success();
 }
-ERROR awkward_index32_to_index64(int64_t* toptr, const int32_t* fromptr, int64_t length) {
+ERROR awkward_index32_to_index64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toptr[i]= (int64_t)fromptr[i];
   }
   return success();
 }
-ERROR awkward_indexU32_to_index64(int64_t* toptr, const uint32_t* fromptr, int64_t length) {
+ERROR awkward_indexU32_to_index64(
+  int64_t* toptr,
+  const uint32_t* fromptr,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toptr[i]= (int64_t)fromptr[i];
   }
@@ -76,7 +103,13 @@ ERROR awkward_indexU32_to_index64(int64_t* toptr, const uint32_t* fromptr, int64
 }
 
 template <typename C, typename T>
-ERROR awkward_index_carry(C* toindex, const C* fromindex, const T* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
+ERROR awkward_index_carry(
+  C* toindex,
+  const C* fromindex,
+  const T* carry,
+  int64_t fromindexoffset,
+  int64_t lenfromindex,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     T j = carry[i];
     if (j > lenfromindex) {
@@ -86,47 +119,167 @@ ERROR awkward_index_carry(C* toindex, const C* fromindex, const T* carry, int64_
   }
   return success();
 }
-ERROR awkward_index8_carry_64(int8_t* toindex, const int8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-  return awkward_index_carry<int8_t, int64_t>(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
+ERROR awkward_index8_carry_64(
+  int8_t* toindex,
+  const int8_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t lenfromindex,
+  int64_t length) {
+  return awkward_index_carry<int8_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    lenfromindex,
+    length);
 }
-ERROR awkward_indexU8_carry_64(uint8_t* toindex, const uint8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-  return awkward_index_carry<uint8_t, int64_t>(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
+ERROR awkward_indexU8_carry_64(
+  uint8_t* toindex,
+  const uint8_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t lenfromindex,
+  int64_t length) {
+  return awkward_index_carry<uint8_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    lenfromindex,
+    length);
 }
-ERROR awkward_index32_carry_64(int32_t* toindex, const int32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-  return awkward_index_carry<int32_t, int64_t>(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
+ERROR awkward_index32_carry_64(
+  int32_t* toindex,
+  const int32_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t lenfromindex,
+  int64_t length) {
+  return awkward_index_carry<int32_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    lenfromindex,
+    length);
 }
-ERROR awkward_indexU32_carry_64(uint32_t* toindex, const uint32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-  return awkward_index_carry<uint32_t, int64_t>(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
+ERROR awkward_indexU32_carry_64(
+  uint32_t* toindex,
+  const uint32_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t lenfromindex,
+  int64_t length) {
+  return awkward_index_carry<uint32_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    lenfromindex,
+    length);
 }
-ERROR awkward_index64_carry_64(int64_t* toindex, const int64_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-  return awkward_index_carry<int64_t, int64_t>(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
+ERROR awkward_index64_carry_64(
+  int64_t* toindex,
+  const int64_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t lenfromindex,
+  int64_t length) {
+  return awkward_index_carry<int64_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    lenfromindex,
+    length);
 }
 
 template <typename C, typename T>
-ERROR awkward_index_carry_nocheck(C* toindex, const C* fromindex, const T* carry, int64_t fromindexoffset, int64_t length) {
+ERROR awkward_index_carry_nocheck(
+  C* toindex,
+  const C* fromindex,
+  const T* carry,
+  int64_t fromindexoffset,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toindex[i] = fromindex[(size_t)(fromindexoffset + carry[i])];
   }
   return success();
 }
-ERROR awkward_index8_carry_nocheck_64(int8_t* toindex, const int8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-  return awkward_index_carry_nocheck<int8_t, int64_t>(toindex, fromindex, carry, fromindexoffset, length);
+ERROR awkward_index8_carry_nocheck_64(
+  int8_t* toindex,
+  const int8_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t length) {
+  return awkward_index_carry_nocheck<int8_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    length);
 }
-ERROR awkward_indexU8_carry_nocheck_64(uint8_t* toindex, const uint8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-  return awkward_index_carry_nocheck<uint8_t, int64_t>(toindex, fromindex, carry, fromindexoffset, length);
+ERROR awkward_indexU8_carry_nocheck_64(
+  uint8_t* toindex,
+  const uint8_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t length) {
+  return awkward_index_carry_nocheck<uint8_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    length);
 }
-ERROR awkward_index32_carry_nocheck_64(int32_t* toindex, const int32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-  return awkward_index_carry_nocheck<int32_t, int64_t>(toindex, fromindex, carry, fromindexoffset, length);
+ERROR awkward_index32_carry_nocheck_64(
+  int32_t* toindex,
+  const int32_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t length) {
+  return awkward_index_carry_nocheck<int32_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    length);
 }
-ERROR awkward_indexU32_carry_nocheck_64(uint32_t* toindex, const uint32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-  return awkward_index_carry_nocheck<uint32_t, int64_t>(toindex, fromindex, carry, fromindexoffset, length);
+ERROR awkward_indexU32_carry_nocheck_64(
+  uint32_t* toindex,
+  const uint32_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t length) {
+  return awkward_index_carry_nocheck<uint32_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    length);
 }
-ERROR awkward_index64_carry_nocheck_64(int64_t* toindex, const int64_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-  return awkward_index_carry_nocheck<int64_t, int64_t>(toindex, fromindex, carry, fromindexoffset, length);
+ERROR awkward_index64_carry_nocheck_64(
+  int64_t* toindex,
+  const int64_t* fromindex,
+  const int64_t* carry,
+  int64_t fromindexoffset,
+  int64_t length) {
+  return awkward_index_carry_nocheck<int64_t, int64_t>(
+    toindex,
+    fromindex,
+    carry,
+    fromindexoffset,
+    length);
 }
 
 template <typename T>
-ERROR awkward_slicearray_ravel(T* toptr, const T* fromptr, int64_t ndim, const int64_t* shape, const int64_t* strides) {
+ERROR awkward_slicearray_ravel(
+  T* toptr,
+  const T* fromptr,
+  int64_t ndim,
+  const int64_t* shape,
+  const int64_t* strides) {
   if (ndim == 1) {
     for (T i = 0;  i < shape[0];  i++) {
       toptr[i] = fromptr[i*strides[0]];
@@ -134,7 +287,12 @@ ERROR awkward_slicearray_ravel(T* toptr, const T* fromptr, int64_t ndim, const i
   }
   else {
     for (T i = 0;  i < shape[0];  i++) {
-      ERROR err = awkward_slicearray_ravel<T>(&toptr[i*shape[1]], &fromptr[i*strides[0]], ndim - 1, &shape[1], &strides[1]);
+      ERROR err =
+        awkward_slicearray_ravel<T>(&toptr[i*shape[1]],
+                                    &fromptr[i*strides[0]],
+                                    ndim - 1,
+                                    &shape[1],
+                                    &strides[1]);
       if (err.str != nullptr) {
         return err;
       }
@@ -142,11 +300,27 @@ ERROR awkward_slicearray_ravel(T* toptr, const T* fromptr, int64_t ndim, const i
   }
   return success();
 }
-ERROR awkward_slicearray_ravel_64(int64_t* toptr, const int64_t* fromptr, int64_t ndim, const int64_t* shape, const int64_t* strides) {
-  return awkward_slicearray_ravel<int64_t>(toptr, fromptr, ndim, shape, strides);
+ERROR awkward_slicearray_ravel_64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t ndim,
+  const int64_t* shape,
+  const int64_t* strides) {
+  return awkward_slicearray_ravel<int64_t>(
+    toptr,
+    fromptr,
+    ndim,
+    shape,
+    strides);
 }
 
-ERROR awkward_slicemissing_check_same(bool* same, const int8_t* bytemask, int64_t bytemaskoffset, const int64_t* missingindex, int64_t missingindexoffset, int64_t length) {
+ERROR awkward_slicemissing_check_same(
+  bool* same,
+  const int8_t* bytemask,
+  int64_t bytemaskoffset,
+  const int64_t* missingindex,
+  int64_t missingindexoffset,
+  int64_t length) {
   *same = true;
   for (int64_t i = 0;  i < length;  i++) {
     bool left = (bytemask[bytemaskoffset + i] != 0);
@@ -160,59 +334,135 @@ ERROR awkward_slicemissing_check_same(bool* same, const int8_t* bytemask, int64_
 }
 
 template <typename T>
-ERROR awkward_carry_arange(T* toptr, int64_t length) {
+ERROR awkward_carry_arange(
+  T* toptr,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toptr[i] = i;
   }
   return success();
 }
-ERROR awkward_carry_arange_64(int64_t* toptr, int64_t length) {
-  return awkward_carry_arange<int64_t>(toptr, length);
+ERROR awkward_carry_arange_64(
+  int64_t* toptr,
+  int64_t length) {
+  return awkward_carry_arange<int64_t>(
+    toptr,
+    length);
 }
 
 template <typename ID, typename T>
-ERROR awkward_identities_getitem_carry(ID* newidentitiesptr, const ID* identitiesptr, const T* carryptr, int64_t lencarry, int64_t offset, int64_t width, int64_t length) {
+ERROR awkward_identities_getitem_carry(
+  ID* newidentitiesptr,
+  const ID* identitiesptr,
+  const T* carryptr,
+  int64_t lencarry,
+  int64_t offset,
+  int64_t width,
+  int64_t length) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     if (carryptr[i] >= length) {
       return failure("index out of range", kSliceNone, carryptr[i]);
     }
     for (int64_t j = 0;  j < width;  j++) {
-      newidentitiesptr[width*i + j] = identitiesptr[offset + width*carryptr[i] + j];
+      newidentitiesptr[width*i + j] =
+        identitiesptr[offset + width*carryptr[i] + j];
     }
   }
   return success();
 }
-ERROR awkward_identities32_getitem_carry_64(int32_t* newidentitiesptr, const int32_t* identitiesptr, const int64_t* carryptr, int64_t lencarry, int64_t offset, int64_t width, int64_t length) {
-  return awkward_identities_getitem_carry<int32_t, int64_t>(newidentitiesptr, identitiesptr, carryptr, lencarry, offset, width, length);
+ERROR awkward_identities32_getitem_carry_64(
+  int32_t* newidentitiesptr,
+  const int32_t* identitiesptr,
+  const int64_t* carryptr,
+  int64_t lencarry,
+  int64_t offset,
+  int64_t width,
+  int64_t length) {
+  return awkward_identities_getitem_carry<int32_t, int64_t>(
+    newidentitiesptr,
+    identitiesptr,
+    carryptr,
+    lencarry,
+    offset,
+    width,
+    length);
 }
-ERROR awkward_identities64_getitem_carry_64(int64_t* newidentitiesptr, const int64_t* identitiesptr, const int64_t* carryptr, int64_t lencarry, int64_t offset, int64_t width, int64_t length) {
-  return awkward_identities_getitem_carry<int64_t, int64_t>(newidentitiesptr, identitiesptr, carryptr, lencarry, offset, width, length);
+ERROR awkward_identities64_getitem_carry_64(
+  int64_t* newidentitiesptr,
+  const int64_t* identitiesptr,
+  const int64_t* carryptr,
+  int64_t lencarry,
+  int64_t offset,
+  int64_t width,
+  int64_t length) {
+  return awkward_identities_getitem_carry<int64_t, int64_t>(
+    newidentitiesptr,
+    identitiesptr,
+    carryptr,
+    lencarry,
+    offset,
+    width,
+    length);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_contiguous_init(T* toptr, int64_t skip, int64_t stride) {
+ERROR awkward_numpyarray_contiguous_init(
+  T* toptr,
+  int64_t skip,
+  int64_t stride) {
   for (int64_t i = 0;  i < skip;  i++) {
     toptr[i] = i*stride;
   }
   return success();
 }
-ERROR awkward_numpyarray_contiguous_init_64(int64_t* toptr, int64_t skip, int64_t stride) {
-  return awkward_numpyarray_contiguous_init<int64_t>(toptr, skip, stride);
+ERROR awkward_numpyarray_contiguous_init_64(
+  int64_t* toptr,
+  int64_t skip,
+  int64_t stride) {
+  return awkward_numpyarray_contiguous_init<int64_t>(
+    toptr,
+    skip,
+    stride);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_contiguous_copy(uint8_t* toptr, const uint8_t* fromptr, int64_t len, int64_t stride, int64_t offset, const T* pos) {
+ERROR awkward_numpyarray_contiguous_copy(
+  uint8_t* toptr,
+  const uint8_t* fromptr,
+  int64_t len,
+  int64_t stride,
+  int64_t offset,
+  const T* pos) {
   for (int64_t i = 0;  i < len;  i++) {
-    memcpy(&toptr[i*stride], &fromptr[offset + (int64_t)pos[i]], (size_t)stride);
+    memcpy(&toptr[i*stride],
+           &fromptr[offset + (int64_t)pos[i]],
+           (size_t)stride);
   }
   return success();
 }
-ERROR awkward_numpyarray_contiguous_copy_64(uint8_t* toptr, const uint8_t* fromptr, int64_t len, int64_t stride, int64_t offset, const int64_t* pos) {
-  return awkward_numpyarray_contiguous_copy<int64_t>(toptr, fromptr, len, stride, offset, pos);
+ERROR awkward_numpyarray_contiguous_copy_64(
+  uint8_t* toptr,
+  const uint8_t* fromptr,
+  int64_t len,
+  int64_t stride,
+  int64_t offset,
+  const int64_t* pos) {
+  return awkward_numpyarray_contiguous_copy<int64_t>(
+    toptr,
+    fromptr,
+    len,
+    stride,
+    offset,
+    pos);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_contiguous_next(T* topos, const T* frompos, int64_t len, int64_t skip, int64_t stride) {
+ERROR awkward_numpyarray_contiguous_next(
+  T* topos,
+  const T* frompos,
+  int64_t len,
+  int64_t skip,
+  int64_t stride) {
   for (int64_t i = 0;  i < len;  i++) {
     for (int64_t j = 0;  j < skip;  j++) {
       topos[i*skip + j] = frompos[i] + j*stride;
@@ -220,34 +470,86 @@ ERROR awkward_numpyarray_contiguous_next(T* topos, const T* frompos, int64_t len
   }
   return success();
 }
-ERROR awkward_numpyarray_contiguous_next_64(int64_t* topos, const int64_t* frompos, int64_t len, int64_t skip, int64_t stride) {
-  return awkward_numpyarray_contiguous_next<int64_t>(topos, frompos, len, skip, stride);
+ERROR awkward_numpyarray_contiguous_next_64(
+  int64_t* topos,
+  const int64_t* frompos,
+  int64_t len,
+  int64_t skip,
+  int64_t stride) {
+  return awkward_numpyarray_contiguous_next<int64_t>(
+    topos,
+    frompos,
+    len,
+    skip,
+    stride);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_getitem_next_null(uint8_t* toptr, const uint8_t* fromptr, int64_t len, int64_t stride, int64_t offset, const T* pos) {
+ERROR awkward_numpyarray_getitem_next_null(
+  uint8_t* toptr,
+  const uint8_t* fromptr,
+  int64_t len,
+  int64_t stride,
+  int64_t offset,
+  const T* pos) {
   for (int64_t i = 0;  i < len;  i++) {
-    std::memcpy(&toptr[i*stride], &fromptr[offset + pos[i]*stride], (size_t)stride);
+    std::memcpy(&toptr[i*stride],
+                &fromptr[offset + pos[i]*stride],
+                (size_t)stride);
   }
   return success();
 }
-ERROR awkward_numpyarray_getitem_next_null_64(uint8_t* toptr, const uint8_t* fromptr, int64_t len, int64_t stride, int64_t offset, const int64_t* pos) {
-  return awkward_numpyarray_getitem_next_null(toptr, fromptr, len, stride, offset, pos);
+ERROR awkward_numpyarray_getitem_next_null_64(
+  uint8_t* toptr,
+  const uint8_t* fromptr,
+  int64_t len,
+  int64_t stride,
+  int64_t offset,
+  const int64_t* pos) {
+  return awkward_numpyarray_getitem_next_null(
+    toptr,
+    fromptr,
+    len,
+    stride,
+    offset,
+    pos);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_getitem_next_at(T* nextcarryptr, const T* carryptr, int64_t lencarry, int64_t skip, int64_t at) {
+ERROR awkward_numpyarray_getitem_next_at(
+  T* nextcarryptr,
+  const T* carryptr,
+  int64_t lencarry,
+  int64_t skip,
+  int64_t at) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     nextcarryptr[i] = skip*carryptr[i] + at;
   }
   return success();
 }
-ERROR awkward_numpyarray_getitem_next_at_64(int64_t* nextcarryptr, const int64_t* carryptr, int64_t lencarry, int64_t skip, int64_t at) {
-  return awkward_numpyarray_getitem_next_at(nextcarryptr, carryptr, lencarry, skip, at);
+ERROR awkward_numpyarray_getitem_next_at_64(
+  int64_t* nextcarryptr,
+  const int64_t* carryptr,
+  int64_t lencarry,
+  int64_t skip,
+  int64_t at) {
+  return awkward_numpyarray_getitem_next_at(
+    nextcarryptr,
+    carryptr,
+    lencarry,
+    skip,
+    at);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_getitem_next_range(T* nextcarryptr, const T* carryptr, int64_t lencarry, int64_t lenhead, int64_t skip, int64_t start, int64_t step) {
+ERROR awkward_numpyarray_getitem_next_range(
+  T* nextcarryptr,
+  const T* carryptr,
+  int64_t lencarry,
+  int64_t lenhead,
+  int64_t skip,
+  int64_t start,
+  int64_t step) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     for (int64_t j = 0;  j < lenhead;  j++) {
       nextcarryptr[i*lenhead + j] = skip*carryptr[i] + start + j*step;
@@ -255,12 +557,35 @@ ERROR awkward_numpyarray_getitem_next_range(T* nextcarryptr, const T* carryptr, 
   }
   return success();
 }
-ERROR awkward_numpyarray_getitem_next_range_64(int64_t* nextcarryptr, const int64_t* carryptr, int64_t lencarry, int64_t lenhead, int64_t skip, int64_t start, int64_t step) {
-  return awkward_numpyarray_getitem_next_range(nextcarryptr, carryptr, lencarry, lenhead, skip, start, step);
+ERROR awkward_numpyarray_getitem_next_range_64(
+  int64_t* nextcarryptr,
+  const int64_t* carryptr,
+  int64_t lencarry,
+  int64_t lenhead,
+  int64_t skip,
+  int64_t start,
+  int64_t step) {
+  return awkward_numpyarray_getitem_next_range(
+    nextcarryptr,
+    carryptr,
+    lencarry,
+    lenhead,
+    skip,
+    start,
+    step);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_getitem_next_range_advanced(T* nextcarryptr, T* nextadvancedptr, const T* carryptr, const T* advancedptr, int64_t lencarry, int64_t lenhead, int64_t skip, int64_t start, int64_t step) {
+ERROR awkward_numpyarray_getitem_next_range_advanced(
+  T* nextcarryptr,
+  T* nextadvancedptr,
+  const T* carryptr,
+  const T* advancedptr,
+  int64_t lencarry,
+  int64_t lenhead,
+  int64_t skip,
+  int64_t start,
+  int64_t step) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     for (int64_t j = 0;  j < lenhead;  j++) {
       nextcarryptr[i*lenhead + j] = skip*carryptr[i] + start + j*step;
@@ -269,12 +594,37 @@ ERROR awkward_numpyarray_getitem_next_range_advanced(T* nextcarryptr, T* nextadv
   }
   return success();
 }
-ERROR awkward_numpyarray_getitem_next_range_advanced_64(int64_t* nextcarryptr, int64_t* nextadvancedptr, const int64_t* carryptr, const int64_t* advancedptr, int64_t lencarry, int64_t lenhead, int64_t skip, int64_t start, int64_t step) {
-  return awkward_numpyarray_getitem_next_range_advanced(nextcarryptr, nextadvancedptr, carryptr, advancedptr, lencarry, lenhead, skip, start, step);
+ERROR awkward_numpyarray_getitem_next_range_advanced_64(
+  int64_t* nextcarryptr,
+  int64_t* nextadvancedptr,
+  const int64_t* carryptr,
+  const int64_t* advancedptr,
+  int64_t lencarry,
+  int64_t lenhead,
+  int64_t skip,
+  int64_t start,
+  int64_t step) {
+  return awkward_numpyarray_getitem_next_range_advanced(
+    nextcarryptr,
+    nextadvancedptr,
+    carryptr,
+    advancedptr,
+    lencarry,
+    lenhead,
+    skip,
+    start,
+    step);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_getitem_next_array(T* nextcarryptr, T* nextadvancedptr, const T* carryptr, const T* flatheadptr, int64_t lencarry, int64_t lenflathead, int64_t skip) {
+ERROR awkward_numpyarray_getitem_next_array(
+  T* nextcarryptr,
+  T* nextadvancedptr,
+  const T* carryptr,
+  const T* flatheadptr,
+  int64_t lencarry,
+  int64_t lenflathead,
+  int64_t skip) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     for (int64_t j = 0;  j < lenflathead;  j++) {
       nextcarryptr[i*lenflathead + j] = skip*carryptr[i] + flatheadptr[j];
@@ -283,22 +633,59 @@ ERROR awkward_numpyarray_getitem_next_array(T* nextcarryptr, T* nextadvancedptr,
   }
   return success();
 }
-ERROR awkward_numpyarray_getitem_next_array_64(int64_t* nextcarryptr, int64_t* nextadvancedptr, const int64_t* carryptr, const int64_t* flatheadptr, int64_t lencarry, int64_t lenflathead, int64_t skip) {
-  return awkward_numpyarray_getitem_next_array(nextcarryptr, nextadvancedptr, carryptr, flatheadptr, lencarry, lenflathead, skip);
+ERROR awkward_numpyarray_getitem_next_array_64(
+  int64_t* nextcarryptr,
+  int64_t* nextadvancedptr,
+  const int64_t* carryptr,
+  const int64_t* flatheadptr,
+  int64_t lencarry,
+  int64_t lenflathead,
+  int64_t skip) {
+  return awkward_numpyarray_getitem_next_array(
+    nextcarryptr,
+    nextadvancedptr,
+    carryptr,
+    flatheadptr,
+    lencarry,
+    lenflathead,
+    skip);
 }
 
 template <typename T>
-ERROR awkward_numpyarray_getitem_next_array_advanced(T* nextcarryptr, const T* carryptr, const T* advancedptr, const T* flatheadptr, int64_t lencarry, int64_t skip) {
+ERROR awkward_numpyarray_getitem_next_array_advanced(
+  T* nextcarryptr,
+  const T* carryptr,
+  const T* advancedptr,
+  const T* flatheadptr,
+  int64_t lencarry,
+  int64_t skip) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     nextcarryptr[i] = skip*carryptr[i] + flatheadptr[advancedptr[i]];
   }
   return success();
 }
-ERROR awkward_numpyarray_getitem_next_array_advanced_64(int64_t* nextcarryptr, const int64_t* carryptr, const int64_t* advancedptr, const int64_t* flatheadptr, int64_t lencarry, int64_t skip) {
-  return awkward_numpyarray_getitem_next_array_advanced(nextcarryptr, carryptr, advancedptr, flatheadptr, lencarry, skip);
+ERROR awkward_numpyarray_getitem_next_array_advanced_64(
+  int64_t* nextcarryptr,
+  const int64_t* carryptr,
+  const int64_t* advancedptr,
+  const int64_t* flatheadptr,
+  int64_t lencarry,
+  int64_t skip) {
+  return awkward_numpyarray_getitem_next_array_advanced(
+    nextcarryptr,
+    carryptr,
+    advancedptr,
+    flatheadptr,
+    lencarry,
+    skip);
 }
 
-ERROR awkward_numpyarray_getitem_boolean_numtrue(int64_t* numtrue, const int8_t* fromptr, int64_t byteoffset, int64_t length, int64_t stride) {
+ERROR awkward_numpyarray_getitem_boolean_numtrue(
+  int64_t* numtrue,
+  const int8_t* fromptr,
+  int64_t byteoffset,
+  int64_t length,
+  int64_t stride) {
   *numtrue = 0;
   for (int64_t i = 0;  i < length;  i += stride) {
     *numtrue = *numtrue + (fromptr[byteoffset + i] != 0);
@@ -307,7 +694,12 @@ ERROR awkward_numpyarray_getitem_boolean_numtrue(int64_t* numtrue, const int8_t*
 }
 
 template <typename T>
-ERROR awkward_numpyarray_getitem_boolean_nonzero(T* toptr, const int8_t* fromptr, int64_t byteoffset, int64_t length, int64_t stride) {
+ERROR awkward_numpyarray_getitem_boolean_nonzero(
+  T* toptr,
+  const int8_t* fromptr,
+  int64_t byteoffset,
+  int64_t length,
+  int64_t stride) {
   int64_t k = 0;
   for (int64_t i = 0;  i < length;  i += stride) {
     if (fromptr[byteoffset + i] != 0) {
@@ -318,12 +710,29 @@ ERROR awkward_numpyarray_getitem_boolean_nonzero(T* toptr, const int8_t* fromptr
   return success();
 }
 
-ERROR awkward_numpyarray_getitem_boolean_nonzero_64(int64_t* toptr, const int8_t* fromptr, int64_t byteoffset, int64_t length, int64_t stride) {
-  return awkward_numpyarray_getitem_boolean_nonzero<int64_t>(toptr, fromptr, byteoffset, length, stride);
+ERROR awkward_numpyarray_getitem_boolean_nonzero_64(
+  int64_t* toptr,
+  const int8_t* fromptr,
+  int64_t byteoffset,
+  int64_t length,
+  int64_t stride) {
+  return awkward_numpyarray_getitem_boolean_nonzero<int64_t>(
+    toptr,
+    fromptr,
+    byteoffset,
+    length,
+    stride);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_next_at(T* tocarry, const C* fromstarts, const C* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at) {
+ERROR awkward_listarray_getitem_next_at(
+  T* tocarry,
+  const C* fromstarts,
+  const C* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t at) {
   for (int64_t i = 0;  i < lenstarts;  i++) {
     int64_t length = fromstops[stopsoffset + i] - fromstarts[startsoffset + i];
     int64_t regular_at = at;
@@ -337,24 +746,77 @@ ERROR awkward_listarray_getitem_next_at(T* tocarry, const C* fromstarts, const C
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_next_at_64(int64_t* tocarry, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at) {
-  return awkward_listarray_getitem_next_at<int32_t, int64_t>(tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, at);
+ERROR awkward_listarray32_getitem_next_at_64(
+  int64_t* tocarry,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t at) {
+  return awkward_listarray_getitem_next_at<int32_t, int64_t>(
+    tocarry,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    at);
 }
-ERROR awkward_listarrayU32_getitem_next_at_64(int64_t* tocarry, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at) {
-  return awkward_listarray_getitem_next_at<uint32_t, int64_t>(tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, at);
+ERROR awkward_listarrayU32_getitem_next_at_64(
+  int64_t* tocarry,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t at) {
+  return awkward_listarray_getitem_next_at<uint32_t, int64_t>(
+    tocarry,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    at);
 }
-ERROR awkward_listarray64_getitem_next_at_64(int64_t* tocarry, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at) {
-  return awkward_listarray_getitem_next_at<int64_t, int64_t>(tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, at);
+ERROR awkward_listarray64_getitem_next_at_64(
+  int64_t* tocarry,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t at) {
+  return awkward_listarray_getitem_next_at<int64_t, int64_t>(
+    tocarry,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    at);
 }
 
 template <typename C>
-ERROR awkward_listarray_getitem_next_range_carrylength(int64_t* carrylength, const C* fromstarts, const C* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
+ERROR awkward_listarray_getitem_next_range_carrylength(
+  int64_t* carrylength,
+  const C* fromstarts,
+  const C* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t start,
+  int64_t stop,
+  int64_t step) {
   *carrylength = 0;
   for (int64_t i = 0;  i < lenstarts;  i++) {
     int64_t length = fromstops[stopsoffset + i] - fromstarts[startsoffset + i];
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, step > 0, start != kSliceNone, stop != kSliceNone, length);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop, step > 0,
+                                  start != kSliceNone, stop != kSliceNone,
+                                  length);
     if (step > 0) {
       for (int64_t j = regular_start;  j < regular_stop;  j += step) {
         *carrylength = *carrylength + 1;
@@ -368,26 +830,93 @@ ERROR awkward_listarray_getitem_next_range_carrylength(int64_t* carrylength, con
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_next_range_carrylength(int64_t* carrylength, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-  return awkward_listarray_getitem_next_range_carrylength<int32_t>(carrylength, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
+ERROR awkward_listarray32_getitem_next_range_carrylength(
+  int64_t* carrylength,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t start,
+  int64_t stop,
+  int64_t step) {
+  return awkward_listarray_getitem_next_range_carrylength<int32_t>(
+    carrylength,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    start,
+    stop,
+    step);
 }
-ERROR awkward_listarrayU32_getitem_next_range_carrylength(int64_t* carrylength, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-  return awkward_listarray_getitem_next_range_carrylength<uint32_t>(carrylength, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
+ERROR awkward_listarrayU32_getitem_next_range_carrylength(
+  int64_t* carrylength,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t start,
+  int64_t stop,
+  int64_t step) {
+  return awkward_listarray_getitem_next_range_carrylength<uint32_t>(
+    carrylength,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    start,
+    stop,
+    step);
 }
-ERROR awkward_listarray64_getitem_next_range_carrylength(int64_t* carrylength, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-  return awkward_listarray_getitem_next_range_carrylength<int64_t>(carrylength, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
+ERROR awkward_listarray64_getitem_next_range_carrylength(
+  int64_t* carrylength,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t start,
+  int64_t stop,
+  int64_t step) {
+  return awkward_listarray_getitem_next_range_carrylength<int64_t>(
+    carrylength,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    start,
+    stop,
+    step);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_next_range(C* tooffsets, T* tocarry, const C* fromstarts, const C* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
+ERROR awkward_listarray_getitem_next_range(
+  C* tooffsets,
+  T* tocarry,
+  const C* fromstarts,
+  const C* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t start,
+  int64_t stop,
+  int64_t step) {
   int64_t k = 0;
   tooffsets[0] = 0;
   if (step > 0) {
     for (int64_t i = 0;  i < lenstarts;  i++) {
-      int64_t length = fromstops[stopsoffset + i] - fromstarts[startsoffset + i];
+      int64_t length =
+        fromstops[stopsoffset + i] - fromstarts[startsoffset + i];
       int64_t regular_start = start;
       int64_t regular_stop = stop;
-      awkward_regularize_rangeslice(&regular_start, &regular_stop, step > 0, start != kSliceNone, stop != kSliceNone, length);
+      awkward_regularize_rangeslice(&regular_start, &regular_stop, step > 0,
+                                    start != kSliceNone, stop != kSliceNone,
+                                    length);
       for (int64_t j = regular_start;  j < regular_stop;  j += step) {
         tocarry[k] = fromstarts[startsoffset + i] + j;
         k++;
@@ -397,10 +926,13 @@ ERROR awkward_listarray_getitem_next_range(C* tooffsets, T* tocarry, const C* fr
   }
   else {
     for (int64_t i = 0;  i < lenstarts;  i++) {
-      int64_t length = fromstops[stopsoffset + i] - fromstarts[startsoffset + i];
+      int64_t length =
+        fromstops[stopsoffset + i] - fromstarts[startsoffset + i];
       int64_t regular_start = start;
       int64_t regular_stop = stop;
-      awkward_regularize_rangeslice(&regular_start, &regular_stop, step > 0, start != kSliceNone, stop != kSliceNone, length);
+      awkward_regularize_rangeslice(&regular_start, &regular_stop, step > 0,
+                                    start != kSliceNone, stop != kSliceNone,
+                                    length);
       for (int64_t j = regular_start;  j > regular_stop;  j += step) {
         tocarry[k] = fromstarts[startsoffset + i] + j;
         k++;
@@ -410,36 +942,121 @@ ERROR awkward_listarray_getitem_next_range(C* tooffsets, T* tocarry, const C* fr
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_next_range_64(int32_t* tooffsets, int64_t* tocarry, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-  return awkward_listarray_getitem_next_range<int32_t, int64_t>(tooffsets, tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
+ERROR awkward_listarray32_getitem_next_range_64(
+  int32_t* tooffsets,
+  int64_t* tocarry,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t start,
+  int64_t stop,
+  int64_t step) {
+  return awkward_listarray_getitem_next_range<int32_t, int64_t>(
+    tooffsets,
+    tocarry,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    start,
+    stop,
+    step);
 }
-ERROR awkward_listarrayU32_getitem_next_range_64(uint32_t* tooffsets, int64_t* tocarry, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-  return awkward_listarray_getitem_next_range<uint32_t, int64_t>(tooffsets, tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
+ERROR awkward_listarrayU32_getitem_next_range_64(
+  uint32_t* tooffsets,
+  int64_t* tocarry,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t start,
+  int64_t stop,
+  int64_t step) {
+  return awkward_listarray_getitem_next_range<uint32_t, int64_t>(
+    tooffsets,
+    tocarry,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    start,
+    stop,
+    step);
 }
-ERROR awkward_listarray64_getitem_next_range_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-  return awkward_listarray_getitem_next_range<int64_t, int64_t>(tooffsets, tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
+ERROR awkward_listarray64_getitem_next_range_64(
+  int64_t* tooffsets,
+  int64_t* tocarry,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t start,
+  int64_t stop,
+  int64_t step) {
+  return awkward_listarray_getitem_next_range<int64_t, int64_t>(
+    tooffsets,
+    tocarry,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset,
+    start,
+    stop,
+    step);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_next_range_counts(int64_t* total, const C* fromoffsets, int64_t lenstarts) {
+ERROR awkward_listarray_getitem_next_range_counts(
+  int64_t* total,
+  const C* fromoffsets,
+  int64_t lenstarts) {
   *total = 0;
   for (int64_t i = 0;  i < lenstarts;  i++) {
     *total = *total + fromoffsets[i + 1] - fromoffsets[i];
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_next_range_counts_64(int64_t* total, const int32_t* fromoffsets, int64_t lenstarts) {
-  return awkward_listarray_getitem_next_range_counts<int32_t, int64_t>(total, fromoffsets, lenstarts);
+ERROR awkward_listarray32_getitem_next_range_counts_64(
+  int64_t* total,
+  const int32_t* fromoffsets,
+  int64_t lenstarts) {
+  return awkward_listarray_getitem_next_range_counts<int32_t, int64_t>(
+    total,
+    fromoffsets,
+    lenstarts);
 }
-ERROR awkward_listarrayU32_getitem_next_range_counts_64(int64_t* total, const uint32_t* fromoffsets, int64_t lenstarts) {
-  return awkward_listarray_getitem_next_range_counts<uint32_t, int64_t>(total, fromoffsets, lenstarts);
+ERROR awkward_listarrayU32_getitem_next_range_counts_64(
+  int64_t* total,
+  const uint32_t* fromoffsets,
+  int64_t lenstarts) {
+  return awkward_listarray_getitem_next_range_counts<uint32_t, int64_t>(
+    total,
+    fromoffsets,
+    lenstarts);
 }
-ERROR awkward_listarray64_getitem_next_range_counts_64(int64_t* total, const int64_t* fromoffsets, int64_t lenstarts) {
-  return awkward_listarray_getitem_next_range_counts<int64_t, int64_t>(total, fromoffsets, lenstarts);
+ERROR awkward_listarray64_getitem_next_range_counts_64(
+  int64_t* total,
+  const int64_t* fromoffsets,
+  int64_t lenstarts) {
+  return awkward_listarray_getitem_next_range_counts<int64_t, int64_t>(
+    total,
+    fromoffsets,
+    lenstarts);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_next_range_spreadadvanced(T* toadvanced, const T* fromadvanced, const C* fromoffsets, int64_t lenstarts) {
+ERROR awkward_listarray_getitem_next_range_spreadadvanced(
+  T* toadvanced,
+  const T* fromadvanced,
+  const C* fromoffsets,
+  int64_t lenstarts) {
   for (int64_t i = 0;  i < lenstarts;  i++) {
     C count = fromoffsets[i + 1] - fromoffsets[i];
     for (int64_t j = 0;  j < count;  j++) {
@@ -448,23 +1065,61 @@ ERROR awkward_listarray_getitem_next_range_spreadadvanced(T* toadvanced, const T
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, const int32_t* fromoffsets, int64_t lenstarts) {
-  return awkward_listarray_getitem_next_range_spreadadvanced<int32_t, int64_t>(toadvanced, fromadvanced, fromoffsets, lenstarts);
+ERROR awkward_listarray32_getitem_next_range_spreadadvanced_64(
+  int64_t* toadvanced,
+  const int64_t* fromadvanced,
+  const int32_t* fromoffsets,
+  int64_t lenstarts) {
+  return awkward_listarray_getitem_next_range_spreadadvanced<int32_t,
+                                                             int64_t>(
+    toadvanced,
+    fromadvanced,
+    fromoffsets,
+    lenstarts);
 }
-ERROR awkward_listarrayU32_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, const uint32_t* fromoffsets, int64_t lenstarts) {
-  return awkward_listarray_getitem_next_range_spreadadvanced<uint32_t, int64_t>(toadvanced, fromadvanced, fromoffsets, lenstarts);
+ERROR awkward_listarrayU32_getitem_next_range_spreadadvanced_64(
+  int64_t* toadvanced,
+  const int64_t* fromadvanced,
+  const uint32_t* fromoffsets,
+  int64_t lenstarts) {
+  return awkward_listarray_getitem_next_range_spreadadvanced<uint32_t,
+                                                             int64_t>(
+    toadvanced,
+    fromadvanced,
+    fromoffsets,
+    lenstarts);
 }
-ERROR awkward_listarray64_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, const int64_t* fromoffsets, int64_t lenstarts) {
-  return awkward_listarray_getitem_next_range_spreadadvanced<int64_t, int64_t>(toadvanced, fromadvanced, fromoffsets, lenstarts);
+ERROR awkward_listarray64_getitem_next_range_spreadadvanced_64(
+  int64_t* toadvanced,
+  const int64_t* fromadvanced,
+  const int64_t* fromoffsets,
+  int64_t lenstarts) {
+  return awkward_listarray_getitem_next_range_spreadadvanced<int64_t,
+                                                             int64_t>(
+    toadvanced,
+    fromadvanced,
+    fromoffsets,
+    lenstarts);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_next_array(T* tocarry, T* toadvanced, const C* fromstarts, const C* fromstops, const T* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
+ERROR awkward_listarray_getitem_next_array(
+  T* tocarry,
+  T* toadvanced,
+  const C* fromstarts,
+  const C* fromstops,
+  const T* fromarray,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lenarray,
+  int64_t lencontent) {
   for (int64_t i = 0;  i < lenstarts;  i++) {
     if (fromstops[stopsoffset + i] < fromstarts[startsoffset + i]) {
       return failure("stops[i] < starts[i]", i, kSliceNone);
     }
-    if (fromstarts[startsoffset + i] != fromstops[stopsoffset + i]  &&  fromstops[stopsoffset + i] > lencontent) {
+    if (fromstarts[startsoffset + i] != fromstops[stopsoffset + i]  &&
+        fromstops[stopsoffset + i] > lencontent) {
       return failure("stops[i] > len(content)", i, kSliceNone);
     }
     int64_t length = fromstops[stopsoffset + i] - fromstarts[startsoffset + i];
@@ -482,23 +1137,95 @@ ERROR awkward_listarray_getitem_next_array(T* tocarry, T* toadvanced, const C* f
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-  return awkward_listarray_getitem_next_array<int32_t, int64_t>(tocarry, toadvanced, fromstarts, fromstops, fromarray, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
+ERROR awkward_listarray32_getitem_next_array_64(
+  int64_t* tocarry,
+  int64_t* toadvanced,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  const int64_t* fromarray,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lenarray,
+  int64_t lencontent) {
+  return awkward_listarray_getitem_next_array<int32_t, int64_t>(
+    tocarry,
+    toadvanced,
+    fromstarts,
+    fromstops,
+    fromarray,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lenarray,
+    lencontent);
 }
-ERROR awkward_listarrayU32_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-  return awkward_listarray_getitem_next_array<uint32_t, int64_t>(tocarry, toadvanced, fromstarts, fromstops, fromarray, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
+ERROR awkward_listarrayU32_getitem_next_array_64(
+  int64_t* tocarry,
+  int64_t* toadvanced,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  const int64_t* fromarray,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lenarray,
+  int64_t lencontent) {
+  return awkward_listarray_getitem_next_array<uint32_t, int64_t>(
+    tocarry,
+    toadvanced,
+    fromstarts,
+    fromstops,
+    fromarray,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lenarray,
+    lencontent);
 }
-ERROR awkward_listarray64_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-  return awkward_listarray_getitem_next_array<int64_t, int64_t>(tocarry, toadvanced, fromstarts, fromstops, fromarray, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
+ERROR awkward_listarray64_getitem_next_array_64(
+  int64_t* tocarry,
+  int64_t* toadvanced,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  const int64_t* fromarray,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lenarray,
+  int64_t lencontent) {
+  return awkward_listarray_getitem_next_array<int64_t, int64_t>(
+    tocarry,
+    toadvanced,
+    fromstarts,
+    fromstops,
+    fromarray,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lenarray,
+    lencontent);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_next_array_advanced(T* tocarry, T* toadvanced, const C* fromstarts, const C* fromstops, const T* fromarray, const T* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
+ERROR awkward_listarray_getitem_next_array_advanced(
+  T* tocarry,
+  T* toadvanced,
+  const C* fromstarts,
+  const C* fromstops,
+  const T* fromarray,
+  const T* fromadvanced,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lenarray,
+  int64_t lencontent) {
   for (int64_t i = 0;  i < lenstarts;  i++) {
     if (fromstops[stopsoffset + i] < fromstarts[startsoffset + i]) {
       return failure("stops[i] < starts[i]", i, kSliceNone);
     }
-    if (fromstarts[startsoffset + i] != fromstops[stopsoffset + i]  &&  fromstops[stopsoffset + i] > lencontent) {
+    if (fromstarts[startsoffset + i] != fromstops[stopsoffset + i]  &&
+        fromstops[stopsoffset + i] > lencontent) {
       return failure("stops[i] > len(content)", i, kSliceNone);
     }
     int64_t length = fromstops[stopsoffset + i] - fromstarts[startsoffset + i];
@@ -514,18 +1241,93 @@ ERROR awkward_listarray_getitem_next_array_advanced(T* tocarry, T* toadvanced, c
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-  return awkward_listarray_getitem_next_array_advanced<int32_t, int64_t>(tocarry, toadvanced, fromstarts, fromstops, fromarray, fromadvanced, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
+ERROR awkward_listarray32_getitem_next_array_advanced_64(
+  int64_t* tocarry,
+  int64_t* toadvanced,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  const int64_t* fromarray,
+  const int64_t* fromadvanced,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lenarray,
+  int64_t lencontent) {
+  return awkward_listarray_getitem_next_array_advanced<int32_t, int64_t>(
+    tocarry,
+    toadvanced,
+    fromstarts,
+    fromstops,
+    fromarray,
+    fromadvanced,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lenarray,
+    lencontent);
 }
-ERROR awkward_listarrayU32_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-  return awkward_listarray_getitem_next_array_advanced<uint32_t, int64_t>(tocarry, toadvanced, fromstarts, fromstops, fromarray, fromadvanced, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
+ERROR awkward_listarrayU32_getitem_next_array_advanced_64(
+  int64_t* tocarry,
+  int64_t* toadvanced,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  const int64_t* fromarray,
+  const int64_t* fromadvanced,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lenarray,
+  int64_t lencontent) {
+  return awkward_listarray_getitem_next_array_advanced<uint32_t, int64_t>(
+    tocarry,
+    toadvanced,
+    fromstarts,
+    fromstops,
+    fromarray,
+    fromadvanced,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lenarray,
+    lencontent);
 }
-ERROR awkward_listarray64_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-  return awkward_listarray_getitem_next_array_advanced<int64_t, int64_t>(tocarry, toadvanced, fromstarts, fromstops, fromarray, fromadvanced, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
+ERROR awkward_listarray64_getitem_next_array_advanced_64(
+  int64_t* tocarry,
+  int64_t* toadvanced,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  const int64_t* fromarray,
+  const int64_t* fromadvanced,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lenarray,
+  int64_t lencontent) {
+  return awkward_listarray_getitem_next_array_advanced<int64_t, int64_t>(
+    tocarry,
+    toadvanced,
+    fromstarts,
+    fromstops,
+    fromarray,
+    fromadvanced,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lenarray,
+    lencontent);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_carry(C* tostarts, C* tostops, const C* fromstarts, const C* fromstops, const T* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry) {
+ERROR awkward_listarray_getitem_carry(
+  C* tostarts,
+  C* tostops,
+  const C* fromstarts,
+  const C* fromstops,
+  const T* fromcarry,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lencarry) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     if (fromcarry[i] >= lenstarts) {
       return failure("index out of range", i, fromcarry[i]);
@@ -535,18 +1337,76 @@ ERROR awkward_listarray_getitem_carry(C* tostarts, C* tostops, const C* fromstar
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_carry_64(int32_t* tostarts, int32_t* tostops, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry) {
-  return awkward_listarray_getitem_carry<int32_t, int64_t>(tostarts, tostops, fromstarts, fromstops, fromcarry, startsoffset, stopsoffset, lenstarts, lencarry);
+ERROR awkward_listarray32_getitem_carry_64(
+  int32_t* tostarts,
+  int32_t* tostops,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  const int64_t* fromcarry,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lencarry) {
+  return awkward_listarray_getitem_carry<int32_t, int64_t>(
+    tostarts,
+    tostops,
+    fromstarts,
+    fromstops,
+    fromcarry,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lencarry);
 }
-ERROR awkward_listarrayU32_getitem_carry_64(uint32_t* tostarts, uint32_t* tostops, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry) {
-  return awkward_listarray_getitem_carry<uint32_t, int64_t>(tostarts, tostops, fromstarts, fromstops, fromcarry, startsoffset, stopsoffset, lenstarts, lencarry);
+ERROR awkward_listarrayU32_getitem_carry_64(
+  uint32_t* tostarts,
+  uint32_t* tostops,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  const int64_t* fromcarry,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lencarry) {
+  return awkward_listarray_getitem_carry<uint32_t, int64_t>(
+    tostarts,
+    tostops,
+    fromstarts,
+    fromstops,
+    fromcarry,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lencarry);
 }
-ERROR awkward_listarray64_getitem_carry_64(int64_t* tostarts, int64_t* tostops, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry) {
-  return awkward_listarray_getitem_carry<int64_t, int64_t>(tostarts, tostops, fromstarts, fromstops, fromcarry, startsoffset, stopsoffset, lenstarts, lencarry);
+ERROR awkward_listarray64_getitem_carry_64(
+  int64_t* tostarts,
+  int64_t* tostops,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  const int64_t* fromcarry,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t lenstarts,
+  int64_t lencarry) {
+  return awkward_listarray_getitem_carry<int64_t, int64_t>(
+    tostarts,
+    tostops,
+    fromstarts,
+    fromstops,
+    fromcarry,
+    startsoffset,
+    stopsoffset,
+    lenstarts,
+    lencarry);
 }
 
 template <typename T>
-ERROR awkward_regulararray_getitem_next_at(T* tocarry, int64_t at, int64_t len, int64_t size) {
+ERROR awkward_regulararray_getitem_next_at(
+  T* tocarry,
+  int64_t at,
+  int64_t len,
+  int64_t size) {
   int64_t regular_at = at;
   if (regular_at < 0) {
     regular_at += size;
@@ -559,12 +1419,26 @@ ERROR awkward_regulararray_getitem_next_at(T* tocarry, int64_t at, int64_t len, 
   }
   return success();
 }
-ERROR awkward_regulararray_getitem_next_at_64(int64_t* tocarry, int64_t at, int64_t len, int64_t size) {
-  return awkward_regulararray_getitem_next_at<int64_t>(tocarry, at, len, size);
+ERROR awkward_regulararray_getitem_next_at_64(
+  int64_t* tocarry,
+  int64_t at,
+  int64_t len,
+  int64_t size) {
+  return awkward_regulararray_getitem_next_at<int64_t>(
+    tocarry,
+    at,
+    len,
+    size);
 }
 
 template <typename T>
-ERROR awkward_regulararray_getitem_next_range(T* tocarry, int64_t regular_start, int64_t step, int64_t len, int64_t size, int64_t nextsize) {
+ERROR awkward_regulararray_getitem_next_range(
+  T* tocarry,
+  int64_t regular_start,
+  int64_t step,
+  int64_t len,
+  int64_t size,
+  int64_t nextsize) {
   for (int64_t i = 0;  i < len;  i++) {
     for (int64_t j = 0;  j < nextsize;  j++) {
       tocarry[i*nextsize + j] = i*size + regular_start + j*step;
@@ -572,12 +1446,28 @@ ERROR awkward_regulararray_getitem_next_range(T* tocarry, int64_t regular_start,
   }
   return success();
 }
-ERROR awkward_regulararray_getitem_next_range_64(int64_t* tocarry, int64_t regular_start, int64_t step, int64_t len, int64_t size, int64_t nextsize) {
-  return awkward_regulararray_getitem_next_range<int64_t>(tocarry, regular_start, step, len, size, nextsize);
+ERROR awkward_regulararray_getitem_next_range_64(
+  int64_t* tocarry,
+  int64_t regular_start,
+  int64_t step,
+  int64_t len,
+  int64_t size,
+  int64_t nextsize) {
+  return awkward_regulararray_getitem_next_range<int64_t>(
+    tocarry,
+    regular_start,
+    step,
+    len,
+    size,
+    nextsize);
 }
 
 template <typename T>
-ERROR awkward_regulararray_getitem_next_range_spreadadvanced(T* toadvanced, const T* fromadvanced, int64_t len, int64_t nextsize) {
+ERROR awkward_regulararray_getitem_next_range_spreadadvanced(
+  T* toadvanced,
+  const T* fromadvanced,
+  int64_t len,
+  int64_t nextsize) {
   for (int64_t i = 0;  i < len;  i++) {
     for (int64_t j = 0;  j < nextsize;  j++) {
       toadvanced[i*nextsize + j] = fromadvanced[i];
@@ -585,12 +1475,24 @@ ERROR awkward_regulararray_getitem_next_range_spreadadvanced(T* toadvanced, cons
   }
   return success();
 }
-ERROR awkward_regulararray_getitem_next_range_spreadadvanced_64(int64_t* toadvanced, const int64_t* fromadvanced, int64_t len, int64_t nextsize) {
-  return awkward_regulararray_getitem_next_range_spreadadvanced<int64_t>(toadvanced, fromadvanced, len, nextsize);
+ERROR awkward_regulararray_getitem_next_range_spreadadvanced_64(
+  int64_t* toadvanced,
+  const int64_t* fromadvanced,
+  int64_t len,
+  int64_t nextsize) {
+  return awkward_regulararray_getitem_next_range_spreadadvanced<int64_t>(
+    toadvanced,
+    fromadvanced,
+    len,
+    nextsize);
 }
 
 template <typename T>
-ERROR awkward_regulararray_getitem_next_array_regularize(T* toarray, const T* fromarray, int64_t lenarray, int64_t size) {
+ERROR awkward_regulararray_getitem_next_array_regularize(
+  T* toarray,
+  const T* fromarray,
+  int64_t lenarray,
+  int64_t size) {
   for (int64_t j = 0;  j < lenarray;  j++) {
     toarray[j] = fromarray[j];
     if (toarray[j] < 0) {
@@ -602,12 +1504,26 @@ ERROR awkward_regulararray_getitem_next_array_regularize(T* toarray, const T* fr
   }
   return success();
 }
-ERROR awkward_regulararray_getitem_next_array_regularize_64(int64_t* toarray, const int64_t* fromarray, int64_t lenarray, int64_t size) {
-  return awkward_regulararray_getitem_next_array_regularize<int64_t>(toarray, fromarray, lenarray, size);
+ERROR awkward_regulararray_getitem_next_array_regularize_64(
+  int64_t* toarray,
+  const int64_t* fromarray,
+  int64_t lenarray,
+  int64_t size) {
+  return awkward_regulararray_getitem_next_array_regularize<int64_t>(
+    toarray,
+    fromarray,
+    lenarray,
+    size);
 }
 
 template <typename T>
-ERROR awkward_regulararray_getitem_next_array(T* tocarry, T* toadvanced, const T* fromarray, int64_t len, int64_t lenarray, int64_t size) {
+ERROR awkward_regulararray_getitem_next_array(
+  T* tocarry,
+  T* toadvanced,
+  const T* fromarray,
+  int64_t len,
+  int64_t lenarray,
+  int64_t size) {
   for (int64_t i = 0;  i < len;  i++) {
     for (int64_t j = 0;  j < lenarray;  j++) {
       tocarry[i*lenarray + j] = i*size + fromarray[j];
@@ -616,24 +1532,61 @@ ERROR awkward_regulararray_getitem_next_array(T* tocarry, T* toadvanced, const T
   }
   return success();
 }
-ERROR awkward_regulararray_getitem_next_array_64(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromarray, int64_t len, int64_t lenarray, int64_t size) {
-  return awkward_regulararray_getitem_next_array<int64_t>(tocarry, toadvanced, fromarray, len, lenarray, size);
+ERROR awkward_regulararray_getitem_next_array_64(
+  int64_t* tocarry,
+  int64_t* toadvanced,
+  const int64_t* fromarray,
+  int64_t len,
+  int64_t lenarray,
+  int64_t size) {
+  return awkward_regulararray_getitem_next_array<int64_t>(
+    tocarry,
+    toadvanced,
+    fromarray,
+    len,
+    lenarray,
+    size);
 }
 
 template <typename T>
-ERROR awkward_regulararray_getitem_next_array_advanced(T* tocarry, T* toadvanced, const T* fromadvanced, const T* fromarray, int64_t len, int64_t lenarray, int64_t size) {
+ERROR awkward_regulararray_getitem_next_array_advanced(
+  T* tocarry,
+  T* toadvanced,
+  const T* fromadvanced,
+  const T* fromarray,
+  int64_t len,
+  int64_t lenarray,
+  int64_t size) {
   for (int64_t i = 0;  i < len;  i++) {
     tocarry[i] = i*size + fromarray[fromadvanced[i]];
     toadvanced[i] = i;
   }
   return success();
 }
-ERROR awkward_regulararray_getitem_next_array_advanced_64(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromadvanced, const int64_t* fromarray, int64_t len, int64_t lenarray, int64_t size) {
-  return awkward_regulararray_getitem_next_array_advanced<int64_t>(tocarry, toadvanced, fromadvanced, fromarray, len, lenarray, size);
+ERROR awkward_regulararray_getitem_next_array_advanced_64(
+  int64_t* tocarry,
+  int64_t* toadvanced,
+  const int64_t* fromadvanced,
+  const int64_t* fromarray,
+  int64_t len,
+  int64_t lenarray,
+  int64_t size) {
+  return awkward_regulararray_getitem_next_array_advanced<int64_t>(
+    tocarry,
+    toadvanced,
+    fromadvanced,
+    fromarray,
+    len,
+    lenarray,
+    size);
 }
 
 template <typename T>
-ERROR awkward_regulararray_getitem_carry(T* tocarry, const T* fromcarry, int64_t lencarry, int64_t size) {
+ERROR awkward_regulararray_getitem_carry(
+  T* tocarry,
+  const T* fromcarry,
+  int64_t lencarry,
+  int64_t size) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     for (int64_t j = 0;  j < size;  j++) {
       tocarry[i*size + j] = fromcarry[i]*size + j;
@@ -641,12 +1594,24 @@ ERROR awkward_regulararray_getitem_carry(T* tocarry, const T* fromcarry, int64_t
   }
   return success();
 }
-ERROR awkward_regulararray_getitem_carry_64(int64_t* tocarry, const int64_t* fromcarry, int64_t lencarry, int64_t size) {
-  return awkward_regulararray_getitem_carry<int64_t>(tocarry, fromcarry, lencarry, size);
+ERROR awkward_regulararray_getitem_carry_64(
+  int64_t* tocarry,
+  const int64_t* fromcarry,
+  int64_t lencarry,
+  int64_t size) {
+  return awkward_regulararray_getitem_carry<int64_t>(
+    tocarry,
+    fromcarry,
+    lencarry,
+    size);
 }
 
 template <typename C>
-ERROR awkward_indexedarray_numnull(int64_t* numnull, const C* fromindex, int64_t indexoffset, int64_t lenindex) {
+ERROR awkward_indexedarray_numnull(
+  int64_t* numnull,
+  const C* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex) {
   *numnull = 0;
   for (int64_t i = 0;  i < lenindex;  i++) {
     if (fromindex[indexoffset + i] < 0) {
@@ -655,18 +1620,48 @@ ERROR awkward_indexedarray_numnull(int64_t* numnull, const C* fromindex, int64_t
   }
   return success();
 }
-ERROR awkward_indexedarray32_numnull(int64_t* numnull, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex) {
-  return awkward_indexedarray_numnull<int32_t>(numnull, fromindex, indexoffset, lenindex);
+ERROR awkward_indexedarray32_numnull(
+  int64_t* numnull,
+  const int32_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex) {
+  return awkward_indexedarray_numnull<int32_t>(
+    numnull,
+    fromindex,
+    indexoffset,
+    lenindex);
 }
-ERROR awkward_indexedarrayU32_numnull(int64_t* numnull, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex) {
-  return awkward_indexedarray_numnull<uint32_t>(numnull, fromindex, indexoffset, lenindex);
+ERROR awkward_indexedarrayU32_numnull(
+  int64_t* numnull,
+  const uint32_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex) {
+  return awkward_indexedarray_numnull<uint32_t>(
+    numnull,
+    fromindex,
+    indexoffset,
+    lenindex);
 }
-ERROR awkward_indexedarray64_numnull(int64_t* numnull, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex) {
-  return awkward_indexedarray_numnull<int64_t>(numnull, fromindex, indexoffset, lenindex);
+ERROR awkward_indexedarray64_numnull(
+  int64_t* numnull,
+  const int64_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex) {
+  return awkward_indexedarray_numnull<int64_t>(
+    numnull,
+    fromindex,
+    indexoffset,
+    lenindex);
 }
 
 template <typename C, typename T>
-ERROR awkward_indexedarray_getitem_nextcarry_outindex(T* tocarry, C* toindex, const C* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
+ERROR awkward_indexedarray_getitem_nextcarry_outindex(
+  T* tocarry,
+  C* toindex,
+  const C* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
   int64_t k = 0;
   for (int64_t i = 0;  i < lenindex;  i++) {
     C j = fromindex[indexoffset + i];
@@ -684,18 +1679,60 @@ ERROR awkward_indexedarray_getitem_nextcarry_outindex(T* tocarry, C* toindex, co
   }
   return success();
 }
-ERROR awkward_indexedarray32_getitem_nextcarry_outindex_64(int64_t* tocarry, int32_t* toindex, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry_outindex<int32_t, int64_t>(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarray32_getitem_nextcarry_outindex_64(
+  int64_t* tocarry,
+  int32_t* toindex,
+  const int32_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry_outindex<int32_t, int64_t>(
+    tocarry,
+    toindex,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
-ERROR awkward_indexedarrayU32_getitem_nextcarry_outindex_64(int64_t* tocarry, uint32_t* toindex, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry_outindex<uint32_t, int64_t>(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarrayU32_getitem_nextcarry_outindex_64(
+  int64_t* tocarry,
+  uint32_t* toindex,
+  const uint32_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry_outindex<uint32_t, int64_t>(
+    tocarry,
+    toindex,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
-ERROR awkward_indexedarray64_getitem_nextcarry_outindex_64(int64_t* tocarry, int64_t* toindex, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry_outindex<int64_t, int64_t>(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarray64_getitem_nextcarry_outindex_64(
+  int64_t* tocarry,
+  int64_t* toindex,
+  const int64_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry_outindex<int64_t, int64_t>(
+    tocarry,
+    toindex,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
 
 template <typename C, typename T>
-ERROR awkward_indexedarray_getitem_nextcarry_outindex_mask(T* tocarry, T* toindex, const C* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
+ERROR awkward_indexedarray_getitem_nextcarry_outindex_mask(
+  T* tocarry,
+  T* toindex,
+  const C* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
   int64_t k = 0;
   for (int64_t i = 0;  i < lenindex;  i++) {
     C j = fromindex[indexoffset + i];
@@ -713,18 +1750,65 @@ ERROR awkward_indexedarray_getitem_nextcarry_outindex_mask(T* tocarry, T* toinde
   }
   return success();
 }
-ERROR awkward_indexedarray32_getitem_nextcarry_outindex_mask_64(int64_t* tocarry, int64_t* toindex, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry_outindex_mask<int32_t, int64_t>(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarray32_getitem_nextcarry_outindex_mask_64(
+  int64_t* tocarry,
+  int64_t* toindex,
+  const int32_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry_outindex_mask<int32_t,
+                                                              int64_t>(
+    tocarry,
+    toindex,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
-ERROR awkward_indexedarrayU32_getitem_nextcarry_outindex_mask_64(int64_t* tocarry, int64_t* toindex, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry_outindex_mask<uint32_t, int64_t>(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarrayU32_getitem_nextcarry_outindex_mask_64(
+  int64_t* tocarry,
+  int64_t* toindex,
+  const uint32_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry_outindex_mask<uint32_t,
+                                                              int64_t>(
+    tocarry,
+    toindex,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
-ERROR awkward_indexedarray64_getitem_nextcarry_outindex_mask_64(int64_t* tocarry, int64_t* toindex, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry_outindex_mask<int64_t, int64_t>(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarray64_getitem_nextcarry_outindex_mask_64(
+  int64_t* tocarry,
+  int64_t* toindex,
+  const int64_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry_outindex_mask<int64_t,
+                                                              int64_t>(
+    tocarry,
+    toindex,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
 
 template <typename T>
-ERROR awkward_listoffsetarray_getitem_adjust_offsets(T* tooffsets, T* tononzero, const T* fromoffsets, int64_t offsetsoffset, int64_t length, const T* nonzero, int64_t nonzerooffset, int64_t nonzerolength) {
+ERROR awkward_listoffsetarray_getitem_adjust_offsets(
+  T* tooffsets,
+  T* tononzero,
+  const T* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  const T* nonzero,
+  int64_t nonzerooffset,
+  int64_t nonzerolength) {
   int64_t j = 0;
   tooffsets[0] = fromoffsets[offsetsoffset + 0];
   for (int64_t i = 0;  i < length;  i++) {
@@ -740,12 +1824,42 @@ ERROR awkward_listoffsetarray_getitem_adjust_offsets(T* tooffsets, T* tononzero,
   }
   return success();
 }
-ERROR awkward_listoffsetarray_getitem_adjust_offsets_64(int64_t* tooffsets, int64_t* tononzero, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length, const int64_t* nonzero, int64_t nonzerooffset, int64_t nonzerolength) {
-  return awkward_listoffsetarray_getitem_adjust_offsets<int64_t>(tooffsets, tononzero, fromoffsets, offsetsoffset, length, nonzero, nonzerooffset, nonzerolength);
+ERROR awkward_listoffsetarray_getitem_adjust_offsets_64(
+  int64_t* tooffsets,
+  int64_t* tononzero,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  const int64_t* nonzero,
+  int64_t nonzerooffset,
+  int64_t nonzerolength) {
+  return awkward_listoffsetarray_getitem_adjust_offsets<int64_t>(
+    tooffsets,
+    tononzero,
+    fromoffsets,
+    offsetsoffset,
+    length,
+    nonzero,
+    nonzerooffset,
+    nonzerolength);
 }
 
 template <typename T>
-ERROR awkward_listoffsetarray_getitem_adjust_offsets_index(T* tooffsets, T* tononzero, const T* fromoffsets, int64_t offsetsoffset, int64_t length, const T* index, int64_t indexoffset, int64_t indexlength, const T* nonzero, int64_t nonzerooffset, int64_t nonzerolength, const int8_t* originalmask, int64_t maskoffset, int64_t masklength) {
+ERROR awkward_listoffsetarray_getitem_adjust_offsets_index(
+  T* tooffsets,
+  T* tononzero,
+  const T* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  const T* index,
+  int64_t indexoffset,
+  int64_t indexlength,
+  const T* nonzero,
+  int64_t nonzerooffset,
+  int64_t nonzerolength,
+  const int8_t* originalmask,
+  int64_t maskoffset,
+  int64_t masklength) {
   int64_t k = 0;
   tooffsets[0] = fromoffsets[offsetsoffset + 0];
   for (int64_t i = 0;  i < length;  i++) {
@@ -757,7 +1871,11 @@ ERROR awkward_listoffsetarray_getitem_adjust_offsets_index(T* tooffsets, T* tono
     }
     int64_t nullcount = 0;
     int64_t count = 0;
-    while (k < indexlength  &&  ((index[indexoffset + k] < 0  &&  nullcount < numnull)  ||  (index[indexoffset + k] >= 0  &&  index[indexoffset + k] < nonzerolength  &&  nonzero[nonzerooffset + index[indexoffset + k]] < slicestop))) {
+    while (k < indexlength  &&
+           ((index[indexoffset + k] < 0  && nullcount < numnull)  ||
+            (index[indexoffset + k] >= 0  &&
+             index[indexoffset + k] < nonzerolength  &&
+             nonzero[nonzerooffset + index[indexoffset + k]] < slicestop))) {
       if (index[indexoffset + k] < 0) {
         nullcount++;
       }
@@ -772,12 +1890,49 @@ ERROR awkward_listoffsetarray_getitem_adjust_offsets_index(T* tooffsets, T* tono
   }
   return success();
 }
-ERROR awkward_listoffsetarray_getitem_adjust_offsets_index_64(int64_t* tooffsets, int64_t* tononzero, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length, const int64_t* index, int64_t indexoffset, int64_t indexlength, const int64_t* nonzero, int64_t nonzerooffset, int64_t nonzerolength, const int8_t* originalmask, int64_t maskoffset, int64_t masklength) {
-  return awkward_listoffsetarray_getitem_adjust_offsets_index<int64_t>(tooffsets, tononzero, fromoffsets, offsetsoffset, length, index, indexoffset, indexlength, nonzero, nonzerooffset, nonzerolength, originalmask, maskoffset, masklength);
+ERROR awkward_listoffsetarray_getitem_adjust_offsets_index_64(
+  int64_t* tooffsets,
+  int64_t* tononzero,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  const int64_t* index,
+  int64_t indexoffset,
+  int64_t indexlength,
+  const int64_t* nonzero,
+  int64_t nonzerooffset,
+  int64_t nonzerolength,
+  const int8_t* originalmask,
+  int64_t maskoffset,
+  int64_t masklength) {
+  return awkward_listoffsetarray_getitem_adjust_offsets_index<int64_t>(
+    tooffsets,
+    tononzero,
+    fromoffsets,
+    offsetsoffset,
+    length,
+    index,
+    indexoffset,
+    indexlength,
+    nonzero,
+    nonzerooffset,
+    nonzerolength,
+    originalmask,
+    maskoffset,
+    masklength);
 }
 
 template <typename T>
-ERROR awkward_indexedarray_getitem_adjust_outindex(int8_t* tomask, T* toindex, T* tononzero, const T* fromindex, int64_t fromindexoffset, int64_t fromindexlength, const T* nonzero, int64_t nonzerooffset, int64_t nonzerolength) {
+ERROR awkward_indexedarray_getitem_adjust_outindex(
+  int8_t* tomask,
+  T* toindex,
+  T* tononzero,
+  const T* fromindex,
+  int64_t fromindexoffset,
+  int64_t fromindexlength,
+  const T* nonzero,
+  int64_t nonzerooffset,
+  int64_t nonzerolength) {
   int64_t j = 0;
   int64_t k = 0;
   for (int64_t i = 0;  i < fromindexlength;  i++) {
@@ -796,12 +1951,35 @@ ERROR awkward_indexedarray_getitem_adjust_outindex(int8_t* tomask, T* toindex, T
   }
   return success();
 }
-ERROR awkward_indexedarray_getitem_adjust_outindex_64(int8_t* tomask, int64_t* toindex, int64_t* tononzero, const int64_t* fromindex, int64_t fromindexoffset, int64_t fromindexlength, const int64_t* nonzero, int64_t nonzerooffset, int64_t nonzerolength) {
-  return awkward_indexedarray_getitem_adjust_outindex<int64_t>(tomask, toindex, tononzero, fromindex, fromindexoffset, fromindexlength, nonzero, nonzerooffset, nonzerolength);
+ERROR awkward_indexedarray_getitem_adjust_outindex_64(
+  int8_t* tomask,
+  int64_t* toindex,
+  int64_t* tononzero,
+  const int64_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t fromindexlength,
+  const int64_t* nonzero,
+  int64_t nonzerooffset,
+  int64_t nonzerolength) {
+  return awkward_indexedarray_getitem_adjust_outindex<int64_t>(
+    tomask,
+    toindex,
+    tononzero,
+    fromindex,
+    fromindexoffset,
+    fromindexlength,
+    nonzero,
+    nonzerooffset,
+    nonzerolength);
 }
 
 template <typename C, typename T>
-ERROR awkward_indexedarray_getitem_nextcarry(T* tocarry, const C* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
+ERROR awkward_indexedarray_getitem_nextcarry(
+  T* tocarry,
+  const C* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
   int64_t k = 0;
   for (int64_t i = 0;  i < lenindex;  i++) {
     C j = fromindex[indexoffset + i];
@@ -815,18 +1993,54 @@ ERROR awkward_indexedarray_getitem_nextcarry(T* tocarry, const C* fromindex, int
   }
   return success();
 }
-ERROR awkward_indexedarray32_getitem_nextcarry_64(int64_t* tocarry, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry<int32_t, int64_t>(tocarry, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarray32_getitem_nextcarry_64(
+  int64_t* tocarry,
+  const int32_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry<int32_t, int64_t>(
+    tocarry,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
-ERROR awkward_indexedarrayU32_getitem_nextcarry_64(int64_t* tocarry, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry<uint32_t, int64_t>(tocarry, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarrayU32_getitem_nextcarry_64(
+  int64_t* tocarry,
+  const uint32_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry<uint32_t, int64_t>(
+    tocarry,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
-ERROR awkward_indexedarray64_getitem_nextcarry_64(int64_t* tocarry, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_getitem_nextcarry<int64_t, int64_t>(tocarry, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarray64_getitem_nextcarry_64(
+  int64_t* tocarry,
+  const int64_t* fromindex,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencontent) {
+  return awkward_indexedarray_getitem_nextcarry<int64_t, int64_t>(
+    tocarry,
+    fromindex,
+    indexoffset,
+    lenindex,
+    lencontent);
 }
 
 template <typename C, typename T>
-ERROR awkward_indexedarray_getitem_carry(C* toindex, const C* fromindex, const T* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry) {
+ERROR awkward_indexedarray_getitem_carry(
+  C* toindex,
+  const C* fromindex,
+  const T* fromcarry,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencarry) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     if (fromcarry[i] >= lenindex) {
       return failure("index out of range", i, fromcarry[i]);
@@ -835,18 +2049,58 @@ ERROR awkward_indexedarray_getitem_carry(C* toindex, const C* fromindex, const T
   }
   return success();
 }
-ERROR awkward_indexedarray32_getitem_carry_64(int32_t* toindex, const int32_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry) {
-  return awkward_indexedarray_getitem_carry<int32_t, int64_t>(toindex, fromindex, fromcarry, indexoffset, lenindex, lencarry);
+ERROR awkward_indexedarray32_getitem_carry_64(
+  int32_t* toindex,
+  const int32_t* fromindex,
+  const int64_t* fromcarry,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencarry) {
+  return awkward_indexedarray_getitem_carry<int32_t, int64_t>(
+    toindex,
+    fromindex,
+    fromcarry,
+    indexoffset,
+    lenindex,
+    lencarry);
 }
-ERROR awkward_indexedarrayU32_getitem_carry_64(uint32_t* toindex, const uint32_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry) {
-  return awkward_indexedarray_getitem_carry<uint32_t, int64_t>(toindex, fromindex, fromcarry, indexoffset, lenindex, lencarry);
+ERROR awkward_indexedarrayU32_getitem_carry_64(
+  uint32_t* toindex,
+  const uint32_t* fromindex,
+  const int64_t* fromcarry,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencarry) {
+  return awkward_indexedarray_getitem_carry<uint32_t, int64_t>(
+    toindex,
+    fromindex,
+    fromcarry,
+    indexoffset,
+    lenindex,
+    lencarry);
 }
-ERROR awkward_indexedarray64_getitem_carry_64(int64_t* toindex, const int64_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry) {
-  return awkward_indexedarray_getitem_carry<int64_t, int64_t>(toindex, fromindex, fromcarry, indexoffset, lenindex, lencarry);
+ERROR awkward_indexedarray64_getitem_carry_64(
+  int64_t* toindex,
+  const int64_t* fromindex,
+  const int64_t* fromcarry,
+  int64_t indexoffset,
+  int64_t lenindex,
+  int64_t lencarry) {
+  return awkward_indexedarray_getitem_carry<int64_t, int64_t>(
+    toindex,
+    fromindex,
+    fromcarry,
+    indexoffset,
+    lenindex,
+    lencarry);
 }
 
 template <typename C, typename I>
-ERROR awkward_unionarray_regular_index(I* toindex, const C* fromtags, int64_t tagsoffset, int64_t length) {
+ERROR awkward_unionarray_regular_index(
+  I* toindex,
+  const C* fromtags,
+  int64_t tagsoffset,
+  int64_t length) {
   std::vector<I> current;
   for (int64_t i = 0;  i < length;  i++) {
     C tag = fromtags[tagsoffset + i];
@@ -858,18 +2112,50 @@ ERROR awkward_unionarray_regular_index(I* toindex, const C* fromtags, int64_t ta
   }
   return success();
 }
-ERROR awkward_unionarray8_32_regular_index(int32_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length) {
-  return awkward_unionarray_regular_index<int8_t, int32_t>(toindex, fromtags, tagsoffset, length);
+ERROR awkward_unionarray8_32_regular_index(
+  int32_t* toindex,
+  const int8_t* fromtags,
+  int64_t tagsoffset,
+  int64_t length) {
+  return awkward_unionarray_regular_index<int8_t, int32_t>(
+    toindex,
+    fromtags,
+    tagsoffset,
+    length);
 }
-ERROR awkward_unionarray8_U32_regular_index(uint32_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length) {
-  return awkward_unionarray_regular_index<int8_t, uint32_t>(toindex, fromtags, tagsoffset, length);
+ERROR awkward_unionarray8_U32_regular_index(
+  uint32_t* toindex,
+  const int8_t* fromtags,
+  int64_t tagsoffset,
+  int64_t length) {
+  return awkward_unionarray_regular_index<int8_t, uint32_t>(
+    toindex,
+    fromtags,
+    tagsoffset,
+    length);
 }
-ERROR awkward_unionarray8_64_regular_index(int64_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length) {
-  return awkward_unionarray_regular_index<int8_t, int64_t>(toindex, fromtags, tagsoffset, length);
+ERROR awkward_unionarray8_64_regular_index(
+  int64_t* toindex,
+  const int8_t* fromtags,
+  int64_t tagsoffset,
+  int64_t length) {
+  return awkward_unionarray_regular_index<int8_t, int64_t>(
+    toindex,
+    fromtags,
+    tagsoffset,
+    length);
 }
 
 template <typename T, typename C, typename I>
-ERROR awkward_unionarray_project(int64_t* lenout, T* tocarry, const C* fromtags, int64_t tagsoffset, const I* fromindex, int64_t indexoffset, int64_t length, int64_t which) {
+ERROR awkward_unionarray_project(
+  int64_t* lenout,
+  T* tocarry,
+  const C* fromtags,
+  int64_t tagsoffset,
+  const I* fromindex,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t which) {
   *lenout = 0;
   for (int64_t i = 0;  i < length;  i++) {
     if (fromtags[tagsoffset + i] == which) {
@@ -879,18 +2165,72 @@ ERROR awkward_unionarray_project(int64_t* lenout, T* tocarry, const C* fromtags,
   }
   return success();
 }
-ERROR awkward_unionarray8_32_project_64(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const int32_t* fromindex, int64_t indexoffset, int64_t length, int64_t which) {
-  return awkward_unionarray_project<int64_t, int8_t, int32_t>(lenout, tocarry, fromtags, tagsoffset, fromindex, indexoffset, length, which);
+ERROR awkward_unionarray8_32_project_64(
+  int64_t* lenout,
+  int64_t* tocarry,
+  const int8_t* fromtags,
+  int64_t tagsoffset,
+  const int32_t* fromindex,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t which) {
+  return awkward_unionarray_project<int64_t, int8_t, int32_t>(
+    lenout,
+    tocarry,
+    fromtags,
+    tagsoffset,
+    fromindex,
+    indexoffset,
+    length,
+    which);
 }
-ERROR awkward_unionarray8_U32_project_64(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const uint32_t* fromindex, int64_t indexoffset, int64_t length, int64_t which) {
-  return awkward_unionarray_project<int64_t, int8_t, uint32_t>(lenout, tocarry, fromtags, tagsoffset, fromindex, indexoffset, length, which);
+ERROR awkward_unionarray8_U32_project_64(
+  int64_t* lenout,
+  int64_t* tocarry,
+  const int8_t* fromtags,
+  int64_t tagsoffset,
+  const uint32_t* fromindex,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t which) {
+  return awkward_unionarray_project<int64_t, int8_t, uint32_t>(
+    lenout,
+    tocarry,
+    fromtags,
+    tagsoffset,
+    fromindex,
+    indexoffset,
+    length,
+    which);
 }
-ERROR awkward_unionarray8_64_project_64(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const int64_t* fromindex, int64_t indexoffset, int64_t length, int64_t which) {
-  return awkward_unionarray_project<int64_t, int8_t, int64_t>(lenout, tocarry, fromtags, tagsoffset, fromindex, indexoffset, length, which);
+ERROR awkward_unionarray8_64_project_64(
+  int64_t* lenout,
+  int64_t* tocarry,
+  const int8_t* fromtags,
+  int64_t tagsoffset,
+  const int64_t* fromindex,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t which) {
+  return awkward_unionarray_project<int64_t, int8_t, int64_t>(
+    lenout,
+    tocarry,
+    fromtags,
+    tagsoffset,
+    fromindex,
+    indexoffset,
+    length,
+    which);
 }
 
 template <typename T>
-ERROR awkward_missing_repeat(T* outindex, const T* index, int64_t indexoffset, int64_t indexlength, int64_t repetitions, int64_t regularsize) {
+ERROR awkward_missing_repeat(
+  T* outindex,
+  const T* index,
+  int64_t indexoffset,
+  int64_t indexlength,
+  int64_t repetitions,
+  int64_t regularsize) {
   for (int64_t i = 0;  i < repetitions;  i++) {
     for (int64_t j = 0;  j < indexlength;  j++) {
       T base = index[indexoffset + j];
@@ -900,12 +2240,29 @@ ERROR awkward_missing_repeat(T* outindex, const T* index, int64_t indexoffset, i
 
   return success();
 }
-ERROR awkward_missing_repeat_64(int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t indexlength, int64_t repetitions, int64_t regularsize) {
-  return awkward_missing_repeat<int64_t>(outindex, index, indexoffset, indexlength, repetitions, regularsize);
+ERROR awkward_missing_repeat_64(
+  int64_t* outindex,
+  const int64_t* index,
+  int64_t indexoffset,
+  int64_t indexlength,
+  int64_t repetitions,
+  int64_t regularsize) {
+  return awkward_missing_repeat<int64_t>(
+    outindex,
+    index,
+    indexoffset,
+    indexlength,
+    repetitions,
+    regularsize);
 }
 
 template <typename T>
-ERROR awkward_regulararray_getitem_jagged_expand(T* multistarts, T* multistops, const T* singleoffsets, int64_t regularsize, int64_t regularlength) {
+ERROR awkward_regulararray_getitem_jagged_expand(
+  T* multistarts,
+  T* multistops,
+  const T* singleoffsets,
+  int64_t regularsize,
+  int64_t regularlength) {
   for (int64_t i = 0;  i < regularlength;  i++) {
     for (int64_t j = 0;  j < regularsize;  j++) {
       multistarts[i*regularsize + j] = singleoffsets[j];
@@ -914,12 +2271,32 @@ ERROR awkward_regulararray_getitem_jagged_expand(T* multistarts, T* multistops, 
   }
   return success();
 }
-ERROR awkward_regulararray_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t regularsize, int64_t regularlength) {
-  return awkward_regulararray_getitem_jagged_expand<int64_t>(multistarts, multistops, singleoffsets, regularsize, regularlength);
+ERROR awkward_regulararray_getitem_jagged_expand_64(
+  int64_t* multistarts,
+  int64_t* multistops,
+  const int64_t* singleoffsets,
+  int64_t regularsize,
+  int64_t regularlength) {
+  return awkward_regulararray_getitem_jagged_expand<int64_t>(
+    multistarts,
+    multistops,
+    singleoffsets,
+    regularsize,
+    regularlength);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_jagged_expand(T* multistarts, T* multistops, const T* singleoffsets, T* tocarry, const C* fromstarts, int64_t fromstartsoffset, const C* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length) {
+ERROR awkward_listarray_getitem_jagged_expand(
+  T* multistarts,
+  T* multistops,
+  const T* singleoffsets,
+  T* tocarry,
+  const C* fromstarts,
+  int64_t fromstartsoffset,
+  const C* fromstops,
+  int64_t fromstopsoffset,
+  int64_t jaggedsize,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     C start = fromstarts[fromstartsoffset + i];
     C stop = fromstops[fromstopsoffset + i];
@@ -927,7 +2304,8 @@ ERROR awkward_listarray_getitem_jagged_expand(T* multistarts, T* multistops, con
       return failure("stops[i] < starts[i]", i, kSliceNone);
     }
     if (stop - start != jaggedsize) {
-      return failure("cannot fit jagged slice into nested list", i, kSliceNone);
+      return failure(
+        "cannot fit jagged slice into nested list", i, kSliceNone);
     }
     for (int64_t j = 0;  j < jaggedsize;  j++) {
       multistarts[i*jaggedsize + j] = singleoffsets[j];
@@ -937,30 +2315,124 @@ ERROR awkward_listarray_getitem_jagged_expand(T* multistarts, T* multistops, con
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length) {
-  return awkward_listarray_getitem_jagged_expand<int32_t, int64_t>(multistarts, multistops, singleoffsets, tocarry, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, jaggedsize, length);
+ERROR awkward_listarray32_getitem_jagged_expand_64(
+  int64_t* multistarts,
+  int64_t* multistops,
+  const int64_t* singleoffsets,
+  int64_t* tocarry,
+  const int32_t* fromstarts,
+  int64_t fromstartsoffset,
+  const int32_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t jaggedsize,
+  int64_t length) {
+  return awkward_listarray_getitem_jagged_expand<int32_t, int64_t>(
+    multistarts,
+    multistops,
+    singleoffsets,
+    tocarry,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    jaggedsize,
+    length);
 }
-ERROR awkward_listarrayU32_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length) {
-  return awkward_listarray_getitem_jagged_expand<uint32_t, int64_t>(multistarts, multistops, singleoffsets, tocarry, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, jaggedsize, length);
+ERROR awkward_listarrayU32_getitem_jagged_expand_64(
+  int64_t* multistarts,
+  int64_t* multistops,
+  const int64_t* singleoffsets,
+  int64_t* tocarry,
+  const uint32_t* fromstarts,
+  int64_t fromstartsoffset,
+  const uint32_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t jaggedsize,
+  int64_t length) {
+  return awkward_listarray_getitem_jagged_expand<uint32_t, int64_t>(
+    multistarts,
+    multistops,
+    singleoffsets,
+    tocarry,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    jaggedsize,
+    length);
 }
-ERROR awkward_listarray64_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length) {
-  return awkward_listarray_getitem_jagged_expand<int64_t, int64_t>(multistarts, multistops, singleoffsets, tocarry, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, jaggedsize, length);
+ERROR awkward_listarray64_getitem_jagged_expand_64(
+  int64_t* multistarts,
+  int64_t* multistops,
+  const int64_t* singleoffsets,
+  int64_t* tocarry,
+  const int64_t* fromstarts,
+  int64_t fromstartsoffset,
+  const int64_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t jaggedsize,
+  int64_t length) {
+  return awkward_listarray_getitem_jagged_expand<int64_t, int64_t>(
+    multistarts,
+    multistops,
+    singleoffsets,
+    tocarry,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    jaggedsize,
+    length);
 }
 
 template <typename T>
-ERROR awkward_listarray_getitem_jagged_carrylen(int64_t* carrylen, const T* slicestarts, int64_t slicestartsoffset, const T* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen) {
+ERROR awkward_listarray_getitem_jagged_carrylen(
+  int64_t* carrylen,
+  const T* slicestarts,
+  int64_t slicestartsoffset,
+  const T* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen) {
   *carrylen = 0;
   for (int64_t i = 0;  i < sliceouterlen;  i++) {
-    *carrylen = *carrylen + (int64_t)(slicestops[slicestopsoffset + i] - slicestarts[slicestartsoffset + i]);
+    *carrylen = *carrylen + (int64_t)(slicestops[slicestopsoffset + i] -
+                                      slicestarts[slicestartsoffset + i]);
   }
   return success();
 }
-ERROR awkward_listarray_getitem_jagged_carrylen_64(int64_t* carrylen, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen) {
-  return awkward_listarray_getitem_jagged_carrylen<int64_t>(carrylen, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen);
+ERROR awkward_listarray_getitem_jagged_carrylen_64(
+  int64_t* carrylen,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen) {
+  return awkward_listarray_getitem_jagged_carrylen<int64_t>(
+    carrylen,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    sliceouterlen);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_jagged_apply(T* tooffsets, T* tocarry, const T* slicestarts, int64_t slicestartsoffset, const T* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const T* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const C* fromstarts, int64_t fromstartsoffset, const C* fromstops, int64_t fromstopsoffset, int64_t contentlen) {
+ERROR awkward_listarray_getitem_jagged_apply(
+  T* tooffsets,
+  T* tocarry,
+  const T* slicestarts,
+  int64_t slicestartsoffset,
+  const T* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen,
+  const T* sliceindex,
+  int64_t sliceindexoffset,
+  int64_t sliceinnerlen,
+  const C* fromstarts,
+  int64_t fromstartsoffset,
+  const C* fromstops,
+  int64_t fromstopsoffset,
+  int64_t contentlen) {
   int64_t k = 0;
   for (int64_t i = 0;  i < sliceouterlen;  i++) {
     T slicestart = slicestarts[slicestartsoffset + i];
@@ -971,7 +2443,8 @@ ERROR awkward_listarray_getitem_jagged_apply(T* tooffsets, T* tocarry, const T* 
         return failure("jagged slice's stops[i] < starts[i]", i, kSliceNone);
       }
       if (slicestop > sliceinnerlen) {
-        return failure("jagged slice's offsets extend beyond its content", i, slicestop);
+        return failure(
+          "jagged slice's offsets extend beyond its content", i, slicestop);
       }
       int64_t start = (int64_t)fromstarts[fromstartsoffset + i];
       int64_t stop = (int64_t)fromstops[fromstopsoffset + i];
@@ -988,7 +2461,10 @@ ERROR awkward_listarray_getitem_jagged_apply(T* tooffsets, T* tocarry, const T* 
           index += count;
         }
         if (!(0 <= index  &&  index < count)) {
-          return failure("index out of range", i, (int64_t)sliceindex[sliceindexoffset + j]);
+          return failure(
+            "index out of range",
+            i,
+            (int64_t)sliceindex[sliceindexoffset + j]);
         }
         tocarry[k] = start + index;
         k++;
@@ -998,18 +2474,117 @@ ERROR awkward_listarray_getitem_jagged_apply(T* tooffsets, T* tocarry, const T* 
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_jagged_apply_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset, int64_t contentlen) {
-  return awkward_listarray_getitem_jagged_apply<int32_t, int64_t>(tooffsets, tocarry, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, sliceindex, sliceindexoffset, sliceinnerlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, contentlen);
+ERROR awkward_listarray32_getitem_jagged_apply_64(
+  int64_t* tooffsets,
+  int64_t* tocarry,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen,
+  const int64_t* sliceindex,
+  int64_t sliceindexoffset,
+  int64_t sliceinnerlen,
+  const int32_t* fromstarts,
+  int64_t fromstartsoffset,
+  const int32_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t contentlen) {
+  return awkward_listarray_getitem_jagged_apply<int32_t, int64_t>(
+    tooffsets,
+    tocarry,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    sliceouterlen,
+    sliceindex,
+    sliceindexoffset,
+    sliceinnerlen,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    contentlen);
 }
-ERROR awkward_listarrayU32_getitem_jagged_apply_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset, int64_t contentlen) {
-  return awkward_listarray_getitem_jagged_apply<uint32_t, int64_t>(tooffsets, tocarry, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, sliceindex, sliceindexoffset, sliceinnerlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, contentlen);
+ERROR awkward_listarrayU32_getitem_jagged_apply_64(
+  int64_t* tooffsets,
+  int64_t* tocarry,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen,
+  const int64_t* sliceindex,
+  int64_t sliceindexoffset,
+  int64_t sliceinnerlen,
+  const uint32_t* fromstarts,
+  int64_t fromstartsoffset,
+  const uint32_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t contentlen) {
+  return awkward_listarray_getitem_jagged_apply<uint32_t, int64_t>(
+    tooffsets,
+    tocarry,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    sliceouterlen,
+    sliceindex,
+    sliceindexoffset,
+    sliceinnerlen,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    contentlen);
 }
-ERROR awkward_listarray64_getitem_jagged_apply_64(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset, int64_t contentlen) {
-  return awkward_listarray_getitem_jagged_apply<int64_t, int64_t>(tooffsets, tocarry, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, sliceindex, sliceindexoffset, sliceinnerlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, contentlen);
+ERROR awkward_listarray64_getitem_jagged_apply_64(
+  int64_t* tooffsets,
+  int64_t* tocarry,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen,
+  const int64_t* sliceindex,
+  int64_t sliceindexoffset,
+  int64_t sliceinnerlen,
+  const int64_t* fromstarts,
+  int64_t fromstartsoffset,
+  const int64_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t contentlen) {
+  return awkward_listarray_getitem_jagged_apply<int64_t, int64_t>(
+    tooffsets,
+    tocarry,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    sliceouterlen,
+    sliceindex,
+    sliceindexoffset,
+    sliceinnerlen,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    contentlen);
 }
 
 template <typename T>
-ERROR awkward_listarray_getitem_jagged_numvalid(int64_t* numvalid, const T* slicestarts, int64_t slicestartsoffset, const T* slicestops, int64_t slicestopsoffset, int64_t length, const T* missing, int64_t missingoffset, int64_t missinglength) {
+ERROR awkward_listarray_getitem_jagged_numvalid(
+  int64_t* numvalid,
+  const T* slicestarts,
+  int64_t slicestartsoffset,
+  const T* slicestops,
+  int64_t slicestopsoffset,
+  int64_t length,
+  const T* missing,
+  int64_t missingoffset,
+  int64_t missinglength) {
   *numvalid = 0;
   for (int64_t i = 0;  i < length;  i++) {
     T slicestart = slicestarts[slicestartsoffset + i];
@@ -1019,7 +2594,8 @@ ERROR awkward_listarray_getitem_jagged_numvalid(int64_t* numvalid, const T* slic
         return failure("jagged slice's stops[i] < starts[i]", i, kSliceNone);
       }
       if (slicestop > missinglength) {
-        return failure("jagged slice's offsets extend beyond its content", i, slicestop);
+        return failure(
+          "jagged slice's offsets extend beyond its content", i, slicestop);
       }
       for (int64_t j = slicestart;  j < slicestop;  j++) {
         *numvalid = *numvalid + (missing[missingoffset + j] >= 0 ? 1 : 0);
@@ -1028,12 +2604,40 @@ ERROR awkward_listarray_getitem_jagged_numvalid(int64_t* numvalid, const T* slic
   }
   return success();
 }
-ERROR awkward_listarray_getitem_jagged_numvalid_64(int64_t* numvalid, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t length, const int64_t* missing, int64_t missingoffset, int64_t missinglength) {
-  return awkward_listarray_getitem_jagged_numvalid<int64_t>(numvalid, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, length, missing, missingoffset, missinglength);
+ERROR awkward_listarray_getitem_jagged_numvalid_64(
+  int64_t* numvalid,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t length,
+  const int64_t* missing,
+  int64_t missingoffset,
+  int64_t missinglength) {
+  return awkward_listarray_getitem_jagged_numvalid<int64_t>(
+    numvalid,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    length,
+    missing,
+    missingoffset,
+    missinglength);
 }
 
 template <typename T>
-ERROR awkward_listarray_getitem_jagged_shrink(T* tocarry, T* tosmalloffsets, T* tolargeoffsets, const T* slicestarts, int64_t slicestartsoffset, const T* slicestops, int64_t slicestopsoffset, int64_t length, const T* missing, int64_t missingoffset) {
+ERROR awkward_listarray_getitem_jagged_shrink(
+  T* tocarry,
+  T* tosmalloffsets,
+  T* tolargeoffsets,
+  const T* slicestarts,
+  int64_t slicestartsoffset,
+  const T* slicestops,
+  int64_t slicestopsoffset,
+  int64_t length,
+  const T* missing,
+  int64_t missingoffset) {
   int64_t k = 0;
   if (length == 0) {
     tosmalloffsets[0] = 0;
@@ -1064,12 +2668,42 @@ ERROR awkward_listarray_getitem_jagged_shrink(T* tocarry, T* tosmalloffsets, T* 
   }
   return success();
 }
-ERROR awkward_listarray_getitem_jagged_shrink_64(int64_t* tocarry, int64_t* tosmalloffsets, int64_t* tolargeoffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t length, const int64_t* missing, int64_t missingoffset) {
-  return awkward_listarray_getitem_jagged_shrink<int64_t>(tocarry, tosmalloffsets, tolargeoffsets, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, length, missing, missingoffset);
+ERROR awkward_listarray_getitem_jagged_shrink_64(
+  int64_t* tocarry,
+  int64_t* tosmalloffsets,
+  int64_t* tolargeoffsets,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t length,
+  const int64_t* missing,
+  int64_t missingoffset) {
+  return awkward_listarray_getitem_jagged_shrink<int64_t>(
+    tocarry,
+    tosmalloffsets,
+    tolargeoffsets,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    length,
+    missing,
+    missingoffset);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_getitem_jagged_descend(T* tooffsets, const T* slicestarts, int64_t slicestartsoffset, const T* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const C* fromstarts, int64_t fromstartsoffset, const C* fromstops, int64_t fromstopsoffset) {
+ERROR awkward_listarray_getitem_jagged_descend(
+  T* tooffsets,
+  const T* slicestarts,
+  int64_t slicestartsoffset,
+  const T* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen,
+  const C* fromstarts,
+  int64_t fromstartsoffset,
+  const C* fromstops,
+  int64_t fromstopsoffset) {
   if (sliceouterlen == 0) {
     tooffsets[0] = 0;
   }
@@ -1077,59 +2711,165 @@ ERROR awkward_listarray_getitem_jagged_descend(T* tooffsets, const T* slicestart
     tooffsets[0] = slicestarts[slicestartsoffset + 0];
   }
   for (int64_t i = 0;  i < sliceouterlen;  i++) {
-    int64_t slicecount = (int64_t)(slicestops[slicestopsoffset + i] - slicestarts[slicestartsoffset + i]);
-    int64_t count = (int64_t)(fromstops[fromstopsoffset + i] - fromstarts[fromstartsoffset + i]);
+    int64_t slicecount = (int64_t)(slicestops[slicestopsoffset + i] -
+                                   slicestarts[slicestartsoffset + i]);
+    int64_t count = (int64_t)(fromstops[fromstopsoffset + i] -
+                              fromstarts[fromstartsoffset + i]);
     if (slicecount != count) {
-      return failure("jagged slice inner length differs from array inner length", i, kSliceNone);
+      return failure(
+        "jagged slice inner length differs from array inner length",
+        i,
+        kSliceNone);
     }
     tooffsets[i + 1] = tooffsets[i] + (T)count;
   }
   return success();
 }
-ERROR awkward_listarray32_getitem_jagged_descend_64(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset) {
-  return awkward_listarray_getitem_jagged_descend<int32_t, int64_t>(tooffsets, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset);
+ERROR awkward_listarray32_getitem_jagged_descend_64(
+  int64_t* tooffsets,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen,
+  const int32_t* fromstarts,
+  int64_t fromstartsoffset,
+  const int32_t* fromstops,
+  int64_t fromstopsoffset) {
+  return awkward_listarray_getitem_jagged_descend<int32_t, int64_t>(
+    tooffsets,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    sliceouterlen,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset);
 }
-ERROR awkward_listarrayU32_getitem_jagged_descend_64(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset) {
-  return awkward_listarray_getitem_jagged_descend<uint32_t, int64_t>(tooffsets, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset);
+ERROR awkward_listarrayU32_getitem_jagged_descend_64(
+  int64_t* tooffsets,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen,
+  const uint32_t* fromstarts,
+  int64_t fromstartsoffset,
+  const uint32_t* fromstops,
+  int64_t fromstopsoffset) {
+  return awkward_listarray_getitem_jagged_descend<uint32_t, int64_t>(
+    tooffsets,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    sliceouterlen,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset);
 }
-ERROR awkward_listarray64_getitem_jagged_descend_64(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset) {
-  return awkward_listarray_getitem_jagged_descend<int64_t, int64_t>(tooffsets, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset);
+ERROR awkward_listarray64_getitem_jagged_descend_64(
+  int64_t* tooffsets,
+  const int64_t* slicestarts,
+  int64_t slicestartsoffset,
+  const int64_t* slicestops,
+  int64_t slicestopsoffset,
+  int64_t sliceouterlen,
+  const int64_t* fromstarts,
+  int64_t fromstartsoffset,
+  const int64_t* fromstops,
+  int64_t fromstopsoffset) {
+  return awkward_listarray_getitem_jagged_descend<int64_t, int64_t>(
+    tooffsets,
+    slicestarts,
+    slicestartsoffset,
+    slicestops,
+    slicestopsoffset,
+    sliceouterlen,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset);
 }
 
-int8_t awkward_index8_getitem_at_nowrap(const int8_t* ptr, int64_t offset, int64_t at) {
+int8_t awkward_index8_getitem_at_nowrap(
+  const int8_t* ptr,
+  int64_t offset,
+  int64_t at) {
   return ptr[(size_t)(offset + at)];
 }
-uint8_t awkward_indexU8_getitem_at_nowrap(const uint8_t* ptr, int64_t offset, int64_t at) {
+uint8_t awkward_indexU8_getitem_at_nowrap(
+  const uint8_t* ptr,
+  int64_t offset,
+  int64_t at) {
   return ptr[(size_t)(offset + at)];
 }
-int32_t awkward_index32_getitem_at_nowrap(const int32_t* ptr, int64_t offset, int64_t at) {
+int32_t awkward_index32_getitem_at_nowrap(
+  const int32_t* ptr,
+  int64_t offset,
+  int64_t at) {
   return ptr[(size_t)(offset + at)];
 }
-uint32_t awkward_indexU32_getitem_at_nowrap(const uint32_t* ptr, int64_t offset, int64_t at) {
+uint32_t awkward_indexU32_getitem_at_nowrap(
+  const uint32_t* ptr,
+  int64_t offset,
+  int64_t at) {
   return ptr[(size_t)(offset + at)];
 }
-int64_t awkward_index64_getitem_at_nowrap(const int64_t* ptr, int64_t offset, int64_t at) {
+int64_t awkward_index64_getitem_at_nowrap(
+  const int64_t* ptr,
+  int64_t offset,
+  int64_t at) {
   return ptr[(size_t)(offset + at)];
 }
 
-void awkward_index8_setitem_at_nowrap(int8_t* ptr, int64_t offset, int64_t at, int8_t value) {
+void awkward_index8_setitem_at_nowrap(
+  int8_t* ptr,
+  int64_t offset,
+  int64_t at,
+  int8_t value) {
   ptr[(size_t)(offset + at)] = value;
 }
-void awkward_indexU8_setitem_at_nowrap(uint8_t* ptr, int64_t offset, int64_t at, uint8_t value) {
+void awkward_indexU8_setitem_at_nowrap(
+  uint8_t* ptr,
+  int64_t offset,
+  int64_t at,
+  uint8_t value) {
   ptr[(size_t)(offset + at)] = value;
 }
-void awkward_index32_setitem_at_nowrap(int32_t* ptr, int64_t offset, int64_t at, int32_t value) {
+void awkward_index32_setitem_at_nowrap(
+  int32_t* ptr,
+  int64_t offset,
+  int64_t at,
+  int32_t value) {
   ptr[(size_t)(offset + at)] = value;
 }
-void awkward_indexU32_setitem_at_nowrap(uint32_t* ptr, int64_t offset, int64_t at, uint32_t value) {
+void awkward_indexU32_setitem_at_nowrap(
+  uint32_t* ptr,
+  int64_t offset,
+  int64_t at,
+  uint32_t value) {
   ptr[(size_t)(offset + at)] = value;
 }
-void awkward_index64_setitem_at_nowrap(int64_t* ptr, int64_t offset, int64_t at, int64_t value) {
+void awkward_index64_setitem_at_nowrap(
+  int64_t* ptr,
+  int64_t offset,
+  int64_t at,
+  int64_t value) {
   ptr[(size_t)(offset + at)] = value;
 }
 
 template <typename T>
-ERROR awkward_bytemaskedarray_getitem_carry(int8_t* tomask, const int8_t* frommask, int64_t frommaskoffset, int64_t lenmask, const T* fromcarry, int64_t lencarry) {
+ERROR awkward_bytemaskedarray_getitem_carry(
+  int8_t* tomask,
+  const int8_t* frommask,
+  int64_t frommaskoffset,
+  int64_t lenmask,
+  const T* fromcarry,
+  int64_t lencarry) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     if (fromcarry[i] >= lenmask) {
       return failure("index out of range", i, fromcarry[i]);
@@ -1138,11 +2878,28 @@ ERROR awkward_bytemaskedarray_getitem_carry(int8_t* tomask, const int8_t* fromma
   }
   return success();
 }
-ERROR awkward_bytemaskedarray_getitem_carry_64(int8_t* tomask, const int8_t* frommask, int64_t frommaskoffset, int64_t lenmask, const int64_t* fromcarry, int64_t lencarry) {
-  return awkward_bytemaskedarray_getitem_carry(tomask, frommask, frommaskoffset, lenmask, fromcarry, lencarry);
+ERROR awkward_bytemaskedarray_getitem_carry_64(
+  int8_t* tomask,
+  const int8_t* frommask,
+  int64_t frommaskoffset,
+  int64_t lenmask,
+  const int64_t* fromcarry,
+  int64_t lencarry) {
+  return awkward_bytemaskedarray_getitem_carry(
+    tomask,
+    frommask,
+    frommaskoffset,
+    lenmask,
+    fromcarry,
+    lencarry);
 }
 
-ERROR awkward_bytemaskedarray_numnull(int64_t* numnull, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen) {
+ERROR awkward_bytemaskedarray_numnull(
+  int64_t* numnull,
+  const int8_t* mask,
+  int64_t maskoffset,
+  int64_t length,
+  bool validwhen) {
   *numnull = 0;
   for (int64_t i = 0;  i < length;  i++) {
     if ((mask[maskoffset + i] != 0) != validwhen) {
@@ -1153,7 +2910,12 @@ ERROR awkward_bytemaskedarray_numnull(int64_t* numnull, const int8_t* mask, int6
 }
 
 template <typename T>
-ERROR awkward_bytemaskedarray_getitem_nextcarry(T* tocarry, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen) {
+ERROR awkward_bytemaskedarray_getitem_nextcarry(
+  T* tocarry,
+  const int8_t* mask,
+  int64_t maskoffset,
+  int64_t length,
+  bool validwhen) {
   int64_t k = 0;
   for (int64_t i = 0;  i < length;  i++) {
     if ((mask[maskoffset + i] != 0) == validwhen) {
@@ -1163,12 +2925,28 @@ ERROR awkward_bytemaskedarray_getitem_nextcarry(T* tocarry, const int8_t* mask, 
   }
   return success();
 }
-ERROR awkward_bytemaskedarray_getitem_nextcarry_64(int64_t* tocarry, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen) {
-  return awkward_bytemaskedarray_getitem_nextcarry<int64_t>(tocarry, mask, maskoffset, length, validwhen);
+ERROR awkward_bytemaskedarray_getitem_nextcarry_64(
+  int64_t* tocarry,
+  const int8_t* mask,
+  int64_t maskoffset,
+  int64_t length,
+  bool validwhen) {
+  return awkward_bytemaskedarray_getitem_nextcarry<int64_t>(
+    tocarry,
+    mask,
+    maskoffset,
+    length,
+    validwhen);
 }
 
 template <typename T>
-ERROR awkward_bytemaskedarray_getitem_nextcarry_outindex(T* tocarry, T* toindex, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen) {
+ERROR awkward_bytemaskedarray_getitem_nextcarry_outindex(
+  T* tocarry,
+  T* toindex,
+  const int8_t* mask,
+  int64_t maskoffset,
+  int64_t length,
+  bool validwhen) {
   int64_t k = 0;
   for (int64_t i = 0;  i < length;  i++) {
     if ((mask[maskoffset + i] != 0) == validwhen) {
@@ -1182,17 +2960,44 @@ ERROR awkward_bytemaskedarray_getitem_nextcarry_outindex(T* tocarry, T* toindex,
   }
   return success();
 }
-ERROR awkward_bytemaskedarray_getitem_nextcarry_outindex_64(int64_t* tocarry, int64_t* toindex, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen) {
-  return awkward_bytemaskedarray_getitem_nextcarry_outindex<int64_t>(tocarry, toindex, mask, maskoffset, length, validwhen);
+ERROR awkward_bytemaskedarray_getitem_nextcarry_outindex_64(
+  int64_t* tocarry,
+  int64_t* toindex,
+  const int8_t* mask,
+  int64_t maskoffset,
+  int64_t length,
+  bool validwhen) {
+  return awkward_bytemaskedarray_getitem_nextcarry_outindex<int64_t>(
+    tocarry,
+    toindex,
+    mask,
+    maskoffset,
+    length,
+    validwhen);
 }
 
 template <typename T>
-ERROR awkward_bytemaskedarray_toindexedarray(T* toindex, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen) {
+ERROR awkward_bytemaskedarray_toindexedarray(
+  T* toindex,
+  const int8_t* mask,
+  int64_t maskoffset,
+  int64_t length,
+  bool validwhen) {
   for (int64_t i = 0;  i < length;  i++) {
     toindex[i] = ((mask[maskoffset + i] != 0) == validwhen ? i : -1);
   }
   return success();
 }
-ERROR awkward_bytemaskedarray_toindexedarray_64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, int64_t length, bool validwhen) {
-  return awkward_bytemaskedarray_toindexedarray<int64_t>(toindex, mask, maskoffset, length, validwhen);
+ERROR awkward_bytemaskedarray_toindexedarray_64(
+  int64_t* toindex,
+  const int8_t* mask,
+  int64_t maskoffset,
+  int64_t length,
+  bool validwhen) {
+  return awkward_bytemaskedarray_toindexedarray<int64_t>(
+    toindex,
+    mask,
+    maskoffset,
+    length,
+    validwhen);
 }

--- a/src/cpu-kernels/identities.cpp
+++ b/src/cpu-kernels/identities.cpp
@@ -3,20 +3,34 @@
 #include "awkward/cpu-kernels/identities.h"
 
 template <typename T>
-ERROR awkward_new_identities(T* toptr, int64_t length) {
+ERROR awkward_new_identities(
+  T* toptr,
+  int64_t length) {
   for (T i = 0;  i < length;  i++) {
     toptr[i] = i;
   }
   return success();
 }
-ERROR awkward_new_identities32(int32_t* toptr, int64_t length) {
-  return awkward_new_identities<int32_t>(toptr, length);
+ERROR awkward_new_identities32(
+  int32_t* toptr,
+  int64_t length) {
+  return awkward_new_identities<int32_t>(
+    toptr,
+    length);
 }
-ERROR awkward_new_identities64(int64_t* toptr, int64_t length) {
-  return awkward_new_identities<int64_t>(toptr, length);
+ERROR awkward_new_identities64(
+  int64_t* toptr,
+  int64_t length) {
+  return awkward_new_identities<int64_t>(
+    toptr,
+    length);
 }
 
-ERROR awkward_identities32_to_identities64(int64_t* toptr, const int32_t* fromptr, int64_t length, int64_t width) {
+ERROR awkward_identities32_to_identities64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t length,
+  int64_t width) {
   for (int64_t i = 0;  i < length*width;  i++) {
     toptr[i]= (int64_t)fromptr[i];
   }
@@ -24,13 +38,23 @@ ERROR awkward_identities32_to_identities64(int64_t* toptr, const int32_t* frompt
 }
 
 template <typename ID, typename T>
-ERROR awkward_identities_from_listoffsetarray(ID* toptr, const ID* fromptr, const T* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
+ERROR awkward_identities_from_listoffsetarray(
+  ID* toptr,
+  const ID* fromptr,
+  const T* fromoffsets,
+  int64_t fromptroffset,
+  int64_t offsetsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
   int64_t globalstart = fromoffsets[offsetsoffset];
   int64_t globalstop = fromoffsets[offsetsoffset + fromlength];
   for (int64_t k = 0;  k < globalstart*(fromwidth + 1);  k++) {
     toptr[k] = -1;
   }
-  for (int64_t k = globalstop*(fromwidth + 1);  k < tolength*(fromwidth + 1);  k++) {
+  for (int64_t k = globalstop*(fromwidth + 1);
+       k < tolength*(fromwidth + 1);
+       k++) {
     toptr[k] = -1;
   }
   for (int64_t i = 0;  i < fromlength;  i++) {
@@ -41,34 +65,142 @@ ERROR awkward_identities_from_listoffsetarray(ID* toptr, const ID* fromptr, cons
     }
     for (int64_t j = start;  j < stop;  j++) {
       for (int64_t k = 0;  k < fromwidth;  k++) {
-        toptr[j*(fromwidth + 1) + k] = fromptr[fromptroffset + i*(fromwidth) + k];
+        toptr[j*(fromwidth + 1) + k] =
+          fromptr[fromptroffset + i*(fromwidth) + k];
       }
       toptr[j*(fromwidth + 1) + fromwidth] = ID(j - start);
     }
   }
   return success();
 }
-ERROR awkward_identities32_from_listoffsetarray32(int32_t* toptr, const int32_t* fromptr, const int32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listoffsetarray<int32_t, int32_t>(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_listoffsetarray32(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int32_t* fromoffsets,
+  int64_t fromptroffset,
+  int64_t offsetsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listoffsetarray<int32_t, int32_t>(
+    toptr,
+    fromptr,
+    fromoffsets,
+    fromptroffset,
+    offsetsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities32_from_listoffsetarrayU32(int32_t* toptr, const int32_t* fromptr, const uint32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listoffsetarray<int32_t, uint32_t>(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_listoffsetarrayU32(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const uint32_t* fromoffsets,
+  int64_t fromptroffset,
+  int64_t offsetsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listoffsetarray<int32_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromoffsets,
+    fromptroffset,
+    offsetsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities32_from_listoffsetarray64(int32_t* toptr, const int32_t* fromptr, const int64_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listoffsetarray<int32_t, int64_t>(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_listoffsetarray64(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int64_t* fromoffsets,
+  int64_t fromptroffset,
+  int64_t offsetsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listoffsetarray<int32_t, int64_t>(
+    toptr,
+    fromptr,
+    fromoffsets,
+    fromptroffset,
+    offsetsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_listoffsetarray32(int64_t* toptr, const int64_t* fromptr, const int32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listoffsetarray<int64_t, int32_t>(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_listoffsetarray32(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int32_t* fromoffsets,
+  int64_t fromptroffset,
+  int64_t offsetsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listoffsetarray<int64_t, int32_t>(
+    toptr,
+    fromptr,
+    fromoffsets,
+    fromptroffset,
+    offsetsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_listoffsetarrayU32(int64_t* toptr, const int64_t* fromptr, const uint32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listoffsetarray<int64_t, uint32_t>(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_listoffsetarrayU32(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const uint32_t* fromoffsets,
+  int64_t fromptroffset,
+  int64_t offsetsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listoffsetarray<int64_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromoffsets,
+    fromptroffset,
+    offsetsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_listoffsetarray64(int64_t* toptr, const int64_t* fromptr, const int64_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listoffsetarray<int64_t, int64_t>(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_listoffsetarray64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int64_t* fromoffsets,
+  int64_t fromptroffset,
+  int64_t offsetsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listoffsetarray<int64_t, int64_t>(
+    toptr,
+    fromptr,
+    fromoffsets,
+    fromptroffset,
+    offsetsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
 
 template <typename ID, typename T>
-ERROR awkward_identities_from_listarray(bool* uniquecontents, ID* toptr, const ID* fromptr, const T* fromstarts, const T* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
+ERROR awkward_identities_from_listarray(
+  bool* uniquecontents,
+  ID* toptr,
+  const ID* fromptr,
+  const T* fromstarts,
+  const T* fromstops,
+  int64_t fromptroffset,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
   for (int64_t k = 0;  k < tolength*(fromwidth + 1);  k++) {
     toptr[k] = -1;
   }
@@ -81,10 +213,11 @@ ERROR awkward_identities_from_listarray(bool* uniquecontents, ID* toptr, const I
     for (int64_t j = start;  j < stop;  j++) {
       if (toptr[j*(fromwidth + 1) + fromwidth] != -1) {
         *uniquecontents = false;
-        return success();   // calling code won't use the (incomplete) toptr if there are any non-unique contents
-      }
+        return success();   // calling code won't use the (incomplete) toptr
+      }                     // if there are any non-unique contents
       for (int64_t k = 0;  k < fromwidth;  k++) {
-        toptr[j*(fromwidth + 1) + k] = fromptr[fromptroffset + i*(fromwidth) + k];
+        toptr[j*(fromwidth + 1) + k] =
+          fromptr[fromptroffset + i*(fromwidth) + k];
       }
       toptr[j*(fromwidth + 1) + fromwidth] = ID(j - start);
     }
@@ -92,49 +225,228 @@ ERROR awkward_identities_from_listarray(bool* uniquecontents, ID* toptr, const I
   *uniquecontents = true;
   return success();
 }
-ERROR awkward_identities32_from_listarray32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int32_t* fromstarts, const int32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listarray<int32_t, int32_t>(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_listarray32(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int64_t fromptroffset,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listarray<int32_t, int32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromstarts,
+    fromstops,
+    fromptroffset,
+    startsoffset,
+    stopsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities32_from_listarrayU32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listarray<int32_t, uint32_t>(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_listarrayU32(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  int64_t fromptroffset,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listarray<int32_t, uint32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromstarts,
+    fromstops,
+    fromptroffset,
+    startsoffset,
+    stopsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities32_from_listarray64(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int64_t* fromstarts, const int64_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listarray<int32_t, int64_t>(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_listarray64(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t fromptroffset,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listarray<int32_t, int64_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromstarts,
+    fromstops,
+    fromptroffset,
+    startsoffset,
+    stopsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_listarray32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int32_t* fromstarts, const int32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listarray<int64_t, int32_t>(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_listarray32(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int64_t fromptroffset,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listarray<int64_t, int32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromstarts,
+    fromstops,
+    fromptroffset,
+    startsoffset,
+    stopsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_listarrayU32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listarray<int64_t, uint32_t>(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_listarrayU32(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  int64_t fromptroffset,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listarray<int64_t, uint32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromstarts,
+    fromstops,
+    fromptroffset,
+    startsoffset,
+    stopsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_listarray64(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int64_t* fromstarts, const int64_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_listarray<int64_t, int64_t>(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_listarray64(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t fromptroffset,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_listarray<int64_t, int64_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromstarts,
+    fromstops,
+    fromptroffset,
+    startsoffset,
+    stopsoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
 
 template <typename ID>
-ERROR awkward_identities_from_regulararray(ID* toptr, const ID* fromptr, int64_t fromptroffset, int64_t size, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
+ERROR awkward_identities_from_regulararray(
+  ID* toptr,
+  const ID* fromptr,
+  int64_t fromptroffset,
+  int64_t size,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
   for (int64_t i = 0;  i < fromlength;  i++) {
     for (int64_t j = 0;  j < size;  j++) {
       for (int64_t k = 0;  k < fromwidth;  k++) {
-        toptr[(i*size + j)*(fromwidth + 1) + k] = fromptr[fromptroffset + i*fromwidth + k];
+        toptr[(i*size + j)*(fromwidth + 1) + k] =
+          fromptr[fromptroffset + i*fromwidth + k];
       }
       toptr[(i*size + j)*(fromwidth + 1) + fromwidth] = ID(j);
     }
   }
-  for (int64_t k = (fromlength + 1)*size*(fromwidth + 1);  k < tolength*(fromwidth + 1);  k++) {
+  for (int64_t k = (fromlength + 1)*size*(fromwidth + 1);
+       k < tolength*(fromwidth + 1);
+       k++) {
     toptr[k] = -1;
   }
   return success();
 }
-ERROR awkward_identities32_from_regulararray(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, int64_t size, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_regulararray<int32_t>(toptr, fromptr, fromptroffset, size, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_regulararray(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  int64_t size,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_regulararray<int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    size,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_regulararray(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, int64_t size, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_regulararray<int64_t>(toptr, fromptr, fromptroffset, size, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_regulararray(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  int64_t size,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_regulararray<int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    size,
+    tolength,
+    fromlength,
+    fromwidth);
 }
 
 template <typename ID, typename T>
-ERROR awkward_identities_from_indexedarray(bool* uniquecontents, ID* toptr, const ID* fromptr, const T* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
+ERROR awkward_identities_from_indexedarray(
+  bool* uniquecontents,
+  ID* toptr,
+  const ID* fromptr,
+  const T* fromindex,
+  int64_t fromptroffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
   for (int64_t k = 0;  k < tolength*fromwidth;  k++) {
     toptr[k] = -1;
   }
@@ -146,8 +458,8 @@ ERROR awkward_identities_from_indexedarray(bool* uniquecontents, ID* toptr, cons
     else if (j >= 0) {
       if (toptr[j*fromwidth] != -1) {
         *uniquecontents = false;
-        return success();   // calling code won't use the (incomplete) toptr if there are any non-unique contents
-      }
+        return success();   // calling code won't use the (incomplete) toptr
+      }                     // if there are any non-unique contents
       for (int64_t k = 0;  k < fromwidth;  k++) {
         toptr[j*fromwidth + k] = fromptr[fromptroffset + i*fromwidth + k];
       }
@@ -156,27 +468,147 @@ ERROR awkward_identities_from_indexedarray(bool* uniquecontents, ID* toptr, cons
   *uniquecontents = true;
   return success();
 }
-ERROR awkward_identities32_from_indexedarray32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_indexedarray<int32_t, int32_t>(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_indexedarray32(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int32_t* fromindex,
+  int64_t fromptroffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_indexedarray<int32_t, int32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromindex,
+    fromptroffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities32_from_indexedarrayU32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const uint32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_indexedarray<int32_t, uint32_t>(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_indexedarrayU32(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const uint32_t* fromindex,
+  int64_t fromptroffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_indexedarray<int32_t, uint32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromindex,
+    fromptroffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities32_from_indexedarray64(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int64_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_indexedarray<int32_t, int64_t>(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities32_from_indexedarray64(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int64_t* fromindex,
+  int64_t fromptroffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_indexedarray<int32_t, int64_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromindex,
+    fromptroffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_indexedarray32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_indexedarray<int64_t, int32_t>(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_indexedarray32(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int32_t* fromindex,
+  int64_t fromptroffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_indexedarray<int64_t, int32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromindex,
+    fromptroffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_indexedarrayU32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const uint32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_indexedarray<int64_t, uint32_t>(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_indexedarrayU32(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const uint32_t* fromindex,
+  int64_t fromptroffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_indexedarray<int64_t, uint32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromindex,
+    fromptroffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
-ERROR awkward_identities64_from_indexedarray64(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int64_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-  return awkward_identities_from_indexedarray<int64_t, int64_t>(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
+ERROR awkward_identities64_from_indexedarray64(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int64_t* fromindex,
+  int64_t fromptroffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth) {
+  return awkward_identities_from_indexedarray<int64_t, int64_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromindex,
+    fromptroffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth);
 }
 
 template <typename ID, typename T, typename I>
-ERROR awkward_identities_from_unionarray(bool* uniquecontents, ID* toptr, const ID* fromptr, const T* fromtags, const I* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
+ERROR awkward_identities_from_unionarray(
+  bool* uniquecontents,
+  ID* toptr,
+  const ID* fromptr,
+  const T* fromtags,
+  const I* fromindex,
+  int64_t fromptroffset,
+  int64_t tagsoffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth,
+  int64_t which) {
   for (int64_t k = 0;  k < tolength*fromwidth;  k++) {
     toptr[k] = -1;
   }
@@ -192,8 +624,8 @@ ERROR awkward_identities_from_unionarray(bool* uniquecontents, ID* toptr, const 
       else {
         if (toptr[j*fromwidth] != -1) {
           *uniquecontents = false;
-          return success();   // calling code won't use the (incomplete) toptr if there are any non-unique contents
-        }
+          return success();   // calling code won't use the (incomplete) toptr
+        }                     // if there are any non-unique contents
         for (int64_t k = 0;  k < fromwidth;  k++) {
           toptr[j*fromwidth + k] = fromptr[fromptroffset + i*fromwidth + k];
         }
@@ -203,27 +635,176 @@ ERROR awkward_identities_from_unionarray(bool* uniquecontents, ID* toptr, const 
   *uniquecontents = true;
   return success();
 }
-ERROR awkward_identities32_from_unionarray8_32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const int32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-  return awkward_identities_from_unionarray<int32_t, int8_t, int32_t>(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
+ERROR awkward_identities32_from_unionarray8_32(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int8_t* fromtags,
+  const int32_t* fromindex,
+  int64_t fromptroffset,
+  int64_t tagsoffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth,
+  int64_t which) {
+  return awkward_identities_from_unionarray<int32_t, int8_t, int32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromtags,
+    fromindex,
+    fromptroffset,
+    tagsoffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth,
+    which);
 }
-ERROR awkward_identities32_from_unionarray8_U32(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const uint32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-  return awkward_identities_from_unionarray<int32_t, int8_t, uint32_t>(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
+ERROR awkward_identities32_from_unionarray8_U32(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int8_t* fromtags,
+  const uint32_t* fromindex,
+  int64_t fromptroffset,
+  int64_t tagsoffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth,
+  int64_t which) {
+  return awkward_identities_from_unionarray<int32_t, int8_t, uint32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromtags,
+    fromindex,
+    fromptroffset,
+    tagsoffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth,
+    which);
 }
-ERROR awkward_identities32_from_unionarray8_64(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const int64_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-  return awkward_identities_from_unionarray<int32_t, int8_t, int64_t>(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
+ERROR awkward_identities32_from_unionarray8_64(
+  bool* uniquecontents,
+  int32_t* toptr,
+  const int32_t* fromptr,
+  const int8_t* fromtags,
+  const int64_t* fromindex,
+  int64_t fromptroffset,
+  int64_t tagsoffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth,
+  int64_t which) {
+  return awkward_identities_from_unionarray<int32_t, int8_t, int64_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromtags,
+    fromindex,
+    fromptroffset,
+    tagsoffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth,
+    which);
 }
-ERROR awkward_identities64_from_unionarray8_32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const int32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-  return awkward_identities_from_unionarray<int64_t, int8_t, int32_t>(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
+ERROR awkward_identities64_from_unionarray8_32(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int8_t* fromtags,
+  const int32_t* fromindex,
+  int64_t fromptroffset,
+  int64_t tagsoffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth,
+  int64_t which) {
+  return awkward_identities_from_unionarray<int64_t, int8_t, int32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromtags,
+    fromindex,
+    fromptroffset,
+    tagsoffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth,
+    which);
 }
-ERROR awkward_identities64_from_unionarray8_U32(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const uint32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-  return awkward_identities_from_unionarray<int64_t, int8_t, uint32_t>(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
+ERROR awkward_identities64_from_unionarray8_U32(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int8_t* fromtags,
+  const uint32_t* fromindex,
+  int64_t fromptroffset,
+  int64_t tagsoffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth,
+  int64_t which) {
+  return awkward_identities_from_unionarray<int64_t, int8_t, uint32_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromtags,
+    fromindex,
+    fromptroffset,
+    tagsoffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth,
+    which);
 }
-ERROR awkward_identities64_from_unionarray8_64(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const int64_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-  return awkward_identities_from_unionarray<int64_t, int8_t, int64_t>(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
+ERROR awkward_identities64_from_unionarray8_64(
+  bool* uniquecontents,
+  int64_t* toptr,
+  const int64_t* fromptr,
+  const int8_t* fromtags,
+  const int64_t* fromindex,
+  int64_t fromptroffset,
+  int64_t tagsoffset,
+  int64_t indexoffset,
+  int64_t tolength,
+  int64_t fromlength,
+  int64_t fromwidth,
+  int64_t which) {
+  return awkward_identities_from_unionarray<int64_t, int8_t, int64_t>(
+    uniquecontents,
+    toptr,
+    fromptr,
+    fromtags,
+    fromindex,
+    fromptroffset,
+    tagsoffset,
+    indexoffset,
+    tolength,
+    fromlength,
+    fromwidth,
+    which);
 }
 
 template <typename ID>
-ERROR awkward_identities_extend(ID* toptr, const ID* fromptr, int64_t fromoffset, int64_t fromlength, int64_t tolength) {
+ERROR awkward_identities_extend(
+  ID* toptr,
+  const ID* fromptr,
+  int64_t fromoffset,
+  int64_t fromlength,
+  int64_t tolength) {
   int64_t i = 0;
   for (;  i < fromlength;  i++) {
     toptr[i] = fromptr[fromoffset + i];
@@ -233,9 +814,29 @@ ERROR awkward_identities_extend(ID* toptr, const ID* fromptr, int64_t fromoffset
   }
   return success();
 }
-ERROR awkward_identities32_extend(int32_t* toptr, const int32_t* fromptr, int64_t fromoffset, int64_t fromlength, int64_t tolength) {
-  return awkward_identities_extend<int32_t>(toptr, fromptr, fromoffset, fromlength, tolength);
+ERROR awkward_identities32_extend(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromoffset,
+  int64_t fromlength,
+  int64_t tolength) {
+  return awkward_identities_extend<int32_t>(
+    toptr,
+    fromptr,
+    fromoffset,
+    fromlength,
+    tolength);
 }
-ERROR awkward_identities64_extend(int64_t* toptr, const int64_t* fromptr, int64_t fromoffset, int64_t fromlength, int64_t tolength) {
-  return awkward_identities_extend<int64_t>(toptr, fromptr, fromoffset, fromlength, tolength);
+ERROR awkward_identities64_extend(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromoffset,
+  int64_t fromlength,
+  int64_t tolength) {
+  return awkward_identities_extend<int64_t>(
+    toptr,
+    fromptr,
+    fromoffset,
+    fromlength,
+    tolength);
 }

--- a/src/cpu-kernels/operations.cpp
+++ b/src/cpu-kernels/operations.cpp
@@ -3161,7 +3161,8 @@ ERROR awkward_listarray_choose_length(
   *totallen = 0;
   tooffsets[0] = 0;
   for (int64_t i = 0;  i < length;  i++) {
-    int64_t size = (int64_t)(stops[stopsoffset + i] - starts[startsoffset + i]);
+    int64_t size = (int64_t)(stops[stopsoffset + i] -
+                             starts[startsoffset + i]);
     if (diagonal) {
       size += (n - 1);
     }

--- a/src/cpu-kernels/operations.cpp
+++ b/src/cpu-kernels/operations.cpp
@@ -5,7 +5,13 @@
 #include "awkward/cpu-kernels/operations.h"
 
 template <typename T, typename C>
-ERROR awkward_listarray_num(T* tonum, const C* fromstarts, int64_t startsoffset, const C* fromstops, int64_t stopsoffset, int64_t length) {
+ERROR awkward_listarray_num(
+  T* tonum, 
+  const C* fromstarts, 
+  int64_t startsoffset, 
+  const C* fromstops, 
+  int64_t stopsoffset, 
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     C start = fromstarts[startsoffset + i];
     C stop = fromstops[stopsoffset + i];
@@ -13,46 +19,148 @@ ERROR awkward_listarray_num(T* tonum, const C* fromstarts, int64_t startsoffset,
   }
   return success();
 }
-ERROR awkward_listarray32_num_64(int64_t* tonum, const int32_t* fromstarts, int64_t startsoffset, const int32_t* fromstops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_num<int64_t, int32_t>(tonum, fromstarts, startsoffset, fromstops, stopsoffset, length);
+ERROR awkward_listarray32_num_64(
+  int64_t* tonum, 
+  const int32_t* fromstarts, 
+  int64_t startsoffset, 
+  const int32_t* fromstops, 
+  int64_t stopsoffset, 
+  int64_t length) {
+  return awkward_listarray_num<int64_t, int32_t>(
+    tonum, 
+    fromstarts, 
+    startsoffset, 
+    fromstops, 
+    stopsoffset, 
+    length);
 }
-ERROR awkward_listarrayU32_num_64(int64_t* tonum, const uint32_t* fromstarts, int64_t startsoffset, const uint32_t* fromstops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_num<int64_t, uint32_t>(tonum, fromstarts, startsoffset, fromstops, stopsoffset, length);
+ERROR awkward_listarrayU32_num_64(
+  int64_t* tonum, 
+  const uint32_t* fromstarts, 
+  int64_t startsoffset, 
+  const uint32_t* fromstops, 
+  int64_t stopsoffset, 
+  int64_t length) {
+  return awkward_listarray_num<int64_t, uint32_t>(
+    tonum, 
+    fromstarts, 
+    startsoffset, 
+    fromstops, 
+    stopsoffset, 
+    length);
 }
-ERROR awkward_listarray64_num_64(int64_t* tonum, const int64_t* fromstarts, int64_t startsoffset, const int64_t* fromstops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_num<int64_t, int64_t>(tonum, fromstarts, startsoffset, fromstops, stopsoffset, length);
+ERROR awkward_listarray64_num_64(
+  int64_t* tonum, 
+  const int64_t* fromstarts, 
+  int64_t startsoffset, 
+  const int64_t* fromstops, 
+  int64_t stopsoffset, 
+  int64_t length) {
+  return awkward_listarray_num<int64_t, int64_t>(
+    tonum, 
+    fromstarts, 
+    startsoffset, 
+    fromstops, 
+    stopsoffset, 
+    length);
 }
 
 template <typename T>
-ERROR awkward_regulararray_num(T* tonum, int64_t size, int64_t length) {
+ERROR awkward_regulararray_num(
+  T* tonum, 
+  int64_t size, 
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     tonum[i] = size;
   }
   return success();
 }
-ERROR awkward_regulararray_num_64(int64_t* tonum, int64_t size, int64_t length) {
-  return awkward_regulararray_num<int64_t>(tonum, size, length);
+ERROR awkward_regulararray_num_64(
+  int64_t* tonum, 
+  int64_t size, 
+  int64_t length) {
+  return awkward_regulararray_num<int64_t>(
+    tonum, 
+    size, 
+    length);
 }
 
 template <typename T, typename C>
-ERROR awkward_listoffsetarray_flatten_offsets(T* tooffsets, const C* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const T* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen) {
+ERROR awkward_listoffsetarray_flatten_offsets(
+  T* tooffsets, 
+  const C* outeroffsets, 
+  int64_t outeroffsetsoffset, 
+  int64_t outeroffsetslen, 
+  const T* inneroffsets, 
+  int64_t inneroffsetsoffset, 
+  int64_t inneroffsetslen) {
   for (int64_t i = 0;  i < outeroffsetslen;  i++) {
-    tooffsets[i] = inneroffsets[inneroffsetsoffset + outeroffsets[outeroffsetsoffset + i]];
+    tooffsets[i] =
+      inneroffsets[inneroffsetsoffset + outeroffsets[outeroffsetsoffset + i]];
   }
   return success();
 }
-ERROR awkward_listoffsetarray32_flatten_offsets_64(int64_t* tooffsets, const int32_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen) {
-  return awkward_listoffsetarray_flatten_offsets<int64_t, int32_t>(tooffsets, outeroffsets, outeroffsetsoffset, outeroffsetslen, inneroffsets, inneroffsetsoffset, inneroffsetslen);
+ERROR awkward_listoffsetarray32_flatten_offsets_64(
+  int64_t* tooffsets, 
+  const int32_t* outeroffsets,
+  int64_t outeroffsetsoffset, 
+  int64_t outeroffsetslen, 
+  const int64_t* inneroffsets,
+  int64_t inneroffsetsoffset, 
+  int64_t inneroffsetslen) {
+  return awkward_listoffsetarray_flatten_offsets<int64_t, int32_t>(
+    tooffsets, 
+    outeroffsets, 
+    outeroffsetsoffset, 
+    outeroffsetslen, 
+    inneroffsets, 
+    inneroffsetsoffset, 
+    inneroffsetslen);
 }
-ERROR awkward_listoffsetarrayU32_flatten_offsets_64(int64_t* tooffsets, const uint32_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen) {
-  return awkward_listoffsetarray_flatten_offsets<int64_t, uint32_t>(tooffsets, outeroffsets, outeroffsetsoffset, outeroffsetslen, inneroffsets, inneroffsetsoffset, inneroffsetslen);
+ERROR awkward_listoffsetarrayU32_flatten_offsets_64(
+  int64_t* tooffsets, 
+  const uint32_t* outeroffsets, 
+  int64_t outeroffsetsoffset, 
+  int64_t outeroffsetslen, 
+  const int64_t* inneroffsets, 
+  int64_t inneroffsetsoffset, 
+  int64_t inneroffsetslen) {
+  return awkward_listoffsetarray_flatten_offsets<int64_t, uint32_t>(
+    tooffsets, 
+    outeroffsets, 
+    outeroffsetsoffset, 
+    outeroffsetslen, 
+    inneroffsets, 
+    inneroffsetsoffset, 
+    inneroffsetslen);
 }
-ERROR awkward_listoffsetarray64_flatten_offsets_64(int64_t* tooffsets, const int64_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen) {
-  return awkward_listoffsetarray_flatten_offsets<int64_t, int64_t>(tooffsets, outeroffsets, outeroffsetsoffset, outeroffsetslen, inneroffsets, inneroffsetsoffset, inneroffsetslen);
+ERROR awkward_listoffsetarray64_flatten_offsets_64(
+  int64_t* tooffsets, 
+  const int64_t* outeroffsets, 
+  int64_t outeroffsetsoffset, 
+  int64_t outeroffsetslen, 
+  const int64_t* inneroffsets, 
+  int64_t inneroffsetsoffset, 
+  int64_t inneroffsetslen) {
+  return awkward_listoffsetarray_flatten_offsets<int64_t, int64_t>(
+    tooffsets, 
+    outeroffsets, 
+    outeroffsetsoffset, 
+    outeroffsetslen, 
+    inneroffsets, 
+    inneroffsetsoffset, 
+    inneroffsetslen);
 }
 
 template <typename T, typename C>
-ERROR awkward_indexedarray_flatten_none2empty(T* outoffsets, const C* outindex, int64_t outindexoffset, int64_t outindexlength, const T* offsets, int64_t offsetsoffset, int64_t offsetslength) {
+ERROR awkward_indexedarray_flatten_none2empty(
+  T* outoffsets, 
+  const C* outindex, 
+  int64_t outindexoffset, 
+  int64_t outindexlength, 
+  const T* offsets, 
+  int64_t offsetsoffset, 
+  int64_t offsetslength) {
   outoffsets[0] = offsets[offsetsoffset + 0];
   int64_t k = 1;
   for (int64_t i = 0;  i < outindexlength;  i++) {
@@ -65,25 +173,76 @@ ERROR awkward_indexedarray_flatten_none2empty(T* outoffsets, const C* outindex, 
       return failure("flattening offset out of range", i, kSliceNone);
     }
     else {
-      T count = offsets[offsetsoffset + idx + 1] - offsets[offsetsoffset + idx];
+      T count =
+        offsets[offsetsoffset + idx + 1] - offsets[offsetsoffset + idx];
       outoffsets[k] = outoffsets[k - 1] + count;
       k++;
     }
   }
   return success();
 }
-ERROR awkward_indexedarray32_flatten_none2empty_64(int64_t* outoffsets, const int32_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength) {
-  return awkward_indexedarray_flatten_none2empty<int64_t, int32_t>(outoffsets, outindex, outindexoffset, outindexlength, offsets, offsetsoffset, offsetslength);
+ERROR awkward_indexedarray32_flatten_none2empty_64(
+  int64_t* outoffsets, 
+  const int32_t* outindex, 
+  int64_t outindexoffset, 
+  int64_t outindexlength, 
+  const int64_t* offsets, 
+  int64_t offsetsoffset, 
+  int64_t offsetslength) {
+  return awkward_indexedarray_flatten_none2empty<int64_t, int32_t>(
+    outoffsets, 
+    outindex, 
+    outindexoffset, 
+    outindexlength, 
+    offsets, 
+    offsetsoffset, 
+    offsetslength);
 }
-ERROR awkward_indexedarrayU32_flatten_none2empty_64(int64_t* outoffsets, const uint32_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength) {
-  return awkward_indexedarray_flatten_none2empty<int64_t, uint32_t>(outoffsets, outindex, outindexoffset, outindexlength, offsets, offsetsoffset, offsetslength);
+ERROR awkward_indexedarrayU32_flatten_none2empty_64(
+  int64_t* outoffsets, 
+  const uint32_t* outindex, 
+  int64_t outindexoffset, 
+  int64_t outindexlength, 
+  const int64_t* offsets, 
+  int64_t offsetsoffset, 
+  int64_t offsetslength) {
+  return awkward_indexedarray_flatten_none2empty<int64_t, uint32_t>(
+    outoffsets, 
+    outindex, 
+    outindexoffset, 
+    outindexlength, 
+    offsets, 
+    offsetsoffset, 
+    offsetslength);
 }
-ERROR awkward_indexedarray64_flatten_none2empty_64(int64_t* outoffsets, const int64_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength) {
-  return awkward_indexedarray_flatten_none2empty<int64_t, int64_t>(outoffsets, outindex, outindexoffset, outindexlength, offsets, offsetsoffset, offsetslength);
+ERROR awkward_indexedarray64_flatten_none2empty_64(
+  int64_t* outoffsets, 
+  const int64_t* outindex, 
+  int64_t outindexoffset, 
+  int64_t outindexlength, 
+  const int64_t* offsets, 
+  int64_t offsetsoffset, 
+  int64_t offsetslength) {
+  return awkward_indexedarray_flatten_none2empty<int64_t, int64_t>(
+    outoffsets, 
+    outindex, 
+    outindexoffset, 
+    outindexlength, 
+    offsets, 
+    offsetsoffset, 
+    offsetslength);
 }
 
 template <typename FROMTAGS, typename FROMINDEX, typename T>
-ERROR awkward_unionarray_flatten_length(int64_t* total_length, const FROMTAGS* fromtags, int64_t fromtagsoffset, const FROMINDEX* fromindex, int64_t fromindexoffset, int64_t length, T** offsetsraws, int64_t* offsetsoffsets) {
+ERROR awkward_unionarray_flatten_length(
+  int64_t* total_length, 
+  const FROMTAGS* fromtags, 
+  int64_t fromtagsoffset, 
+  const FROMINDEX* fromindex, 
+  int64_t fromindexoffset, 
+  int64_t length, 
+  T** offsetsraws, 
+  int64_t* offsetsoffsets) {
   *total_length = 0;
   for (int64_t i = 0;  i < length;  i++) {
     FROMTAGS tag = fromtags[fromtagsoffset + i];
@@ -94,18 +253,80 @@ ERROR awkward_unionarray_flatten_length(int64_t* total_length, const FROMTAGS* f
   }
   return success();
 }
-ERROR awkward_unionarray32_flatten_length_64(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-  return awkward_unionarray_flatten_length<int8_t, int32_t, int64_t>(total_length, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
+ERROR awkward_unionarray32_flatten_length_64(
+  int64_t* total_length, 
+  const int8_t* fromtags, 
+  int64_t fromtagsoffset, 
+  const int32_t* fromindex, 
+  int64_t fromindexoffset, 
+  int64_t length, 
+  int64_t** offsetsraws, 
+  int64_t* offsetsoffsets) {
+  return awkward_unionarray_flatten_length<int8_t, int32_t, int64_t>(
+    total_length, 
+    fromtags, 
+    fromtagsoffset, 
+    fromindex, 
+    fromindexoffset, 
+    length, 
+    offsetsraws, 
+    offsetsoffsets);
 }
-ERROR awkward_unionarrayU32_flatten_length_64(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-  return awkward_unionarray_flatten_length<int8_t, uint32_t, int64_t>(total_length, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
+ERROR awkward_unionarrayU32_flatten_length_64(
+  int64_t* total_length, 
+  const int8_t* fromtags, 
+  int64_t fromtagsoffset, 
+  const uint32_t* fromindex, 
+  int64_t fromindexoffset, 
+  int64_t length, 
+  int64_t** offsetsraws, 
+  int64_t* offsetsoffsets) {
+  return awkward_unionarray_flatten_length<int8_t, uint32_t, int64_t>(
+    total_length, 
+    fromtags, 
+    fromtagsoffset, 
+    fromindex, 
+    fromindexoffset, 
+    length, 
+    offsetsraws, 
+    offsetsoffsets);
 }
-ERROR awkward_unionarray64_flatten_length_64(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-  return awkward_unionarray_flatten_length<int8_t, int64_t, int64_t>(total_length, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
+ERROR awkward_unionarray64_flatten_length_64(
+  int64_t* total_length, 
+  const int8_t* fromtags, 
+  int64_t fromtagsoffset, 
+  const int64_t* fromindex, 
+  int64_t fromindexoffset, 
+  int64_t length, 
+  int64_t** offsetsraws, 
+  int64_t* offsetsoffsets) {
+  return awkward_unionarray_flatten_length<int8_t, int64_t, int64_t>(
+    total_length, 
+    fromtags, 
+    fromtagsoffset, 
+    fromindex, 
+    fromindexoffset, 
+    length, 
+    offsetsraws, 
+    offsetsoffsets);
 }
 
-template <typename FROMTAGS, typename FROMINDEX, typename TOTAGS, typename TOINDEX, typename T>
-ERROR awkward_unionarray_flatten_combine(TOTAGS* totags, TOINDEX* toindex, T* tooffsets, const FROMTAGS* fromtags, int64_t fromtagsoffset, const FROMINDEX* fromindex, int64_t fromindexoffset, int64_t length, T** offsetsraws, int64_t* offsetsoffsets) {
+template <typename FROMTAGS,
+          typename FROMINDEX,
+          typename TOTAGS,
+          typename TOINDEX,
+          typename T>
+ERROR awkward_unionarray_flatten_combine(
+  TOTAGS* totags, 
+  TOINDEX* toindex, 
+  T* tooffsets, 
+  const FROMTAGS* fromtags, 
+  int64_t fromtagsoffset, 
+  const FROMINDEX* fromindex, 
+  int64_t fromindexoffset, 
+  int64_t length, 
+  T** offsetsraws, 
+  int64_t* offsetsoffsets) {
   tooffsets[0] = 0;
   int64_t k = 0;
   for (int64_t i = 0;  i < length;  i++) {
@@ -122,18 +343,95 @@ ERROR awkward_unionarray_flatten_combine(TOTAGS* totags, TOINDEX* toindex, T* to
   }
   return success();
 }
-ERROR awkward_unionarray32_flatten_combine_64(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-  return awkward_unionarray_flatten_combine<int8_t, int32_t, int8_t, int64_t, int64_t>(totags, toindex, tooffsets, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
+ERROR awkward_unionarray32_flatten_combine_64(
+  int8_t* totags, 
+  int64_t* toindex, 
+  int64_t* tooffsets, 
+  const int8_t* fromtags, 
+  int64_t fromtagsoffset, 
+  const int32_t* fromindex, 
+  int64_t fromindexoffset, 
+  int64_t length, 
+  int64_t** offsetsraws, 
+  int64_t* offsetsoffsets) {
+  return awkward_unionarray_flatten_combine<int8_t, 
+                                            int32_t, 
+                                            int8_t, 
+                                            int64_t, 
+                                            int64_t>(
+    totags, 
+    toindex, 
+    tooffsets, 
+    fromtags, 
+    fromtagsoffset, 
+    fromindex, 
+    fromindexoffset, 
+    length, 
+    offsetsraws, 
+    offsetsoffsets);
 }
-ERROR awkward_unionarrayU32_flatten_combine_64(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-  return awkward_unionarray_flatten_combine<int8_t, uint32_t, int8_t, int64_t, int64_t>(totags, toindex, tooffsets, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
+ERROR awkward_unionarrayU32_flatten_combine_64(
+  int8_t* totags, 
+  int64_t* toindex, 
+  int64_t* tooffsets, 
+  const int8_t* fromtags, 
+  int64_t fromtagsoffset, 
+  const uint32_t* fromindex, 
+  int64_t fromindexoffset, 
+  int64_t length, 
+  int64_t** offsetsraws, 
+  int64_t* offsetsoffsets) {
+  return awkward_unionarray_flatten_combine<int8_t, 
+                                            uint32_t, 
+                                            int8_t, 
+                                            int64_t, 
+                                            int64_t>(
+    totags, 
+    toindex, 
+    tooffsets, 
+    fromtags, 
+    fromtagsoffset, 
+    fromindex, 
+    fromindexoffset, 
+    length, 
+    offsetsraws, 
+    offsetsoffsets);
 }
-ERROR awkward_unionarray64_flatten_combine_64(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-  return awkward_unionarray_flatten_combine<int8_t, int64_t, int8_t, int64_t, int64_t>(totags, toindex, tooffsets, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
+ERROR awkward_unionarray64_flatten_combine_64(
+  int8_t* totags, 
+  int64_t* toindex, 
+  int64_t* tooffsets, 
+  const int8_t* fromtags, 
+  int64_t fromtagsoffset, 
+  const int64_t* fromindex, 
+  int64_t fromindexoffset, 
+  int64_t length, 
+  int64_t** offsetsraws, 
+  int64_t* offsetsoffsets) {
+  return awkward_unionarray_flatten_combine<int8_t, 
+                                            int64_t, 
+                                            int8_t, 
+                                            int64_t, 
+                                            int64_t>(
+    totags, 
+    toindex, 
+    tooffsets, 
+    fromtags, 
+    fromtagsoffset, 
+    fromindex, 
+    fromindexoffset, 
+    length, 
+    offsetsraws, 
+    offsetsoffsets);
 }
 
 template <typename C, typename T>
-ERROR awkward_indexedarray_flatten_nextcarry(T* tocarry, const C* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
+ERROR awkward_indexedarray_flatten_nextcarry(
+  T* tocarry, 
+  const C* fromindex, 
+  int64_t indexoffset, 
+  int64_t lenindex, 
+  int64_t lencontent) {
   int64_t k = 0;
   for (int64_t i = 0;  i < lenindex;  i++) {
     C j = fromindex[indexoffset + i];
@@ -147,75 +445,201 @@ ERROR awkward_indexedarray_flatten_nextcarry(T* tocarry, const C* fromindex, int
   }
   return success();
 }
-ERROR awkward_indexedarray32_flatten_nextcarry_64(int64_t* tocarry, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_flatten_nextcarry<int32_t, int64_t>(tocarry, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarray32_flatten_nextcarry_64(
+  int64_t* tocarry, 
+  const int32_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t lenindex, 
+  int64_t lencontent) {
+  return awkward_indexedarray_flatten_nextcarry<int32_t, int64_t>(
+    tocarry, 
+    fromindex, 
+    indexoffset, 
+    lenindex, 
+    lencontent);
 }
-ERROR awkward_indexedarrayU32_flatten_nextcarry_64(int64_t* tocarry, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_flatten_nextcarry<uint32_t, int64_t>(tocarry, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarrayU32_flatten_nextcarry_64(
+  int64_t* tocarry, 
+  const uint32_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t lenindex, 
+  int64_t lencontent) {
+  return awkward_indexedarray_flatten_nextcarry<uint32_t, int64_t>(
+    tocarry, 
+    fromindex, 
+    indexoffset, 
+    lenindex, 
+    lencontent);
 }
-ERROR awkward_indexedarray64_flatten_nextcarry_64(int64_t* tocarry, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-  return awkward_indexedarray_flatten_nextcarry<int64_t, int64_t>(tocarry, fromindex, indexoffset, lenindex, lencontent);
+ERROR awkward_indexedarray64_flatten_nextcarry_64(
+  int64_t* tocarry, 
+  const int64_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t lenindex, 
+  int64_t lencontent) {
+  return awkward_indexedarray_flatten_nextcarry<int64_t, int64_t>(
+    tocarry, 
+    fromindex, 
+    indexoffset, 
+    lenindex, 
+    lencontent);
 }
 
 template <typename C, typename M, typename TO>
-ERROR awkward_indexedarray_overlay_mask(TO* toindex, const M* mask, int64_t maskoffset, const C* fromindex, int64_t indexoffset, int64_t length) {
+ERROR awkward_indexedarray_overlay_mask(
+  TO* toindex, 
+  const M* mask, 
+  int64_t maskoffset, 
+  const C* fromindex, 
+  int64_t indexoffset, 
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     M m = mask[maskoffset + i];
     toindex[i] = (m ? -1 : fromindex[indexoffset + i]);
   }
   return success();
 }
-ERROR awkward_indexedarray32_overlay_mask8_to64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const int32_t* fromindex, int64_t indexoffset, int64_t length) {
-  return awkward_indexedarray_overlay_mask<int32_t, int8_t, int64_t>(toindex, mask, maskoffset, fromindex, indexoffset, length);
+ERROR awkward_indexedarray32_overlay_mask8_to64(
+  int64_t* toindex, 
+  const int8_t* mask, 
+  int64_t maskoffset, 
+  const int32_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t length) {
+  return awkward_indexedarray_overlay_mask<int32_t, int8_t, int64_t>(
+    toindex, 
+    mask, 
+    maskoffset, 
+    fromindex, 
+    indexoffset, 
+    length);
 }
-ERROR awkward_indexedarrayU32_overlay_mask8_to64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const uint32_t* fromindex, int64_t indexoffset, int64_t length) {
-  return awkward_indexedarray_overlay_mask<uint32_t, int8_t, int64_t>(toindex, mask, maskoffset, fromindex, indexoffset, length);
+ERROR awkward_indexedarrayU32_overlay_mask8_to64(
+  int64_t* toindex, 
+  const int8_t* mask, 
+  int64_t maskoffset, 
+  const uint32_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t length) {
+  return awkward_indexedarray_overlay_mask<uint32_t, int8_t, int64_t>(
+    toindex, 
+    mask, 
+    maskoffset, 
+    fromindex, 
+    indexoffset, 
+    length);
 }
-ERROR awkward_indexedarray64_overlay_mask8_to64(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const int64_t* fromindex, int64_t indexoffset, int64_t length) {
-  return awkward_indexedarray_overlay_mask<int64_t, int8_t, int64_t>(toindex, mask, maskoffset, fromindex, indexoffset, length);
+ERROR awkward_indexedarray64_overlay_mask8_to64(
+  int64_t* toindex, 
+  const int8_t* mask, 
+  int64_t maskoffset, 
+  const int64_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t length) {
+  return awkward_indexedarray_overlay_mask<int64_t, int8_t, int64_t>(
+    toindex, 
+    mask, 
+    maskoffset, 
+    fromindex, 
+    indexoffset, 
+    length);
 }
 
 template <typename C, typename M>
-ERROR awkward_indexedarray_mask(M* tomask, const C* fromindex, int64_t indexoffset, int64_t length) {
+ERROR awkward_indexedarray_mask(
+  M* tomask, 
+  const C* fromindex, 
+  int64_t indexoffset, 
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     tomask[i] = (fromindex[indexoffset + i] < 0);
   }
   return success();
 }
-ERROR awkward_indexedarray32_mask8(int8_t* tomask, const int32_t* fromindex, int64_t indexoffset, int64_t length) {
-  return awkward_indexedarray_mask<int32_t, int8_t>(tomask, fromindex, indexoffset, length);
+ERROR awkward_indexedarray32_mask8(
+  int8_t* tomask, 
+  const int32_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t length) {
+  return awkward_indexedarray_mask<int32_t, int8_t>(
+    tomask, 
+    fromindex, 
+    indexoffset, 
+    length);
 }
-ERROR awkward_indexedarrayU32_mask8(int8_t* tomask, const uint32_t* fromindex, int64_t indexoffset, int64_t length) {
-  return awkward_indexedarray_mask<uint32_t, int8_t>(tomask, fromindex, indexoffset, length);
+ERROR awkward_indexedarrayU32_mask8(
+  int8_t* tomask, 
+  const uint32_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t length) {
+  return awkward_indexedarray_mask<uint32_t, int8_t>(
+    tomask, 
+    fromindex, 
+    indexoffset, 
+    length);
 }
-ERROR awkward_indexedarray64_mask8(int8_t* tomask, const int64_t* fromindex, int64_t indexoffset, int64_t length) {
-  return awkward_indexedarray_mask<int64_t, int8_t>(tomask, fromindex, indexoffset, length);
+ERROR awkward_indexedarray64_mask8(
+  int8_t* tomask, 
+  const int64_t* fromindex, 
+  int64_t indexoffset, 
+  int64_t length) {
+  return awkward_indexedarray_mask<int64_t, int8_t>(
+    tomask, 
+    fromindex, 
+    indexoffset, 
+    length);
 }
 
 template <typename M>
-ERROR awkward_bytemaskedarray_mask(M* tomask, const M* frommask, int64_t maskoffset, int64_t length, bool validwhen) {
+ERROR awkward_bytemaskedarray_mask(
+  M* tomask, 
+  const M* frommask, 
+  int64_t maskoffset, 
+  int64_t length, 
+  bool validwhen) {
   for (int64_t i = 0;  i < length;  i++) {
     tomask[i] = ((frommask[maskoffset + i] != 0) != validwhen);
   }
   return success();
 }
-ERROR awkward_bytemaskedarray_mask8(int8_t* tomask, const int8_t* frommask, int64_t maskoffset, int64_t length, bool validwhen) {
-  return awkward_bytemaskedarray_mask(tomask, frommask, maskoffset, length, validwhen);
+ERROR awkward_bytemaskedarray_mask8(
+  int8_t* tomask, 
+  const int8_t* frommask, 
+  int64_t maskoffset, 
+  int64_t length, 
+  bool validwhen) {
+  return awkward_bytemaskedarray_mask(
+    tomask, 
+    frommask, 
+    maskoffset, 
+    length, 
+    validwhen);
 }
 
 template <typename M>
-ERROR awkward_zero_mask(M* tomask, int64_t length) {
+ERROR awkward_zero_mask(
+  M* tomask,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     tomask[i] = 0;
   }
   return success();
 }
-ERROR awkward_zero_mask8(int8_t* tomask, int64_t length) {
+ERROR awkward_zero_mask8(
+  int8_t* tomask,
+  int64_t length) {
   return awkward_zero_mask<int8_t>(tomask, length);
 }
 
 template <typename OUT, typename IN, typename TO>
-ERROR awkward_indexedarray_simplify(TO* toindex, const OUT* outerindex, int64_t outeroffset, int64_t outerlength, const IN* innerindex, int64_t inneroffset, int64_t innerlength) {
+ERROR awkward_indexedarray_simplify(
+  TO* toindex,
+  const OUT* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const IN* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
   for (int64_t i = 0;  i < outerlength;  i++) {
     OUT j = outerindex[outeroffset + i];
     if (j < 0) {
@@ -230,48 +654,189 @@ ERROR awkward_indexedarray_simplify(TO* toindex, const OUT* outerindex, int64_t 
   }
   return success();
 }
-ERROR awkward_indexedarray32_simplify32_to64(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<int32_t, int32_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarray32_simplify32_to64(
+  int64_t* toindex,
+  const int32_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const int32_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<int32_t, int32_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
-ERROR awkward_indexedarray32_simplifyU32_to64(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<int32_t, uint32_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarray32_simplifyU32_to64(
+  int64_t* toindex,
+  const int32_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const uint32_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<int32_t, uint32_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
-ERROR awkward_indexedarray32_simplify64_to64(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<int32_t, int64_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarray32_simplify64_to64(
+  int64_t* toindex,
+  const int32_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const int64_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<int32_t, int64_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
-ERROR awkward_indexedarrayU32_simplify32_to64(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<uint32_t, int32_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarrayU32_simplify32_to64(
+  int64_t* toindex,
+  const uint32_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const int32_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<uint32_t, int32_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
-ERROR awkward_indexedarrayU32_simplifyU32_to64(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<uint32_t, uint32_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarrayU32_simplifyU32_to64(
+  int64_t* toindex,
+  const uint32_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const uint32_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<uint32_t, uint32_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
-ERROR awkward_indexedarrayU32_simplify64_to64(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<uint32_t, int64_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarrayU32_simplify64_to64(
+  int64_t* toindex,
+  const uint32_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const int64_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<uint32_t, int64_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
-ERROR awkward_indexedarray64_simplify32_to64(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<int64_t, int32_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarray64_simplify32_to64(
+  int64_t* toindex,
+  const int64_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const int32_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<int64_t, int32_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
-ERROR awkward_indexedarray64_simplifyU32_to64(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<int64_t, uint32_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarray64_simplifyU32_to64(
+  int64_t* toindex,
+  const int64_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const uint32_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<int64_t, uint32_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
-ERROR awkward_indexedarray64_simplify64_to64(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-  return awkward_indexedarray_simplify<int64_t, int64_t, int64_t>(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+ERROR awkward_indexedarray64_simplify64_to64(
+  int64_t* toindex,
+  const int64_t* outerindex,
+  int64_t outeroffset,
+  int64_t outerlength,
+  const int64_t* innerindex,
+  int64_t inneroffset,
+  int64_t innerlength) {
+  return awkward_indexedarray_simplify<int64_t, int64_t, int64_t>(
+    toindex,
+    outerindex,
+    outeroffset,
+    outerlength,
+    innerindex,
+    inneroffset,
+    innerlength);
 }
 
 template <typename T>
-ERROR awkward_regulararray_compact_offsets(T* tooffsets, int64_t length, int64_t size) {
+ERROR awkward_regulararray_compact_offsets(
+  T* tooffsets,
+  int64_t length,
+  int64_t size) {
   tooffsets[0] = 0;
   for (int64_t i = 0;  i < length;  i++) {
     tooffsets[i + 1] = (i + 1)*size;
   }
   return success();
 }
-ERROR awkward_regulararray_compact_offsets64(int64_t* tooffsets, int64_t length, int64_t size) {
-  return awkward_regulararray_compact_offsets<int64_t>(tooffsets, length, size);
+ERROR awkward_regulararray_compact_offsets64(
+  int64_t* tooffsets,
+  int64_t length,
+  int64_t size) {
+  return awkward_regulararray_compact_offsets<int64_t>(
+    tooffsets,
+    length,
+    size);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_compact_offsets(T* tooffsets, const C* fromstarts, const C* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length) {
+ERROR awkward_listarray_compact_offsets(
+  T* tooffsets,
+  const C* fromstarts,
+  const C* fromstops,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t length) {
   tooffsets[0] = 0;
   for (int64_t i = 0;  i < length;  i++) {
     C start = fromstarts[startsoffset + i];
@@ -283,18 +848,58 @@ ERROR awkward_listarray_compact_offsets(T* tooffsets, const C* fromstarts, const
   }
   return success();
 }
-ERROR awkward_listarray32_compact_offsets64(int64_t* tooffsets, const int32_t* fromstarts, const int32_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_compact_offsets<int32_t, int64_t>(tooffsets, fromstarts, fromstops, startsoffset, stopsoffset, length);
+ERROR awkward_listarray32_compact_offsets64(
+  int64_t* tooffsets,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_compact_offsets<int32_t, int64_t>(
+    tooffsets,
+    fromstarts,
+    fromstops,
+    startsoffset,
+    stopsoffset,
+    length);
 }
-ERROR awkward_listarrayU32_compact_offsets64(int64_t* tooffsets, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_compact_offsets<uint32_t, int64_t>(tooffsets, fromstarts, fromstops, startsoffset, stopsoffset, length);
+ERROR awkward_listarrayU32_compact_offsets64(
+  int64_t* tooffsets,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_compact_offsets<uint32_t, int64_t>(
+    tooffsets,
+    fromstarts,
+    fromstops,
+    startsoffset,
+    stopsoffset,
+    length);
 }
-ERROR awkward_listarray64_compact_offsets64(int64_t* tooffsets, const int64_t* fromstarts, const int64_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_compact_offsets<int64_t, int64_t>(tooffsets, fromstarts, fromstops, startsoffset, stopsoffset, length);
+ERROR awkward_listarray64_compact_offsets64(
+  int64_t* tooffsets,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t startsoffset,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_compact_offsets<int64_t, int64_t>(
+    tooffsets,
+    fromstarts,
+    fromstops,
+    startsoffset,
+    stopsoffset,
+    length);
 }
 
 template <typename C, typename T>
-ERROR awkward_listoffsetarray_compact_offsets(T* tooffsets, const C* fromoffsets, int64_t offsetsoffset, int64_t length) {
+ERROR awkward_listoffsetarray_compact_offsets(
+  T* tooffsets,
+  const C* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length) {
   int64_t diff = (int64_t)fromoffsets[offsetsoffset + 0];
   tooffsets[0] = 0;
   for (int64_t i = 0;  i < length;  i++) {
@@ -302,18 +907,51 @@ ERROR awkward_listoffsetarray_compact_offsets(T* tooffsets, const C* fromoffsets
   }
   return success();
 }
-ERROR awkward_listoffsetarray32_compact_offsets64(int64_t* tooffsets, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t length) {
-  return awkward_listoffsetarray_compact_offsets<int32_t, int64_t>(tooffsets, fromoffsets, offsetsoffset, length);
+ERROR awkward_listoffsetarray32_compact_offsets64(
+  int64_t* tooffsets,
+  const int32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length) {
+  return awkward_listoffsetarray_compact_offsets<int32_t, int64_t>(
+    tooffsets,
+    fromoffsets,
+    offsetsoffset,
+    length);
 }
-ERROR awkward_listoffsetarrayU32_compact_offsets64(int64_t* tooffsets, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t length) {
-  return awkward_listoffsetarray_compact_offsets<uint32_t, int64_t>(tooffsets, fromoffsets, offsetsoffset, length);
+ERROR awkward_listoffsetarrayU32_compact_offsets64(
+  int64_t* tooffsets,
+  const uint32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length) {
+  return awkward_listoffsetarray_compact_offsets<uint32_t, int64_t>(
+    tooffsets,
+    fromoffsets,
+    offsetsoffset,
+    length);
 }
-ERROR awkward_listoffsetarray64_compact_offsets64(int64_t* tooffsets, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length) {
-  return awkward_listoffsetarray_compact_offsets<int64_t, int64_t>(tooffsets, fromoffsets, offsetsoffset, length);
+ERROR awkward_listoffsetarray64_compact_offsets64(
+  int64_t* tooffsets,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length) {
+  return awkward_listoffsetarray_compact_offsets<int64_t, int64_t>(
+    tooffsets,
+    fromoffsets,
+    offsetsoffset,
+    length);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_broadcast_tooffsets(T* tocarry, const T* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const C* fromstarts, int64_t startsoffset, const C* fromstops, int64_t stopsoffset, int64_t lencontent) {
+ERROR awkward_listarray_broadcast_tooffsets(
+  T* tocarry,
+  const T* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength,
+  const C* fromstarts,
+  int64_t startsoffset,
+  const C* fromstops,
+  int64_t stopsoffset,
+  int64_t lencontent) {
   int64_t k = 0;
   for (int64_t i = 0;  i < offsetslength - 1;  i++) {
     int64_t start = (int64_t)fromstarts[startsoffset + i];
@@ -321,9 +959,11 @@ ERROR awkward_listarray_broadcast_tooffsets(T* tocarry, const T* fromoffsets, in
     if (start != stop  &&  stop > lencontent) {
       return failure("stops[i] > len(content)", i, stop);
     }
-    int64_t count = (int64_t)(fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i]);
+    int64_t count = (int64_t)(fromoffsets[offsetsoffset + i + 1] -
+                              fromoffsets[offsetsoffset + i]);
     if (count < 0) {
-      return failure("broadcast's offsets must be monotonically increasing", i, kSliceNone);
+      return failure(
+        "broadcast's offsets must be monotonically increasing", i, kSliceNone);
     }
     if (stop - start != count) {
       return failure("cannot broadcast nested list", i, kSliceNone);
@@ -335,22 +975,82 @@ ERROR awkward_listarray_broadcast_tooffsets(T* tocarry, const T* fromoffsets, in
   }
   return success();
 }
-ERROR awkward_listarray32_broadcast_tooffsets64(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const int32_t* fromstarts, int64_t startsoffset, const int32_t* fromstops, int64_t stopsoffset, int64_t lencontent) {
-  return awkward_listarray_broadcast_tooffsets<int32_t, int64_t>(tocarry, fromoffsets, offsetsoffset, offsetslength, fromstarts, startsoffset, fromstops, stopsoffset, lencontent);
+ERROR awkward_listarray32_broadcast_tooffsets64(
+  int64_t* tocarry,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength,
+  const int32_t* fromstarts,
+  int64_t startsoffset,
+  const int32_t* fromstops,
+  int64_t stopsoffset,
+  int64_t lencontent) {
+  return awkward_listarray_broadcast_tooffsets<int32_t, int64_t>(
+    tocarry,
+    fromoffsets,
+    offsetsoffset,
+    offsetslength,
+    fromstarts,
+    startsoffset,
+    fromstops,
+    stopsoffset,
+    lencontent);
 }
-ERROR awkward_listarrayU32_broadcast_tooffsets64(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const uint32_t* fromstarts, int64_t startsoffset, const uint32_t* fromstops, int64_t stopsoffset, int64_t lencontent) {
-  return awkward_listarray_broadcast_tooffsets<uint32_t, int64_t>(tocarry, fromoffsets, offsetsoffset, offsetslength, fromstarts, startsoffset, fromstops, stopsoffset, lencontent);
+ERROR awkward_listarrayU32_broadcast_tooffsets64(
+  int64_t* tocarry,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength,
+  const uint32_t* fromstarts,
+  int64_t startsoffset,
+  const uint32_t* fromstops,
+  int64_t stopsoffset,
+  int64_t lencontent) {
+  return awkward_listarray_broadcast_tooffsets<uint32_t, int64_t>(
+    tocarry,
+    fromoffsets,
+    offsetsoffset,
+    offsetslength,
+    fromstarts,
+    startsoffset,
+    fromstops,
+    stopsoffset,
+    lencontent);
 }
-ERROR awkward_listarray64_broadcast_tooffsets64(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const int64_t* fromstarts, int64_t startsoffset, const int64_t* fromstops, int64_t stopsoffset, int64_t lencontent) {
-  return awkward_listarray_broadcast_tooffsets<int64_t, int64_t>(tocarry, fromoffsets, offsetsoffset, offsetslength, fromstarts, startsoffset, fromstops, stopsoffset, lencontent);
+ERROR awkward_listarray64_broadcast_tooffsets64(
+  int64_t* tocarry,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength,
+  const int64_t* fromstarts,
+  int64_t startsoffset,
+  const int64_t* fromstops,
+  int64_t stopsoffset,
+  int64_t lencontent) {
+  return awkward_listarray_broadcast_tooffsets<int64_t, int64_t>(
+    tocarry,
+    fromoffsets,
+    offsetsoffset,
+    offsetslength,
+    fromstarts,
+    startsoffset,
+    fromstops,
+    stopsoffset,
+    lencontent);
 }
 
 template <typename T>
-ERROR awkward_regulararray_broadcast_tooffsets(const T* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, int64_t size) {
+ERROR awkward_regulararray_broadcast_tooffsets(
+  const T* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength,
+  int64_t size) {
   for (int64_t i = 0;  i < offsetslength - 1;  i++) {
-    int64_t count = (int64_t)(fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i]);
+    int64_t count = (int64_t)(fromoffsets[offsetsoffset + i + 1] -
+                              fromoffsets[offsetsoffset + i]);
     if (count < 0) {
-      return failure("broadcast's offsets must be monotonically increasing", i, kSliceNone);
+      return failure(
+        "broadcast's offsets must be monotonically increasing", i, kSliceNone);
     }
     if (size != count) {
       return failure("cannot broadcast nested list", i, kSliceNone);
@@ -358,17 +1058,31 @@ ERROR awkward_regulararray_broadcast_tooffsets(const T* fromoffsets, int64_t off
   }
   return success();
 }
-ERROR awkward_regulararray_broadcast_tooffsets64(const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, int64_t size) {
-  return awkward_regulararray_broadcast_tooffsets<int64_t>(fromoffsets, offsetsoffset, offsetslength, size);
+ERROR awkward_regulararray_broadcast_tooffsets64(
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength,
+  int64_t size) {
+  return awkward_regulararray_broadcast_tooffsets<int64_t>(
+    fromoffsets,
+    offsetsoffset,
+    offsetslength,
+    size);
 }
 
 template <typename T>
-ERROR awkward_regulararray_broadcast_tooffsets_size1(T* tocarry, const T* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
+ERROR awkward_regulararray_broadcast_tooffsets_size1(
+  T* tocarry,
+  const T* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength) {
   int64_t k = 0;
   for (int64_t i = 0;  i < offsetslength - 1;  i++) {
-    int64_t count = (int64_t)(fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i]);
+    int64_t count = (int64_t)(fromoffsets[offsetsoffset + i + 1] -
+                              fromoffsets[offsetsoffset + i]);
     if (count < 0) {
-      return failure("broadcast's offsets must be monotonically increasing", i, kSliceNone);
+      return failure(
+        "broadcast's offsets must be monotonically increasing", i, kSliceNone);
     }
     for (int64_t j = 0;  j < count;  j++) {
       tocarry[k] = (T)i;
@@ -377,23 +1091,41 @@ ERROR awkward_regulararray_broadcast_tooffsets_size1(T* tocarry, const T* fromof
   }
   return success();
 }
-ERROR awkward_regulararray_broadcast_tooffsets64_size1(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
-  return awkward_regulararray_broadcast_tooffsets_size1<int64_t>(tocarry, fromoffsets, offsetsoffset, offsetslength);
+ERROR awkward_regulararray_broadcast_tooffsets64_size1(
+  int64_t* tocarry,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength) {
+  return awkward_regulararray_broadcast_tooffsets_size1<int64_t>(
+    tocarry,
+    fromoffsets,
+    offsetsoffset,
+    offsetslength);
 }
 
 template <typename C>
-ERROR awkward_listoffsetarray_toRegularArray(int64_t* size, const C* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
+ERROR awkward_listoffsetarray_toRegularArray(
+  int64_t* size,
+  const C* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength) {
   *size = -1;
   for (int64_t i = 0;  i < offsetslength - 1;  i++) {
-    int64_t count = (int64_t)(fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i]);
+    int64_t count = (int64_t)(fromoffsets[offsetsoffset + i + 1] -
+                              fromoffsets[offsetsoffset + i]);
     if (count < 0) {
-      return failure("offsets must be monotonically increasing", i, kSliceNone);
+      return failure(
+        "offsets must be monotonically increasing", i, kSliceNone);
     }
     if (*size == -1) {
       *size = count;
     }
     else if (*size != count) {
-      return failure("cannot convert to RegularArray because subarray lengths are not regular", i, kSliceNone);
+      return failure(
+        "cannot convert to RegularArray because subarray lengths are not "
+        "regular",
+        i,
+        kSliceNone);
     }
   }
   if (*size == -1) {
@@ -401,70 +1133,239 @@ ERROR awkward_listoffsetarray_toRegularArray(int64_t* size, const C* fromoffsets
   }
   return success();
 }
-ERROR awkward_listoffsetarray32_toRegularArray(int64_t* size, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
-  return awkward_listoffsetarray_toRegularArray<int32_t>(size, fromoffsets, offsetsoffset, offsetslength);
+ERROR awkward_listoffsetarray32_toRegularArray(
+  int64_t* size,
+  const int32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength) {
+  return awkward_listoffsetarray_toRegularArray<int32_t>(
+    size,
+    fromoffsets,
+    offsetsoffset,
+    offsetslength);
 }
-ERROR awkward_listoffsetarrayU32_toRegularArray(int64_t* size, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
-  return awkward_listoffsetarray_toRegularArray<uint32_t>(size, fromoffsets, offsetsoffset, offsetslength);
+ERROR awkward_listoffsetarrayU32_toRegularArray(
+  int64_t* size,
+  const uint32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength) {
+  return awkward_listoffsetarray_toRegularArray<uint32_t>(
+    size,
+    fromoffsets,
+    offsetsoffset,
+    offsetslength);
 }
-ERROR awkward_listoffsetarray64_toRegularArray(int64_t* size, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
-  return awkward_listoffsetarray_toRegularArray<int64_t>(size, fromoffsets, offsetsoffset, offsetslength);
+ERROR awkward_listoffsetarray64_toRegularArray(
+  int64_t* size,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t offsetslength) {
+  return awkward_listoffsetarray_toRegularArray<int64_t>(
+    size,
+    fromoffsets,
+    offsetsoffset,
+    offsetslength);
 }
 
 template <typename FROM, typename TO>
-ERROR awkward_numpyarray_fill(TO* toptr, int64_t tooffset, const FROM* fromptr, int64_t fromoffset, int64_t length) {
+ERROR awkward_numpyarray_fill(
+  TO* toptr,
+  int64_t tooffset,
+  const FROM* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toptr[tooffset + i] = (TO)fromptr[fromoffset + i];
   }
   return success();
 }
 template <typename TO>
-ERROR awkward_numpyarray_fill_frombool(TO* toptr, int64_t tooffset, const bool* fromptr, int64_t fromoffset, int64_t length) {
+ERROR awkward_numpyarray_fill_frombool(
+  TO* toptr,
+  int64_t tooffset,
+  const bool* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toptr[tooffset + i] = (TO)(fromptr[fromoffset + i] != 0);
   }
   return success();
 }
-ERROR awkward_numpyarray_fill_todouble_fromdouble(double* toptr, int64_t tooffset, const double* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<double, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_fromdouble(
+  double* toptr,
+  int64_t tooffset,
+  const double* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<double, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_fromfloat(double* toptr, int64_t tooffset, const float* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<float, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_fromfloat(
+  double* toptr,
+  int64_t tooffset,
+  const float* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<float, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_from64(double* toptr, int64_t tooffset, const int64_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<int64_t, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_from64(
+  double* toptr,
+  int64_t tooffset,
+  const int64_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<int64_t, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_fromU64(double* toptr, int64_t tooffset, const uint64_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<uint64_t, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_fromU64(
+  double* toptr,
+  int64_t tooffset,
+  const uint64_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<uint64_t, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_from32(double* toptr, int64_t tooffset, const int32_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<int32_t, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_from32(
+  double* toptr,
+  int64_t tooffset,
+  const int32_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<int32_t, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_fromU32(double* toptr, int64_t tooffset, const uint32_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<uint32_t, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_fromU32(
+  double* toptr,
+  int64_t tooffset,
+  const uint32_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<uint32_t, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_from16(double* toptr, int64_t tooffset, const int16_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<int16_t, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_from16(
+  double* toptr,
+  int64_t tooffset,
+  const int16_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<int16_t, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_fromU16(double* toptr, int64_t tooffset, const uint16_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<uint16_t, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_fromU16(
+  double* toptr,
+  int64_t tooffset,
+  const uint16_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<uint16_t, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_from8(double* toptr, int64_t tooffset, const int8_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<int8_t, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_from8(
+  double* toptr,
+  int64_t tooffset,
+  const int8_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<int8_t, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_fromU8(double* toptr, int64_t tooffset, const uint8_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<uint8_t, double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_fromU8(
+  double* toptr,
+  int64_t tooffset,
+  const uint8_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<uint8_t, double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_todouble_frombool(double* toptr, int64_t tooffset, const bool* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill_frombool<double>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_todouble_frombool(
+  double* toptr,
+  int64_t tooffset,
+  const bool* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill_frombool<double>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_toU64_fromU64(uint64_t* toptr, int64_t tooffset, const uint64_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<uint64_t, uint64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_toU64_fromU64(
+  uint64_t* toptr,
+  int64_t tooffset,
+  const uint64_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<uint64_t, uint64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_to64_from64(int64_t* toptr, int64_t tooffset, const int64_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<int64_t, int64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_to64_from64(
+  int64_t* toptr,
+  int64_t tooffset,
+  const int64_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<int64_t, int64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_to64_fromU64(int64_t* toptr, int64_t tooffset, const uint64_t* fromptr, int64_t fromoffset, int64_t length) {
+ERROR awkward_numpyarray_fill_to64_fromU64(
+  int64_t* toptr,
+  int64_t tooffset,
+  const uint64_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     if (fromptr[fromoffset + i] > kMaxInt64) {
       return failure("uint64 value too large for int64 output", i, kSliceNone);
@@ -473,130 +1374,430 @@ ERROR awkward_numpyarray_fill_to64_fromU64(int64_t* toptr, int64_t tooffset, con
   }
   return success();
 }
-ERROR awkward_numpyarray_fill_to64_from32(int64_t* toptr, int64_t tooffset, const int32_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<int32_t, int64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_to64_from32(
+  int64_t* toptr,
+  int64_t tooffset,
+  const int32_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<int32_t, int64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_to64_fromU32(int64_t* toptr, int64_t tooffset, const uint32_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<uint32_t, int64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_to64_fromU32(
+  int64_t* toptr,
+  int64_t tooffset,
+  const uint32_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<uint32_t, int64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_to64_from16(int64_t* toptr, int64_t tooffset, const int16_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<int16_t, int64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_to64_from16(
+  int64_t* toptr,
+  int64_t tooffset,
+  const int16_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<int16_t, int64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_to64_fromU16(int64_t* toptr, int64_t tooffset, const uint16_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<uint16_t, int64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_to64_fromU16(
+  int64_t* toptr,
+  int64_t tooffset,
+  const uint16_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<uint16_t, int64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_to64_from8(int64_t* toptr, int64_t tooffset, const int8_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<int8_t, int64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_to64_from8(
+  int64_t* toptr,
+  int64_t tooffset,
+  const int8_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<int8_t, int64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_to64_fromU8(int64_t* toptr, int64_t tooffset, const uint8_t* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill<uint8_t, int64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_to64_fromU8(
+  int64_t* toptr,
+  int64_t tooffset,
+  const uint8_t* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill<uint8_t, int64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_to64_frombool(int64_t* toptr, int64_t tooffset, const bool* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill_frombool<int64_t>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_to64_frombool(
+  int64_t* toptr,
+  int64_t tooffset,
+  const bool* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill_frombool<int64_t>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
-ERROR awkward_numpyarray_fill_tobool_frombool(bool* toptr, int64_t tooffset, const bool* fromptr, int64_t fromoffset, int64_t length) {
-  return awkward_numpyarray_fill_frombool<bool>(toptr, tooffset, fromptr, fromoffset, length);
+ERROR awkward_numpyarray_fill_tobool_frombool(
+  bool* toptr,
+  int64_t tooffset,
+  const bool* fromptr,
+  int64_t fromoffset,
+  int64_t length) {
+  return awkward_numpyarray_fill_frombool<bool>(
+    toptr,
+    tooffset,
+    fromptr,
+    fromoffset,
+    length);
 }
 
 template <typename FROM, typename TO>
-ERROR awkward_listarray_fill(TO* tostarts, int64_t tostartsoffset, TO* tostops, int64_t tostopsoffset, const FROM* fromstarts, int64_t fromstartsoffset, const FROM* fromstops, int64_t fromstopsoffset, int64_t length, int64_t base) {
+ERROR awkward_listarray_fill(
+  TO* tostarts,
+  int64_t tostartsoffset,
+  TO* tostops,
+  int64_t tostopsoffset,
+  const FROM* fromstarts,
+  int64_t fromstartsoffset,
+  const FROM* fromstops,
+  int64_t fromstopsoffset,
+  int64_t length,
+  int64_t base) {
   for (int64_t i = 0;  i < length;  i++) {
-    tostarts[tostartsoffset + i] = (TO)(fromstarts[fromstartsoffset + i] + base);
-    tostops[tostopsoffset + i] = (TO)(fromstops[fromstopsoffset + i] + base);
+    tostarts[tostartsoffset + i] =
+      (TO)(fromstarts[fromstartsoffset + i] + base);
+    tostops[tostopsoffset + i] =
+      (TO)(fromstops[fromstopsoffset + i] + base);
   }
   return success();
 }
-ERROR awkward_listarray_fill_to64_from32(int64_t* tostarts, int64_t tostartsoffset, int64_t* tostops, int64_t tostopsoffset, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset, int64_t length, int64_t base) {
-  return awkward_listarray_fill<int32_t, int64_t>(tostarts, tostartsoffset, tostops, tostopsoffset, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, length, base);
+ERROR awkward_listarray_fill_to64_from32(
+  int64_t* tostarts,
+  int64_t tostartsoffset,
+  int64_t* tostops,
+  int64_t tostopsoffset,
+  const int32_t* fromstarts,
+  int64_t fromstartsoffset,
+  const int32_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_listarray_fill<int32_t, int64_t>(
+    tostarts,
+    tostartsoffset,
+    tostops,
+    tostopsoffset,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    length,
+    base);
 }
-ERROR awkward_listarray_fill_to64_fromU32(int64_t* tostarts, int64_t tostartsoffset, int64_t* tostops, int64_t tostopsoffset, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset, int64_t length, int64_t base) {
-  return awkward_listarray_fill<uint32_t, int64_t>(tostarts, tostartsoffset, tostops, tostopsoffset, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, length, base);
+ERROR awkward_listarray_fill_to64_fromU32(
+  int64_t* tostarts,
+  int64_t tostartsoffset,
+  int64_t* tostops,
+  int64_t tostopsoffset,
+  const uint32_t* fromstarts,
+  int64_t fromstartsoffset,
+  const uint32_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_listarray_fill<uint32_t, int64_t>(
+    tostarts,
+    tostartsoffset,
+    tostops,
+    tostopsoffset,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    length,
+    base);
 }
-ERROR awkward_listarray_fill_to64_from64(int64_t* tostarts, int64_t tostartsoffset, int64_t* tostops, int64_t tostopsoffset, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset, int64_t length, int64_t base) {
-  return awkward_listarray_fill<int64_t, int64_t>(tostarts, tostartsoffset, tostops, tostopsoffset, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, length, base);
+ERROR awkward_listarray_fill_to64_from64(
+  int64_t* tostarts,
+  int64_t tostartsoffset,
+  int64_t* tostops,
+  int64_t tostopsoffset,
+  const int64_t* fromstarts,
+  int64_t fromstartsoffset,
+  const int64_t* fromstops,
+  int64_t fromstopsoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_listarray_fill<int64_t, int64_t>(
+    tostarts,
+    tostartsoffset,
+    tostops,
+    tostopsoffset,
+    fromstarts,
+    fromstartsoffset,
+    fromstops,
+    fromstopsoffset,
+    length,
+    base);
 }
 
 template <typename FROM, typename TO>
-ERROR awkward_indexedarray_fill(TO* toindex, int64_t toindexoffset, const FROM* fromindex, int64_t fromindexoffset, int64_t length, int64_t base) {
+ERROR awkward_indexedarray_fill(
+  TO* toindex,
+  int64_t toindexoffset,
+  const FROM* fromindex,
+  int64_t fromindexoffset,
+  int64_t length,
+  int64_t base) {
   for (int64_t i = 0;  i < length;  i++) {
     FROM from = fromindex[fromindexoffset + i];
     toindex[toindexoffset + i] = from < 0 ? -1 : (TO)(from + base);
   }
   return success();
 }
-ERROR awkward_indexedarray_fill_to64_from32(int64_t* toindex, int64_t toindexoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t base) {
-  return awkward_indexedarray_fill<int32_t, int64_t>(toindex, toindexoffset, fromindex, fromindexoffset, length, base);
+ERROR awkward_indexedarray_fill_to64_from32(
+  int64_t* toindex,
+  int64_t toindexoffset,
+  const int32_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_indexedarray_fill<int32_t, int64_t>(
+    toindex,
+    toindexoffset,
+    fromindex,
+    fromindexoffset,
+    length,
+    base);
 }
-ERROR awkward_indexedarray_fill_to64_fromU32(int64_t* toindex, int64_t toindexoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t base) {
-  return awkward_indexedarray_fill<uint32_t, int64_t>(toindex, toindexoffset, fromindex, fromindexoffset, length, base);
+ERROR awkward_indexedarray_fill_to64_fromU32(
+  int64_t* toindex,
+  int64_t toindexoffset,
+  const uint32_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_indexedarray_fill<uint32_t, int64_t>(
+    toindex,
+    toindexoffset,
+    fromindex,
+    fromindexoffset,
+    length,
+    base);
 }
-ERROR awkward_indexedarray_fill_to64_from64(int64_t* toindex, int64_t toindexoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t base) {
-  return awkward_indexedarray_fill<int64_t, int64_t>(toindex, toindexoffset, fromindex, fromindexoffset, length, base);
+ERROR awkward_indexedarray_fill_to64_from64(
+  int64_t* toindex,
+  int64_t toindexoffset,
+  const int64_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_indexedarray_fill<int64_t, int64_t>(
+    toindex,
+    toindexoffset,
+    fromindex,
+    fromindexoffset,
+    length,
+    base);
 }
 
 template <typename TO>
-ERROR awkward_indexedarray_fill_count(TO* toindex, int64_t toindexoffset, int64_t length, int64_t base) {
+ERROR awkward_indexedarray_fill_count(
+  TO* toindex,
+  int64_t toindexoffset,
+  int64_t length,
+  int64_t base) {
   for (int64_t i = 0;  i < length;  i++) {
     toindex[toindexoffset + i] = i + base;
   }
   return success();
 }
-ERROR awkward_indexedarray_fill_to64_count(int64_t* toindex, int64_t toindexoffset, int64_t length, int64_t base) {
-  return awkward_indexedarray_fill_count(toindex, toindexoffset, length, base);
+ERROR awkward_indexedarray_fill_to64_count(
+  int64_t* toindex,
+  int64_t toindexoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_indexedarray_fill_count(
+    toindex,
+    toindexoffset,
+    length,
+    base);
 }
 
 template <typename FROM, typename TO>
-ERROR awkward_unionarray_filltags(TO* totags, int64_t totagsoffset, const FROM* fromtags, int64_t fromtagsoffset, int64_t length, int64_t base) {
+ERROR awkward_unionarray_filltags(
+  TO* totags,
+  int64_t totagsoffset,
+  const FROM* fromtags,
+  int64_t fromtagsoffset,
+  int64_t length,
+  int64_t base) {
   for (int64_t i = 0;  i < length;  i++) {
     totags[totagsoffset + i] = (TO)(fromtags[fromtagsoffset + i] + base);
   }
   return success();
 }
-ERROR awkward_unionarray_filltags_to8_from8(int8_t* totags, int64_t totagsoffset, const int8_t* fromtags, int64_t fromtagsoffset, int64_t length, int64_t base) {
-  return awkward_unionarray_filltags<int8_t, int8_t>(totags, totagsoffset, fromtags, fromtagsoffset, length, base);
+ERROR awkward_unionarray_filltags_to8_from8(
+  int8_t* totags,
+  int64_t totagsoffset,
+  const int8_t* fromtags,
+  int64_t fromtagsoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_filltags<int8_t, int8_t>(
+    totags,
+    totagsoffset,
+    fromtags,
+    fromtagsoffset,
+    length,
+    base);
 }
 
 template <typename FROM, typename TO>
-ERROR awkward_unionarray_fillindex(TO* toindex, int64_t toindexoffset, const FROM* fromindex, int64_t fromindexoffset, int64_t length) {
+ERROR awkward_unionarray_fillindex(
+  TO* toindex,
+  int64_t toindexoffset,
+  const FROM* fromindex,
+  int64_t fromindexoffset,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toindex[toindexoffset + i] = (TO)fromindex[fromindexoffset + i];
   }
   return success();
 }
-ERROR awkward_unionarray_fillindex_to64_from32(int64_t* toindex, int64_t toindexoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length) {
-  return awkward_unionarray_fillindex<int32_t, int64_t>(toindex, toindexoffset, fromindex, fromindexoffset, length);
+ERROR awkward_unionarray_fillindex_to64_from32(
+  int64_t* toindex,
+  int64_t toindexoffset,
+  const int32_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t length) {
+  return awkward_unionarray_fillindex<int32_t, int64_t>(
+    toindex,
+    toindexoffset,
+    fromindex,
+    fromindexoffset,
+    length);
 }
-ERROR awkward_unionarray_fillindex_to64_fromU32(int64_t* toindex, int64_t toindexoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length) {
-  return awkward_unionarray_fillindex<uint32_t, int64_t>(toindex, toindexoffset, fromindex, fromindexoffset, length);
+ERROR awkward_unionarray_fillindex_to64_fromU32(
+  int64_t* toindex,
+  int64_t toindexoffset,
+  const uint32_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t length) {
+  return awkward_unionarray_fillindex<uint32_t, int64_t>(
+    toindex,
+    toindexoffset,
+    fromindex,
+    fromindexoffset,
+    length);
 }
-ERROR awkward_unionarray_fillindex_to64_from64(int64_t* toindex, int64_t toindexoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length) {
-  return awkward_unionarray_fillindex<int64_t, int64_t>(toindex, toindexoffset, fromindex, fromindexoffset, length);
+ERROR awkward_unionarray_fillindex_to64_from64(
+  int64_t* toindex,
+  int64_t toindexoffset,
+  const int64_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t length) {
+  return awkward_unionarray_fillindex<int64_t, int64_t>(
+    toindex,
+    toindexoffset,
+    fromindex,
+    fromindexoffset,
+    length);
 }
 
 template <typename TO>
-ERROR awkward_unionarray_filltags_const(TO* totags, int64_t totagsoffset, int64_t length, int64_t base) {
+ERROR awkward_unionarray_filltags_const(
+  TO* totags,
+  int64_t totagsoffset,
+  int64_t length,
+  int64_t base) {
   for (int64_t i = 0;  i < length;  i++) {
     totags[totagsoffset + i] = (TO)base;
   }
   return success();
 }
-ERROR awkward_unionarray_filltags_to8_const(int8_t* totags, int64_t totagsoffset, int64_t length, int64_t base) {
-  return awkward_unionarray_filltags_const<int8_t>(totags, totagsoffset, length, base);
+ERROR awkward_unionarray_filltags_to8_const(
+  int8_t* totags,
+  int64_t totagsoffset,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_filltags_const<int8_t>(
+    totags,
+    totagsoffset,
+    length,
+    base);
 }
 
 template <typename TO>
-ERROR awkward_unionarray_fillindex_count(TO* toindex, int64_t toindexoffset, int64_t length) {
+ERROR awkward_unionarray_fillindex_count(
+  TO* toindex,
+  int64_t toindexoffset,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toindex[toindexoffset + i] = (TO)i;
   }
   return success();
 }
-ERROR awkward_unionarray_fillindex_to64_count(int64_t* toindex, int64_t toindexoffset, int64_t length) {
-  return awkward_unionarray_fillindex_count<int64_t>(toindex, toindexoffset, length);
+ERROR awkward_unionarray_fillindex_to64_count(
+  int64_t* toindex,
+  int64_t toindexoffset,
+  int64_t length) {
+  return awkward_unionarray_fillindex_count<int64_t>(
+    toindex,
+    toindexoffset,
+    length);
 }
 
-template <typename OUTERTAGS, typename OUTERINDEX, typename INNERTAGS, typename INNERINDEX, typename TOTAGS, typename TOINDEX>
-ERROR awkward_unionarray_simplify(TOTAGS* totags, TOINDEX* toindex, const OUTERTAGS* outertags, int64_t outertagsoffset, const OUTERINDEX* outerindex, int64_t outerindexoffset, const INNERTAGS* innertags, int64_t innertagsoffset, const INNERINDEX* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
+template <typename OUTERTAGS,
+          typename OUTERINDEX,
+          typename INNERTAGS,
+          typename INNERINDEX,
+          typename TOTAGS,
+          typename TOINDEX>
+ERROR awkward_unionarray_simplify(
+  TOTAGS* totags,
+  TOINDEX* toindex,
+  const OUTERTAGS* outertags,
+  int64_t outertagsoffset,
+  const OUTERINDEX* outerindex,
+  int64_t outerindexoffset,
+  const INNERTAGS* innertags,
+  int64_t innertagsoffset,
+  const INNERINDEX* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
   for (int64_t i = 0;  i < length;  i++) {
     if (outertags[outertagsoffset + i] == outerwhich) {
       OUTERINDEX j = outerindex[outerindexoffset + i];
@@ -608,36 +1809,364 @@ ERROR awkward_unionarray_simplify(TOTAGS* totags, TOINDEX* toindex, const OUTERT
   }
   return success();
 }
-ERROR awkward_unionarray8_32_simplify8_32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, int32_t, int8_t, int32_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_32_simplify8_32_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const int32_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const int32_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     int32_t,
+                                     int8_t,
+                                     int32_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_32_simplify8_U32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, int32_t, int8_t, uint32_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_32_simplify8_U32_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const int32_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const uint32_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     int32_t,
+                                     int8_t,
+                                     uint32_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_32_simplify8_64_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, int32_t, int8_t, int64_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_32_simplify8_64_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const int32_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const int64_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     int32_t,
+                                     int8_t,
+                                     int64_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_U32_simplify8_32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, uint32_t, int8_t, int32_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_U32_simplify8_32_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const uint32_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const int32_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     uint32_t,
+                                     int8_t,
+                                     int32_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_U32_simplify8_U32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, uint32_t, int8_t, uint32_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_U32_simplify8_U32_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const uint32_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const uint32_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     uint32_t,
+                                     int8_t,
+                                     uint32_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_U32_simplify8_64_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, uint32_t, int8_t, int64_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_U32_simplify8_64_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const uint32_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const int64_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     uint32_t,
+                                     int8_t,
+                                     int64_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_64_simplify8_32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, int64_t, int8_t, int32_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_64_simplify8_32_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const int64_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const int32_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     int64_t,
+                                     int8_t,
+                                     int32_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_64_simplify8_U32_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, int64_t, int8_t, uint32_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_64_simplify8_U32_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const int64_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const uint32_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     int64_t,
+                                     int8_t,
+                                     uint32_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_64_simplify8_64_to8_64(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify<int8_t, int64_t, int8_t, int64_t, int8_t, int64_t>(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+ERROR awkward_unionarray8_64_simplify8_64_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* outertags,
+  int64_t outertagsoffset,
+  const int64_t* outerindex,
+  int64_t outerindexoffset,
+  const int8_t* innertags,
+  int64_t innertagsoffset,
+  const int64_t* innerindex,
+  int64_t innerindexoffset,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify<int8_t,
+                                     int64_t,
+                                     int8_t,
+                                     int64_t,
+                                     int8_t,
+                                     int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outertagsoffset,
+    outerindex,
+    outerindexoffset,
+    innertags,
+    innertagsoffset,
+    innerindex,
+    innerindexoffset,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
 }
 
-template <typename FROMTAGS, typename FROMINDEX, typename TOTAGS, typename TOINDEX>
-ERROR awkward_unionarray_simplify_one(TOTAGS* totags, TOINDEX* toindex, const FROMTAGS* fromtags, int64_t fromtagsoffset, const FROMINDEX* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base) {
+template <typename FROMTAGS,
+          typename FROMINDEX,
+          typename TOTAGS,
+          typename TOINDEX>
+ERROR awkward_unionarray_simplify_one(
+  TOTAGS* totags,
+  TOINDEX* toindex,
+  const FROMTAGS* fromtags,
+  int64_t fromtagsoffset,
+  const FROMINDEX* fromindex,
+  int64_t fromindexoffset,
+  int64_t towhich,
+  int64_t fromwhich,
+  int64_t length,
+  int64_t base) {
   for (int64_t i = 0;  i < length;  i++) {
     if (fromtags[fromtagsoffset + i] == fromwhich) {
       totags[i] = (TOTAGS)towhich;
@@ -646,18 +2175,84 @@ ERROR awkward_unionarray_simplify_one(TOTAGS* totags, TOINDEX* toindex, const FR
   }
   return success();
 }
-ERROR awkward_unionarray8_32_simplify_one_to8_64(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify_one<int8_t, int32_t, int8_t, int64_t>(totags, toindex, fromtags, fromtagsoffset, fromindex, fromindexoffset, towhich, fromwhich, length, base);
+ERROR awkward_unionarray8_32_simplify_one_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* fromtags,
+  int64_t fromtagsoffset,
+  const int32_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t towhich,
+  int64_t fromwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify_one<int8_t, int32_t, int8_t, int64_t>(
+    totags,
+    toindex,
+    fromtags,
+    fromtagsoffset,
+    fromindex,
+    fromindexoffset,
+    towhich,
+    fromwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_U32_simplify_one_to8_64(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify_one<int8_t, uint32_t, int8_t, int64_t>(totags, toindex, fromtags, fromtagsoffset, fromindex, fromindexoffset, towhich, fromwhich, length, base);
+ERROR awkward_unionarray8_U32_simplify_one_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* fromtags,
+  int64_t fromtagsoffset,
+  const uint32_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t towhich,
+  int64_t fromwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify_one<int8_t, uint32_t, int8_t, int64_t>(
+    totags,
+    toindex,
+    fromtags,
+    fromtagsoffset,
+    fromindex,
+    fromindexoffset,
+    towhich,
+    fromwhich,
+    length,
+    base);
 }
-ERROR awkward_unionarray8_64_simplify_one_to8_64(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base) {
-  return awkward_unionarray_simplify_one<int8_t, int64_t, int8_t, int64_t>(totags, toindex, fromtags, fromtagsoffset, fromindex, fromindexoffset, towhich, fromwhich, length, base);
+ERROR awkward_unionarray8_64_simplify_one_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int8_t* fromtags,
+  int64_t fromtagsoffset,
+  const int64_t* fromindex,
+  int64_t fromindexoffset,
+  int64_t towhich,
+  int64_t fromwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_unionarray_simplify_one<int8_t, int64_t, int8_t, int64_t>(
+    totags,
+    toindex,
+    fromtags,
+    fromtagsoffset,
+    fromindex,
+    fromindexoffset,
+    towhich,
+    fromwhich,
+    length,
+    base);
 }
 
 template <typename C>
-ERROR awkward_listarray_validity(const C* starts, int64_t startsoffset, const C* stops, int64_t stopsoffset, int64_t length, int64_t lencontent) {
+ERROR awkward_listarray_validity(
+  const C* starts,
+  int64_t startsoffset,
+  const C* stops,
+  int64_t stopsoffset,
+  int64_t length,
+  int64_t lencontent) {
   for (int64_t i = 0;  i < length;  i++) {
     C start = starts[startsoffset + i];
     C stop = stops[stopsoffset + i];
@@ -676,18 +2271,58 @@ ERROR awkward_listarray_validity(const C* starts, int64_t startsoffset, const C*
   return success();
 }
 
-ERROR awkward_listarray32_validity(const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent) {
-  return awkward_listarray_validity<int32_t>(starts, startsoffset, stops, stopsoffset, length, lencontent);
+ERROR awkward_listarray32_validity(
+  const int32_t* starts,
+  int64_t startsoffset,
+  const int32_t* stops,
+  int64_t stopsoffset,
+  int64_t length,
+  int64_t lencontent) {
+  return awkward_listarray_validity<int32_t>(
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length,
+    lencontent);
 }
-ERROR awkward_listarrayU32_validity(const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent) {
-  return awkward_listarray_validity<uint32_t>(starts, startsoffset, stops, stopsoffset, length, lencontent);
+ERROR awkward_listarrayU32_validity(
+  const uint32_t* starts,
+  int64_t startsoffset,
+  const uint32_t* stops,
+  int64_t stopsoffset,
+  int64_t length,
+  int64_t lencontent) {
+  return awkward_listarray_validity<uint32_t>(
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length,
+    lencontent);
 }
-ERROR awkward_listarray64_validity(const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent) {
-  return awkward_listarray_validity<int64_t>(starts, startsoffset, stops, stopsoffset, length, lencontent);
+ERROR awkward_listarray64_validity(
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* stops,
+  int64_t stopsoffset,
+  int64_t length,
+  int64_t lencontent) {
+  return awkward_listarray_validity<int64_t>(
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length,
+    lencontent);
 }
 
 template <typename C, bool ISOPTION>
-ERROR awkward_indexedarray_validity(const C* index, int64_t indexoffset, int64_t length, int64_t lencontent) {
+ERROR awkward_indexedarray_validity(
+  const C* index,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t lencontent) {
   for (int64_t i = 0;  i < length;  i++) {
     C idx = index[indexoffset + i];
     if (!ISOPTION) {
@@ -701,33 +2336,79 @@ ERROR awkward_indexedarray_validity(const C* index, int64_t indexoffset, int64_t
   }
   return success();
 }
-ERROR awkward_indexedarray32_validity(const int32_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption) {
+ERROR awkward_indexedarray32_validity(
+  const int32_t* index,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t lencontent,
+  bool isoption) {
   if (isoption) {
-    return awkward_indexedarray_validity<int32_t, true>(index, indexoffset, length, lencontent);
+    return awkward_indexedarray_validity<int32_t, true>(
+    index,
+    indexoffset,
+    length,
+    lencontent);
   }
   else {
-    return awkward_indexedarray_validity<int32_t, false>(index, indexoffset, length, lencontent);
+    return awkward_indexedarray_validity<int32_t, false>(
+    index,
+    indexoffset,
+    length,
+    lencontent);
   }
 }
-ERROR awkward_indexedarrayU32_validity(const uint32_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption) {
+ERROR awkward_indexedarrayU32_validity(
+  const uint32_t* index,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t lencontent,
+  bool isoption) {
   if (isoption) {
-    return awkward_indexedarray_validity<uint32_t, true>(index, indexoffset, length, lencontent);
+    return awkward_indexedarray_validity<uint32_t, true>(
+    index,
+    indexoffset,
+    length,
+    lencontent);
   }
   else {
-    return awkward_indexedarray_validity<uint32_t, false>(index, indexoffset, length, lencontent);
+    return awkward_indexedarray_validity<uint32_t, false>(
+    index,
+    indexoffset,
+    length,
+    lencontent);
   }
 }
-ERROR awkward_indexedarray64_validity(const int64_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption) {
+ERROR awkward_indexedarray64_validity(
+  const int64_t* index,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t lencontent,
+  bool isoption) {
   if (isoption) {
-    return awkward_indexedarray_validity<int64_t, true>(index, indexoffset, length, lencontent);
+    return awkward_indexedarray_validity<int64_t, true>(
+    index,
+    indexoffset,
+    length,
+    lencontent);
   }
   else {
-    return awkward_indexedarray_validity<int64_t, false>(index, indexoffset, length, lencontent);
+    return awkward_indexedarray_validity<int64_t, false>(
+    index,
+    indexoffset,
+    length,
+    lencontent);
   }
 }
 
 template <typename T, typename I>
-ERROR awkward_unionarray_validity(const T* tags, int64_t tagsoffset, const I* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents) {
+ERROR awkward_unionarray_validity(
+  const T* tags,
+  int64_t tagsoffset,
+  const I* index,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t numcontents,
+  const int64_t* lencontents) {
   for (int64_t i = 0;  i < length;  i++) {
     T tag = tags[tagsoffset + i];
     I idx = index[indexoffset + i];
@@ -747,36 +2428,109 @@ ERROR awkward_unionarray_validity(const T* tags, int64_t tagsoffset, const I* in
   }
   return success();
 }
-ERROR awkward_unionarray8_32_validity(const int8_t* tags, int64_t tagsoffset, const int32_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents) {
-  return awkward_unionarray_validity<int8_t, int32_t>(tags, tagsoffset, index, indexoffset, length, numcontents, lencontents);
+ERROR awkward_unionarray8_32_validity(
+  const int8_t* tags,
+  int64_t tagsoffset,
+  const int32_t* index,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t numcontents,
+  const int64_t* lencontents) {
+  return awkward_unionarray_validity<int8_t, int32_t>(
+    tags,
+    tagsoffset,
+    index,
+    indexoffset,
+    length,
+    numcontents,
+    lencontents);
 }
-ERROR awkward_unionarray8_U32_validity(const int8_t* tags, int64_t tagsoffset, const uint32_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents) {
-  return awkward_unionarray_validity<int8_t, uint32_t>(tags, tagsoffset, index, indexoffset, length, numcontents, lencontents);
+ERROR awkward_unionarray8_U32_validity(
+  const int8_t* tags,
+  int64_t tagsoffset,
+  const uint32_t* index,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t numcontents,
+  const int64_t* lencontents) {
+  return awkward_unionarray_validity<int8_t, uint32_t>(
+    tags,
+    tagsoffset,
+    index,
+    indexoffset,
+    length,
+    numcontents,
+    lencontents);
 }
-ERROR awkward_unionarray8_64_validity(const int8_t* tags, int64_t tagsoffset, const int64_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents) {
-  return awkward_unionarray_validity<int8_t, int64_t>(tags, tagsoffset, index, indexoffset, length, numcontents, lencontents);
+ERROR awkward_unionarray8_64_validity(
+  const int8_t* tags,
+  int64_t tagsoffset,
+  const int64_t* index,
+  int64_t indexoffset,
+  int64_t length,
+  int64_t numcontents,
+  const int64_t* lencontents) {
+  return awkward_unionarray_validity<int8_t, int64_t>(
+    tags,
+    tagsoffset,
+    index,
+    indexoffset,
+    length,
+    numcontents,
+    lencontents);
 }
 
 template <typename T, typename C>
-ERROR awkward_UnionArray_fillna(T* toindex, const C* fromindex, int64_t offset, int64_t length) {
+ERROR awkward_UnionArray_fillna(
+  T* toindex,
+  const C* fromindex,
+  int64_t offset,
+  int64_t length) {
   for (int64_t i = 0; i < length; i++)
   {
     toindex[i] = fromindex[offset + i] >= 0 ? fromindex[offset + i] : 0;
   }
   return success();
 }
-ERROR awkward_UnionArray_fillna_from32_to64(int64_t* toindex, const int32_t* fromindex, int64_t offset, int64_t length) {
-  return awkward_UnionArray_fillna<int64_t, int32_t>(toindex, fromindex, offset, length);
+ERROR awkward_UnionArray_fillna_from32_to64(
+  int64_t* toindex,
+  const int32_t* fromindex,
+  int64_t offset,
+  int64_t length) {
+  return awkward_UnionArray_fillna<int64_t, int32_t>(
+    toindex,
+    fromindex,
+    offset,
+    length);
 }
-ERROR awkward_UnionArray_fillna_fromU32_to64(int64_t* toindex, const uint32_t* fromindex, int64_t offset, int64_t length) {
-  return awkward_UnionArray_fillna<int64_t, uint32_t>(toindex, fromindex, offset, length);
+ERROR awkward_UnionArray_fillna_fromU32_to64(
+  int64_t* toindex,
+  const uint32_t* fromindex,
+  int64_t offset,
+  int64_t length) {
+  return awkward_UnionArray_fillna<int64_t, uint32_t>(
+    toindex,
+    fromindex,
+    offset,
+    length);
 }
-ERROR awkward_UnionArray_fillna_from64_to64(int64_t* toindex, const int64_t* fromindex, int64_t offset, int64_t length) {
-  return awkward_UnionArray_fillna<int64_t, int64_t>(toindex, fromindex, offset, length);
+ERROR awkward_UnionArray_fillna_from64_to64(
+  int64_t* toindex,
+  const int64_t* fromindex,
+  int64_t offset,
+  int64_t length) {
+  return awkward_UnionArray_fillna<int64_t, int64_t>(
+    toindex,
+    fromindex,
+    offset,
+    length);
 }
 
 template <typename T>
-ERROR awkward_IndexedOptionArray_rpad_and_clip_mask_axis1(T* toindex, const int8_t* frommask, int64_t length) {
+ERROR awkward_IndexedOptionArray_rpad_and_clip_mask_axis1(
+  T* toindex,
+  const int8_t* frommask,
+  int64_t length) {
   int64_t count = 0;
   for (int64_t i = 0; i < length; i++) {
     if(frommask[i]) {
@@ -788,12 +2542,21 @@ ERROR awkward_IndexedOptionArray_rpad_and_clip_mask_axis1(T* toindex, const int8
   }
   return success();
 }
-ERROR awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(int64_t* toindex, const int8_t* frommask, int64_t length) {
-  return awkward_IndexedOptionArray_rpad_and_clip_mask_axis1<int64_t>(toindex, frommask, length);
+ERROR awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
+  int64_t* toindex,
+  const int8_t* frommask,
+  int64_t length) {
+  return awkward_IndexedOptionArray_rpad_and_clip_mask_axis1<int64_t>(
+    toindex,
+    frommask,
+    length);
 }
 
 template <typename T>
-ERROR awkward_index_rpad_and_clip_axis0(T* toindex, int64_t target, int64_t length) {
+ERROR awkward_index_rpad_and_clip_axis0(
+  T* toindex,
+  int64_t target,
+  int64_t length) {
   int64_t shorter = (target < length ? target : length);
   for (int64_t i = 0; i < shorter; i++) {
     toindex[i] = i;
@@ -803,12 +2566,22 @@ ERROR awkward_index_rpad_and_clip_axis0(T* toindex, int64_t target, int64_t leng
   }
   return success();
 }
-ERROR awkward_index_rpad_and_clip_axis0_64(int64_t* toindex, int64_t target, int64_t length) {
-  return awkward_index_rpad_and_clip_axis0<int64_t>(toindex, target, length);
+ERROR awkward_index_rpad_and_clip_axis0_64(
+  int64_t* toindex,
+  int64_t target,
+  int64_t length) {
+  return awkward_index_rpad_and_clip_axis0<int64_t>(
+    toindex,
+    target,
+    length);
 }
 
 template <typename T>
-ERROR awkward_index_rpad_and_clip_axis1(T* tostarts, T* tostops, int64_t target, int64_t length) {
+ERROR awkward_index_rpad_and_clip_axis1(
+  T* tostarts,
+  T* tostops,
+  int64_t target,
+  int64_t length) {
   int64_t offset = 0;
   for (int64_t i = 0; i < length; i++) {
     tostarts[i] = offset;
@@ -817,12 +2590,24 @@ ERROR awkward_index_rpad_and_clip_axis1(T* tostarts, T* tostops, int64_t target,
    }
   return success();
 }
-ERROR awkward_index_rpad_and_clip_axis1_64(int64_t* tostarts, int64_t* tostops, int64_t target, int64_t length) {
-  return awkward_index_rpad_and_clip_axis1<int64_t>(tostarts, tostops, target, length);
+ERROR awkward_index_rpad_and_clip_axis1_64(
+  int64_t* tostarts,
+  int64_t* tostops,
+  int64_t target,
+  int64_t length) {
+  return awkward_index_rpad_and_clip_axis1<int64_t>(
+    tostarts,
+    tostops,
+    target,
+    length);
 }
 
 template <typename T>
-ERROR awkward_RegularArray_rpad_and_clip_axis1(T* toindex, int64_t target, int64_t size, int64_t length) {
+ERROR awkward_RegularArray_rpad_and_clip_axis1(
+  T* toindex,
+  int64_t target,
+  int64_t size,
+  int64_t length) {
   int64_t shorter = (target < size ? target : size);
   for (int64_t i = 0;  i < length;  i++) {
     for (int64_t j = 0;  j < shorter;  j++) {
@@ -834,12 +2619,26 @@ ERROR awkward_RegularArray_rpad_and_clip_axis1(T* toindex, int64_t target, int64
   }
   return success();
 }
-ERROR awkward_RegularArray_rpad_and_clip_axis1_64(int64_t* toindex, int64_t target, int64_t size, int64_t length) {
-  return awkward_RegularArray_rpad_and_clip_axis1<int64_t>(toindex, target, size, length);
+ERROR awkward_RegularArray_rpad_and_clip_axis1_64(
+  int64_t* toindex,
+  int64_t target,
+  int64_t size,
+  int64_t length) {
+  return awkward_RegularArray_rpad_and_clip_axis1<int64_t>(
+    toindex,
+    target,
+    size,
+    length);
 }
 
 template <typename C>
-ERROR awkward_ListArray_min_range(int64_t* tomin, const C* fromstarts, const C* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
+ERROR awkward_ListArray_min_range(
+  int64_t* tomin,
+  const C* fromstarts,
+  const C* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
   int64_t shorter = fromstops[stopsoffset + 0] - fromstarts[startsoffset + 0];
   for (int64_t i = 1;  i < lenstarts;  i++) {
     int64_t range = fromstops[startsoffset + i] - fromstarts[stopsoffset + i];
@@ -848,18 +2647,61 @@ ERROR awkward_ListArray_min_range(int64_t* tomin, const C* fromstarts, const C* 
   *tomin = shorter;
   return success();
 }
-ERROR awkward_ListArray32_min_range(int64_t* tomin, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_min_range<int32_t>(tomin, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset);
+ERROR awkward_ListArray32_min_range(
+  int64_t* tomin,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_min_range<int32_t>(
+    tomin,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset);
 }
-ERROR awkward_ListArrayU32_min_range(int64_t* tomin, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_min_range<uint32_t>(tomin, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset);
+ERROR awkward_ListArrayU32_min_range(
+  int64_t* tomin,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_min_range<uint32_t>(
+    tomin,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset);
 }
-ERROR awkward_ListArray64_min_range(int64_t* tomin, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_min_range<int64_t>(tomin, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset);
+ERROR awkward_ListArray64_min_range(
+  int64_t* tomin,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_min_range<int64_t>(
+    tomin,
+    fromstarts,
+    fromstops,
+    lenstarts,
+    startsoffset,
+    stopsoffset);
 }
 
 template <typename C>
-ERROR awkward_ListArray_rpad_and_clip_length_axis1(int64_t* tolength, const C* fromstarts, const C* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
+ERROR awkward_ListArray_rpad_and_clip_length_axis1(
+  int64_t* tolength,
+  const C* fromstarts,
+  const C* fromstops,
+  int64_t target,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
   int64_t length = 0;
   for (int64_t i = 0;  i < lenstarts;  i++) {
     int64_t range = fromstops[startsoffset + i] - fromstarts[stopsoffset + i];
@@ -868,18 +2710,69 @@ ERROR awkward_ListArray_rpad_and_clip_length_axis1(int64_t* tolength, const C* f
   *tolength = length;
   return success();
 }
-ERROR awkward_ListArray32_rpad_and_clip_length_axis1(int64_t* tomin, const int32_t* fromstarts, const int32_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_rpad_and_clip_length_axis1<int32_t>(tomin, fromstarts, fromstops, target, lenstarts, startsoffset, stopsoffset);
+ERROR awkward_ListArray32_rpad_and_clip_length_axis1(
+  int64_t* tomin,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int64_t target,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_rpad_and_clip_length_axis1<int32_t>(
+    tomin,
+    fromstarts,
+    fromstops,
+    target,
+    lenstarts,
+    startsoffset,
+    stopsoffset);
 }
-ERROR awkward_ListArrayU32_rpad_and_clip_length_axis1(int64_t* tomin, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_rpad_and_clip_length_axis1<uint32_t>(tomin, fromstarts, fromstops, target, lenstarts, startsoffset, stopsoffset);
+ERROR awkward_ListArrayU32_rpad_and_clip_length_axis1(
+  int64_t* tomin,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  int64_t target,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_rpad_and_clip_length_axis1<uint32_t>(
+    tomin,
+    fromstarts,
+    fromstops,
+    target,
+    lenstarts,
+    startsoffset,
+    stopsoffset);
 }
-ERROR awkward_ListArray64_rpad_and_clip_length_axis1(int64_t* tomin, const int64_t* fromstarts, const int64_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_rpad_and_clip_length_axis1<int64_t>(tomin, fromstarts, fromstops, target, lenstarts, startsoffset, stopsoffset);
+ERROR awkward_ListArray64_rpad_and_clip_length_axis1(
+  int64_t* tomin,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t target,
+  int64_t lenstarts,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_rpad_and_clip_length_axis1<int64_t>(
+    tomin,
+    fromstarts,
+    fromstops,
+    target,
+    lenstarts,
+    startsoffset,
+    stopsoffset);
 }
 
 template <typename T, typename C>
-ERROR awkward_ListArray_rpad_axis1(T* toindex, const C* fromstarts, const C* fromstops, C* tostarts, C* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset) {
+ERROR awkward_ListArray_rpad_axis1(
+  T* toindex,
+  const C* fromstarts,
+  const C* fromstops,
+  C* tostarts,
+  C* tostops,
+  int64_t target,
+  int64_t length,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
   int64_t offset = 0;
   for (int64_t i = 0; i < length; i++) {
     tostarts[i] = offset;
@@ -895,20 +2788,80 @@ ERROR awkward_ListArray_rpad_axis1(T* toindex, const C* fromstarts, const C* fro
    }
   return success();
 }
-ERROR awkward_ListArray32_rpad_axis1_64(int64_t* toindex, const int32_t* fromstarts, const int32_t* fromstops, int32_t* tostarts, int32_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_rpad_axis1<int64_t, int32_t>(toindex, fromstarts, fromstops, tostarts, tostops, target, length, startsoffset, stopsoffset);
+ERROR awkward_ListArray32_rpad_axis1_64(
+  int64_t* toindex,
+  const int32_t* fromstarts,
+  const int32_t* fromstops,
+  int32_t* tostarts,
+  int32_t* tostops,
+  int64_t target,
+  int64_t length,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_rpad_axis1<int64_t, int32_t>(
+    toindex,
+    fromstarts,
+    fromstops,
+    tostarts,
+    tostops,
+    target,
+    length,
+    startsoffset,
+    stopsoffset);
 }
-ERROR awkward_ListArrayU32_rpad_axis1_64(int64_t* toindex, const uint32_t* fromstarts, const uint32_t* fromstops, uint32_t* tostarts, uint32_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_rpad_axis1<int64_t, uint32_t>(toindex, fromstarts, fromstops, tostarts, tostops, target, length, startsoffset, stopsoffset);
+ERROR awkward_ListArrayU32_rpad_axis1_64(
+  int64_t* toindex,
+  const uint32_t* fromstarts,
+  const uint32_t* fromstops,
+  uint32_t* tostarts,
+  uint32_t* tostops,
+  int64_t target,
+  int64_t length,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_rpad_axis1<int64_t, uint32_t>(
+    toindex,
+    fromstarts,
+    fromstops,
+    tostarts,
+    tostops,
+    target,
+    length,
+    startsoffset,
+    stopsoffset);
 }
-ERROR awkward_ListArray64_rpad_axis1_64(int64_t* toindex, const int64_t* fromstarts, const int64_t* fromstops, int64_t* tostarts, int64_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset) {
-  return awkward_ListArray_rpad_axis1<int64_t, int64_t>(toindex, fromstarts, fromstops, tostarts, tostops, target, length, startsoffset, stopsoffset);
+ERROR awkward_ListArray64_rpad_axis1_64(
+  int64_t* toindex,
+  const int64_t* fromstarts,
+  const int64_t* fromstops,
+  int64_t* tostarts,
+  int64_t* tostops,
+  int64_t target,
+  int64_t length,
+  int64_t startsoffset,
+  int64_t stopsoffset) {
+  return awkward_ListArray_rpad_axis1<int64_t, int64_t>(
+    toindex,
+    fromstarts,
+    fromstops,
+    tostarts,
+    tostops,
+    target,
+    length,
+    startsoffset,
+    stopsoffset);
 }
 
 template <typename T, typename C>
-ERROR awkward_ListOffsetArray_rpad_and_clip_axis1(T* toindex, const C* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target) {
+ERROR awkward_ListOffsetArray_rpad_and_clip_axis1(
+  T* toindex,
+  const C* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  int64_t target) {
   for (int64_t i = 0; i < length; i++) {
-    int64_t range = (T)(fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i]);
+    int64_t range = (T)(fromoffsets[offsetsoffset + i + 1] -
+                        fromoffsets[offsetsoffset + i]);
     int64_t shorter = (target < range) ? target : range;
     for (int64_t j = 0; j < shorter; j++) {
       toindex[i*target + j] = (T)fromoffsets[offsetsoffset + i] + j;
@@ -919,22 +2872,59 @@ ERROR awkward_ListOffsetArray_rpad_and_clip_axis1(T* toindex, const C* fromoffse
   }
   return success();
 }
-ERROR awkward_ListOffsetArray32_rpad_and_clip_axis1_64(int64_t* toindex, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target) {
-  return awkward_ListOffsetArray_rpad_and_clip_axis1<int64_t, int32_t>(toindex, fromoffsets, offsetsoffset, length, target);
+ERROR awkward_ListOffsetArray32_rpad_and_clip_axis1_64(
+  int64_t* toindex,
+  const int32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  int64_t target) {
+  return awkward_ListOffsetArray_rpad_and_clip_axis1<int64_t, int32_t>(
+    toindex,
+    fromoffsets,
+    offsetsoffset,
+    length,
+    target);
 }
-ERROR awkward_ListOffsetArrayU32_rpad_and_clip_axis1_64(int64_t* toindex, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target) {
-  return awkward_ListOffsetArray_rpad_and_clip_axis1<int64_t, uint32_t>(toindex, fromoffsets, offsetsoffset, length, target);
+ERROR awkward_ListOffsetArrayU32_rpad_and_clip_axis1_64(
+  int64_t* toindex,
+  const uint32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  int64_t target) {
+  return awkward_ListOffsetArray_rpad_and_clip_axis1<int64_t, uint32_t>(
+    toindex,
+    fromoffsets,
+    offsetsoffset,
+    length,
+    target);
 }
-ERROR awkward_ListOffsetArray64_rpad_and_clip_axis1_64(int64_t* toindex, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target) {
-  return awkward_ListOffsetArray_rpad_and_clip_axis1<int64_t, int64_t>(toindex, fromoffsets, offsetsoffset, length, target);
+ERROR awkward_ListOffsetArray64_rpad_and_clip_axis1_64(
+  int64_t* toindex,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  int64_t target) {
+  return awkward_ListOffsetArray_rpad_and_clip_axis1<int64_t, int64_t>(
+    toindex,
+    fromoffsets,
+    offsetsoffset,
+    length,
+    target);
 }
 
 template <typename C>
-ERROR awkward_ListOffsetArray_rpad_length_axis1(C* tooffsets, const C* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target, int64_t* tolength) {
+ERROR awkward_ListOffsetArray_rpad_length_axis1(
+  C* tooffsets,
+  const C* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t fromlength,
+  int64_t target,
+  int64_t* tolength) {
   int64_t length = 0;
   tooffsets[0] = 0;
   for (int64_t i = 0; i < fromlength; i++) {
-    int64_t range = fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i];
+    int64_t range =
+      fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i];
     int64_t longer = (target < range) ? range : target;
     length = length + longer;
     tooffsets[i + 1] = tooffsets[i] + longer;
@@ -943,21 +2933,63 @@ ERROR awkward_ListOffsetArray_rpad_length_axis1(C* tooffsets, const C* fromoffse
 
   return success();
 }
-ERROR awkward_ListOffsetArray32_rpad_length_axis1(int32_t* tooffsets, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target, int64_t* tolength) {
-  return awkward_ListOffsetArray_rpad_length_axis1<int32_t>(tooffsets, fromoffsets, offsetsoffset, fromlength, target, tolength);
+ERROR awkward_ListOffsetArray32_rpad_length_axis1(
+  int32_t* tooffsets,
+  const int32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t fromlength,
+  int64_t target,
+  int64_t* tolength) {
+  return awkward_ListOffsetArray_rpad_length_axis1<int32_t>(
+    tooffsets,
+    fromoffsets,
+    offsetsoffset,
+    fromlength,
+    target,
+    tolength);
 }
-ERROR awkward_ListOffsetArrayU32_rpad_length_axis1(uint32_t* tooffsets, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target, int64_t* tolength) {
-  return awkward_ListOffsetArray_rpad_length_axis1<uint32_t>(tooffsets, fromoffsets, offsetsoffset, fromlength, target, tolength);
+ERROR awkward_ListOffsetArrayU32_rpad_length_axis1(
+  uint32_t* tooffsets,
+  const uint32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t fromlength,
+  int64_t target,
+  int64_t* tolength) {
+  return awkward_ListOffsetArray_rpad_length_axis1<uint32_t>(
+    tooffsets,
+    fromoffsets,
+    offsetsoffset,
+    fromlength,
+    target,
+    tolength);
 }
-ERROR awkward_ListOffsetArray64_rpad_length_axis1(int64_t* tooffsets, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target, int64_t* tolength) {
-  return awkward_ListOffsetArray_rpad_length_axis1<int64_t>(tooffsets, fromoffsets, offsetsoffset, fromlength, target, tolength);
+ERROR awkward_ListOffsetArray64_rpad_length_axis1(
+  int64_t* tooffsets,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t fromlength,
+  int64_t target,
+  int64_t* tolength) {
+  return awkward_ListOffsetArray_rpad_length_axis1<int64_t>(
+    tooffsets,
+    fromoffsets,
+    offsetsoffset,
+    fromlength,
+    target,
+    tolength);
 }
 
 template <typename T, typename C>
-ERROR awkward_ListOffsetArray_rpad_axis1(T* toindex, const C* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target) {
+ERROR awkward_ListOffsetArray_rpad_axis1(
+  T* toindex,
+  const C* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t fromlength,
+  int64_t target) {
   int64_t count = 0;
   for (int64_t i = 0; i < fromlength; i++) {
-    int64_t range = (T)(fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i]);
+    int64_t range =
+      (T)(fromoffsets[offsetsoffset + i + 1] - fromoffsets[offsetsoffset + i]);
     for (int64_t j = 0; j < range; j++) {
       toindex[count++] = (T)fromoffsets[offsetsoffset + i] + j;
     }
@@ -967,29 +2999,69 @@ ERROR awkward_ListOffsetArray_rpad_axis1(T* toindex, const C* fromoffsets, int64
   }
   return success();
 }
-ERROR awkward_ListOffsetArray32_rpad_axis1_64(int64_t* toindex, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target) {
-  return awkward_ListOffsetArray_rpad_axis1<int64_t, int32_t>(toindex, fromoffsets, offsetsoffset, fromlength, target);
+ERROR awkward_ListOffsetArray32_rpad_axis1_64(
+  int64_t* toindex,
+  const int32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t fromlength,
+  int64_t target) {
+  return awkward_ListOffsetArray_rpad_axis1<int64_t, int32_t>(
+    toindex,
+    fromoffsets,
+    offsetsoffset,
+    fromlength,
+    target);
 }
-ERROR awkward_ListOffsetArrayU32_rpad_axis1_64(int64_t* toindex, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target) {
-  return awkward_ListOffsetArray_rpad_axis1<int64_t, uint32_t>(toindex, fromoffsets, offsetsoffset, fromlength, target);
+ERROR awkward_ListOffsetArrayU32_rpad_axis1_64(
+  int64_t* toindex,
+  const uint32_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t fromlength,
+  int64_t target) {
+  return awkward_ListOffsetArray_rpad_axis1<int64_t, uint32_t>(
+    toindex,
+    fromoffsets,
+    offsetsoffset,
+    fromlength,
+    target);
 }
-ERROR awkward_ListOffsetArray64_rpad_axis1_64(int64_t* toindex, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target) {
-  return awkward_ListOffsetArray_rpad_axis1<int64_t, int64_t>(toindex, fromoffsets, offsetsoffset, fromlength, target);
+ERROR awkward_ListOffsetArray64_rpad_axis1_64(
+  int64_t* toindex,
+  const int64_t* fromoffsets,
+  int64_t offsetsoffset,
+  int64_t fromlength,
+  int64_t target) {
+  return awkward_ListOffsetArray_rpad_axis1<int64_t, int64_t>(
+    toindex,
+    fromoffsets,
+    offsetsoffset,
+    fromlength,
+    target);
 }
 
 template <typename T>
-ERROR awkward_localindex(T* toindex, int64_t length) {
+ERROR awkward_localindex(
+  T* toindex,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toindex[i] = i;
   }
   return success();
 }
-ERROR awkward_localindex_64(int64_t* toindex, int64_t length) {
-  return awkward_localindex<int64_t>(toindex, length);
+ERROR awkward_localindex_64(
+  int64_t* toindex,
+  int64_t length) {
+  return awkward_localindex<int64_t>(
+    toindex,
+    length);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_localindex(T* toindex, const C* offsets, int64_t offsetsoffset, int64_t length) {
+ERROR awkward_listarray_localindex(
+  T* toindex,
+  const C* offsets,
+  int64_t offsetsoffset,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     int64_t start = (int64_t)offsets[offsetsoffset + i];
     int64_t stop = (int64_t)offsets[offsetsoffset + i + 1];
@@ -999,18 +3071,45 @@ ERROR awkward_listarray_localindex(T* toindex, const C* offsets, int64_t offsets
   }
   return success();
 }
-ERROR awkward_listarray32_localindex_64(int64_t* toindex, const int32_t* offsets, int64_t offsetsoffset, int64_t length) {
-  return awkward_listarray_localindex<int32_t, int64_t>(toindex, offsets, offsetsoffset, length);
+ERROR awkward_listarray32_localindex_64(
+  int64_t* toindex,
+  const int32_t* offsets,
+  int64_t offsetsoffset,
+  int64_t length) {
+  return awkward_listarray_localindex<int32_t, int64_t>(
+    toindex,
+    offsets,
+    offsetsoffset,
+    length);
 }
-ERROR awkward_listarrayU32_localindex_64(int64_t* toindex, const uint32_t* offsets, int64_t offsetsoffset, int64_t length) {
-  return awkward_listarray_localindex<uint32_t, int64_t>(toindex, offsets, offsetsoffset, length);
+ERROR awkward_listarrayU32_localindex_64(
+  int64_t* toindex,
+  const uint32_t* offsets,
+  int64_t offsetsoffset,
+  int64_t length) {
+  return awkward_listarray_localindex<uint32_t, int64_t>(
+    toindex,
+    offsets,
+    offsetsoffset,
+    length);
 }
-ERROR awkward_listarray64_localindex_64(int64_t* toindex, const int64_t* offsets, int64_t offsetsoffset, int64_t length) {
-  return awkward_listarray_localindex<int64_t, int64_t>(toindex, offsets, offsetsoffset, length);
+ERROR awkward_listarray64_localindex_64(
+  int64_t* toindex,
+  const int64_t* offsets,
+  int64_t offsetsoffset,
+  int64_t length) {
+  return awkward_listarray_localindex<int64_t, int64_t>(
+    toindex,
+    offsets,
+    offsetsoffset,
+    length);
 }
 
 template <typename T>
-ERROR awkward_regulararray_localindex(T* toindex, int64_t size, int64_t length) {
+ERROR awkward_regulararray_localindex(
+  T* toindex,
+  int64_t size,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     for (int64_t j = 0;  j < size;  j++) {
       toindex[i*size + j] = j;
@@ -1018,20 +3117,47 @@ ERROR awkward_regulararray_localindex(T* toindex, int64_t size, int64_t length) 
   }
   return success();
 }
-ERROR awkward_regulararray_localindex_64(int64_t* toindex, int64_t size, int64_t length) {
-  return awkward_regulararray_localindex<int64_t>(toindex, size, length);
+ERROR awkward_regulararray_localindex_64(
+  int64_t* toindex,
+  int64_t size,
+  int64_t length) {
+  return awkward_regulararray_localindex<int64_t>(
+    toindex,
+    size,
+    length);
 }
 
 template <typename T>
-ERROR awkward_choose(T* toindex, int64_t n, bool diagonal, int64_t singlelen) {
+ERROR awkward_choose(
+  T* toindex,
+  int64_t n,
+  bool diagonal,
+  int64_t singlelen) {
   return failure("FIXME: awkward_choose", 0, kSliceNone);
 }
-ERROR awkward_choose_64(int64_t* toindex, int64_t n, bool diagonal, int64_t singlelen) {
-  return awkward_choose<int64_t>(toindex, n, diagonal, singlelen);
+ERROR awkward_choose_64(
+  int64_t* toindex,
+  int64_t n,
+  bool diagonal,
+  int64_t singlelen) {
+  return awkward_choose<int64_t>(
+    toindex,
+    n,
+    diagonal,
+    singlelen);
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_choose_length(int64_t* totallen, T* tooffsets, int64_t n, bool diagonal, const C* starts, int64_t startsoffset, const C* stops, int64_t stopsoffset, int64_t length) {
+ERROR awkward_listarray_choose_length(
+  int64_t* totallen,
+  T* tooffsets,
+  int64_t n,
+  bool diagonal,
+  const C* starts,
+  int64_t startsoffset,
+  const C* stops,
+  int64_t stopsoffset,
+  int64_t length) {
   *totallen = 0;
   tooffsets[0] = 0;
   for (int64_t i = 0;  i < length;  i++) {
@@ -1062,18 +3188,79 @@ ERROR awkward_listarray_choose_length(int64_t* totallen, T* tooffsets, int64_t n
   }
   return success();
 }
-ERROR awkward_listarray32_choose_length_64(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_choose_length<int32_t, int64_t>(totallen, tooffsets, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+ERROR awkward_listarray32_choose_length_64(
+  int64_t* totallen,
+  int64_t* tooffsets,
+  int64_t n,
+  bool diagonal,
+  const int32_t* starts,
+  int64_t startsoffset,
+  const int32_t* stops,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_choose_length<int32_t, int64_t>(
+    totallen,
+    tooffsets,
+    n,
+    diagonal,
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length);
 }
-ERROR awkward_listarrayU32_choose_length_64(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_choose_length<uint32_t, int64_t>(totallen, tooffsets, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+ERROR awkward_listarrayU32_choose_length_64(
+  int64_t* totallen,
+  int64_t* tooffsets,
+  int64_t n,
+  bool diagonal,
+  const uint32_t* starts,
+  int64_t startsoffset,
+  const uint32_t* stops,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_choose_length<uint32_t, int64_t>(
+    totallen,
+    tooffsets,
+    n,
+    diagonal,
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length);
 }
-ERROR awkward_listarray64_choose_length_64(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_choose_length<int64_t, int64_t>(totallen, tooffsets, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+ERROR awkward_listarray64_choose_length_64(
+  int64_t* totallen,
+  int64_t* tooffsets,
+  int64_t n,
+  bool diagonal,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* stops,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_choose_length<int64_t, int64_t>(
+    totallen,
+    tooffsets,
+    n,
+    diagonal,
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length);
 }
 
 template <typename T>
-void awkward_listarray_choose_step(T** tocarry, int64_t* toindex, int64_t* fromindex, int64_t j, int64_t stop, int64_t n, bool diagonal) {
+void awkward_listarray_choose_step(
+  T** tocarry,
+  int64_t* toindex,
+  int64_t* fromindex,
+  int64_t j,
+  int64_t stop,
+  int64_t n,
+  bool diagonal) {
   while (fromindex[j] < stop) {
     if (diagonal) {
       for (int64_t k = j + 1;  k < n;  k++) {
@@ -1092,14 +3279,28 @@ void awkward_listarray_choose_step(T** tocarry, int64_t* toindex, int64_t* fromi
       }
     }
     else {
-      awkward_listarray_choose_step<T>(tocarry, toindex, fromindex, j + 1, stop, n, diagonal);
+      awkward_listarray_choose_step<T>(tocarry,
+                                       toindex,
+                                       fromindex,
+                                       j + 1,
+                                       stop,
+                                       n,
+                                       diagonal);
     }
     fromindex[j]++;
   }
 }
 
 template <typename C, typename T>
-ERROR awkward_listarray_choose(T** tocarry, int64_t n, bool diagonal, const C* starts, int64_t startsoffset, const C* stops, int64_t stopsoffset, int64_t length) {
+ERROR awkward_listarray_choose(
+  T** tocarry,
+  int64_t n,
+  bool diagonal,
+  const C* starts,
+  int64_t startsoffset,
+  const C* stops,
+  int64_t stopsoffset,
+  int64_t length) {
   // delete these before any return!
   int64_t* toindex = new int64_t[n];
   int64_t* fromindex = new int64_t[n];
@@ -1110,24 +3311,83 @@ ERROR awkward_listarray_choose(T** tocarry, int64_t n, bool diagonal, const C* s
     int64_t start = (int64_t)starts[startsoffset + i];
     int64_t stop = (int64_t)stops[stopsoffset + i];
     fromindex[0] = start;
-    awkward_listarray_choose_step<T>(tocarry, toindex, fromindex, 0, stop, n, diagonal);
+    awkward_listarray_choose_step<T>(tocarry,
+                                     toindex,
+                                     fromindex,
+                                     0,
+                                     stop,
+                                     n,
+                                     diagonal);
   }
   delete [] toindex;
   delete [] fromindex;
   return success();
 }
-ERROR awkward_listarray32_choose_64(int64_t** tocarry, int64_t n, bool diagonal, const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_choose<int32_t, int64_t>(tocarry, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+ERROR awkward_listarray32_choose_64(
+  int64_t** tocarry,
+  int64_t n,
+  bool diagonal,
+  const int32_t* starts,
+  int64_t startsoffset,
+  const int32_t* stops,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_choose<int32_t, int64_t>(
+    tocarry,
+    n,
+    diagonal,
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length);
 }
-ERROR awkward_listarrayU32_choose_64(int64_t** tocarry, int64_t n, bool diagonal, const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_choose<uint32_t, int64_t>(tocarry, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+ERROR awkward_listarrayU32_choose_64(
+  int64_t** tocarry,
+  int64_t n,
+  bool diagonal,
+  const uint32_t* starts,
+  int64_t startsoffset,
+  const uint32_t* stops,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_choose<uint32_t, int64_t>(
+    tocarry,
+    n,
+    diagonal,
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length);
 }
-ERROR awkward_listarray64_choose_64(int64_t** tocarry, int64_t n, bool diagonal, const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length) {
-  return awkward_listarray_choose<int64_t, int64_t>(tocarry, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+ERROR awkward_listarray64_choose_64(
+  int64_t** tocarry,
+  int64_t n,
+  bool diagonal,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* stops,
+  int64_t stopsoffset,
+  int64_t length) {
+  return awkward_listarray_choose<int64_t, int64_t>(
+    tocarry,
+    n,
+    diagonal,
+    starts,
+    startsoffset,
+    stops,
+    stopsoffset,
+    length);
 }
 
 template <typename C, typename T>
-ERROR awkward_regulararray_choose(T** tocarry, int64_t n, bool diagonal, int64_t size, int64_t length) {
+ERROR awkward_regulararray_choose(
+  T** tocarry,
+  int64_t n,
+  bool diagonal,
+  int64_t size,
+  int64_t length) {
   // delete these before any return!
   int64_t* toindex = new int64_t[n];
   int64_t* fromindex = new int64_t[n];
@@ -1138,18 +3398,41 @@ ERROR awkward_regulararray_choose(T** tocarry, int64_t n, bool diagonal, int64_t
     int64_t start = size*i;
     int64_t stop = start + size;
     fromindex[0] = start;
-    awkward_listarray_choose_step<T>(tocarry, toindex, fromindex, 0, stop, n, diagonal);
+    awkward_listarray_choose_step<T>(tocarry,
+                                     toindex,
+                                     fromindex,
+                                     0,
+                                     stop,
+                                     n,
+                                     diagonal);
   }
   delete [] toindex;
   delete [] fromindex;
   return success();
 }
-ERROR awkward_regulararray_choose_64(int64_t** tocarry, int64_t n, bool diagonal, int64_t size, int64_t length) {
-  return awkward_regulararray_choose<int32_t, int64_t>(tocarry, n, diagonal, size, length);
+ERROR awkward_regulararray_choose_64(
+  int64_t** tocarry,
+  int64_t n,
+  bool diagonal,
+  int64_t size,
+  int64_t length) {
+  return awkward_regulararray_choose<int32_t, int64_t>(
+    tocarry,
+    n,
+    diagonal,
+    size,
+    length);
 }
 
 template <typename M>
-ERROR awkward_bytemaskedarray_overlay_mask(M* tomask, const M* theirmask, int64_t theirmaskoffset, const M* mymask, int64_t mymaskoffset, int64_t length, bool validwhen) {
+ERROR awkward_bytemaskedarray_overlay_mask(
+  M* tomask,
+  const M* theirmask,
+  int64_t theirmaskoffset,
+  const M* mymask,
+  int64_t mymaskoffset,
+  int64_t length,
+  bool validwhen) {
   for (int64_t i = 0;  i < length;  i++) {
     bool theirs = theirmask[theirmaskoffset + i];
     bool mine = ((mymask[mymaskoffset + i] != 0) != validwhen);
@@ -1157,11 +3440,31 @@ ERROR awkward_bytemaskedarray_overlay_mask(M* tomask, const M* theirmask, int64_
   }
   return success();
 }
-ERROR awkward_bytemaskedarray_overlay_mask8(int8_t* tomask, const int8_t* theirmask, int64_t theirmaskoffset, const int8_t* mymask, int64_t mymaskoffset, int64_t length, bool validwhen) {
-  return awkward_bytemaskedarray_overlay_mask<int8_t>(tomask, theirmask, theirmaskoffset, mymask, mymaskoffset, length, validwhen);
+ERROR awkward_bytemaskedarray_overlay_mask8(
+  int8_t* tomask,
+  const int8_t* theirmask,
+  int64_t theirmaskoffset,
+  const int8_t* mymask,
+  int64_t mymaskoffset,
+  int64_t length,
+  bool validwhen) {
+  return awkward_bytemaskedarray_overlay_mask<int8_t>(
+    tomask,
+    theirmask,
+    theirmaskoffset,
+    mymask,
+    mymaskoffset,
+    length,
+    validwhen);
 }
 
-ERROR awkward_bitmaskedarray_to_bytemaskedarray(int8_t* tobytemask, const uint8_t* frombitmask, int64_t bitmaskoffset, int64_t bitmasklength, bool validwhen, bool lsb_order) {
+ERROR awkward_bitmaskedarray_to_bytemaskedarray(
+  int8_t* tobytemask,
+  const uint8_t* frombitmask,
+  int64_t bitmaskoffset,
+  int64_t bitmasklength,
+  bool validwhen,
+  bool lsb_order) {
   if (lsb_order) {
     for (int64_t i = 0;  i < bitmasklength;  i++) {
       uint8_t byte = frombitmask[bitmaskoffset + i];
@@ -1206,7 +3509,13 @@ ERROR awkward_bitmaskedarray_to_bytemaskedarray(int8_t* tobytemask, const uint8_
 }
 
 template <typename T>
-ERROR awkward_bitmaskedarray_to_indexedoptionarray(T* toindex, const uint8_t* frombitmask, int64_t bitmaskoffset, int64_t bitmasklength, bool validwhen, bool lsb_order) {
+ERROR awkward_bitmaskedarray_to_indexedoptionarray(
+  T* toindex,
+  const uint8_t* frombitmask,
+  int64_t bitmaskoffset,
+  int64_t bitmasklength,
+  bool validwhen,
+  bool lsb_order) {
   if (lsb_order) {
     for (int64_t i = 0;  i < bitmasklength;  i++) {
       uint8_t byte = frombitmask[bitmaskoffset + i];
@@ -1329,6 +3638,18 @@ ERROR awkward_bitmaskedarray_to_indexedoptionarray(T* toindex, const uint8_t* fr
   }
   return success();
 }
-ERROR awkward_bitmaskedarray_to_indexedoptionarray_64(int64_t* toindex, const uint8_t* frombitmask, int64_t bitmaskoffset, int64_t bitmasklength, bool validwhen, bool lsb_order) {
-  return awkward_bitmaskedarray_to_indexedoptionarray<int64_t>(toindex, frombitmask, bitmaskoffset, bitmasklength, validwhen, lsb_order);
+ERROR awkward_bitmaskedarray_to_indexedoptionarray_64(
+  int64_t* toindex,
+  const uint8_t* frombitmask,
+  int64_t bitmaskoffset,
+  int64_t bitmasklength,
+  bool validwhen,
+  bool lsb_order) {
+  return awkward_bitmaskedarray_to_indexedoptionarray<int64_t>(
+    toindex,
+    frombitmask,
+    bitmaskoffset,
+    bitmasklength,
+    validwhen,
+    lsb_order);
 }

--- a/src/cpu-kernels/reducers.cpp
+++ b/src/cpu-kernels/reducers.cpp
@@ -5,7 +5,12 @@
 
 #include "awkward/cpu-kernels/reducers.h"
 
-ERROR awkward_reduce_count_64(int64_t* toptr, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_count_64(
+  int64_t* toptr,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = 0;
   }
@@ -16,7 +21,14 @@ ERROR awkward_reduce_count_64(int64_t* toptr, const int64_t* parents, int64_t pa
 }
 
 template <typename IN>
-ERROR awkward_reduce_countnonzero(int64_t* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_countnonzero(
+  int64_t* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = 0;
   }
@@ -25,42 +37,203 @@ ERROR awkward_reduce_countnonzero(int64_t* toptr, const IN* fromptr, int64_t fro
   }
   return success();
 }
-ERROR awkward_reduce_countnonzero_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<bool>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_bool_64(
+  int64_t* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<bool>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_int8_64(
+  int64_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_uint8_64(int64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_uint8_64(
+  int64_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_int16_64(
+  int64_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_uint16_64(int64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_uint16_64(
+  int64_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_int32_64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_uint32_64(int64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_uint32_64(
+  int64_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<int64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_int64_64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_uint64_64(int64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<uint64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_uint64_64(
+  int64_t* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_float32_64(int64_t* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<float>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_float32_64(
+  int64_t* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_countnonzero_float64_64(int64_t* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_countnonzero<double>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_countnonzero_float64_64(
+  int64_t* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_countnonzero<double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
 
 template <typename OUT, typename IN>
-ERROR awkward_reduce_sum(OUT* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_sum(
+  OUT* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = (OUT)0;
   }
@@ -69,7 +242,14 @@ ERROR awkward_reduce_sum(OUT* toptr, const IN* fromptr, int64_t fromptroffset, c
   }
   return success();
 }
-ERROR awkward_reduce_sum_int64_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_sum_int64_bool_64(
+  int64_t* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = 0;
   }
@@ -78,37 +258,184 @@ ERROR awkward_reduce_sum_int64_bool_64(int64_t* toptr, const bool* fromptr, int6
   }
   return success();
 }
-ERROR awkward_reduce_sum_int64_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<int64_t, int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_int64_int8_64(
+  int64_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<int64_t, int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_uint64_uint8_64(uint64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<uint64_t, uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_uint64_uint8_64(
+  uint64_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<uint64_t, uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_int64_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<int64_t, int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_int64_int16_64(
+  int64_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<int64_t, int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_uint64_uint16_64(uint64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<uint64_t, uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_uint64_uint16_64(
+  uint64_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<uint64_t, uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_int64_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<int64_t, int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_int64_int32_64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<int64_t, int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_uint64_uint32_64(uint64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<uint64_t, uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_uint64_uint32_64(
+  uint64_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<uint64_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_int64_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<int64_t, int64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_int64_int64_64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<int64_t, int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_uint64_uint64_64(uint64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<uint64_t, uint64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_uint64_uint64_64(
+  uint64_t* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<uint64_t, uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_float32_float32_64(float* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<float, float>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_float32_float32_64(
+  float* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<float, float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_float64_float64_64(double* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<double, double>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_float64_float64_64(
+  double* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<double, double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_int32_bool_64(int32_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_sum_int32_bool_64(
+  int32_t* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = 0;
   }
@@ -117,27 +444,118 @@ ERROR awkward_reduce_sum_int32_bool_64(int32_t* toptr, const bool* fromptr, int6
   }
   return success();
 }
-ERROR awkward_reduce_sum_int32_int8_64(int32_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<int32_t, int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_int32_int8_64(
+  int32_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<int32_t, int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_uint32_uint8_64(uint32_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<uint32_t, uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_uint32_uint8_64(
+  uint32_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<uint32_t, uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_int32_int16_64(int32_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<int32_t, int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_int32_int16_64(
+  int32_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<int32_t, int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_uint32_uint16_64(uint32_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<uint32_t, uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_uint32_uint16_64(
+  uint32_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<uint32_t, uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_int32_int32_64(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<int32_t, int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_int32_int32_64(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<int32_t, int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_uint32_uint32_64(uint32_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum<uint32_t, uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_uint32_uint32_64(
+  uint32_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum<uint32_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
 
 template <typename IN>
-ERROR awkward_reduce_sum_bool(bool* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_sum_bool(
+  bool* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = (bool)0;
   }
@@ -146,42 +564,203 @@ ERROR awkward_reduce_sum_bool(bool* toptr, const IN* fromptr, int64_t fromptroff
   }
   return success();
 }
-ERROR awkward_reduce_sum_bool_bool_64(bool* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<bool>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_bool_64(
+  bool* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<bool>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_int8_64(bool* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_int8_64(
+  bool* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_uint8_64(bool* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_uint8_64(
+  bool* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_int16_64(bool* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_int16_64(
+  bool* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_uint16_64(bool* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_uint16_64(
+  bool* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_int32_64(bool* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_int32_64(
+  bool* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_uint32_64(bool* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_uint32_64(
+  bool* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_int64_64(bool* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<int64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_int64_64(
+  bool* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_uint64_64(bool* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<uint64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_uint64_64(
+  bool* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_float32_64(bool* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<float>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_float32_64(
+  bool* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_sum_bool_float64_64(bool* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_sum_bool<double>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_sum_bool_float64_64(
+  bool* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_sum_bool<double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
 
 template <typename OUT, typename IN>
-ERROR awkward_reduce_prod(OUT* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_prod(
+  OUT* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = (OUT)1;
   }
@@ -190,7 +769,14 @@ ERROR awkward_reduce_prod(OUT* toptr, const IN* fromptr, int64_t fromptroffset, 
   }
   return success();
 }
-ERROR awkward_reduce_prod_int64_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_prod_int64_bool_64(
+  int64_t* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = 1;
   }
@@ -199,37 +785,184 @@ ERROR awkward_reduce_prod_int64_bool_64(int64_t* toptr, const bool* fromptr, int
   }
   return success();
 }
-ERROR awkward_reduce_prod_int64_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<int64_t, int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_int64_int8_64(
+  int64_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<int64_t, int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_uint64_uint8_64(uint64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<uint64_t, uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_uint64_uint8_64(
+  uint64_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<uint64_t, uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_int64_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<int64_t, int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_int64_int16_64(
+  int64_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<int64_t, int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_uint64_uint16_64(uint64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<uint64_t, uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_uint64_uint16_64(
+  uint64_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<uint64_t, uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_int64_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<int64_t, int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_int64_int32_64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<int64_t, int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_uint64_uint32_64(uint64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<uint64_t, uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_uint64_uint32_64(
+  uint64_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<uint64_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_int64_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<int64_t, int64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_int64_int64_64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<int64_t, int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_uint64_uint64_64(uint64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<uint64_t, uint64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_uint64_uint64_64(
+  uint64_t* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<uint64_t, uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_float32_float32_64(float* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<float, float>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_float32_float32_64(
+  float* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<float, float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_float64_float64_64(double* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<double, double>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_float64_float64_64(
+  double* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<double, double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_int32_bool_64(int32_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_prod_int32_bool_64(
+  int32_t* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = 1;
   }
@@ -238,27 +971,118 @@ ERROR awkward_reduce_prod_int32_bool_64(int32_t* toptr, const bool* fromptr, int
   }
   return success();
 }
-ERROR awkward_reduce_prod_int32_int8_64(int32_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<int32_t, int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_int32_int8_64(
+  int32_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<int32_t, int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_uint32_uint8_64(uint32_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<uint32_t, uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_uint32_uint8_64(
+  uint32_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<uint32_t, uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_int32_int16_64(int32_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<int32_t, int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_int32_int16_64(
+  int32_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<int32_t, int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_uint32_uint16_64(uint32_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<uint32_t, uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_uint32_uint16_64(
+  uint32_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<uint32_t, uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_int32_int32_64(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<int32_t, int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_int32_int32_64(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<int32_t, int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_uint32_uint32_64(uint32_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod<uint32_t, uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_uint32_uint32_64(
+  uint32_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod<uint32_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
 
 template <typename IN>
-ERROR awkward_reduce_prod_bool(bool* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_prod_bool(
+  bool* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = (bool)1;
   }
@@ -267,258 +1091,1171 @@ ERROR awkward_reduce_prod_bool(bool* toptr, const IN* fromptr, int64_t fromptrof
   }
   return success();
 }
-ERROR awkward_reduce_prod_bool_bool_64(bool* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<bool>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_bool_64(
+  bool* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<bool>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_int8_64(bool* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_int8_64(
+  bool* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_uint8_64(bool* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_uint8_64(
+  bool* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_int16_64(bool* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_int16_64(
+  bool* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_uint16_64(bool* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_uint16_64(
+  bool* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_int32_64(bool* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_int32_64(
+  bool* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_uint32_64(bool* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_uint32_64(
+  bool* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_int64_64(bool* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<int64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_int64_64(
+  bool* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_uint64_64(bool* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<uint64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_uint64_64(
+  bool* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_float32_64(bool* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<float>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_float32_64(
+  bool* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_prod_bool_float64_64(bool* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_prod_bool<double>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_prod_bool_float64_64(
+  bool* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_prod_bool<double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
 
 template <typename OUT, typename IN>
-ERROR awkward_reduce_min(OUT* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, OUT identity) {
+ERROR awkward_reduce_min(
+  OUT* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  OUT identity) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = identity;
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     IN x = fromptr[fromptroffset + i];
-    toptr[parents[parentsoffset + i]] = (x < toptr[parents[parentsoffset + i]] ? x : toptr[parents[parentsoffset + i]]);
+    toptr[parents[parentsoffset + i]] =
+      (x < toptr[parents[parentsoffset + i]]
+           ? x
+           : toptr[parents[parentsoffset + i]]);
   }
   return success();
 }
-ERROR awkward_reduce_min_int8_int8_64(int8_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int8_t identity) {
-  return awkward_reduce_min<int8_t, int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_int8_int8_64(
+  int8_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  int8_t identity) {
+  return awkward_reduce_min<int8_t, int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_uint8_uint8_64(uint8_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint8_t identity) {
-  return awkward_reduce_min<uint8_t, uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_uint8_uint8_64(
+  uint8_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  uint8_t identity) {
+  return awkward_reduce_min<uint8_t, uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_int16_int16_64(int16_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int16_t identity) {
-  return awkward_reduce_min<int16_t, int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_int16_int16_64(
+  int16_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  int16_t identity) {
+  return awkward_reduce_min<int16_t, int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_uint16_uint16_64(uint16_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint16_t identity) {
-  return awkward_reduce_min<uint16_t, uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_uint16_uint16_64(
+  uint16_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  uint16_t identity) {
+  return awkward_reduce_min<uint16_t, uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_int32_int32_64(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int32_t identity) {
-  return awkward_reduce_min<int32_t, int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_int32_int32_64(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  int32_t identity) {
+  return awkward_reduce_min<int32_t, int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_uint32_uint32_64(uint32_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint32_t identity) {
-  return awkward_reduce_min<uint32_t, uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_uint32_uint32_64(
+  uint32_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  uint32_t identity) {
+  return awkward_reduce_min<uint32_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_int64_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int64_t identity) {
-  return awkward_reduce_min<int64_t, int64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_int64_int64_64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  int64_t identity) {
+  return awkward_reduce_min<int64_t, int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_uint64_uint64_64(uint64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint64_t identity) {
-  return awkward_reduce_min<uint64_t, uint64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_uint64_uint64_64(
+  uint64_t* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  uint64_t identity) {
+  return awkward_reduce_min<uint64_t, uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_float32_float32_64(float* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, float identity) {
-  return awkward_reduce_min<float, float>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_float32_float32_64(
+  float* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  float identity) {
+  return awkward_reduce_min<float, float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_min_float64_float64_64(double* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, double identity) {
-  return awkward_reduce_min<double, double>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_min_float64_float64_64(
+  double* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  double identity) {
+  return awkward_reduce_min<double, double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
 
 template <typename OUT, typename IN>
-ERROR awkward_reduce_max(OUT* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, OUT identity) {
+ERROR awkward_reduce_max(
+  OUT* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  OUT identity) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = identity;
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     IN x = fromptr[fromptroffset + i];
-    toptr[parents[parentsoffset + i]] = (x > toptr[parents[parentsoffset + i]] ? x : toptr[parents[parentsoffset + i]]);
+    toptr[parents[parentsoffset + i]] =
+      (x > toptr[parents[parentsoffset + i]]
+           ? x
+           : toptr[parents[parentsoffset + i]]);
   }
   return success();
 }
-ERROR awkward_reduce_max_int8_int8_64(int8_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int8_t identity) {
-  return awkward_reduce_max<int8_t, int8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_int8_int8_64(
+  int8_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  int8_t identity) {
+  return awkward_reduce_max<int8_t, int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_uint8_uint8_64(uint8_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint8_t identity) {
-  return awkward_reduce_max<uint8_t, uint8_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_uint8_uint8_64(
+  uint8_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  uint8_t identity) {
+  return awkward_reduce_max<uint8_t, uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_int16_int16_64(int16_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int16_t identity) {
-  return awkward_reduce_max<int16_t, int16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_int16_int16_64(
+  int16_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  int16_t identity) {
+  return awkward_reduce_max<int16_t, int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_uint16_uint16_64(uint16_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint16_t identity) {
-  return awkward_reduce_max<uint16_t, uint16_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_uint16_uint16_64(
+  uint16_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  uint16_t identity) {
+  return awkward_reduce_max<uint16_t, uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_int32_int32_64(int32_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int32_t identity) {
-  return awkward_reduce_max<int32_t, int32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_int32_int32_64(
+  int32_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  int32_t identity) {
+  return awkward_reduce_max<int32_t, int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_uint32_uint32_64(uint32_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint32_t identity) {
-  return awkward_reduce_max<uint32_t, uint32_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_uint32_uint32_64(
+  uint32_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  uint32_t identity) {
+  return awkward_reduce_max<uint32_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_int64_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, int64_t identity) {
-  return awkward_reduce_max<int64_t, int64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_int64_int64_64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  int64_t identity) {
+  return awkward_reduce_max<int64_t, int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_uint64_uint64_64(uint64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, uint64_t identity) {
-  return awkward_reduce_max<uint64_t, uint64_t>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_uint64_uint64_64(
+  uint64_t* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  uint64_t identity) {
+  return awkward_reduce_max<uint64_t, uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_float32_float32_64(float* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, float identity) {
-  return awkward_reduce_max<float, float>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_float32_float32_64(
+  float* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  float identity) {
+  return awkward_reduce_max<float, float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
-ERROR awkward_reduce_max_float64_float64_64(double* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength, double identity) {
-  return awkward_reduce_max<double, double>(toptr, fromptr, fromptroffset, parents, parentsoffset, lenparents, outlength, identity);
+ERROR awkward_reduce_max_float64_float64_64(
+  double* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength,
+  double identity) {
+  return awkward_reduce_max<double, double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength,
+    identity);
 }
 
 template <typename OUT, typename IN>
-ERROR awkward_reduce_argmin(OUT* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_argmin(
+  OUT* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = -1;
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     int64_t parent = parents[parentsoffset + i];
     int64_t start = starts[parent];
-    if (toptr[parent] == -1  ||  fromptr[fromptroffset + i] < fromptr[fromptroffset + toptr[parent] + start]) {
+    if (toptr[parent] == -1  ||
+        fromptr[fromptroffset + i] <
+          fromptr[fromptroffset + toptr[parent] + start]) {
       toptr[parent] = i - start;
     }
   }
   return success();
 }
-ERROR awkward_reduce_argmin_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_argmin_bool_64(
+  int64_t* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = -1;
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     int64_t parent = parents[parentsoffset + i];
     int64_t start = starts[parent];
-    if (toptr[parent] == -1  ||  (fromptr[fromptroffset + i] != 0) < (fromptr[fromptroffset + toptr[parent] + start] != 0)) {
+    if (toptr[parent] == -1  ||
+        (fromptr[fromptroffset + i] != 0) <
+          (fromptr[fromptroffset + toptr[parent] + start] != 0)) {
       toptr[parent] = i - start;
     }
   }
   return success();
 }
-ERROR awkward_reduce_argmin_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, int8_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_int8_64(
+  int64_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_uint8_64(int64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, uint8_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_uint8_64(
+  int64_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, int16_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_int16_64(
+  int64_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_uint16_64(int64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, uint16_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_uint16_64(
+  int64_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, int32_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_int32_64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_uint32_64(int64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, uint32_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_uint32_64(
+  int64_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, int64_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_int64_64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_uint64_64(int64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, uint64_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_uint64_64(
+  int64_t* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_float32_64(int64_t* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, float>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_float32_64(
+  int64_t* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmin_float64_64(int64_t* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmin<int64_t, double>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmin_float64_64(
+  int64_t* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmin<int64_t, double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
 
 template <typename OUT, typename IN>
-ERROR awkward_reduce_argmax(OUT* toptr, const IN* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_argmax(
+  OUT* toptr,
+  const IN* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = -1;
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     int64_t parent = parents[parentsoffset + i];
     int64_t start = starts[parent];
-    if (toptr[parent] == -1  ||  fromptr[fromptroffset + i] > fromptr[fromptroffset + toptr[parent] + start]) {
+    if (toptr[parent] == -1  ||
+        fromptr[fromptroffset + i] >
+          fromptr[fromptroffset + toptr[parent] + start]) {
       toptr[parent] = i - start;
     }
   }
   return success();
 }
-ERROR awkward_reduce_argmax_bool_64(int64_t* toptr, const bool* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_reduce_argmax_bool_64(
+  int64_t* toptr,
+  const bool* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = -1;
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     int64_t parent = parents[parentsoffset + i];
     int64_t start = starts[parent];
-    if (toptr[parent] == -1  ||  (fromptr[fromptroffset + i] != 0) > (fromptr[fromptroffset + toptr[parent] + start] != 0)) {
+    if (toptr[parent] == -1  ||
+        (fromptr[fromptroffset + i] != 0) >
+          (fromptr[fromptroffset + toptr[parent] + start] != 0)) {
       toptr[parent] = i - start;
     }
   }
   return success();
 }
-ERROR awkward_reduce_argmax_int8_64(int64_t* toptr, const int8_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, int8_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_int8_64(
+  int64_t* toptr,
+  const int8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, int8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_uint8_64(int64_t* toptr, const uint8_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, uint8_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_uint8_64(
+  int64_t* toptr,
+  const uint8_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, uint8_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_int16_64(int64_t* toptr, const int16_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, int16_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_int16_64(
+  int64_t* toptr,
+  const int16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, int16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_uint16_64(int64_t* toptr, const uint16_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, uint16_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_uint16_64(
+  int64_t* toptr,
+  const uint16_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, uint16_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_int32_64(int64_t* toptr, const int32_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, int32_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_int32_64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, int32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_uint32_64(int64_t* toptr, const uint32_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, uint32_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_uint32_64(
+  int64_t* toptr,
+  const uint32_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, uint32_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_int64_64(int64_t* toptr, const int64_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, int64_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_int64_64(
+  int64_t* toptr,
+  const int64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, int64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_uint64_64(int64_t* toptr, const uint64_t* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, uint64_t>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_uint64_64(
+  int64_t* toptr,
+  const uint64_t* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, uint64_t>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_float32_64(int64_t* toptr, const float* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, float>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_float32_64(
+  int64_t* toptr,
+  const float* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, float>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
-ERROR awkward_reduce_argmax_float64_64(int64_t* toptr, const double* fromptr, int64_t fromptroffset, const int64_t* starts, int64_t startsoffset, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
-  return awkward_reduce_argmax<int64_t, double>(toptr, fromptr, fromptroffset, starts, startsoffset, parents, parentsoffset, lenparents, outlength);
+ERROR awkward_reduce_argmax_float64_64(
+  int64_t* toptr,
+  const double* fromptr,
+  int64_t fromptroffset,
+  const int64_t* starts,
+  int64_t startsoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
+  return awkward_reduce_argmax<int64_t, double>(
+    toptr,
+    fromptr,
+    fromptroffset,
+    starts,
+    startsoffset,
+    parents,
+    parentsoffset,
+    lenparents,
+    outlength);
 }
 
-ERROR awkward_content_reduce_zeroparents_64(int64_t* toparents, int64_t length) {
+ERROR awkward_content_reduce_zeroparents_64(
+  int64_t* toparents,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
     toparents[i] = 0;
   }
   return success();
 }
 
-ERROR awkward_listoffsetarray_reduce_global_startstop_64(int64_t* globalstart, int64_t* globalstop, const int64_t* offsets, int64_t offsetsoffset, int64_t length) {
+ERROR awkward_listoffsetarray_reduce_global_startstop_64(
+  int64_t* globalstart,
+  int64_t* globalstop,
+  const int64_t* offsets,
+  int64_t offsetsoffset,
+  int64_t length) {
   *globalstart = offsets[offsetsoffset + 0];
   *globalstop = offsets[offsetsoffset + length];
   return success();
 }
 
-ERROR awkward_listoffsetarray_reduce_nonlocal_maxcount_offsetscopy_64(int64_t* maxcount, int64_t* offsetscopy, const int64_t* offsets, int64_t offsetsoffset, int64_t length) {
+ERROR awkward_listoffsetarray_reduce_nonlocal_maxcount_offsetscopy_64(
+  int64_t* maxcount,
+  int64_t* offsetscopy,
+  const int64_t* offsets,
+  int64_t offsetsoffset,
+  int64_t length) {
   *maxcount = 0;
   offsetscopy[0] = offsets[offsetsoffset + 0];
   for (int64_t i = 0;  i < length;  i++) {
-    int64_t count = offsets[offsetsoffset + i + 1] - offsets[offsetsoffset + i];
+    int64_t count = (offsets[offsetsoffset + i + 1] -
+                     offsets[offsetsoffset + i]);
     if (*maxcount < count) {
       *maxcount = count;
     }
@@ -527,7 +2264,20 @@ ERROR awkward_listoffsetarray_reduce_nonlocal_maxcount_offsetscopy_64(int64_t* m
   return success();
 }
 
-ERROR awkward_listoffsetarray_reduce_nonlocal_preparenext_64(int64_t* nextcarry, int64_t* nextparents, int64_t nextlen, int64_t* maxnextparents, int64_t* distincts, int64_t distinctslen, int64_t* offsetscopy, const int64_t* offsets, int64_t offsetsoffset, int64_t length, const int64_t* parents, int64_t parentsoffset, int64_t maxcount) {
+ERROR awkward_listoffsetarray_reduce_nonlocal_preparenext_64(
+  int64_t* nextcarry,
+  int64_t* nextparents,
+  int64_t nextlen,
+  int64_t* maxnextparents,
+  int64_t* distincts,
+  int64_t distinctslen,
+  int64_t* offsetscopy,
+  const int64_t* offsets,
+  int64_t offsetsoffset,
+  int64_t length,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t maxcount) {
   *maxnextparents = 0;
   for (int64_t i = 0;  i < distinctslen;  i++) {
     distincts[i] = -1;
@@ -538,7 +2288,8 @@ ERROR awkward_listoffsetarray_reduce_nonlocal_preparenext_64(int64_t* nextcarry,
     int64_t j = 0;
     for (int64_t i = 0;  i < length;  i++) {
       if (offsetscopy[i] < offsets[offsetsoffset + i + 1]) {
-        int64_t count = offsets[offsetsoffset + i + 1] - offsets[offsetsoffset + i];
+        int64_t count = (offsets[offsetsoffset + i + 1] -
+                         offsets[offsetsoffset + i]);
         int64_t diff = offsetscopy[i] - offsets[offsetsoffset + i];
         int64_t parent = parents[parentsoffset + i];
 
@@ -562,7 +2313,10 @@ ERROR awkward_listoffsetarray_reduce_nonlocal_preparenext_64(int64_t* nextcarry,
   return success();
 }
 
-ERROR awkward_listoffsetarray_reduce_nonlocal_nextstarts_64(int64_t* nextstarts, const int64_t* nextparents, int64_t nextlen) {
+ERROR awkward_listoffsetarray_reduce_nonlocal_nextstarts_64(
+  int64_t* nextstarts,
+  const int64_t* nextparents,
+  int64_t nextlen) {
   int64_t lastnextparent = -1;
   for (int64_t k = 0;  k < nextlen;  k++) {
     if (nextparents[k] != lastnextparent) {
@@ -573,7 +2327,11 @@ ERROR awkward_listoffsetarray_reduce_nonlocal_nextstarts_64(int64_t* nextstarts,
   return success();
 }
 
-ERROR awkward_listoffsetarray_reduce_nonlocal_findgaps_64(int64_t* gaps, const int64_t* parents, int64_t parentsoffset, int64_t lenparents) {
+ERROR awkward_listoffsetarray_reduce_nonlocal_findgaps_64(
+  int64_t* gaps,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents) {
   int64_t k = 0;
   int64_t last = -1;
   for (int64_t i = 0;  i < lenparents;  i++) {
@@ -587,7 +2345,12 @@ ERROR awkward_listoffsetarray_reduce_nonlocal_findgaps_64(int64_t* gaps, const i
   return success();
 }
 
-ERROR awkward_listoffsetarray_reduce_nonlocal_outstartsstops_64(int64_t* outstarts, int64_t* outstops, const int64_t* distincts, int64_t lendistincts, const int64_t* gaps) {
+ERROR awkward_listoffsetarray_reduce_nonlocal_outstartsstops_64(
+  int64_t* outstarts,
+  int64_t* outstops,
+  const int64_t* distincts,
+  int64_t lendistincts,
+  const int64_t* gaps) {
   int64_t j = 0;
   int64_t k = 0;
   int64_t maxdistinct = -1;
@@ -608,16 +2371,27 @@ ERROR awkward_listoffsetarray_reduce_nonlocal_outstartsstops_64(int64_t* outstar
   return success();
 }
 
-ERROR awkward_listoffsetarray_reduce_local_nextparents_64(int64_t* nextparents, const int64_t* offsets, int64_t offsetsoffset, int64_t length) {
+ERROR awkward_listoffsetarray_reduce_local_nextparents_64(
+  int64_t* nextparents,
+  const int64_t* offsets,
+  int64_t offsetsoffset,
+  int64_t length) {
   for (int64_t i = 0;  i < length;  i++) {
-    for (int64_t j = offsets[offsetsoffset + i];  j < offsets[offsetsoffset + i + 1];  j++) {
+    for (int64_t j = offsets[offsetsoffset + i];
+         j < offsets[offsetsoffset + i + 1];
+         j++) {
       nextparents[j] = i;
     }
   }
   return success();
 }
 
-ERROR awkward_listoffsetarray_reduce_local_outoffsets_64(int64_t* outoffsets, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_listoffsetarray_reduce_local_outoffsets_64(
+  int64_t* outoffsets,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   outoffsets[outlength] = lenparents;
   int64_t k = 0;
   int64_t last = -1;
@@ -632,7 +2406,15 @@ ERROR awkward_listoffsetarray_reduce_local_outoffsets_64(int64_t* outoffsets, co
 }
 
 template <typename T>
-ERROR awkward_indexedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const T* index, int64_t indexoffset, const int64_t* parents, int64_t parentsoffset, int64_t length) {
+ERROR awkward_indexedarray_reduce_next_64(
+  int64_t* nextcarry,
+  int64_t* nextparents,
+  int64_t* outindex,
+  const T* index,
+  int64_t indexoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t length) {
   int64_t k = 0;
   for (int64_t i = 0;  i < length;  i++) {
     if (index[indexoffset + i] >= 0) {
@@ -647,17 +2429,70 @@ ERROR awkward_indexedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparen
   }
   return success();
 }
-ERROR awkward_indexedarray32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-  return awkward_indexedarray_reduce_next_64<int32_t>(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
+ERROR awkward_indexedarray32_reduce_next_64(
+  int64_t* nextcarry,
+  int64_t* nextparents,
+  int64_t* outindex,
+  const int32_t* index,
+  int64_t indexoffset,
+  int64_t* parents,
+  int64_t parentsoffset,
+  int64_t length) {
+  return awkward_indexedarray_reduce_next_64<int32_t>(
+    nextcarry,
+    nextparents,
+    outindex,
+    index,
+    indexoffset,
+    parents,
+    parentsoffset,
+    length);
 }
-ERROR awkward_indexedarrayU32_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-  return awkward_indexedarray_reduce_next_64<uint32_t>(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
+ERROR awkward_indexedarrayU32_reduce_next_64(
+  int64_t* nextcarry,
+  int64_t* nextparents,
+  int64_t* outindex,
+  const uint32_t* index,
+  int64_t indexoffset,
+  int64_t* parents,
+  int64_t parentsoffset,
+  int64_t length) {
+  return awkward_indexedarray_reduce_next_64<uint32_t>(
+    nextcarry,
+    nextparents,
+    outindex,
+    index,
+    indexoffset,
+    parents,
+    parentsoffset,
+    length);
 }
-ERROR awkward_indexedarray64_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-  return awkward_indexedarray_reduce_next_64<int64_t>(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
+ERROR awkward_indexedarray64_reduce_next_64(
+  int64_t* nextcarry,
+  int64_t* nextparents,
+  int64_t* outindex,
+  const int64_t* index,
+  int64_t indexoffset,
+  int64_t* parents,
+  int64_t parentsoffset,
+  int64_t length) {
+  return awkward_indexedarray_reduce_next_64<int64_t>(
+    nextcarry,
+    nextparents,
+    outindex,
+    index,
+    indexoffset,
+    parents,
+    parentsoffset,
+    length);
 }
 
-ERROR awkward_indexedarray_reduce_next_fix_offsets_64(int64_t* outoffsets, const int64_t* starts, int64_t startsoffset, int64_t startslength, int64_t outindexlength) {
+ERROR awkward_indexedarray_reduce_next_fix_offsets_64(
+  int64_t* outoffsets,
+  const int64_t* starts,
+  int64_t startsoffset,
+  int64_t startslength,
+  int64_t outindexlength) {
   for (int64_t i = 0;  i < startslength;  i++) {
     outoffsets[i] = starts[startsoffset + i];
   }
@@ -665,7 +2500,12 @@ ERROR awkward_indexedarray_reduce_next_fix_offsets_64(int64_t* outoffsets, const
   return success();
 }
 
-ERROR awkward_numpyarray_reduce_mask_bytemaskedarray(int8_t* toptr, const int64_t* parents, int64_t parentsoffset, int64_t lenparents, int64_t outlength) {
+ERROR awkward_numpyarray_reduce_mask_bytemaskedarray(
+  int8_t* toptr,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t lenparents,
+  int64_t outlength) {
   for (int64_t i = 0;  i < outlength;  i++) {
     toptr[i] = 1;
   }
@@ -675,7 +2515,16 @@ ERROR awkward_numpyarray_reduce_mask_bytemaskedarray(int8_t* toptr, const int64_
   return success();
 }
 
-ERROR awkward_bytemaskedarray_reduce_next_64(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int8_t* mask, int64_t maskoffset, const int64_t* parents, int64_t parentsoffset, int64_t length, bool validwhen) {
+ERROR awkward_bytemaskedarray_reduce_next_64(
+  int64_t* nextcarry,
+  int64_t* nextparents,
+  int64_t* outindex,
+  const int8_t* mask,
+  int64_t maskoffset,
+  const int64_t* parents,
+  int64_t parentsoffset,
+  int64_t length,
+  bool validwhen) {
   int64_t k = 0;
   for (int64_t i = 0;  i < length;  i++) {
     if ((mask[maskoffset + i] != 0) == validwhen) {

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -18,7 +18,7 @@
 #include "awkward/Content.h"
 
 namespace awkward {
-  Content::Content(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters)
+  Content::Content(const IdentitiesPtr& identities, const util::Parameters& parameters)
       : identities_(identities)
       , parameters_(parameters) { }
 
@@ -28,7 +28,7 @@ namespace awkward {
     return false;
   }
 
-  const std::shared_ptr<Identities> Content::identities() const {
+  const IdentitiesPtr Content::identities() const {
     return identities_;
   }
 
@@ -198,7 +198,7 @@ namespace awkward {
     return std::make_shared<NumpyArray>(localindex);
   }
 
-  const ContentPtr Content::choose_axis0(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters) const {
+  const ContentPtr Content::choose_axis0(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters) const {
     int64_t size = length();
     if (diagonal) {
       size += (n - 1);
@@ -247,7 +247,7 @@ namespace awkward {
   const ContentPtr Content::getitem(const Slice& where) const {
     ContentPtr next = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), shallow_copy(), length());
 
-    std::shared_ptr<SliceItem> nexthead = where.head();
+    SliceItemPtr nexthead = where.head();
     Slice nexttail = where.tail();
     Index64 nextadvanced(0);
     ContentPtr out = next.get()->getitem_next(nexthead, nexttail, nextadvanced);
@@ -260,7 +260,7 @@ namespace awkward {
     }
   }
 
-  const ContentPtr Content::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr Content::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -296,7 +296,7 @@ namespace awkward {
     }
   }
 
-  const ContentPtr Content::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const {
+  const ContentPtr Content::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceItemPtr& slicecontent, const Slice& tail) const {
     if (SliceArray64* array = dynamic_cast<SliceArray64*>(slicecontent.get())) {
       return getitem_next_jagged(slicestarts, slicestops, *array, tail);
     }
@@ -317,7 +317,7 @@ namespace awkward {
     int64_t maxdepth = minmax.second;
 
     if (tail.length() == 0  ||  (mindepth - 1 == tail.dimlength()  &&  maxdepth - 1 == tail.dimlength())) {
-      std::shared_ptr<SliceItem> nexthead = tail.head();
+      SliceItemPtr nexthead = tail.head();
       Slice nexttail = tail.tail();
       return getitem_next(nexthead, nexttail, advanced);
     }
@@ -325,29 +325,29 @@ namespace awkward {
       throw std::invalid_argument("ellipsis (...) can't be used on a data structure of different depths");
     }
     else {
-      std::vector<std::shared_ptr<SliceItem>> tailitems = tail.items();
-      std::vector<std::shared_ptr<SliceItem>> items = { std::make_shared<SliceEllipsis>() };
+      std::vector<SliceItemPtr> tailitems = tail.items();
+      std::vector<SliceItemPtr> items = { std::make_shared<SliceEllipsis>() };
       items.insert(items.end(), tailitems.begin(), tailitems.end());
-      std::shared_ptr<SliceItem> nexthead = std::make_shared<SliceRange>(Slice::none(), Slice::none(), 1);
+      SliceItemPtr nexthead = std::make_shared<SliceRange>(Slice::none(), Slice::none(), 1);
       Slice nexttail(items);
       return getitem_next(nexthead, nexttail, advanced);
     }
   }
 
   const ContentPtr Content::getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const {
-    std::shared_ptr<SliceItem> nexthead = tail.head();
+    SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
     return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), getitem_next(nexthead, nexttail, advanced), 1);
   }
 
   const ContentPtr Content::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
-    std::shared_ptr<SliceItem> nexthead = tail.head();
+    SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
     return getitem_field(field.key()).get()->getitem_next(nexthead, nexttail, advanced);
   }
 
   const ContentPtr Content::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
-    std::shared_ptr<SliceItem> nexthead = tail.head();
+    SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
     return getitem_fields(fields.keys()).get()->getitem_next(nexthead, nexttail, advanced);
   }

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -315,7 +315,9 @@ namespace awkward {
     SliceItemPtr nexthead = where.head();
     Slice nexttail = where.tail();
     Index64 nextadvanced(0);
-    ContentPtr out = next.get()->getitem_next(nexthead, nexttail, nextadvanced);
+    ContentPtr out = next.get()->getitem_next(nexthead,
+                                              nexttail,
+                                              nextadvanced);
 
     if (out.get()->length() == 0) {
       return out.get()->getitem_nothing();
@@ -414,7 +416,8 @@ namespace awkward {
     else if (mindepth - 1 == tail.dimlength()  ||
              maxdepth - 1 == tail.dimlength()) {
       throw std::invalid_argument(
-        "ellipsis (...) can't be used on a data structure of different depths");
+        "ellipsis (...) can't be used on a data structure of "
+        "different depths");
     }
     else {
       std::vector<SliceItemPtr> tailitems = tail.items();

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -18,25 +18,30 @@
 #include "awkward/Content.h"
 
 namespace awkward {
-  Content::Content(const IdentitiesPtr& identities, const util::Parameters& parameters)
+  Content::Content(const IdentitiesPtr& identities,
+                   const util::Parameters& parameters)
       : identities_(identities)
       , parameters_(parameters) { }
 
   Content::~Content() { }
 
-  bool Content::isscalar() const {
+  bool
+  Content::isscalar() const {
     return false;
   }
 
-  const IdentitiesPtr Content::identities() const {
+  const IdentitiesPtr
+  Content::identities() const {
     return identities_;
   }
 
-  const std::string Content::tostring() const {
+  const std::string
+  Content::tostring() const {
     return tostring_part("", "", "");
   }
 
-  const std::string Content::tojson(bool pretty, int64_t maxdecimals) const {
+  const std::string
+  Content::tojson(bool pretty, int64_t maxdecimals) const {
     if (pretty) {
       ToJsonPrettyString builder(maxdecimals);
       tojson_part(builder);
@@ -49,7 +54,11 @@ namespace awkward {
     }
   }
 
-  void Content::tojson(FILE* destination, bool pretty, int64_t maxdecimals, int64_t buffersize) const {
+  void
+  Content::tojson(FILE* destination,
+                  bool pretty,
+                  int64_t maxdecimals,
+                  int64_t buffersize) const {
     if (pretty) {
       ToJsonPrettyFile builder(destination, maxdecimals, buffersize);
       builder.beginlist();
@@ -64,9 +73,11 @@ namespace awkward {
     }
   }
 
-  int64_t Content::nbytes() const {
-    // FIXME: this is only accurate if all subintervals of allocated arrays are nested
-    // (which is likely, but not guaranteed). In general, it's <= the correct nbytes.
+  int64_t
+  Content::nbytes() const {
+    // FIXME: this is only accurate if all subintervals of allocated arrays are
+    // nested (which is likely, but not guaranteed). In general, it's <= the 
+    // correct nbytes.
     std::map<size_t, int64_t> largest;
     nbytes_part(largest);
     int64_t out = 0;
@@ -76,7 +87,11 @@ namespace awkward {
     return out;
   }
 
-  const ContentPtr Content::reduce(const Reducer& reducer, int64_t axis, bool mask, bool keepdims) const {
+  const ContentPtr
+  Content::reduce(const Reducer& reducer,
+                  int64_t axis,
+                  bool mask,
+                  bool keepdims) const {
     int64_t negaxis = -axis;
     std::pair<bool, int64_t> branchdepth = branch_depth();
     bool branch = branchdepth.first;
@@ -84,10 +99,17 @@ namespace awkward {
 
     if (branch) {
       if (negaxis <= 0) {
-        throw std::invalid_argument("cannot use non-negative axis on a nested list structure of variable depth (negative axis counts from the leaves of the tree; non-negative from the root)");
+        throw std::invalid_argument(
+        "cannot use non-negative axis on a nested list structure "
+        "of variable depth (negative axis counts from the leaves of the tree; "
+        "non-negative from the root)");
       }
       if (negaxis > depth) {
-        throw std::invalid_argument(std::string("cannot use axis=") + std::to_string(axis) + std::string(" on a nested list structure that splits into different depths, the minimum of which is depth=") + std::to_string(depth) + std::string(" from the leaves"));
+        throw std::invalid_argument(
+          std::string("cannot use axis=") + std::to_string(axis)
+          + std::string(" on a nested list structure that splits into "
+                        "different depths, the minimum of which is depth=")
+          + std::to_string(depth) + std::string(" from the leaves"));
       }
     }
     else {
@@ -95,7 +117,11 @@ namespace awkward {
         negaxis += depth;
       }
       if (!(0 < negaxis  &&  negaxis <= depth)) {
-        throw std::invalid_argument(std::string("axis=") + std::to_string(axis) + std::string(" exceeds the depth of the nested list structure (which is ") + std::to_string(depth) + std::string(")"));
+        throw std::invalid_argument(
+          std::string("axis=") + std::to_string(axis)
+          + std::string(" exceeds the depth of the nested list structure "
+                        "(which is ")
+          + std::to_string(depth) + std::string(")"));
       }
     }
 
@@ -108,19 +134,28 @@ namespace awkward {
       length());
     util::handle_error(err, classname(), identities_.get());
 
-    ContentPtr next = reduce_next(reducer, negaxis, starts, parents, 1, mask, keepdims);
+    ContentPtr next = reduce_next(reducer,
+                                  negaxis,
+                                  starts,
+                                  parents,
+                                  1,
+                                  mask,
+                                  keepdims);
     return next.get()->getitem_at_nowrap(0);
   }
 
-  const util::Parameters Content::parameters() const {
+  const util::Parameters
+  Content::parameters() const {
     return parameters_;
   }
 
-  void Content::setparameters(const util::Parameters& parameters) {
+  void
+  Content::setparameters(const util::Parameters& parameters) {
     parameters_ = parameters;
   }
 
-  const std::string Content::parameter(const std::string& key) const {
+  const std::string
+  Content::parameter(const std::string& key) const {
     auto item = parameters_.find(key);
     if (item == parameters_.end()) {
       return "null";
@@ -128,19 +163,24 @@ namespace awkward {
     return item->second;
   }
 
-  void Content::setparameter(const std::string& key, const std::string& value) {
+  void
+  Content::setparameter(const std::string& key, const std::string& value) {
     parameters_[key] = value;
   }
 
-  bool Content::parameter_equals(const std::string& key, const std::string& value) const {
+  bool
+  Content::parameter_equals(const std::string& key,
+                            const std::string& value) const {
     return util::parameter_equals(parameters_, key, value);
   }
 
-  bool Content::parameters_equal(const util::Parameters& other) const {
+  bool
+  Content::parameters_equal(const util::Parameters& other) const {
     return util::parameters_equal(parameters_, other);
   }
 
-  const ContentPtr Content::merge_as_union(const ContentPtr& other) const {
+  const ContentPtr
+  Content::merge_as_union(const ContentPtr& other) const {
     int64_t mylength = length();
     int64_t theirlength = other.get()->length();
     Index8 tags(mylength + theirlength);
@@ -172,10 +212,15 @@ namespace awkward {
       theirlength);
     util::handle_error(err4, classname(), identities_.get());
 
-    return std::make_shared<UnionArray8_64>(Identities::none(), util::Parameters(), tags, index, contents);
+    return std::make_shared<UnionArray8_64>(Identities::none(),
+                                            util::Parameters(),
+                                            tags,
+                                            index,
+                                            contents);
   }
 
-  const ContentPtr Content::rpad_axis0(int64_t target, bool clip) const {
+  const ContentPtr
+  Content::rpad_axis0(int64_t target, bool clip) const {
     if (!clip  &&  target < length()) {
       return shallow_copy();
     }
@@ -185,11 +230,16 @@ namespace awkward {
       target,
       length());
     util::handle_error(err, classname(), identities_.get());
-    std::shared_ptr<IndexedOptionArray64> next = std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, shallow_copy());
+    std::shared_ptr<IndexedOptionArray64> next =
+      std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                             util::Parameters(),
+                                             index,
+                                             shallow_copy());
     return next.get()->simplify_optiontype();
   }
 
-  const ContentPtr Content::localindex_axis0() const {
+  const ContentPtr
+  Content::localindex_axis0() const {
     Index64 localindex(length());
     struct Error err = awkward_localindex_64(
       localindex.ptr().get(),
@@ -198,7 +248,11 @@ namespace awkward {
     return std::make_shared<NumpyArray>(localindex);
   }
 
-  const ContentPtr Content::choose_axis0(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters) const {
+  const ContentPtr
+  Content::choose_axis0(int64_t n,
+                        bool diagonal,
+                        const util::RecordLookupPtr& recordlookup,
+                        const util::Parameters& parameters) const {
     int64_t size = length();
     if (diagonal) {
       size += (n - 1);
@@ -225,7 +279,8 @@ namespace awkward {
     std::vector<std::shared_ptr<int64_t>> tocarry;
     std::vector<int64_t*> tocarryraw;
     for (int64_t j = 0;  j < n;  j++) {
-      std::shared_ptr<int64_t> ptr(new int64_t[(size_t)chooselen], util::array_deleter<int64_t>());
+      std::shared_ptr<int64_t> ptr(new int64_t[(size_t)chooselen],
+                                   util::array_deleter<int64_t>());
       tocarry.push_back(ptr);
       tocarryraw.push_back(ptr.get());
     }
@@ -239,14 +294,24 @@ namespace awkward {
 
     ContentPtrVec contents;
     for (auto ptr : tocarry) {
-      contents.push_back(std::make_shared<IndexedArray64>(Identities::none(), util::Parameters(), Index64(ptr, 0, chooselen), shallow_copy()));
+      contents.push_back(std::make_shared<IndexedArray64>(
+        Identities::none(),
+        util::Parameters(),
+        Index64(ptr, 0, chooselen),
+        shallow_copy()));
     }
-    return std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
+    return std::make_shared<RecordArray>(Identities::none(),
+                                         parameters,
+                                         contents,
+                                         recordlookup);
   }
 
-  const ContentPtr Content::getitem(const Slice& where) const {
-    ContentPtr next = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), shallow_copy(), length());
-
+  const ContentPtr
+  Content::getitem(const Slice& where) const {
+    ContentPtr next = std::make_shared<RegularArray>(Identities::none(),
+                                                     util::Parameters(),
+                                                     shallow_copy(),
+                                                     length());
     SliceItemPtr nexthead = where.head();
     Slice nexttail = where.tail();
     Index64 nextadvanced(0);
@@ -260,35 +325,47 @@ namespace awkward {
     }
   }
 
-  const ContentPtr Content::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  Content::getitem_next(const SliceItemPtr& head,
+                        const Slice& tail,
+                        const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
-    else if (SliceAt* at = dynamic_cast<SliceAt*>(head.get())) {
+    else if (SliceAt* at =
+             dynamic_cast<SliceAt*>(head.get())) {
       return getitem_next(*at, tail, advanced);
     }
-    else if (SliceRange* range = dynamic_cast<SliceRange*>(head.get())) {
+    else if (SliceRange* range =
+             dynamic_cast<SliceRange*>(head.get())) {
       return getitem_next(*range, tail, advanced);
     }
-    else if (SliceEllipsis* ellipsis = dynamic_cast<SliceEllipsis*>(head.get())) {
+    else if (SliceEllipsis* ellipsis =
+             dynamic_cast<SliceEllipsis*>(head.get())) {
       return getitem_next(*ellipsis, tail, advanced);
     }
-    else if (SliceNewAxis* newaxis = dynamic_cast<SliceNewAxis*>(head.get())) {
+    else if (SliceNewAxis* newaxis =
+             dynamic_cast<SliceNewAxis*>(head.get())) {
       return getitem_next(*newaxis, tail, advanced);
     }
-    else if (SliceArray64* array = dynamic_cast<SliceArray64*>(head.get())) {
+    else if (SliceArray64* array =
+             dynamic_cast<SliceArray64*>(head.get())) {
       return getitem_next(*array, tail, advanced);
     }
-    else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {
+    else if (SliceField* field =
+             dynamic_cast<SliceField*>(head.get())) {
       return getitem_next(*field, tail, advanced);
     }
-    else if (SliceFields* fields = dynamic_cast<SliceFields*>(head.get())) {
+    else if (SliceFields* fields =
+             dynamic_cast<SliceFields*>(head.get())) {
       return getitem_next(*fields, tail, advanced);
     }
-    else if (SliceMissing64* missing = dynamic_cast<SliceMissing64*>(head.get())) {
+    else if (SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(head.get())) {
       return getitem_next(*missing, tail, advanced);
     }
-    else if (SliceJagged64* jagged = dynamic_cast<SliceJagged64*>(head.get())) {
+    else if (SliceJagged64* jagged =
+             dynamic_cast<SliceJagged64*>(head.get())) {
       return getitem_next(*jagged, tail, advanced);
     }
     else {
@@ -296,63 +373,102 @@ namespace awkward {
     }
   }
 
-  const ContentPtr Content::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceItemPtr& slicecontent, const Slice& tail) const {
-    if (SliceArray64* array = dynamic_cast<SliceArray64*>(slicecontent.get())) {
+  const ContentPtr
+  Content::getitem_next_jagged(const Index64& slicestarts,
+                               const Index64& slicestops,
+                               const SliceItemPtr& slicecontent,
+                               const Slice& tail) const {
+    if (SliceArray64* array =
+        dynamic_cast<SliceArray64*>(slicecontent.get())) {
       return getitem_next_jagged(slicestarts, slicestops, *array, tail);
     }
-    else if (SliceMissing64* missing = dynamic_cast<SliceMissing64*>(slicecontent.get())) {
+    else if (SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(slicecontent.get())) {
       return getitem_next_jagged(slicestarts, slicestops, *missing, tail);
     }
-    else if (SliceJagged64* jagged = dynamic_cast<SliceJagged64*>(slicecontent.get())) {
+    else if (SliceJagged64* jagged =
+             dynamic_cast<SliceJagged64*>(slicecontent.get())) {
       return getitem_next_jagged(slicestarts, slicestops, *jagged, tail);
     }
     else {
-      throw std::runtime_error("unexpected slice type for getitem_next_jagged");
+      throw std::runtime_error(
+        "unexpected slice type for getitem_next_jagged");
     }
   }
 
-  const ContentPtr Content::getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  Content::getitem_next(const SliceEllipsis& ellipsis,
+                        const Slice& tail,
+                        const Index64& advanced) const {
     std::pair<int64_t, int64_t> minmax = minmax_depth();
     int64_t mindepth = minmax.first;
     int64_t maxdepth = minmax.second;
 
-    if (tail.length() == 0  ||  (mindepth - 1 == tail.dimlength()  &&  maxdepth - 1 == tail.dimlength())) {
+    if (tail.length() == 0  ||
+        (mindepth - 1 == tail.dimlength()  &&
+         maxdepth - 1 == tail.dimlength())) {
       SliceItemPtr nexthead = tail.head();
       Slice nexttail = tail.tail();
       return getitem_next(nexthead, nexttail, advanced);
     }
-    else if (mindepth - 1 == tail.dimlength()  ||  maxdepth - 1 == tail.dimlength()) {
-      throw std::invalid_argument("ellipsis (...) can't be used on a data structure of different depths");
+    else if (mindepth - 1 == tail.dimlength()  ||
+             maxdepth - 1 == tail.dimlength()) {
+      throw std::invalid_argument(
+        "ellipsis (...) can't be used on a data structure of different depths");
     }
     else {
       std::vector<SliceItemPtr> tailitems = tail.items();
       std::vector<SliceItemPtr> items = { std::make_shared<SliceEllipsis>() };
       items.insert(items.end(), tailitems.begin(), tailitems.end());
-      SliceItemPtr nexthead = std::make_shared<SliceRange>(Slice::none(), Slice::none(), 1);
+      SliceItemPtr nexthead = std::make_shared<SliceRange>(Slice::none(),
+                                                           Slice::none(),
+                                                           1);
       Slice nexttail(items);
       return getitem_next(nexthead, nexttail, advanced);
     }
   }
 
-  const ContentPtr Content::getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  Content::getitem_next(const SliceNewAxis& newaxis,
+                        const Slice& tail,
+                        const Index64& advanced) const {
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
-    return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), getitem_next(nexthead, nexttail, advanced), 1);
+    return std::make_shared<RegularArray>(
+      Identities::none(),
+      util::Parameters(),
+      getitem_next(nexthead, nexttail, advanced),
+      1);
   }
 
-  const ContentPtr Content::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  Content::getitem_next(const SliceField& field,
+                        const Slice& tail,
+                        const Index64& advanced) const {
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
-    return getitem_field(field.key()).get()->getitem_next(nexthead, nexttail, advanced);
+    return getitem_field(field.key()).get()->getitem_next(nexthead,
+                                                          nexttail,
+                                                          advanced);
   }
 
-  const ContentPtr Content::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  Content::getitem_next(const SliceFields& fields,
+                        const Slice& tail,
+                        const Index64& advanced) const {
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
-    return getitem_fields(fields.keys()).get()->getitem_next(nexthead, nexttail, advanced);
+    return getitem_fields(fields.keys()).get()->getitem_next(nexthead,
+                                                             nexttail,
+                                                             advanced);
   }
 
-  const ContentPtr getitem_next_regular_missing(const SliceMissing64& missing, const Slice& tail, const Index64& advanced, const RegularArray* raw, int64_t length, const std::string& classname) {
+  const ContentPtr getitem_next_regular_missing(const SliceMissing64& missing,
+                                                const Slice& tail,
+                                                const Index64& advanced,
+                                                const RegularArray* raw,
+                                                int64_t length,
+                                                const std::string& classname) {
     Index64 index(missing.index());
     Index64 outindex(index.length()*length);
 
@@ -365,11 +481,19 @@ namespace awkward {
       raw->size());
     util::handle_error(err, classname, nullptr);
 
-    IndexedOptionArray64 out(Identities::none(), util::Parameters(), outindex, raw->content());
-    return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out.simplify_optiontype(), index.length());
+    IndexedOptionArray64 out(Identities::none(),
+                             util::Parameters(),
+                             outindex,
+                             raw->content());
+    return std::make_shared<RegularArray>(Identities::none(),
+                                          util::Parameters(),
+                                          out.simplify_optiontype(),
+                                          index.length());
   }
 
-  bool check_missing_jagged_same(const ContentPtr& that, const Index8& bytemask, const SliceMissing64& missing) {
+  bool check_missing_jagged_same(const ContentPtr& that,
+                                 const Index8& bytemask,
+                                 const SliceMissing64& missing) {
     if (bytemask.length() != missing.length()) {
       return false;
     }
@@ -382,42 +506,52 @@ namespace awkward {
       missingindex.ptr().get(),
       missingindex.offset(),
       bytemask.length());
-    util::handle_error(err, that.get()->classname(), that.get()->identities().get());
+    util::handle_error(err,
+                       that.get()->classname(),
+                       that.get()->identities().get());
     return same;
   }
 
-  const ContentPtr check_missing_jagged(const ContentPtr& that, const SliceMissing64& missing) {
-    // FIXME: This function is insufficiently general. While working on something else,
-    // I noticed that it wasn't possible to slice option-type data with a jagged array.
-    // This handles the case where that happens at top-level; the most likely case
-    // for physics analysis, but it should be more deeply considered in general.
-    //
-    // Note that it only replaces the Content that would be passed to
-    // getitem_next(missing.content()) in getitem_next(SliceMissing64) in a particular
-    // scenario; it can probably be generalized by handling more general scenarios.
+  const ContentPtr check_missing_jagged(const ContentPtr& that,
+                                        const SliceMissing64& missing) {
+    // FIXME: This function is insufficiently general. While working on
+    // something else, I noticed that it wasn't possible to slice option-type
+    // data with a jagged array. This handles the case where that happens at
+    // top-level; the most likely case for physics analysis, but it should be
+    // more deeply considered in general.
 
-    if (that.get()->length() == 1  &&  dynamic_cast<SliceJagged64*>(missing.content().get())) {
+    // Note that it only replaces the Content that would be passed to
+    // getitem_next(missing.content()) in getitem_next(SliceMissing64) in a
+    // particular scenario; it can probably be generalized by handling more
+    // general scenarios.
+
+    if (that.get()->length() == 1  &&
+        dynamic_cast<SliceJagged64*>(missing.content().get())) {
       ContentPtr tmp1 = that.get()->getitem_at_nowrap(0);
       ContentPtr tmp2(nullptr);
-      if (IndexedOptionArray32* rawtmp1 = dynamic_cast<IndexedOptionArray32*>(tmp1.get())) {
+      if (IndexedOptionArray32* rawtmp1 =
+          dynamic_cast<IndexedOptionArray32*>(tmp1.get())) {
         tmp2 = rawtmp1->project();
         if (!check_missing_jagged_same(that, rawtmp1->bytemask(), missing)) {
           return that;
         }
       }
-      else if (IndexedOptionArray64* rawtmp1 = dynamic_cast<IndexedOptionArray64*>(tmp1.get())) {
+      else if (IndexedOptionArray64* rawtmp1 =
+               dynamic_cast<IndexedOptionArray64*>(tmp1.get())) {
         tmp2 = rawtmp1->project();
         if (!check_missing_jagged_same(that, rawtmp1->bytemask(), missing)) {
           return that;
         }
       }
-      else if (ByteMaskedArray* rawtmp1 = dynamic_cast<ByteMaskedArray*>(tmp1.get())) {
+      else if (ByteMaskedArray* rawtmp1 =
+               dynamic_cast<ByteMaskedArray*>(tmp1.get())) {
         tmp2 = rawtmp1->project();
         if (!check_missing_jagged_same(that, rawtmp1->bytemask(), missing)) {
           return that;
         }
       }
-      else if (BitMaskedArray* rawtmp1 = dynamic_cast<BitMaskedArray*>(tmp1.get())) {
+      else if (BitMaskedArray* rawtmp1 =
+               dynamic_cast<BitMaskedArray*>(tmp1.get())) {
         tmp2 = rawtmp1->project();
         if (!check_missing_jagged_same(that, rawtmp1->bytemask(), missing)) {
           return that;
@@ -425,21 +559,36 @@ namespace awkward {
       }
 
       if (tmp2.get() != nullptr) {
-        return std::make_shared<RegularArray>(Identities::none(), that.get()->parameters(), tmp2, tmp2.get()->length());
+        return std::make_shared<RegularArray>(Identities::none(),
+                                              that.get()->parameters(),
+                                              tmp2,
+                                              tmp2.get()->length());
       }
     }
     return that;
   }
 
-  const ContentPtr Content::getitem_next(const SliceMissing64& missing, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  Content::getitem_next(const SliceMissing64& missing,
+                        const Slice& tail,
+                        const Index64& advanced) const {
     if (advanced.length() != 0) {
-      throw std::invalid_argument("cannot mix missing values in slice with NumPy-style advanced indexing");
+      throw std::invalid_argument("cannot mix missing values in slice "
+                                  "with NumPy-style advanced indexing");
     }
 
-    ContentPtr next = check_missing_jagged(shallow_copy(), missing).get()->getitem_next(missing.content(), tail, advanced);
+    ContentPtr tmp = check_missing_jagged(shallow_copy(), missing);
+    ContentPtr next = tmp.get()->getitem_next(missing.content(),
+                                              tail,
+                                              advanced);
 
     if (RegularArray* raw = dynamic_cast<RegularArray*>(next.get())) {
-      return getitem_next_regular_missing(missing, tail, advanced, raw, length(), classname());
+      return getitem_next_regular_missing(missing,
+                                          tail,
+                                          advanced,
+                                          raw,
+                                          length(),
+                                          classname());
     }
 
     else if (RecordArray* rec = dynamic_cast<RecordArray*>(next.get())) {
@@ -449,29 +598,54 @@ namespace awkward {
       ContentPtrVec contents;
       for (auto content : rec->contents()) {
         if (RegularArray* raw = dynamic_cast<RegularArray*>(content.get())) {
-          contents.push_back(getitem_next_regular_missing(missing, tail, advanced, raw, length(), classname()));
+          contents.push_back(getitem_next_regular_missing(missing,
+                                                          tail,
+                                                          advanced,
+                                                          raw,
+                                                          length(),
+                                                          classname()));
         }
         else {
-          throw std::runtime_error(std::string("FIXME: unhandled case of SliceMissing with RecordArray containing\n") + content.get()->tostring());
+          throw std::runtime_error(
+            std::string("FIXME: unhandled case of SliceMissing with ")
+            + std::string("RecordArray containing\n")
+            + content.get()->tostring());
         }
       }
-      return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, rec->recordlookup());
+      return std::make_shared<RecordArray>(Identities::none(),
+                                           util::Parameters(),
+                                           contents,
+                                           rec->recordlookup());
     }
 
     else {
-      throw std::runtime_error(std::string("FIXME: unhandled case of SliceMissing with\n") + next.get()->tostring());
+      throw std::runtime_error(
+        std::string("FIXME: unhandled case of SliceMissing with\n")
+        + next.get()->tostring());
     }
   }
 
-  const ContentPtr Content::getitem_next_array_wrap(const ContentPtr& outcontent, const std::vector<int64_t>& shape) const {
-    ContentPtr out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), outcontent, (int64_t)shape[shape.size() - 1]);
+  const ContentPtr
+  Content::getitem_next_array_wrap(const ContentPtr& outcontent,
+                                   const std::vector<int64_t>& shape) const {
+    ContentPtr out =
+      std::make_shared<RegularArray>(Identities::none(),
+                                     util::Parameters(),
+                                     outcontent,
+                                     (int64_t)shape[shape.size() - 1]);
     for (int64_t i = (int64_t)shape.size() - 2;  i >= 0;  i--) {
-      out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out, (int64_t)shape[(size_t)i]);
+      out = std::make_shared<RegularArray>(Identities::none(),
+                                           util::Parameters(),
+                                           out,
+                                           (int64_t)shape[(size_t)i]);
     }
     return out;
   }
 
-  const std::string Content::parameters_tostring(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  Content::parameters_tostring(const std::string& indent,
+                               const std::string& pre,
+                               const std::string& post) const {
     if (parameters_.empty()) {
       return "";
     }
@@ -479,14 +653,16 @@ namespace awkward {
       std::stringstream out;
       out << indent << pre << "<parameters>\n";
       for (auto pair : parameters_) {
-        out << indent << "    <param key=" << util::quote(pair.first, true) << ">" << pair.second << "</param>\n";
+        out << indent << "    <param key=" << util::quote(pair.first, true)
+            << ">" << pair.second << "</param>\n";
       }
       out << indent << "</parameters>" << post;
       return out.str();
     }
   }
 
-  const int64_t Content::axis_wrap_if_negative(int64_t axis) const {
+  const int64_t
+  Content::axis_wrap_if_negative(int64_t axis) const {
     if (axis < 0) {
       throw std::runtime_error("FIXME: negative axis not implemented yet");
     }

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -76,7 +76,7 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Content> Content::reduce(const Reducer& reducer, int64_t axis, bool mask, bool keepdims) const {
+  ContentPtr Content::reduce(const Reducer& reducer, int64_t axis, bool mask, bool keepdims) const {
     int64_t negaxis = -axis;
     std::pair<bool, int64_t> branchdepth = branch_depth();
     bool branch = branchdepth.first;
@@ -140,7 +140,7 @@ namespace awkward {
     return util::parameters_equal(parameters_, other);
   }
 
-  const std::shared_ptr<Content> Content::merge_as_union(const std::shared_ptr<Content>& other) const {
+  ContentPtr Content::merge_as_union(ContentPtr& other) const {
     int64_t mylength = length();
     int64_t theirlength = other.get()->length();
     Index8 tags(mylength + theirlength);
@@ -175,7 +175,7 @@ namespace awkward {
     return std::make_shared<UnionArray8_64>(Identities::none(), util::Parameters(), tags, index, contents);
   }
 
-  const std::shared_ptr<Content> Content::rpad_axis0(int64_t target, bool clip) const {
+  ContentPtr Content::rpad_axis0(int64_t target, bool clip) const {
     if (!clip  &&  target < length()) {
       return shallow_copy();
     }
@@ -189,7 +189,7 @@ namespace awkward {
     return next.get()->simplify_optiontype();
   }
 
-  const std::shared_ptr<Content> Content::localindex_axis0() const {
+  ContentPtr Content::localindex_axis0() const {
     Index64 localindex(length());
     struct Error err = awkward_localindex_64(
       localindex.ptr().get(),
@@ -198,7 +198,7 @@ namespace awkward {
     return std::make_shared<NumpyArray>(localindex);
   }
 
-  const std::shared_ptr<Content> Content::choose_axis0(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters) const {
+  ContentPtr Content::choose_axis0(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters) const {
     int64_t size = length();
     if (diagonal) {
       size += (n - 1);
@@ -244,7 +244,7 @@ namespace awkward {
     return std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
   }
 
-  const std::shared_ptr<Content> Content::getitem(const Slice& where) const {
+  ContentPtr Content::getitem(const Slice& where) const {
     std::shared_ptr<Content> next = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), shallow_copy(), length());
 
     std::shared_ptr<SliceItem> nexthead = where.head();
@@ -260,7 +260,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> Content::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Content::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -296,7 +296,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> Content::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const {
+  ContentPtr Content::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const {
     if (SliceArray64* array = dynamic_cast<SliceArray64*>(slicecontent.get())) {
       return getitem_next_jagged(slicestarts, slicestops, *array, tail);
     }
@@ -311,7 +311,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> Content::getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Content::getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& advanced) const {
     std::pair<int64_t, int64_t> minmax = minmax_depth();
     int64_t mindepth = minmax.first;
     int64_t maxdepth = minmax.second;
@@ -334,25 +334,25 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> Content::getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Content::getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), getitem_next(nexthead, nexttail, advanced), 1);
   }
 
-  const std::shared_ptr<Content> Content::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Content::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     return getitem_field(field.key()).get()->getitem_next(nexthead, nexttail, advanced);
   }
 
-  const std::shared_ptr<Content> Content::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Content::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     return getitem_fields(fields.keys()).get()->getitem_next(nexthead, nexttail, advanced);
   }
 
-  const std::shared_ptr<Content> getitem_next_regular_missing(const SliceMissing64& missing, const Slice& tail, const Index64& advanced, const RegularArray* raw, int64_t length, const std::string& classname) {
+  ContentPtr getitem_next_regular_missing(const SliceMissing64& missing, const Slice& tail, const Index64& advanced, const RegularArray* raw, int64_t length, const std::string& classname) {
     Index64 index(missing.index());
     Index64 outindex(index.length()*length);
 
@@ -369,7 +369,7 @@ namespace awkward {
     return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out.simplify_optiontype(), index.length());
   }
 
-  bool check_missing_jagged_same(const std::shared_ptr<Content>& that, const Index8& bytemask, const SliceMissing64& missing) {
+  bool check_missing_jagged_same(ContentPtr& that, const Index8& bytemask, const SliceMissing64& missing) {
     if (bytemask.length() != missing.length()) {
       return false;
     }
@@ -386,7 +386,7 @@ namespace awkward {
     return same;
   }
 
-  const std::shared_ptr<Content> check_missing_jagged(const std::shared_ptr<Content>& that, const SliceMissing64& missing) {
+  ContentPtr check_missing_jagged(ContentPtr& that, const SliceMissing64& missing) {
     // FIXME: This function is insufficiently general. While working on something else,
     // I noticed that it wasn't possible to slice option-type data with a jagged array.
     // This handles the case where that happens at top-level; the most likely case
@@ -431,7 +431,7 @@ namespace awkward {
     return that;
   }
 
-  const std::shared_ptr<Content> Content::getitem_next(const SliceMissing64& missing, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Content::getitem_next(const SliceMissing64& missing, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument("cannot mix missing values in slice with NumPy-style advanced indexing");
     }
@@ -463,7 +463,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> Content::getitem_next_array_wrap(const std::shared_ptr<Content>& outcontent, const std::vector<int64_t>& shape) const {
+  ContentPtr Content::getitem_next_array_wrap(ContentPtr& outcontent, const std::vector<int64_t>& shape) const {
     std::shared_ptr<Content> out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), outcontent, (int64_t)shape[shape.size() - 1]);
     for (int64_t i = (int64_t)shape.size() - 2;  i >= 0;  i--) {
       out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out, (int64_t)shape[(size_t)i]);

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -146,7 +146,7 @@ namespace awkward {
     Index8 tags(mylength + theirlength);
     Index64 index(mylength + theirlength);
 
-    std::vector<ContentPtr> contents({ shallow_copy(), other });
+    ContentPtrVec contents({ shallow_copy(), other });
 
     struct Error err1 = awkward_unionarray_filltags_to8_const(
       tags.ptr().get(),
@@ -237,7 +237,7 @@ namespace awkward {
       1);
     util::handle_error(err, classname(), identities_.get());
 
-    std::vector<ContentPtr> contents;
+    ContentPtrVec contents;
     for (auto ptr : tocarry) {
       contents.push_back(std::make_shared<IndexedArray64>(Identities::none(), util::Parameters(), Index64(ptr, 0, chooselen), shallow_copy()));
     }
@@ -446,7 +446,7 @@ namespace awkward {
       if (rec->numfields() == 0) {
         return next;
       }
-      std::vector<ContentPtr> contents;
+      ContentPtrVec contents;
       for (auto content : rec->contents()) {
         if (RegularArray* raw = dynamic_cast<RegularArray*>(content.get())) {
           contents.push_back(getitem_next_regular_missing(missing, tail, advanced, raw, length(), classname()));

--- a/src/libawkward/Identities.cpp
+++ b/src/libawkward/Identities.cpp
@@ -15,58 +15,81 @@
 namespace awkward {
   std::atomic<Identities::Ref> numrefs{0};
 
-  Identities::Ref Identities::newref() {
+  Identities::Ref
+  Identities::newref() {
     return numrefs++;
   }
 
-  IdentitiesPtr Identities::none() {
+  IdentitiesPtr
+  Identities::none() {
     return IdentitiesPtr(nullptr);
   }
 
-  Identities::Identities(const Ref ref, const FieldLoc& fieldloc, int64_t offset, int64_t width, int64_t length)
+  Identities::Identities(const Ref ref,
+                         const FieldLoc& fieldloc,
+                         int64_t offset,
+                         int64_t width,
+                         int64_t length)
       : ref_(ref)
       , fieldloc_(fieldloc)
       , offset_(offset)
       , width_(width)
       , length_(length) { }
 
-  const Identities::Ref Identities::ref() const {
+  const Identities::Ref
+  Identities::ref() const {
     return ref_;
   }
 
-  const Identities::FieldLoc Identities::fieldloc() const {
+  const Identities::FieldLoc
+  Identities::fieldloc() const {
     return fieldloc_;
   }
 
-  const int64_t Identities::offset() const {
+  const int64_t
+  Identities::offset() const {
     return offset_;
   }
 
-  const int64_t Identities::width() const {
+  const int64_t
+  Identities::width() const {
     return width_;
   }
 
-  const int64_t Identities::length() const {
+  const int64_t
+  Identities::length() const {
     return length_;
   }
 
   template <typename T>
-  IdentitiesOf<T>::IdentitiesOf(const Ref ref, const FieldLoc& fieldloc, int64_t width, int64_t length)
+  IdentitiesOf<T>::IdentitiesOf(const Ref ref,
+                                const FieldLoc& fieldloc,
+                                int64_t width,
+                                int64_t length)
       : Identities(ref, fieldloc, 0, width, length)
-      , ptr_(std::shared_ptr<T>(length*width == 0 ? nullptr : new T[(size_t)(length*width)], util::array_deleter<T>())) { }
+      , ptr_(std::shared_ptr<T>(
+          length*width == 0 ? nullptr : new T[(size_t)(length*width)],
+          util::array_deleter<T>())) { }
 
   template <typename T>
-  IdentitiesOf<T>::IdentitiesOf(const Ref ref, const FieldLoc& fieldloc, int64_t offset, int64_t width, int64_t length, const std::shared_ptr<T> ptr)
+  IdentitiesOf<T>::IdentitiesOf(const Ref ref,
+                                const FieldLoc& fieldloc,
+                                int64_t offset,
+                                int64_t width,
+                                int64_t length,
+                                const std::shared_ptr<T> ptr)
       : Identities(ref, fieldloc, offset, width, length)
       , ptr_(ptr) { }
 
   template <typename T>
-  const std::shared_ptr<T> IdentitiesOf<T>::ptr() const {
+  const std::shared_ptr<T>
+  IdentitiesOf<T>::ptr() const {
     return ptr_;
   }
 
   template <typename T>
-  const std::string IdentitiesOf<T>::classname() const {
+  const std::string
+  IdentitiesOf<T>::classname() const {
     if (std::is_same<T, int32_t>::value) {
       return "Identities32";
     }
@@ -79,7 +102,8 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::string IdentitiesOf<T>::identity_at(int64_t at) const {
+  const std::string
+  IdentitiesOf<T>::identity_at(int64_t at) const {
     std::stringstream out;
     for (int64_t i = 0;  i < width_;  i++) {
       if (i != 0) {
@@ -96,20 +120,31 @@ namespace awkward {
   }
 
   template <typename T>
-  const IdentitiesPtr IdentitiesOf<T>::to64() const {
+  const IdentitiesPtr
+  IdentitiesOf<T>::to64() const {
     if (std::is_same<T, int64_t>::value) {
       return shallow_copy();
     }
     else if (std::is_same<T, int32_t>::value) {
-      IdentitiesPtr out = std::make_shared<Identities64>(ref_, fieldloc_, width_, length_);
+      IdentitiesPtr out = std::make_shared<Identities64>(ref_,
+                                                         fieldloc_,
+                                                         width_,
+                                                         length_);
       Identities64* raw = reinterpret_cast<Identities64*>(out.get());
-      awkward_identities32_to_identities64(raw->ptr().get(), reinterpret_cast<int32_t*>(ptr_.get()), length_, width_);
+      awkward_identities32_to_identities64(
+        raw->ptr().get(),
+        reinterpret_cast<int32_t*>(ptr_.get()),
+        length_,
+        width_);
       return out;
     }
   }
 
   template <typename T>
-  const std::string IdentitiesOf<T>::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  IdentitiesOf<T>::tostring_part(const std::string& indent,
+                                 const std::string& pre,
+                                 const std::string& post) const {
     std::stringstream out;
     std::string name = "Unrecognized Identities";
     if (std::is_same<T, int32_t>::value) {
@@ -118,52 +153,87 @@ namespace awkward {
     else if (std::is_same<T, int64_t>::value) {
       name = "Identities64";
     }
-    out << indent << pre << "<" << name << " ref=\"" << ref_ << "\" fieldloc=\"[";
+    out << indent << pre << "<" << name << " ref=\"" << ref_
+        << "\" fieldloc=\"[";
     for (size_t i = 0;  i < fieldloc_.size();  i++) {
       if (i != 0) {
         out << " ";
       }
-      out << "(" << fieldloc_[i].first << ", " << util::quote(fieldloc_[i].second, false) << ")";
+      out << "(" << fieldloc_[i].first << ", "
+          << util::quote(fieldloc_[i].second, false) << ")";
     }
-    out << "]\" width=\"" << width_ << "\" offset=\"" << offset_ << "\" length=\"" << length_ << "\" at=\"0x";
-    out << std::hex << std::setw(12) << std::setfill('0') << reinterpret_cast<ssize_t>(ptr_.get()) << "\"/>" << post;
+    out << "]\" width=\"" << width_ << "\" offset=\"" << offset_
+        << "\" length=\"" << length_ << "\" at=\"0x";
+    out << std::hex << std::setw(12) << std::setfill('0')
+        << reinterpret_cast<ssize_t>(ptr_.get()) << "\"/>" << post;
     return out.str();
   }
 
   template <typename T>
-  const IdentitiesPtr IdentitiesOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    if (!(0 <= start  &&  start < length_  &&  0 <= stop  &&  stop <= length_)  &&  start != stop) {
-      throw std::runtime_error("Identities::getitem_range_nowrap with illegal start:stop for this length");
+  const IdentitiesPtr
+  IdentitiesOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+    if (!(0 <= start  &&  start < length_  &&  0 <= stop  &&  stop <= length_)
+        &&  start != stop) {
+      throw std::runtime_error(
+        "Identities::getitem_range_nowrap with illegal start:stop "
+        "for this length");
     }
-    return std::make_shared<IdentitiesOf<T>>(ref_, fieldloc_, offset_ + width_*start*(start != stop), width_, (stop - start), ptr_);
+    return std::make_shared<IdentitiesOf<T>>(
+      ref_,
+      fieldloc_,
+      offset_ + width_*start*(start != stop),
+      width_,
+      (stop - start),
+      ptr_);
   }
 
   template <typename T>
-  void IdentitiesOf<T>::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  IdentitiesOf<T>::nbytes_part(std::map<size_t, int64_t>& largest) const {
     size_t x = (size_t)ptr_.get();
     auto it = largest.find(x);
-    if (it == largest.end()  ||  it->second < (int64_t)(sizeof(T)*length_*width_)) {
+    if (it == largest.end()  ||
+        it->second < (int64_t)(sizeof(T)*length_*width_)) {
       largest[x] = (int64_t)(sizeof(T)*length_*width_);
     }
   }
 
   template <typename T>
-  const IdentitiesPtr IdentitiesOf<T>::shallow_copy() const {
-    return std::make_shared<IdentitiesOf<T>>(ref_, fieldloc_, offset_, width_, length_, ptr_);
+  const IdentitiesPtr
+  IdentitiesOf<T>::shallow_copy() const {
+    return std::make_shared<IdentitiesOf<T>>(ref_,
+                                             fieldloc_,
+                                             offset_,
+                                             width_,
+                                             length_,
+                                             ptr_);
   }
 
   template <typename T>
-  const IdentitiesPtr IdentitiesOf<T>::deep_copy() const {
-    std::shared_ptr<T> ptr(length_ == 0 ? nullptr : new T[(size_t)length_], util::array_deleter<T>());
+  const IdentitiesPtr
+  IdentitiesOf<T>::deep_copy() const {
+    std::shared_ptr<T> ptr(length_ == 0 ? nullptr : new T[(size_t)length_],
+                           util::array_deleter<T>());
     if (length_ != 0) {
-      memcpy(ptr.get(), &ptr_.get()[(size_t)offset_], sizeof(T)*((size_t)length_));
+      memcpy(ptr.get(),
+             &ptr_.get()[(size_t)offset_],
+             sizeof(T)*((size_t)length_));
     }
-    return std::make_shared<IdentitiesOf<T>>(ref_, fieldloc_, 0, width_, length_, ptr);
+    return std::make_shared<IdentitiesOf<T>>(ref_,
+                                             fieldloc_,
+                                             0,
+                                             width_,
+                                             length_,
+                                             ptr);
   }
 
   template <typename T>
-  const IdentitiesPtr IdentitiesOf<T>::getitem_carry_64(const Index64& carry) const {
-    IdentitiesPtr out = std::make_shared<IdentitiesOf<T>>(ref_, fieldloc_, width_, carry.length());
+  const IdentitiesPtr
+  IdentitiesOf<T>::getitem_carry_64(const Index64& carry) const {
+    IdentitiesPtr out = std::make_shared<IdentitiesOf<T>>(ref_,
+                                                          fieldloc_,
+                                                          width_,
+                                                          carry.length());
     IdentitiesOf<T>* rawout = reinterpret_cast<IdentitiesOf<T>*>(out.get());
 
     if (std::is_same<T, int32_t>::value) {
@@ -195,49 +265,65 @@ namespace awkward {
     return out;
   }
 
-  const std::string Identities::tostring() const {
+  const std::string
+  Identities::tostring() const {
     return tostring_part("", "", "");
   }
 
   template <typename T>
-  const IdentitiesPtr IdentitiesOf<T>::withfieldloc(const FieldLoc& fieldloc) const {
-    return std::make_shared<IdentitiesOf<T>>(ref_, fieldloc, offset_, width_, length_, ptr_);
+  const IdentitiesPtr
+  IdentitiesOf<T>::withfieldloc(const FieldLoc& fieldloc) const {
+    return std::make_shared<IdentitiesOf<T>>(ref_,
+                                             fieldloc,
+                                             offset_,
+                                             width_,
+                                             length_,
+                                             ptr_);
   }
 
   template <typename T>
-  int64_t IdentitiesOf<T>::value(int64_t row, int64_t col) const {
+  int64_t
+  IdentitiesOf<T>::value(int64_t row, int64_t col) const {
     return (int64_t)ptr_.get()[offset_ + row*width_ + col];
   }
 
   template <typename T>
-  const std::vector<T> IdentitiesOf<T>::getitem_at(int64_t at) const {
+  const std::vector<T>
+  IdentitiesOf<T>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length_;
     }
     if (!(0 <= regular_at  &&  regular_at < length_)) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), nullptr);
+      util::handle_error(
+        failure("index out of range", kSliceNone, at), classname(), nullptr);
     }
     return getitem_at_nowrap(regular_at);
   }
 
   template <typename T>
-  const std::vector<T> IdentitiesOf<T>::getitem_at_nowrap(int64_t at) const {
+  const std::vector<T>
+  IdentitiesOf<T>::getitem_at_nowrap(int64_t at) const {
     if (!(0 <= at  &&  at < length_)) {
-      throw std::runtime_error("Identities::getitem_at_nowrap with illegal index for this length");
+      throw std::runtime_error(
+        "Identities::getitem_at_nowrap with illegal index for this length");
     }
     std::vector<T> out;
-    for (size_t i = (size_t)(offset_ + at);  i < (size_t)(offset_ + at + width_);  i++) {
+    for (size_t i = (size_t)(offset_ + at);
+         i < (size_t)(offset_ + at + width_);
+         i++) {
       out.push_back(ptr_.get()[i]);
     }
     return out;
   }
 
   template <typename T>
-  const IdentitiesPtr IdentitiesOf<T>::getitem_range(int64_t start, int64_t stop) const {
+  const IdentitiesPtr
+  IdentitiesOf<T>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), length_);
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 

--- a/src/libawkward/Identities.cpp
+++ b/src/libawkward/Identities.cpp
@@ -19,8 +19,8 @@ namespace awkward {
     return numrefs++;
   }
 
-  std::shared_ptr<Identities> Identities::none() {
-    return std::shared_ptr<Identities>(nullptr);
+  IdentitiesPtr Identities::none() {
+    return IdentitiesPtr(nullptr);
   }
 
   Identities::Identities(const Ref ref, const FieldLoc& fieldloc, int64_t offset, int64_t width, int64_t length)
@@ -96,12 +96,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Identities> IdentitiesOf<T>::to64() const {
+  const IdentitiesPtr IdentitiesOf<T>::to64() const {
     if (std::is_same<T, int64_t>::value) {
       return shallow_copy();
     }
     else if (std::is_same<T, int32_t>::value) {
-      std::shared_ptr<Identities> out = std::make_shared<Identities64>(ref_, fieldloc_, width_, length_);
+      IdentitiesPtr out = std::make_shared<Identities64>(ref_, fieldloc_, width_, length_);
       Identities64* raw = reinterpret_cast<Identities64*>(out.get());
       awkward_identities32_to_identities64(raw->ptr().get(), reinterpret_cast<int32_t*>(ptr_.get()), length_, width_);
       return out;
@@ -131,7 +131,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Identities> IdentitiesOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const IdentitiesPtr IdentitiesOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     if (!(0 <= start  &&  start < length_  &&  0 <= stop  &&  stop <= length_)  &&  start != stop) {
       throw std::runtime_error("Identities::getitem_range_nowrap with illegal start:stop for this length");
     }
@@ -148,12 +148,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Identities> IdentitiesOf<T>::shallow_copy() const {
+  const IdentitiesPtr IdentitiesOf<T>::shallow_copy() const {
     return std::make_shared<IdentitiesOf<T>>(ref_, fieldloc_, offset_, width_, length_, ptr_);
   }
 
   template <typename T>
-  const std::shared_ptr<Identities> IdentitiesOf<T>::deep_copy() const {
+  const IdentitiesPtr IdentitiesOf<T>::deep_copy() const {
     std::shared_ptr<T> ptr(length_ == 0 ? nullptr : new T[(size_t)length_], util::array_deleter<T>());
     if (length_ != 0) {
       memcpy(ptr.get(), &ptr_.get()[(size_t)offset_], sizeof(T)*((size_t)length_));
@@ -162,8 +162,8 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Identities> IdentitiesOf<T>::getitem_carry_64(const Index64& carry) const {
-    std::shared_ptr<Identities> out = std::make_shared<IdentitiesOf<T>>(ref_, fieldloc_, width_, carry.length());
+  const IdentitiesPtr IdentitiesOf<T>::getitem_carry_64(const Index64& carry) const {
+    IdentitiesPtr out = std::make_shared<IdentitiesOf<T>>(ref_, fieldloc_, width_, carry.length());
     IdentitiesOf<T>* rawout = reinterpret_cast<IdentitiesOf<T>*>(out.get());
 
     if (std::is_same<T, int32_t>::value) {
@@ -200,7 +200,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Identities> IdentitiesOf<T>::withfieldloc(const FieldLoc& fieldloc) const {
+  const IdentitiesPtr IdentitiesOf<T>::withfieldloc(const FieldLoc& fieldloc) const {
     return std::make_shared<IdentitiesOf<T>>(ref_, fieldloc, offset_, width_, length_, ptr_);
   }
 
@@ -234,7 +234,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Identities> IdentitiesOf<T>::getitem_range(int64_t start, int64_t stop) const {
+  const IdentitiesPtr IdentitiesOf<T>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);

--- a/src/libawkward/Index.cpp
+++ b/src/libawkward/Index.cpp
@@ -12,33 +12,40 @@
 namespace awkward {
   template <typename T>
   IndexOf<T>::IndexOf(int64_t length)
-      : ptr_(std::shared_ptr<T>(length == 0 ? nullptr : new T[(size_t)length], util::array_deleter<T>()))
+      : ptr_(std::shared_ptr<T>(length == 0 ? nullptr : new T[(size_t)length],
+                                util::array_deleter<T>()))
       , offset_(0)
       , length_(length) { }
 
   template <typename T>
-  IndexOf<T>::IndexOf(const std::shared_ptr<T>& ptr, int64_t offset, int64_t length)
+  IndexOf<T>::IndexOf(const std::shared_ptr<T>& ptr,
+                      int64_t offset,
+                      int64_t length)
       : ptr_(ptr)
       , offset_(offset)
       , length_(length) { }
 
   template <typename T>
-  const std::shared_ptr<T> IndexOf<T>::ptr() const {
+  const std::shared_ptr<T>
+  IndexOf<T>::ptr() const {
     return ptr_;
   }
 
   template <typename T>
-  int64_t IndexOf<T>::offset() const {
+  int64_t
+  IndexOf<T>::offset() const {
     return offset_;
   }
 
   template <typename T>
-  int64_t IndexOf<T>::length() const {
+  int64_t
+  IndexOf<T>::length() const {
     return length_;
   }
 
   template <typename T>
-  const std::string IndexOf<T>::classname() const {
+  const std::string
+  IndexOf<T>::classname() const {
     if (std::is_same<T, int8_t>::value) {
       return "Index8";
     }
@@ -60,12 +67,16 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::string IndexOf<T>::tostring() const {
+  const std::string
+  IndexOf<T>::tostring() const {
     return tostring_part("", "", "");
   }
 
   template <typename T>
-  const std::string IndexOf<T>::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  IndexOf<T>::tostring_part(const std::string& indent,
+                            const std::string& pre,
+                            const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << " i=\"[";
     if (length_ <= 10) {
@@ -91,51 +102,63 @@ namespace awkward {
         out << (int64_t)getitem_at_nowrap(i);
       }
     }
-    out << "]\" offset=\"" << offset_ << "\" length=\"" << length_ << "\" at=\"0x";
-    out << std::hex << std::setw(12) << std::setfill('0') << reinterpret_cast<ssize_t>(ptr_.get()) << "\"/>" << post;
+    out << "]\" offset=\"" << offset_ << "\" length=\"" << length_
+        << "\" at=\"0x" << std::hex << std::setw(12) << std::setfill('0')
+        << reinterpret_cast<ssize_t>(ptr_.get()) << "\"/>" << post;
     return out.str();
   }
 
   template <typename T>
-  T IndexOf<T>::getitem_at(int64_t at) const {
+  T
+  IndexOf<T>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length_;
     }
     if (!(0 <= regular_at  &&  regular_at < length_)) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), nullptr);
+      util::handle_error(failure("index out of range", kSliceNone, at),
+                         classname(),
+                         nullptr);
     }
     return getitem_at_nowrap(regular_at);
   }
 
   template <typename T>
-  T IndexOf<T>::getitem_at_nowrap(int64_t at) const {
+  T
+  IndexOf<T>::getitem_at_nowrap(int64_t at) const {
     return util::awkward_index_getitem_at_nowrap<T>(ptr_.get(), offset_, at);
   }
 
   template <typename T>
-  void IndexOf<T>::setitem_at_nowrap(int64_t at, T value) const {
+  void
+  IndexOf<T>::setitem_at_nowrap(int64_t at, T value) const {
     util::awkward_index_setitem_at_nowrap<T>(ptr_.get(), offset_, at, value);
   }
 
   template <typename T>
-  IndexOf<T> IndexOf<T>::getitem_range(int64_t start, int64_t stop) const {
+  IndexOf<T>
+  IndexOf<T>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), length_);
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
   template <typename T>
-  IndexOf<T> IndexOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    if (!(0 <= start  &&  start < length_  &&  0 <= stop  &&  stop <= length_)  &&  start != stop) {
-      throw std::runtime_error("Index::getitem_range_nowrap with illegal start:stop for this length");
+  IndexOf<T>
+  IndexOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+    if (!(0 <= start  &&  start < length_  &&  0 <= stop  &&  stop <= length_)
+        &&  start != stop) {
+      throw std::runtime_error(
+        "Index::getitem_range_nowrap with illegal start:stop for this length");
     }
     return IndexOf<T>(ptr_, offset_ + start*(start != stop), stop - start);
   }
 
   template <typename T>
-  void IndexOf<T>::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  IndexOf<T>::nbytes_part(std::map<size_t, int64_t>& largest) const {
     size_t x = (size_t)ptr_.get();
     auto it = largest.find(x);
     if (it == largest.end()  ||  it->second < (int64_t)(sizeof(T)*length_)) {
@@ -144,42 +167,57 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Index> IndexOf<T>::shallow_copy() const {
+  const std::shared_ptr<Index>
+  IndexOf<T>::shallow_copy() const {
     return std::make_shared<IndexOf<T>>(ptr_, offset_, length_);
   }
 
   template <>
   IndexOf<int64_t> IndexOf<int8_t>::to64() const {
-    std::shared_ptr<int64_t> ptr(length_ == 0 ? nullptr : new int64_t[(size_t)length_], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(
+      length_ == 0 ? nullptr : new int64_t[(size_t)length_],
+      util::array_deleter<int64_t>());
     if (length_ != 0) {
-      awkward_index8_to_index64(ptr.get(), &ptr_.get()[(size_t)offset_], length_);
+      awkward_index8_to_index64(ptr.get(), &ptr_.get()[(size_t)offset_],
+                                length_);
     }
     return IndexOf<int64_t>(ptr, 0, length_);
   }
 
   template <>
   IndexOf<int64_t> IndexOf<uint8_t>::to64() const {
-    std::shared_ptr<int64_t> ptr(length_ == 0 ? nullptr : new int64_t[(size_t)length_], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(
+      length_ == 0 ? nullptr : new int64_t[(size_t)length_],
+      util::array_deleter<int64_t>());
     if (length_ != 0) {
-      awkward_indexU8_to_index64(ptr.get(), &ptr_.get()[(size_t)offset_], length_);
+      awkward_indexU8_to_index64(ptr.get(), &ptr_.get()[(size_t)offset_],
+                                 length_);
     }
     return IndexOf<int64_t>(ptr, 0, length_);
   }
 
   template <>
   IndexOf<int64_t> IndexOf<int32_t>::to64() const {
-    std::shared_ptr<int64_t> ptr(length_ == 0 ? nullptr : new int64_t[(size_t)length_], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(
+      length_ == 0 ? nullptr : new int64_t[(size_t)length_],
+      util::array_deleter<int64_t>());
     if (length_ != 0) {
-      awkward_index32_to_index64(ptr.get(), &ptr_.get()[(size_t)offset_], length_);
+      awkward_index32_to_index64(ptr.get(),
+                                 &ptr_.get()[(size_t)offset_],
+                                 length_);
     }
     return IndexOf<int64_t>(ptr, 0, length_);
   }
 
   template <>
   IndexOf<int64_t> IndexOf<uint32_t>::to64() const {
-    std::shared_ptr<int64_t> ptr(length_ == 0 ? nullptr : new int64_t[(size_t)length_], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(
+      length_ == 0 ? nullptr : new int64_t[(size_t)length_],
+      util::array_deleter<int64_t>());
     if (length_ != 0) {
-      awkward_indexU32_to_index64(ptr.get(), &ptr_.get()[(size_t)offset_], length_);
+      awkward_indexU32_to_index64(ptr.get(),
+                                  &ptr_.get()[(size_t)offset_],
+                                  length_);
     }
     return IndexOf<int64_t>(ptr, 0, length_);
   }
@@ -190,10 +228,15 @@ namespace awkward {
   }
 
   template <typename T>
-  const IndexOf<T> IndexOf<T>::deep_copy() const {
-    std::shared_ptr<T> ptr(length_ == 0 ? nullptr : new T[(size_t)length_], util::array_deleter<T>());
+  const IndexOf<T>
+  IndexOf<T>::deep_copy() const {
+    std::shared_ptr<T> ptr(
+      length_ == 0 ? nullptr : new T[(size_t)length_],
+      util::array_deleter<T>());
     if (length_ != 0) {
-      memcpy(ptr.get(), &ptr_.get()[(size_t)offset_], sizeof(T)*((size_t)length_));
+      memcpy(ptr.get(),
+             &ptr_.get()[(size_t)offset_],
+             sizeof(T)*((size_t)length_));
     }
     return IndexOf<T>(ptr, 0, length_);
   }

--- a/src/libawkward/Iterator.cpp
+++ b/src/libawkward/Iterator.cpp
@@ -11,23 +11,30 @@ namespace awkward {
     content.get()->check_for_iteration();
   }
 
-  const ContentPtr Iterator::content() const {
+  const ContentPtr
+  Iterator::content() const {
     return content_;
   }
 
-  const int64_t Iterator::at() const {
+  const int64_t
+  Iterator::at() const {
     return at_;
   }
 
-  const bool Iterator::isdone() const {
+  const bool
+  Iterator::isdone() const {
     return at_ >= content_.get()->length();
   }
 
-  const ContentPtr Iterator::next() {
+  const ContentPtr
+  Iterator::next() {
     return content_.get()->getitem_at_nowrap(at_++);
   }
 
-  const std::string Iterator::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  Iterator::tostring_part(const std::string& indent,
+                          const std::string& pre,
+                          const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<Iterator at=\"" << at_ << "\">\n";
     out << content_.get()->tostring_part(indent + std::string("    "), "", "\n");
@@ -35,7 +42,8 @@ namespace awkward {
     return out.str();
   }
 
-  const std::string Iterator::tostring() const {
+  const std::string
+  Iterator::tostring() const {
     return tostring_part("", "", "");
   }
 }

--- a/src/libawkward/Iterator.cpp
+++ b/src/libawkward/Iterator.cpp
@@ -37,7 +37,8 @@ namespace awkward {
                           const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<Iterator at=\"" << at_ << "\">\n";
-    out << content_.get()->tostring_part(indent + std::string("    "), "", "\n");
+    out << content_.get()->tostring_part(
+             indent + std::string("    "), "", "\n");
     out << indent << "</Iterator>" << post;
     return out.str();
   }

--- a/src/libawkward/Iterator.cpp
+++ b/src/libawkward/Iterator.cpp
@@ -5,13 +5,13 @@
 #include "awkward/Iterator.h"
 
 namespace awkward {
-  Iterator::Iterator(ContentPtr& content)
+  Iterator::Iterator(const ContentPtr& content)
     : content_(content)
     , at_(0) {
     content.get()->check_for_iteration();
   }
 
-  ContentPtr Iterator::content() const {
+  const ContentPtr Iterator::content() const {
     return content_;
   }
 
@@ -23,7 +23,7 @@ namespace awkward {
     return at_ >= content_.get()->length();
   }
 
-  ContentPtr Iterator::next() {
+  const ContentPtr Iterator::next() {
     return content_.get()->getitem_at_nowrap(at_++);
   }
 

--- a/src/libawkward/Iterator.cpp
+++ b/src/libawkward/Iterator.cpp
@@ -5,13 +5,13 @@
 #include "awkward/Iterator.h"
 
 namespace awkward {
-  Iterator::Iterator(const std::shared_ptr<Content>& content)
+  Iterator::Iterator(ContentPtr& content)
     : content_(content)
     , at_(0) {
     content.get()->check_for_iteration();
   }
 
-  const std::shared_ptr<Content> Iterator::content() const {
+  ContentPtr Iterator::content() const {
     return content_;
   }
 
@@ -23,7 +23,7 @@ namespace awkward {
     return at_ >= content_.get()->length();
   }
 
-  const std::shared_ptr<Content> Iterator::next() {
+  ContentPtr Iterator::next() {
     return content_.get()->getitem_at_nowrap(at_++);
   }
 

--- a/src/libawkward/Reducer.cpp
+++ b/src/libawkward/Reducer.cpp
@@ -7,11 +7,13 @@
 #include "awkward/Reducer.h"
 
 namespace awkward {
-  const std::string Reducer::return_type(const std::string& given_type) const {
+  const std::string
+  Reducer::return_type(const std::string& given_type) const {
     return given_type;
   }
 
-  ssize_t Reducer::return_typesize(const std::string& given_type) const {
+  ssize_t
+  Reducer::return_typesize(const std::string& given_type) const {
     if (given_type.compare("?") == 0) {
       return 1;
     }
@@ -66,21 +68,25 @@ namespace awkward {
     }
   }
 
-  /////////////////////////////////////////////////////////////// count
+  ////////// count
 
-  const std::string ReducerCount::name() const {
+  const std::string
+  ReducerCount::name() const {
     return "count";
   }
 
-  const std::string ReducerCount::preferred_type() const {
+  const std::string
+  ReducerCount::preferred_type() const {
     return "d";
   }
 
-  ssize_t ReducerCount::preferred_typesize() const {
+  ssize_t
+  ReducerCount::preferred_typesize() const {
     return 8;
   }
 
-  const std::string ReducerCount::return_type(const std::string& given_type) const {
+  const std::string
+  ReducerCount::return_type(const std::string& given_type) const {
 #if defined _MSC_VER || defined __i386__
     return "q";
 #else
@@ -88,13 +94,20 @@ namespace awkward {
 #endif
   }
 
-  ssize_t ReducerCount::return_typesize(const std::string& given_type) const {
+  ssize_t
+  ReducerCount::return_typesize(const std::string& given_type) const {
     return 8;
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerCount::apply_bool(const bool* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
     // This is the only reducer that completely ignores the data.
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_count_64(
       ptr.get(),
       parents.ptr().get(),
@@ -105,61 +118,155 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_int8(const int8_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_uint8(const uint8_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_int16(const int16_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_uint16(const uint16_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_int32(const int32_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_uint32(const uint32_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_int64(const int64_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_uint64(const uint64_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_float32(const float* data,
+                              int64_t offset,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  const std::shared_ptr<void> ReducerCount::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    return apply_bool(reinterpret_cast<const bool*>(data), offset, starts, parents, outlength);
+  const std::shared_ptr<void>
+  ReducerCount::apply_float64(const double* data,
+                              int64_t offset,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength) const {
+    return apply_bool(reinterpret_cast<const bool*>(data),
+                      offset,
+                      starts,
+                      parents,
+                      outlength);
   }
 
-  /////////////////////////////////////////////////////////////// count nonzero
+  ////////// count nonzero
 
-  const std::string ReducerCountNonzero::name() const {
+  const std::string
+  ReducerCountNonzero::name() const {
     return "count_nonzero";
   }
 
-  const std::string ReducerCountNonzero::preferred_type() const {
+  const std::string
+  ReducerCountNonzero::preferred_type() const {
     return "d";
   }
 
-  ssize_t ReducerCountNonzero::preferred_typesize() const {
+  ssize_t
+  ReducerCountNonzero::preferred_typesize() const {
     return 8;
   }
 
-  const std::string ReducerCountNonzero::return_type(const std::string& given_type) const {
+  const std::string
+  ReducerCountNonzero::return_type(const std::string& given_type) const {
 #if defined _MSC_VER || defined __i386__
     return "q";
 #else
@@ -167,12 +274,19 @@ namespace awkward {
 #endif
   }
 
-  ssize_t ReducerCountNonzero::return_typesize(const std::string& given_type) const {
+  ssize_t
+  ReducerCountNonzero::return_typesize(const std::string& given_type) const {
     return 8;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_bool(const bool* data,
+                                  int64_t offset,
+                                  const Index64& starts,
+                                  const Index64& parents,
+                                  int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_bool_64(
       ptr.get(),
       data,
@@ -185,8 +299,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_int8(const int8_t* data,
+                                  int64_t offset,
+                                  const Index64& starts,
+                                  const Index64& parents,
+                                  int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_int8_64(
       ptr.get(),
       data,
@@ -199,8 +319,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_uint8(const uint8_t* data,
+                                   int64_t offset,
+                                   const Index64& starts,
+                                   const Index64& parents,
+                                   int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_uint8_64(
       ptr.get(),
       data,
@@ -213,8 +339,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_int16(const int16_t* data,
+                                   int64_t offset,
+                                   const Index64& starts,
+                                   const Index64& parents,
+                                   int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_int16_64(
       ptr.get(),
       data,
@@ -227,8 +359,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_uint16(const uint16_t* data,
+                                    int64_t offset,
+                                    const Index64& starts,
+                                    const Index64& parents,
+                                    int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_uint16_64(
       ptr.get(),
       data,
@@ -241,8 +379,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_int32(const int32_t* data,
+                                   int64_t offset,
+                                   const Index64& starts,
+                                   const Index64& parents,
+                                   int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_int32_64(
       ptr.get(),
       data,
@@ -255,8 +399,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_uint32(const uint32_t* data,
+                                    int64_t offset,
+                                    const Index64& starts,
+                                    const Index64& parents,
+                                    int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_uint32_64(
       ptr.get(),
       data,
@@ -269,8 +419,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_int64(const int64_t* data,
+                                   int64_t offset,
+                                   const Index64& starts,
+                                   const Index64& parents,
+                                   int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_int64_64(
       ptr.get(),
       data,
@@ -283,8 +439,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_uint64(const uint64_t* data,
+                                    int64_t offset,
+                                    const Index64& starts,
+                                    const Index64& parents,
+                                    int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_uint64_64(
       ptr.get(),
       data,
@@ -297,8 +459,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_float32(const float* data,
+                                     int64_t offset,
+                                     const Index64& starts,
+                                     const Index64& parents,
+                                     int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_float32_64(
       ptr.get(),
       data,
@@ -311,8 +479,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerCountNonzero::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerCountNonzero::apply_float64(const double* data,
+                                     int64_t offset,
+                                     const Index64& starts,
+                                     const Index64& parents,
+                                     int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_countnonzero_float64_64(
       ptr.get(),
       data,
@@ -325,23 +499,27 @@ namespace awkward {
     return ptr;
   }
 
-  /////////////////////////////////////////////////////////////// sum (addition)
+  ////////// sum (addition)
 
-  const std::string ReducerSum::name() const {
+  const std::string
+  ReducerSum::name() const {
     return "sum";
   }
 
-  const std::string ReducerSum::preferred_type() const {
+  const std::string
+  ReducerSum::preferred_type() const {
     return "d";
   }
 
-  ssize_t ReducerSum::preferred_typesize() const {
+  ssize_t
+  ReducerSum::preferred_typesize() const {
     return 8;
   }
 
-  const std::string ReducerSum::return_type(const std::string& given_type) const {
+  const std::string
+  ReducerSum::return_type(const std::string& given_type) const {
 #if defined _MSC_VER || defined __i386__
-    // if the NumPy array is 64-bit, even Windows and 32-bit platforms return 64-bit
+    // if the array is 64-bit, even Windows and 32-bit platforms return 64-bit
     if (given_type.compare("q") == 0) {
       return "q";
     }
@@ -355,8 +533,8 @@ namespace awkward {
         given_type.compare("i") == 0  ||
         given_type.compare("l") == 0  ||
         given_type.compare("q") == 0) {
-      // for _MSC_VER or __i386__, "l" means 32-bit, and that's what the default dtype should be
-      // for MacOS/Linux 64-bit,   "l" means 64-bit, and that's what the default dtype should be
+      // for _MSC_VER or __i386__, "l" means 32-bit
+      // for MacOS/Linux 64-bit,   "l" means 64-bit
       return "l";
     }
     else if (
@@ -365,8 +543,8 @@ namespace awkward {
         given_type.compare("I") == 0  ||
         given_type.compare("L") == 0  ||
         given_type.compare("Q") == 0) {
-      // for _MSC_VER or __i386__, "L" means unsigned 32-bit, and that's what the default dtype should be
-      // for MacOS/Linux 64-bit,   "L" means unsigned 64-bit, and that's what the default dtype should be
+      // for _MSC_VER or __i386__, "L" means unsigned 32-bit
+      // for MacOS/Linux 64-bit,   "L" means unsigned 64-bit
       return "L";
     }
     else {
@@ -374,7 +552,8 @@ namespace awkward {
     }
   }
 
-  ssize_t ReducerSum::return_typesize(const std::string& given_type) const {
+  ssize_t
+  ReducerSum::return_typesize(const std::string& given_type) const {
 #if defined _MSC_VER || defined __i386__
     if (given_type.compare("q") == 0  ||
         given_type.compare("Q") == 0) {
@@ -409,9 +588,15 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerSum::apply_bool(const bool* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_sum_int32_bool_64(
       ptr.get(),
       data,
@@ -421,7 +606,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_sum_int64_bool_64(
       ptr.get(),
       data,
@@ -435,9 +621,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerSum::apply_int8(const int8_t* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_sum_int32_int8_64(
       ptr.get(),
       data,
@@ -447,7 +639,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_sum_int64_int8_64(
       ptr.get(),
       data,
@@ -461,9 +654,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerSum::apply_uint8(const uint8_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength], util::array_deleter<uint32_t>());
+    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength],
+                                  util::array_deleter<uint32_t>());
     struct Error err = awkward_reduce_sum_uint32_uint8_64(
       ptr.get(),
       data,
@@ -473,7 +672,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_sum_uint64_uint8_64(
       ptr.get(),
       data,
@@ -487,9 +687,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerSum::apply_int16(const int16_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_sum_int32_int16_64(
       ptr.get(),
       data,
@@ -499,7 +705,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_sum_int64_int16_64(
       ptr.get(),
       data,
@@ -513,9 +720,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerSum::apply_uint16(const uint16_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength], util::array_deleter<uint32_t>());
+    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength],
+                                  util::array_deleter<uint32_t>());
     struct Error err = awkward_reduce_sum_uint32_uint16_64(
       ptr.get(),
       data,
@@ -525,7 +738,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_sum_uint64_uint16_64(
       ptr.get(),
       data,
@@ -539,9 +753,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerSum::apply_int32(const int32_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_sum_int32_int32_64(
       ptr.get(),
       data,
@@ -551,7 +771,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_sum_int64_int32_64(
       ptr.get(),
       data,
@@ -565,9 +786,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerSum::apply_uint32(const uint32_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength], util::array_deleter<uint32_t>());
+    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength],
+                                  util::array_deleter<uint32_t>());
     struct Error err = awkward_reduce_sum_uint32_uint32_64(
       ptr.get(),
       data,
@@ -577,7 +804,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_sum_uint64_uint32_64(
       ptr.get(),
       data,
@@ -591,8 +819,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerSum::apply_int64(const int64_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_sum_int64_int64_64(
       ptr.get(),
       data,
@@ -605,8 +839,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+  const std::shared_ptr<void>
+  ReducerSum::apply_uint64(const uint64_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_sum_uint64_uint64_64(
       ptr.get(),
       data,
@@ -619,8 +859,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<float> ptr(new float[(size_t)outlength], util::array_deleter<float>());
+  const std::shared_ptr<void>
+  ReducerSum::apply_float32(const float* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<float> ptr(new float[(size_t)outlength],
+                               util::array_deleter<float>());
     struct Error err = awkward_reduce_sum_float32_float32_64(
       ptr.get(),
       data,
@@ -633,8 +879,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerSum::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<double> ptr(new double[(size_t)outlength], util::array_deleter<double>());
+  const std::shared_ptr<void>
+  ReducerSum::apply_float64(const double* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<double> ptr(new double[(size_t)outlength],
+                                util::array_deleter<double>());
     struct Error err = awkward_reduce_sum_float64_float64_64(
       ptr.get(),
       data,
@@ -647,13 +899,15 @@ namespace awkward {
     return ptr;
   }
 
-  /////////////////////////////////////////////////////////////// prod (multiplication)
+  ////////// prod (multiplication)
 
-  const std::string ReducerProd::name() const {
+  const std::string
+  ReducerProd::name() const {
     return "prod";
   }
 
-  const std::string ReducerProd::preferred_type() const {
+  const std::string
+  ReducerProd::preferred_type() const {
 #if defined _MSC_VER || defined __i386__
     return "q";
 #else
@@ -661,13 +915,15 @@ namespace awkward {
 #endif
   }
 
-  ssize_t ReducerProd::preferred_typesize() const {
+  ssize_t
+  ReducerProd::preferred_typesize() const {
     return 8;
   }
 
-  const std::string ReducerProd::return_type(const std::string& given_type) const {
+  const std::string
+  ReducerProd::return_type(const std::string& given_type) const {
 #if defined _MSC_VER || defined __i386__
-    // if the NumPy array is 64-bit, even Windows and 32-bit platforms return 64-bit
+    // if the array is 64-bit, even Windows and 32-bit platforms return 64-bit
     if (given_type.compare("q") == 0) {
       return "q";
     }
@@ -681,8 +937,8 @@ namespace awkward {
         given_type.compare("i") == 0  ||
         given_type.compare("l") == 0  ||
         given_type.compare("q") == 0) {
-      // for _MSC_VER or __i386__, "l" means 32-bit, and that's what the default dtype should be
-      // for MacOS/Linux 64-bit,   "l" means 64-bit, and that's what the default dtype should be
+      // for _MSC_VER or __i386__, "l" means 32-bit
+      // for MacOS/Linux 64-bit,   "l" means 64-bit
       return "l";
     }
     else if (
@@ -691,8 +947,8 @@ namespace awkward {
         given_type.compare("I") == 0  ||
         given_type.compare("L") == 0  ||
         given_type.compare("Q") == 0) {
-      // for _MSC_VER or __i386__, "L" means unsigned 32-bit, and that's what the default dtype should be
-      // for MacOS/Linux 64-bit,   "L" means unsigned 64-bit, and that's what the default dtype should be
+      // for _MSC_VER or __i386__, "L" means unsigned 32-bit
+      // for MacOS/Linux 64-bit,   "L" means unsigned 64-bit
       return "L";
     }
     else {
@@ -700,7 +956,8 @@ namespace awkward {
     }
   }
 
-  ssize_t ReducerProd::return_typesize(const std::string& given_type) const {
+  ssize_t
+  ReducerProd::return_typesize(const std::string& given_type) const {
 #if defined _MSC_VER || defined __i386__
     if (given_type.compare("q") == 0  ||
         given_type.compare("Q") == 0) {
@@ -735,9 +992,15 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerProd::apply_bool(const bool* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_prod_int32_bool_64(
       ptr.get(),
       data,
@@ -747,7 +1010,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_prod_int64_bool_64(
       ptr.get(),
       data,
@@ -761,9 +1025,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerProd::apply_int8(const int8_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_prod_int32_int8_64(
       ptr.get(),
       data,
@@ -773,7 +1043,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_prod_int64_int8_64(
       ptr.get(),
       data,
@@ -787,9 +1058,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerProd::apply_uint8(const uint8_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength], util::array_deleter<uint32_t>());
+    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength],
+                                  util::array_deleter<uint32_t>());
     struct Error err = awkward_reduce_prod_uint32_uint8_64(
       ptr.get(),
       data,
@@ -799,7 +1076,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_prod_uint64_uint8_64(
       ptr.get(),
       data,
@@ -813,9 +1091,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerProd::apply_int16(const int16_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_prod_int32_int16_64(
       ptr.get(),
       data,
@@ -825,7 +1109,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_prod_int64_int16_64(
       ptr.get(),
       data,
@@ -839,9 +1124,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerProd::apply_uint16(const uint16_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength], util::array_deleter<uint32_t>());
+    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength],
+                                  util::array_deleter<uint32_t>());
     struct Error err = awkward_reduce_prod_uint32_uint16_64(
       ptr.get(),
       data,
@@ -851,7 +1142,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_prod_uint64_uint16_64(
       ptr.get(),
       data,
@@ -865,9 +1157,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerProd::apply_int32(const int32_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_prod_int32_int32_64(
       ptr.get(),
       data,
@@ -877,7 +1175,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_prod_int64_int32_64(
       ptr.get(),
       data,
@@ -891,9 +1190,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
+  const std::shared_ptr<void>
+  ReducerProd::apply_uint32(const uint32_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
 #if defined _MSC_VER || defined __i386__
-    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength], util::array_deleter<uint32_t>());
+    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength],
+                                  util::array_deleter<uint32_t>());
     struct Error err = awkward_reduce_prod_uint32_uint32_64(
       ptr.get(),
       data,
@@ -903,7 +1208,8 @@ namespace awkward {
       parents.length(),
       outlength);
 #else
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_prod_uint64_uint32_64(
       ptr.get(),
       data,
@@ -917,8 +1223,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerProd::apply_int64(const int64_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_prod_int64_int64_64(
       ptr.get(),
       data,
@@ -931,8 +1243,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+  const std::shared_ptr<void>
+  ReducerProd::apply_uint64(const uint64_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_prod_uint64_uint64_64(
       ptr.get(),
       data,
@@ -945,8 +1263,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<float> ptr(new float[(size_t)outlength], util::array_deleter<float>());
+  const std::shared_ptr<void>
+  ReducerProd::apply_float32(const float* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<float> ptr(new float[(size_t)outlength],
+                               util::array_deleter<float>());
     struct Error err = awkward_reduce_prod_float32_float32_64(
       ptr.get(),
       data,
@@ -959,8 +1283,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerProd::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<double> ptr(new double[(size_t)outlength], util::array_deleter<double>());
+  const std::shared_ptr<void>
+  ReducerProd::apply_float64(const double* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<double> ptr(new double[(size_t)outlength],
+                                util::array_deleter<double>());
     struct Error err = awkward_reduce_prod_float64_float64_64(
       ptr.get(),
       data,
@@ -973,30 +1303,41 @@ namespace awkward {
     return ptr;
   }
 
-  /////////////////////////////////////////////////////////////// any (logical or)
+  ////////// any (logical or)
 
-  const std::string ReducerAny::name() const {
+  const std::string
+  ReducerAny::name() const {
     return "any";
   }
 
-  const std::string ReducerAny::preferred_type() const {
+  const std::string
+  ReducerAny::preferred_type() const {
     return "?";
   }
 
-  ssize_t ReducerAny::preferred_typesize() const {
+  ssize_t
+  ReducerAny::preferred_typesize() const {
     return 1;
   }
 
-  const std::string ReducerAny::return_type(const std::string& given_type) const {
+  const std::string
+  ReducerAny::return_type(const std::string& given_type) const {
     return "?";
   }
 
-  ssize_t ReducerAny::return_typesize(const std::string& given_type) const {
+  ssize_t
+  ReducerAny::return_typesize(const std::string& given_type) const {
     return 1;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_bool(const bool* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_bool_64(
       ptr.get(),
       data,
@@ -1009,8 +1350,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_int8(const int8_t* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_int8_64(
       ptr.get(),
       data,
@@ -1023,8 +1370,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_uint8(const uint8_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_uint8_64(
       ptr.get(),
       data,
@@ -1037,8 +1390,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_int16(const int16_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_int16_64(
       ptr.get(),
       data,
@@ -1051,8 +1410,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_uint16(const uint16_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_uint16_64(
       ptr.get(),
       data,
@@ -1065,8 +1430,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_int32(const int32_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_int32_64(
       ptr.get(),
       data,
@@ -1079,8 +1450,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_uint32(const uint32_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_uint32_64(
       ptr.get(),
       data,
@@ -1093,8 +1470,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_int64(const int64_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_int64_64(
       ptr.get(),
       data,
@@ -1107,8 +1490,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_uint64(const uint64_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_uint64_64(
       ptr.get(),
       data,
@@ -1121,8 +1510,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_float32(const float* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_float32_64(
       ptr.get(),
       data,
@@ -1135,8 +1530,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAny::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAny::apply_float64(const double* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_float64_64(
       ptr.get(),
       data,
@@ -1149,30 +1550,41 @@ namespace awkward {
     return ptr;
   }
 
-  /////////////////////////////////////////////////////////////// all (logical and)
+  ////////// all (logical and)
 
-  const std::string ReducerAll::name() const {
+  const std::string
+  ReducerAll::name() const {
     return "all";
   }
 
-  const std::string ReducerAll::preferred_type() const {
+  const std::string
+  ReducerAll::preferred_type() const {
     return "?";
   }
 
-  ssize_t ReducerAll::preferred_typesize() const {
+  ssize_t
+  ReducerAll::preferred_typesize() const {
     return 1;
   }
 
-  const std::string ReducerAll::return_type(const std::string& given_type) const {
+  const std::string
+  ReducerAll::return_type(const std::string& given_type) const {
     return "?";
   }
 
-  ssize_t ReducerAll::return_typesize(const std::string& given_type) const {
+  ssize_t
+  ReducerAll::return_typesize(const std::string& given_type) const {
     return 1;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_bool(const bool* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_bool_64(
       ptr.get(),
       data,
@@ -1185,8 +1597,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_int8(const int8_t* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_int8_64(
       ptr.get(),
       data,
@@ -1199,8 +1617,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_uint8(const uint8_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_uint8_64(
       ptr.get(),
       data,
@@ -1213,8 +1637,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_int16(const int16_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_int16_64(
       ptr.get(),
       data,
@@ -1227,8 +1657,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_uint16(const uint16_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_uint16_64(
       ptr.get(),
       data,
@@ -1241,8 +1677,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_int32(const int32_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_int32_64(
       ptr.get(),
       data,
@@ -1255,8 +1697,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_uint32(const uint32_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_uint32_64(
       ptr.get(),
       data,
@@ -1269,8 +1717,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_int64(const int64_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_int64_64(
       ptr.get(),
       data,
@@ -1283,8 +1737,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_uint64(const uint64_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_uint64_64(
       ptr.get(),
       data,
@@ -1297,8 +1757,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_float32(const float* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_float32_64(
       ptr.get(),
       data,
@@ -1311,8 +1777,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerAll::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerAll::apply_float64(const double* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_float64_64(
       ptr.get(),
       data,
@@ -1325,22 +1797,31 @@ namespace awkward {
     return ptr;
   }
 
-  /////////////////////////////////////////////////////////////// min (minimum, in which infinity is the identity)
+  ////////// min (minimum, in which infinity is the identity)
 
-  const std::string ReducerMin::name() const {
+  const std::string
+  ReducerMin::name() const {
     return "min";
   }
 
-  const std::string ReducerMin::preferred_type() const {
+  const std::string
+  ReducerMin::preferred_type() const {
     return "d";
   }
 
-  ssize_t ReducerMin::preferred_typesize() const {
+  ssize_t
+  ReducerMin::preferred_typesize() const {
     return 8;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_bool(const bool* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_prod_bool_bool_64(
       ptr.get(),
       data,
@@ -1353,8 +1834,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int8_t> ptr(new int8_t[(size_t)outlength], util::array_deleter<int8_t>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_int8(const int8_t* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
+    std::shared_ptr<int8_t> ptr(new int8_t[(size_t)outlength],
+                                util::array_deleter<int8_t>());
     struct Error err = awkward_reduce_min_int8_int8_64(
       ptr.get(),
       data,
@@ -1368,8 +1855,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint8_t> ptr(new uint8_t[(size_t)outlength], util::array_deleter<uint8_t>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_uint8(const uint8_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<uint8_t> ptr(new uint8_t[(size_t)outlength],
+                                 util::array_deleter<uint8_t>());
     struct Error err = awkward_reduce_min_uint8_uint8_64(
       ptr.get(),
       data,
@@ -1383,8 +1876,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int16_t> ptr(new int16_t[(size_t)outlength], util::array_deleter<int16_t>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_int16(const int16_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<int16_t> ptr(new int16_t[(size_t)outlength],
+                                 util::array_deleter<int16_t>());
     struct Error err = awkward_reduce_min_int16_int16_64(
       ptr.get(),
       data,
@@ -1398,8 +1897,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint16_t> ptr(new uint16_t[(size_t)outlength], util::array_deleter<uint16_t>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_uint16(const uint16_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<uint16_t> ptr(new uint16_t[(size_t)outlength],
+                                  util::array_deleter<uint16_t>());
     struct Error err = awkward_reduce_min_uint16_uint16_64(
       ptr.get(),
       data,
@@ -1413,8 +1918,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_int32(const int32_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_min_int32_int32_64(
       ptr.get(),
       data,
@@ -1428,8 +1939,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength], util::array_deleter<uint32_t>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_uint32(const uint32_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength],
+                                  util::array_deleter<uint32_t>());
     struct Error err = awkward_reduce_min_uint32_uint32_64(
       ptr.get(),
       data,
@@ -1443,8 +1960,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_int64(const int64_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_min_int64_int64_64(
       ptr.get(),
       data,
@@ -1458,8 +1981,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_uint64(const uint64_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_min_uint64_uint64_64(
       ptr.get(),
       data,
@@ -1473,8 +2002,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<float> ptr(new float[(size_t)outlength], util::array_deleter<float>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_float32(const float* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<float> ptr(new float[(size_t)outlength],
+                               util::array_deleter<float>());
     struct Error err = awkward_reduce_min_float32_float32_64(
       ptr.get(),
       data,
@@ -1488,8 +2023,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMin::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<double> ptr(new double[(size_t)outlength], util::array_deleter<double>());
+  const std::shared_ptr<void>
+  ReducerMin::apply_float64(const double* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<double> ptr(new double[(size_t)outlength],
+                                util::array_deleter<double>());
     struct Error err = awkward_reduce_min_float64_float64_64(
       ptr.get(),
       data,
@@ -1503,22 +2044,31 @@ namespace awkward {
     return ptr;
   }
 
-  /////////////////////////////////////////////////////////////// max (maximum, in which -infinity is the identity)
+  ////////// max (maximum, in which -infinity is the identity)
 
-  const std::string ReducerMax::name() const {
+  const std::string
+  ReducerMax::name() const {
     return "max";
   }
 
-  const std::string ReducerMax::preferred_type() const {
+  const std::string
+  ReducerMax::preferred_type() const {
     return "d";
   }
 
-  ssize_t ReducerMax::preferred_typesize() const {
+  ssize_t
+  ReducerMax::preferred_typesize() const {
     return 8;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<bool> ptr(new bool[(size_t)outlength], util::array_deleter<bool>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_bool(const bool* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
+    std::shared_ptr<bool> ptr(new bool[(size_t)outlength],
+                              util::array_deleter<bool>());
     struct Error err = awkward_reduce_sum_bool_bool_64(
       ptr.get(),
       data,
@@ -1531,8 +2081,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int8_t> ptr(new int8_t[(size_t)outlength], util::array_deleter<int8_t>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_int8(const int8_t* data,
+                         int64_t offset,
+                         const Index64& starts,
+                         const Index64& parents,
+                         int64_t outlength) const {
+    std::shared_ptr<int8_t> ptr(new int8_t[(size_t)outlength],
+                                util::array_deleter<int8_t>());
     struct Error err = awkward_reduce_max_int8_int8_64(
       ptr.get(),
       data,
@@ -1546,8 +2102,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint8_t> ptr(new uint8_t[(size_t)outlength], util::array_deleter<uint8_t>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_uint8(const uint8_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<uint8_t> ptr(new uint8_t[(size_t)outlength],
+                                 util::array_deleter<uint8_t>());
     struct Error err = awkward_reduce_max_uint8_uint8_64(
       ptr.get(),
       data,
@@ -1561,8 +2123,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int16_t> ptr(new int16_t[(size_t)outlength], util::array_deleter<int16_t>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_int16(const int16_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<int16_t> ptr(new int16_t[(size_t)outlength],
+                                 util::array_deleter<int16_t>());
     struct Error err = awkward_reduce_max_int16_int16_64(
       ptr.get(),
       data,
@@ -1576,8 +2144,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint16_t> ptr(new uint16_t[(size_t)outlength], util::array_deleter<uint16_t>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_uint16(const uint16_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<uint16_t> ptr(new uint16_t[(size_t)outlength],
+                                  util::array_deleter<uint16_t>());
     struct Error err = awkward_reduce_max_uint16_uint16_64(
       ptr.get(),
       data,
@@ -1591,8 +2165,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength], util::array_deleter<int32_t>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_int32(const int32_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<int32_t> ptr(new int32_t[(size_t)outlength],
+                                 util::array_deleter<int32_t>());
     struct Error err = awkward_reduce_max_int32_int32_64(
       ptr.get(),
       data,
@@ -1606,8 +2186,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength], util::array_deleter<uint32_t>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_uint32(const uint32_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<uint32_t> ptr(new uint32_t[(size_t)outlength],
+                                  util::array_deleter<uint32_t>());
     struct Error err = awkward_reduce_max_uint32_uint32_64(
       ptr.get(),
       data,
@@ -1621,8 +2207,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_int64(const int64_t* data,
+                          int64_t offset,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_max_int64_int64_64(
       ptr.get(),
       data,
@@ -1636,8 +2228,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength], util::array_deleter<uint64_t>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_uint64(const uint64_t* data,
+                           int64_t offset,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength) const {
+    std::shared_ptr<uint64_t> ptr(new uint64_t[(size_t)outlength],
+                                  util::array_deleter<uint64_t>());
     struct Error err = awkward_reduce_max_uint64_uint64_64(
       ptr.get(),
       data,
@@ -1651,8 +2249,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<float> ptr(new float[(size_t)outlength], util::array_deleter<float>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_float32(const float* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<float> ptr(new float[(size_t)outlength],
+                               util::array_deleter<float>());
     struct Error err = awkward_reduce_max_float32_float32_64(
       ptr.get(),
       data,
@@ -1666,8 +2270,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerMax::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<double> ptr(new double[(size_t)outlength], util::array_deleter<double>());
+  const std::shared_ptr<void>
+  ReducerMax::apply_float64(const double* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<double> ptr(new double[(size_t)outlength],
+                                util::array_deleter<double>());
     struct Error err = awkward_reduce_max_float64_float64_64(
       ptr.get(),
       data,
@@ -1681,13 +2291,15 @@ namespace awkward {
     return ptr;
   }
 
-  /////////////////////////////////////////////////////////////// argmin (argument minimum, in which -1 is the identity)
+  ////////// argmin (argument minimum, in which -1 is the identity)
 
-  const std::string ReducerArgmin::name() const {
+  const std::string
+  ReducerArgmin::name() const {
     return "argmin";
   }
 
-  const std::string ReducerArgmin::preferred_type() const {
+  const std::string
+  ReducerArgmin::preferred_type() const {
 #if defined _MSC_VER || defined __i386__
     return "q";
 #else
@@ -1695,11 +2307,13 @@ namespace awkward {
 #endif
   }
 
-  ssize_t ReducerArgmin::preferred_typesize() const {
+  ssize_t
+  ReducerArgmin::preferred_typesize() const {
     return 8;
   }
 
-  const std::string ReducerArgmin::return_type(const std::string& given_type) const {
+  const std::string
+  ReducerArgmin::return_type(const std::string& given_type) const {
 #if defined _MSC_VER || defined __i386__
     return "q";
 #else
@@ -1707,12 +2321,19 @@ namespace awkward {
 #endif
   }
 
-  ssize_t ReducerArgmin::return_typesize(const std::string& given_type) const {
+  ssize_t
+  ReducerArgmin::return_typesize(const std::string& given_type) const {
     return 8;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_bool(const bool* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_bool_64(
       ptr.get(),
       data,
@@ -1727,8 +2348,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_int8(const int8_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_int8_64(
       ptr.get(),
       data,
@@ -1743,8 +2370,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_uint8(const uint8_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_uint8_64(
       ptr.get(),
       data,
@@ -1759,8 +2392,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_int16(const int16_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_int16_64(
       ptr.get(),
       data,
@@ -1775,8 +2414,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_uint16(const uint16_t* data,
+                              int64_t offset,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_uint16_64(
       ptr.get(),
       data,
@@ -1791,8 +2436,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_int32(const int32_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_int32_64(
       ptr.get(),
       data,
@@ -1807,8 +2458,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_uint32(const uint32_t* data,
+                              int64_t offset,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_uint32_64(
       ptr.get(),
       data,
@@ -1823,8 +2480,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_int64(const int64_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_int64_64(
       ptr.get(),
       data,
@@ -1839,8 +2502,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_uint64(const uint64_t* data,
+                              int64_t offset,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_uint64_64(
       ptr.get(),
       data,
@@ -1855,8 +2524,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_float32(const float* data,
+                               int64_t offset,
+                               const Index64& starts,
+                               const Index64& parents,
+                               int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_float32_64(
       ptr.get(),
       data,
@@ -1871,8 +2546,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmin::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmin::apply_float64(const double* data,
+                               int64_t offset,
+                               const Index64& starts,
+                               const Index64& parents,
+                               int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmin_float64_64(
       ptr.get(),
       data,
@@ -1887,13 +2568,15 @@ namespace awkward {
     return ptr;
   }
 
-  /////////////////////////////////////////////////////////////// argmax (argument maximum, in which -1 is the identity)
+  ////////// argmax (argument maximum, in which -1 is the identity)
 
-  const std::string ReducerArgmax::name() const {
+  const std::string
+  ReducerArgmax::name() const {
     return "argmax";
   }
 
-  const std::string ReducerArgmax::preferred_type() const {
+  const std::string
+  ReducerArgmax::preferred_type() const {
 #if defined _MSC_VER || defined __i386__
     return "q";
 #else
@@ -1901,11 +2584,13 @@ namespace awkward {
 #endif
   }
 
-  ssize_t ReducerArgmax::preferred_typesize() const {
+  ssize_t
+  ReducerArgmax::preferred_typesize() const {
     return 8;
   }
 
-  const std::string ReducerArgmax::return_type(const std::string& given_type) const {
+  const std::string
+  ReducerArgmax::return_type(const std::string& given_type) const {
 #if defined _MSC_VER || defined __i386__
     return "q";
 #else
@@ -1913,12 +2598,19 @@ namespace awkward {
 #endif
   }
 
-  ssize_t ReducerArgmax::return_typesize(const std::string& given_type) const {
+  ssize_t
+  ReducerArgmax::return_typesize(const std::string& given_type) const {
     return 8;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_bool(const bool* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_bool(const bool* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_bool_64(
       ptr.get(),
       data,
@@ -1933,8 +2625,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_int8(const int8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_int8(const int8_t* data,
+                            int64_t offset,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_int8_64(
       ptr.get(),
       data,
@@ -1949,8 +2647,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_uint8(const uint8_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_uint8(const uint8_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_uint8_64(
       ptr.get(),
       data,
@@ -1965,8 +2669,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_int16(const int16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_int16(const int16_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_int16_64(
       ptr.get(),
       data,
@@ -1981,8 +2691,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_uint16(const uint16_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_uint16(const uint16_t* data,
+                              int64_t offset,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_uint16_64(
       ptr.get(),
       data,
@@ -1997,8 +2713,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_int32(const int32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_int32(const int32_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_int32_64(
       ptr.get(),
       data,
@@ -2013,8 +2735,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_uint32(const uint32_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_uint32(const uint32_t* data,
+                              int64_t offset,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_uint32_64(
       ptr.get(),
       data,
@@ -2029,8 +2757,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_int64(const int64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_int64(const int64_t* data,
+                             int64_t offset,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_int64_64(
       ptr.get(),
       data,
@@ -2045,8 +2779,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_uint64(const uint64_t* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_uint64(const uint64_t* data,
+                              int64_t offset,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_uint64_64(
       ptr.get(),
       data,
@@ -2061,8 +2801,14 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_float32(const float* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_float32(const float* data,
+                               int64_t offset,
+                               const Index64& starts,
+                               const Index64& parents,
+                               int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_float32_64(
       ptr.get(),
       data,
@@ -2077,8 +2823,15 @@ namespace awkward {
     return ptr;
   }
 
-  const std::shared_ptr<void> ReducerArgmax::apply_float64(const double* data, int64_t offset, const Index64& starts, const Index64& parents, int64_t outlength) const {
-    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength], util::array_deleter<int64_t>());
+  const std::shared_ptr<void>
+  ReducerArgmax::apply_float64(const double* data,
+                               int64_t offset,
+                               const Index64& starts,
+                               const Index64& parents,
+                               int64_t outlength) const {
+    std::shared_ptr<int64_t> ptr(new int64_t[(size_t)outlength],
+                                
+                                 util::array_deleter<int64_t>());
     struct Error err = awkward_reduce_argmax_float64_64(
       ptr.get(),
       data,

--- a/src/libawkward/Slice.cpp
+++ b/src/libawkward/Slice.cpp
@@ -25,7 +25,7 @@ namespace awkward {
     return at_;
   }
 
-  const std::shared_ptr<SliceItem> SliceAt::shallow_copy() const {
+  const SliceItemPtr SliceAt::shallow_copy() const {
     return std::make_shared<SliceAt>(at_);
   }
 
@@ -68,7 +68,7 @@ namespace awkward {
     return stop_ != none();
   }
 
-  const std::shared_ptr<SliceItem> SliceRange::shallow_copy() const {
+  const SliceItemPtr SliceRange::shallow_copy() const {
     return std::make_shared<SliceRange>(start_, stop_, step_);
   }
 
@@ -95,7 +95,7 @@ namespace awkward {
 
   SliceEllipsis::SliceEllipsis() { }
 
-  const std::shared_ptr<SliceItem> SliceEllipsis::shallow_copy() const {
+  const SliceItemPtr SliceEllipsis::shallow_copy() const {
     return std::make_shared<SliceEllipsis>();
   }
 
@@ -111,7 +111,7 @@ namespace awkward {
 
   SliceNewAxis::SliceNewAxis() { }
 
-  const std::shared_ptr<SliceItem> SliceNewAxis::shallow_copy() const {
+  const SliceItemPtr SliceNewAxis::shallow_copy() const {
     return std::make_shared<SliceNewAxis>();
   }
 
@@ -170,7 +170,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<SliceItem> SliceArrayOf<T>::shallow_copy() const {
+  const SliceItemPtr SliceArrayOf<T>::shallow_copy() const {
     return std::make_shared<SliceArrayOf<T>>(index_, shape_, strides_, frombool_);
   }
 
@@ -279,7 +279,7 @@ namespace awkward {
     return key_;
   }
 
-  const std::shared_ptr<SliceItem> SliceField::shallow_copy() const {
+  const SliceItemPtr SliceField::shallow_copy() const {
     return std::make_shared<SliceField>(key_);
   }
 
@@ -300,7 +300,7 @@ namespace awkward {
     return keys_;
   }
 
-  const std::shared_ptr<SliceItem> SliceFields::shallow_copy() const {
+  const SliceItemPtr SliceFields::shallow_copy() const {
     return std::make_shared<SliceFields>(keys_);
   }
 
@@ -324,7 +324,7 @@ namespace awkward {
   /////////////////////////////////////////////////////// SliceMissingOf<T>
 
   template <typename T>
-  SliceMissingOf<T>::SliceMissingOf(const IndexOf<T>& index, const Index8& originalmask, const std::shared_ptr<SliceItem>& content)
+  SliceMissingOf<T>::SliceMissingOf(const IndexOf<T>& index, const Index8& originalmask, const SliceItemPtr& content)
       : index_(index)
       , originalmask_(originalmask)
       , content_(content) { }
@@ -345,12 +345,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<SliceItem> SliceMissingOf<T>::content() const {
+  const SliceItemPtr SliceMissingOf<T>::content() const {
     return content_;
   }
 
   template <typename T>
-  const std::shared_ptr<SliceItem> SliceMissingOf<T>::shallow_copy() const {
+  const SliceItemPtr SliceMissingOf<T>::shallow_copy() const {
     return std::make_shared<SliceMissingOf<T>>(index_, originalmask_, content_);
   }
 
@@ -400,7 +400,7 @@ namespace awkward {
   /////////////////////////////////////////////////////// SliceJaggedOf<T>
 
   template <typename T>
-  SliceJaggedOf<T>::SliceJaggedOf(const IndexOf<T>& offsets, const std::shared_ptr<SliceItem>& content)
+  SliceJaggedOf<T>::SliceJaggedOf(const IndexOf<T>& offsets, const SliceItemPtr& content)
       : offsets_(offsets)
       , content_(content) { }
 
@@ -415,12 +415,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<SliceItem> SliceJaggedOf<T>::content() const {
+  const SliceItemPtr SliceJaggedOf<T>::content() const {
     return content_;
   }
 
   template <typename T>
-  const std::shared_ptr<SliceItem> SliceJaggedOf<T>::shallow_copy() const {
+  const SliceItemPtr SliceJaggedOf<T>::shallow_copy() const {
     return std::make_shared<SliceJaggedOf<T>>(offsets_, content_);
   }
 
@@ -474,18 +474,18 @@ namespace awkward {
   }
 
   Slice::Slice()
-      : items_(std::vector<std::shared_ptr<SliceItem>>())
+      : items_(std::vector<SliceItemPtr>())
       , sealed_(false) { }
 
-  Slice::Slice(const std::vector<std::shared_ptr<SliceItem>>& items)
+  Slice::Slice(const std::vector<SliceItemPtr>& items)
       : items_(items)
       , sealed_(false) { }
 
-  Slice::Slice(const std::vector<std::shared_ptr<SliceItem>>& items, bool sealed)
+  Slice::Slice(const std::vector<SliceItemPtr>& items, bool sealed)
       : items_(items)
       , sealed_(sealed) { }
 
-  const std::vector<std::shared_ptr<SliceItem>> Slice::items() const {
+  const std::vector<SliceItemPtr> Slice::items() const {
     return items_;
   }
 
@@ -513,17 +513,17 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<SliceItem> Slice::head() const {
+  const SliceItemPtr Slice::head() const {
     if (!items_.empty()) {
       return items_[0];
     }
     else {
-      return std::shared_ptr<SliceItem>(nullptr);
+      return SliceItemPtr(nullptr);
     }
   }
 
   const Slice Slice::tail() const {
-    std::vector<std::shared_ptr<SliceItem>> items;
+    std::vector<SliceItemPtr> items;
     if (!items_.empty()) {
       items.insert(items.end(), items_.begin() + 1, items_.end());
     }
@@ -543,7 +543,7 @@ namespace awkward {
     return out.str();
   }
 
-  void Slice::append(const std::shared_ptr<SliceItem>& item) {
+  void Slice::append(const SliceItemPtr& item) {
     if (sealed_) {
       throw std::runtime_error("Slice::append when sealed_ == true");
     }

--- a/src/libawkward/Slice.cpp
+++ b/src/libawkward/Slice.cpp
@@ -10,7 +10,8 @@
 #include "awkward/Slice.h"
 
 namespace awkward {
-  int64_t SliceItem::none() {
+  int64_t
+  SliceItem::none() {
     return kSliceNone;
   }
 
@@ -21,19 +22,23 @@ namespace awkward {
   SliceAt::SliceAt(int64_t at)
       : at_(at) { }
 
-  int64_t SliceAt::at() const {
+  int64_t
+  SliceAt::at() const {
     return at_;
   }
 
-  const SliceItemPtr SliceAt::shallow_copy() const {
+  const SliceItemPtr
+  SliceAt::shallow_copy() const {
     return std::make_shared<SliceAt>(at_);
   }
 
-  const std::string SliceAt::tostring() const {
+  const std::string
+  SliceAt::tostring() const {
     return std::to_string(at_);
   }
 
-  bool SliceAt::preserves_type(const Index64& advanced) const {
+  bool
+  SliceAt::preserves_type(const Index64& advanced) const {
     return false;
   }
 
@@ -48,31 +53,38 @@ namespace awkward {
     }
   }
 
-  int64_t SliceRange::start() const {
+  int64_t
+  SliceRange::start() const {
     return start_;
   }
 
-  int64_t SliceRange::stop() const {
+  int64_t
+  SliceRange::stop() const {
     return stop_;
   }
 
-  int64_t SliceRange::step() const {
+  int64_t
+  SliceRange::step() const {
     return step_;
   }
 
-  bool SliceRange::hasstart() const {
+  bool
+  SliceRange::hasstart() const {
     return start_ != none();
   }
 
-  bool SliceRange::hasstop() const {
+  bool
+  SliceRange::hasstop() const {
     return stop_ != none();
   }
 
-  const SliceItemPtr SliceRange::shallow_copy() const {
+  const SliceItemPtr
+  SliceRange::shallow_copy() const {
     return std::make_shared<SliceRange>(start_, stop_, step_);
   }
 
-  const std::string SliceRange::tostring() const {
+  const std::string
+  SliceRange::tostring() const {
     std::stringstream out;
     if (hasstart()) {
       out << start_;
@@ -87,7 +99,8 @@ namespace awkward {
     return out.str();
   }
 
-  bool SliceRange::preserves_type(const Index64& advanced) const {
+  bool
+  SliceRange::preserves_type(const Index64& advanced) const {
     return true;
   }
 
@@ -95,15 +108,18 @@ namespace awkward {
 
   SliceEllipsis::SliceEllipsis() { }
 
-  const SliceItemPtr SliceEllipsis::shallow_copy() const {
+  const SliceItemPtr
+  SliceEllipsis::shallow_copy() const {
     return std::make_shared<SliceEllipsis>();
   }
 
-  const std::string SliceEllipsis::tostring() const {
+  const std::string
+  SliceEllipsis::tostring() const {
     return std::string("...");
   }
 
-  bool SliceEllipsis::preserves_type(const Index64& advanced) const {
+  bool
+  SliceEllipsis::preserves_type(const Index64& advanced) const {
     return true;
   }
 
@@ -111,22 +127,28 @@ namespace awkward {
 
   SliceNewAxis::SliceNewAxis() { }
 
-  const SliceItemPtr SliceNewAxis::shallow_copy() const {
+  const SliceItemPtr
+  SliceNewAxis::shallow_copy() const {
     return std::make_shared<SliceNewAxis>();
   }
 
-  const std::string SliceNewAxis::tostring() const {
+  const std::string
+  SliceNewAxis::tostring() const {
     return std::string("newaxis");
   }
 
-  bool SliceNewAxis::preserves_type(const Index64& advanced) const {
+  bool
+  SliceNewAxis::preserves_type(const Index64& advanced) const {
     return false;
   }
 
   /////////////////////////////////////////////////////// SliceArrayOf<T>
 
   template <typename T>
-  SliceArrayOf<T>::SliceArrayOf(const IndexOf<T>& index, const std::vector<int64_t>& shape, const std::vector<int64_t>& strides, bool frombool)
+  SliceArrayOf<T>::SliceArrayOf(const IndexOf<T>& index,
+                                const std::vector<int64_t>& shape,
+                                const std::vector<int64_t>& strides,
+                                bool frombool)
       : index_(index)
       , shape_(shape)
       , strides_(strides)
@@ -135,52 +157,65 @@ namespace awkward {
       throw std::runtime_error("shape must not be zero-dimensional");
     }
     if (shape_.size() != strides_.size()) {
-      throw std::runtime_error("shape must have the same number of dimensions as strides");
+      throw std::runtime_error(
+        "shape must have the same number of dimensions as strides");
     }
   }
 
   template <typename T>
-  const IndexOf<T> SliceArrayOf<T>::index() const {
+  const IndexOf<T>
+  SliceArrayOf<T>::index() const {
     return index_;
   }
 
   template <typename T>
-  const int64_t SliceArrayOf<T>::length() const {
+  const int64_t
+  SliceArrayOf<T>::length() const {
     return shape_[0];
   }
 
   template <typename T>
-  const std::vector<int64_t> SliceArrayOf<T>::shape() const {
+  const std::vector<int64_t>
+  SliceArrayOf<T>::shape() const {
     return shape_;
   }
 
   template <typename T>
-  const std::vector<int64_t> SliceArrayOf<T>::strides() const {
+  const std::vector<int64_t>
+  SliceArrayOf<T>::strides() const {
     return strides_;
   }
 
   template <typename T>
-  bool SliceArrayOf<T>::frombool() const {
+  bool
+  SliceArrayOf<T>::frombool() const {
     return frombool_;
   }
 
   template <typename T>
-  int64_t SliceArrayOf<T>::ndim() const {
+  int64_t
+  SliceArrayOf<T>::ndim() const {
     return (int64_t)shape_.size();
   }
 
   template <typename T>
-  const SliceItemPtr SliceArrayOf<T>::shallow_copy() const {
-    return std::make_shared<SliceArrayOf<T>>(index_, shape_, strides_, frombool_);
+  const SliceItemPtr
+  SliceArrayOf<T>::shallow_copy() const {
+    return std::make_shared<SliceArrayOf<T>>(index_,
+                                             shape_,
+                                             strides_,
+                                             frombool_);
   }
 
   template <typename T>
-  const std::string SliceArrayOf<T>::tostring() const {
+  const std::string
+  SliceArrayOf<T>::tostring() const {
     return std::string("array(") + tostring_part() + std::string(")");
   }
 
   template <typename T>
-  const std::string SliceArrayOf<T>::tostring_part() const {
+  const std::string
+  SliceArrayOf<T>::tostring_part() const {
     std::stringstream out;
     out << "[";
     if (shape_.size() == 1) {
@@ -216,7 +251,9 @@ namespace awkward {
           if (i != 0) {
             out << ", ";
           }
-          IndexOf<T> index(index_.ptr(), index_.offset() + i*strides_[0], shape_[1]);
+          IndexOf<T> index(index_.ptr(),
+                           index_.offset() + i*strides_[0],
+                           shape_[1]);
           SliceArrayOf<T> subarray(index, shape, strides, frombool_);
           out << subarray.tostring_part();
         }
@@ -226,7 +263,9 @@ namespace awkward {
           if (i != 0) {
             out << ", ";
           }
-          IndexOf<T> index(index_.ptr(), index_.offset() + i*strides_[0], shape_[1]);
+          IndexOf<T> index(index_.ptr(),
+                           index_.offset() + i*strides_[0],
+                           shape_[1]);
           SliceArrayOf<T> subarray(index, shape, strides, frombool_);
           out << subarray.tostring_part();
         }
@@ -235,7 +274,9 @@ namespace awkward {
           if (i != shape_[0] - 3) {
             out << ", ";
           }
-          IndexOf<T> index(index_.ptr(), index_.offset() + i*strides_[0], shape_[1]);
+          IndexOf<T> index(index_.ptr(),
+                           index_.offset() + i*strides_[0],
+                           shape_[1]);
           SliceArrayOf<T> subarray(index, shape, strides, frombool_);
           out << subarray.tostring_part();
         }
@@ -246,12 +287,14 @@ namespace awkward {
   }
 
   template <typename T>
-  bool SliceArrayOf<T>::preserves_type(const Index64& advanced) const {
+  bool
+  SliceArrayOf<T>::preserves_type(const Index64& advanced) const {
     return advanced.length() == 0;
   }
 
   template <typename T>
-  const IndexOf<T> SliceArrayOf<T>::ravel() const {
+  const IndexOf<T>
+  SliceArrayOf<T>::ravel() const {
     int64_t length = 1;
     for (int64_t i = 0;  i < ndim();  i++) {
       length *= shape_[(size_t)i];
@@ -259,7 +302,11 @@ namespace awkward {
 
     IndexOf<T> index(length);
     if (std::is_same<T, int64_t>::value) {
-      awkward_slicearray_ravel_64(index.ptr().get(), index_.ptr().get(), ndim(), shape_.data(), strides_.data());
+      awkward_slicearray_ravel_64(index.ptr().get(),
+                                  index_.ptr().get(),
+                                  ndim(),
+                                  shape_.data(),
+                                  strides_.data());
     }
     else {
       throw std::runtime_error("unrecognized SliceArrayOf<T> type");
@@ -275,19 +322,23 @@ namespace awkward {
   SliceField::SliceField(const std::string& key)
       : key_(key) { }
 
-  const std::string SliceField::key() const {
+  const std::string
+  SliceField::key() const {
     return key_;
   }
 
-  const SliceItemPtr SliceField::shallow_copy() const {
+  const SliceItemPtr
+  SliceField::shallow_copy() const {
     return std::make_shared<SliceField>(key_);
   }
 
-  const std::string SliceField::tostring() const {
+  const std::string
+  SliceField::tostring() const {
     return util::quote(key_, true);
   }
 
-  bool SliceField::preserves_type(const Index64& advanced) const {
+  bool
+  SliceField::preserves_type(const Index64& advanced) const {
     return false;
   }
 
@@ -296,15 +347,18 @@ namespace awkward {
   SliceFields::SliceFields(const std::vector<std::string>& keys)
       : keys_(keys) { }
 
-  const std::vector<std::string> SliceFields::keys() const {
+  const std::vector<std::string>
+  SliceFields::keys() const {
     return keys_;
   }
 
-  const SliceItemPtr SliceFields::shallow_copy() const {
+  const SliceItemPtr
+  SliceFields::shallow_copy() const {
     return std::make_shared<SliceFields>(keys_);
   }
 
-  const std::string SliceFields::tostring() const {
+  const std::string
+  SliceFields::tostring() const {
     std::stringstream out;
     out << "[";
     for (size_t i = 0;  i < keys_.size();  i++) {
@@ -317,50 +371,63 @@ namespace awkward {
     return out.str();
   }
 
-  bool SliceFields::preserves_type(const Index64& advanced) const {
+  bool
+  SliceFields::preserves_type(const Index64& advanced) const {
     return false;
   }
 
   /////////////////////////////////////////////////////// SliceMissingOf<T>
 
   template <typename T>
-  SliceMissingOf<T>::SliceMissingOf(const IndexOf<T>& index, const Index8& originalmask, const SliceItemPtr& content)
+  SliceMissingOf<T>::SliceMissingOf(const IndexOf<T>& index,
+                                    const Index8& originalmask,
+                                    const SliceItemPtr& content)
       : index_(index)
       , originalmask_(originalmask)
       , content_(content) { }
 
   template <typename T>
-  int64_t SliceMissingOf<T>::length() const {
+  int64_t
+  SliceMissingOf<T>::length() const {
     return index_.length();
   }
 
   template <typename T>
-  const IndexOf<T> SliceMissingOf<T>::index() const {
+  const IndexOf<T>
+  SliceMissingOf<T>::index() const {
     return index_;
   }
 
   template <typename T>
-  const Index8 SliceMissingOf<T>::originalmask() const {
+  const Index8
+  SliceMissingOf<T>::originalmask() const {
     return originalmask_;
   }
 
   template <typename T>
-  const SliceItemPtr SliceMissingOf<T>::content() const {
+  const SliceItemPtr
+  SliceMissingOf<T>::content() const {
     return content_;
   }
 
   template <typename T>
-  const SliceItemPtr SliceMissingOf<T>::shallow_copy() const {
-    return std::make_shared<SliceMissingOf<T>>(index_, originalmask_, content_);
+  const SliceItemPtr
+  SliceMissingOf<T>::shallow_copy() const {
+    return std::make_shared<SliceMissingOf<T>>(index_,
+                                               originalmask_,
+                                               content_);
   }
 
   template <typename T>
-  const std::string SliceMissingOf<T>::tostring() const {
-    return std::string("missing(") + tostring_part() + std::string(", ") + content_.get()->tostring() + std::string(")");
+  const std::string
+  SliceMissingOf<T>::tostring() const {
+    return std::string("missing(") + tostring_part() + std::string(", ")
+      + content_.get()->tostring() + std::string(")");
   }
 
   template <typename T>
-  const std::string SliceMissingOf<T>::tostring_part() const {
+  const std::string
+  SliceMissingOf<T>::tostring_part() const {
     std::stringstream out;
     out << "[";
     if (index_.length() < 6) {
@@ -391,7 +458,8 @@ namespace awkward {
   }
 
   template <typename T>
-  bool SliceMissingOf<T>::preserves_type(const Index64& advanced) const {
+  bool
+  SliceMissingOf<T>::preserves_type(const Index64& advanced) const {
     return true;
   }
 
@@ -400,37 +468,45 @@ namespace awkward {
   /////////////////////////////////////////////////////// SliceJaggedOf<T>
 
   template <typename T>
-  SliceJaggedOf<T>::SliceJaggedOf(const IndexOf<T>& offsets, const SliceItemPtr& content)
+  SliceJaggedOf<T>::SliceJaggedOf(const IndexOf<T>& offsets,
+                                  const SliceItemPtr& content)
       : offsets_(offsets)
       , content_(content) { }
 
   template <typename T>
-  int64_t SliceJaggedOf<T>::length() const {
+  int64_t
+  SliceJaggedOf<T>::length() const {
     return offsets_.length() - 1;
   }
 
   template <typename T>
-  const IndexOf<T> SliceJaggedOf<T>::offsets() const {
+  const IndexOf<T>
+  SliceJaggedOf<T>::offsets() const {
     return offsets_;
   }
 
   template <typename T>
-  const SliceItemPtr SliceJaggedOf<T>::content() const {
+  const SliceItemPtr
+  SliceJaggedOf<T>::content() const {
     return content_;
   }
 
   template <typename T>
-  const SliceItemPtr SliceJaggedOf<T>::shallow_copy() const {
+  const SliceItemPtr
+  SliceJaggedOf<T>::shallow_copy() const {
     return std::make_shared<SliceJaggedOf<T>>(offsets_, content_);
   }
 
   template <typename T>
-  const std::string SliceJaggedOf<T>::tostring() const {
-    return std::string("jagged(") + tostring_part() + std::string(", ") + content_.get()->tostring() + std::string(")");
+  const std::string
+  SliceJaggedOf<T>::tostring() const {
+    return std::string("jagged(") + tostring_part() + std::string(", ")
+      + content_.get()->tostring() + std::string(")");
   }
 
   template <typename T>
-  const std::string SliceJaggedOf<T>::tostring_part() const {
+  const std::string
+  SliceJaggedOf<T>::tostring_part() const {
     std::stringstream out;
     out << "[";
     if (offsets_.length() < 6) {
@@ -461,7 +537,8 @@ namespace awkward {
   }
 
   template <typename T>
-  bool SliceJaggedOf<T>::preserves_type(const Index64& advanced) const {
+  bool
+  SliceJaggedOf<T>::preserves_type(const Index64& advanced) const {
     return true;
   }
 
@@ -485,19 +562,23 @@ namespace awkward {
       : items_(items)
       , sealed_(sealed) { }
 
-  const std::vector<SliceItemPtr> Slice::items() const {
+  const std::vector<SliceItemPtr>
+  Slice::items() const {
     return items_;
   }
 
-  bool Slice::sealed() const {
+  bool
+  Slice::sealed() const {
     return sealed_;
   }
 
-  int64_t Slice::length() const {
+  int64_t
+  Slice::length() const {
     return (int64_t)items_.size();
   }
 
-  int64_t Slice::dimlength() const {
+  int64_t
+  Slice::dimlength() const {
     int64_t out = 0;
     for (auto x : items_) {
       if (dynamic_cast<SliceAt*>(x.get()) != nullptr) {
@@ -513,7 +594,8 @@ namespace awkward {
     return out;
   }
 
-  const SliceItemPtr Slice::head() const {
+  const SliceItemPtr
+  Slice::head() const {
     if (!items_.empty()) {
       return items_[0];
     }
@@ -522,7 +604,8 @@ namespace awkward {
     }
   }
 
-  const Slice Slice::tail() const {
+  const Slice
+  Slice::tail() const {
     std::vector<SliceItemPtr> items;
     if (!items_.empty()) {
       items.insert(items.end(), items_.begin() + 1, items_.end());
@@ -530,7 +613,8 @@ namespace awkward {
     return Slice(items, true);
   }
 
-  const std::string Slice::tostring() const {
+  const std::string
+  Slice::tostring() const {
     std::stringstream out;
     out << "[";
     for (size_t i = 0;  i < items_.size();  i++) {
@@ -543,35 +627,42 @@ namespace awkward {
     return out.str();
   }
 
-  void Slice::append(const SliceItemPtr& item) {
+  void
+  Slice::append(const SliceItemPtr& item) {
     if (sealed_) {
       throw std::runtime_error("Slice::append when sealed_ == true");
     }
     items_.push_back(item);
   }
 
-  void Slice::append(const SliceAt& item) {
+  void
+  Slice::append(const SliceAt& item) {
     items_.push_back(item.shallow_copy());
   }
 
-  void Slice::append(const SliceRange& item) {
+  void
+  Slice::append(const SliceRange& item) {
     items_.push_back(item.shallow_copy());
   }
 
-  void Slice::append(const SliceEllipsis& item) {
+  void
+  Slice::append(const SliceEllipsis& item) {
     items_.push_back(item.shallow_copy());
   }
 
-  void Slice::append(const SliceNewAxis& item) {
+  void
+  Slice::append(const SliceNewAxis& item) {
     items_.push_back(item.shallow_copy());
   }
 
   template <typename T>
-  void Slice::append(const SliceArrayOf<T>& item) {
+  void
+  Slice::append(const SliceArrayOf<T>& item) {
     items_.push_back(item.shallow_copy());
   }
 
-  void Slice::become_sealed() {
+  void
+  Slice::become_sealed() {
     if (sealed_) {
       throw std::runtime_error("Slice::become_sealed when sealed_ == true");
     }
@@ -608,9 +699,13 @@ namespace awkward {
           for (size_t j = 0;  j < shape.size();  j++) {
             strides.push_back(0);
           }
-          items_[i] = std::make_shared<SliceArray64>(index, shape, strides, false);
+          items_[i] = std::make_shared<SliceArray64>(index,
+                                                     shape,
+                                                     strides,
+                                                     false);
         }
-        else if (SliceArray64* array = dynamic_cast<SliceArray64*>(items_[i].get())) {
+        else if (SliceArray64* array =
+                 dynamic_cast<SliceArray64*>(items_[i].get())) {
           std::vector<int64_t> arrayshape = array->shape();
           std::vector<int64_t> arraystrides = array->strides();
           std::vector<int64_t> strides;
@@ -625,7 +720,10 @@ namespace awkward {
               throw std::invalid_argument("cannot broadcast arrays in slice");
             }
           }
-          items_[i] = std::make_shared<SliceArray64>(array->index(), shape, strides, array->frombool());
+          items_[i] = std::make_shared<SliceArray64>(array->index(),
+                                                     shape,
+                                                     strides,
+                                                     array->frombool());
         }
       }
 
@@ -661,14 +759,18 @@ namespace awkward {
       }
 
       if (std::count(types.begin(), types.end(), '.') > 1) {
-        throw std::invalid_argument("a slice can have no more than one ellipsis ('...')");
+        throw std::invalid_argument(
+          "a slice can have no more than one ellipsis ('...')");
       }
 
       size_t numadvanced = std::count(types.begin(), types.end(), 'A');
       if (numadvanced != 0) {
-        types = types.substr(0, types.find_last_of("A") + 1).substr(types.find_first_of("A"));
+        types = types.substr(0, types.find_last_of("A") + 1)
+                     .substr(types.find_first_of("A"));
         if (numadvanced != types.size()) {
-          throw std::invalid_argument("advanced indexes separated by basic indexes is not permitted (simple integers are advanced when any arrays are present)");
+          throw std::invalid_argument(
+            "advanced indexes separated by basic indexes is not permitted "
+            "(simple integers are advanced when any arrays are present)");
         }
       }
     }
@@ -676,7 +778,8 @@ namespace awkward {
     sealed_ = true;
   }
 
-  bool Slice::isadvanced() const {
+  bool
+  Slice::isadvanced() const {
     if (!sealed_) {
       throw std::runtime_error("Slice::isadvanced when sealed_ == false");
     }

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -20,7 +20,13 @@
 #include "awkward/array/BitMaskedArray.h"
 
 namespace awkward {
-  BitMaskedArray::BitMaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexU8& mask, const ContentPtr& content, bool validwhen, int64_t length, bool lsb_order)
+  BitMaskedArray::BitMaskedArray(const IdentitiesPtr& identities,
+                                 const util::Parameters& parameters,
+                                 const IndexU8& mask,
+                                 const ContentPtr& content,
+                                 bool validwhen,
+                                 int64_t length,
+                                 bool lsb_order)
       : Content(identities, parameters)
       , mask_(mask)
       , content_(content)
@@ -29,38 +35,47 @@ namespace awkward {
       , lsb_order_(lsb_order) {
     int64_t bitlength = ((length / 8) + ((length % 8) != 0));
     if (mask.length() < bitlength) {
-      throw std::invalid_argument("BitMaskedArray mask must not be shorter than its ceil(length / 8.0)");
+      throw std::invalid_argument(
+        "BitMaskedArray mask must not be shorter than its ceil(length / 8.0)");
     }
     if (content.get()->length() < length) {
-      throw std::invalid_argument("BitMaskedArray content must not be shorter than its length");
+      throw std::invalid_argument(
+        "BitMaskedArray content must not be shorter than its length");
     }
   }
 
-  const IndexU8 BitMaskedArray::mask() const {
+  const IndexU8
+  BitMaskedArraymask() const {
     return mask_;
   }
 
-  const ContentPtr BitMaskedArray::content() const {
+  const ContentPtr
+  BitMaskedArraycontent() const {
     return content_;
   }
 
-  bool BitMaskedArray::validwhen() const {
+  bool
+  BitMaskedArrayvalidwhen() const {
     return validwhen_;
   }
 
-  bool BitMaskedArray::lsb_order() const {
+  bool
+  BitMaskedArraylsb_order() const {
     return lsb_order_;
   }
 
-  const ContentPtr BitMaskedArray::project() const {
+  const ContentPtr
+  BitMaskedArrayproject() const {
     return toByteMaskedArray().get()->project();
   }
 
-  const ContentPtr BitMaskedArray::project(const Index8& mask) const {
+  const ContentPtr
+  BitMaskedArrayproject(const Index8& mask) const {
     return toByteMaskedArray().get()->project(mask);
   }
 
-  const Index8 BitMaskedArray::bytemask() const {
+  const Index8
+  BitMaskedArraybytemask() const {
     Index8 bytemask(mask_.length() * 8);
     struct Error err = awkward_bitmaskedarray_to_bytemaskedarray(
       bytemask.ptr().get(),
@@ -73,7 +88,8 @@ namespace awkward {
     return bytemask.getitem_range_nowrap(0, length_);
   }
 
-  const ContentPtr BitMaskedArray::simplify_optiontype() const {
+  const ContentPtr
+  BitMaskedArraysimplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -83,7 +99,8 @@ namespace awkward {
         dynamic_cast<BitMaskedArray*>(content_.get())        ||
         dynamic_cast<UnmaskedArray*>(content_.get())) {
       ContentPtr step1 = toIndexedOptionArray64();
-      IndexedOptionArray64* step2 = dynamic_cast<IndexedOptionArray64*>(step1.get());
+      IndexedOptionArray64* step2 =
+        dynamic_cast<IndexedOptionArray64*>(step1.get());
       return step2->simplify_optiontype();
     }
     else {
@@ -91,7 +108,8 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<ByteMaskedArray> BitMaskedArray::toByteMaskedArray() const {
+  const std::shared_ptr<ByteMaskedArray>
+  BitMaskedArraytoByteMaskedArray() const {
     Index8 bytemask(mask_.length() * 8);
     struct Error err = awkward_bitmaskedarray_to_bytemaskedarray(
       bytemask.ptr().get(),
@@ -101,10 +119,16 @@ namespace awkward {
       validwhen_,
       lsb_order_);
     util::handle_error(err, classname(), identities_.get());
-    return std::make_shared<ByteMaskedArray>(identities_, parameters_, bytemask.getitem_range_nowrap(0, length_), content_, validwhen_);
+    return std::make_shared<ByteMaskedArray>(
+      identities_,
+      parameters_,
+      bytemask.getitem_range_nowrap(0, length_),
+      content_,
+      validwhen_);
   }
 
-  const std::shared_ptr<IndexedOptionArray64> BitMaskedArray::toIndexedOptionArray64() const {
+  const std::shared_ptr<IndexedOptionArray64>
+  BitMaskedArraytoIndexedOptionArray64() const {
     Index64 index(mask_.length() * 8);
     struct Error err = awkward_bitmaskedarray_to_indexedoptionarray_64(
       index.ptr().get(),
@@ -114,24 +138,41 @@ namespace awkward {
       validwhen_,
       lsb_order_);
     util::handle_error(err, classname(), identities_.get());
-    return std::make_shared<IndexedOptionArray64>(identities_, parameters_, index.getitem_range_nowrap(0, length_), content_);
+    return std::make_shared<IndexedOptionArray64>(
+      identities_,
+      parameters_,
+      index.getitem_range_nowrap(0, length_),
+      content_);
   }
 
-  const std::string BitMaskedArray::classname() const {
+  const std::string
+  BitMaskedArrayclassname() const {
     return "BitMaskedArray";
   }
 
-  void BitMaskedArray::setidentities(const IdentitiesPtr& identities) {
+  void
+  BitMaskedArraysetidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
     else {
       if (length() != identities.get()->length()) {
-        util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(
+          failure("content and its identities must have the same length",
+                  kSliceNone,
+                  kSliceNone),
+          classname(),
+          identities_.get());
       }
-      if (Identities32* rawidentities = dynamic_cast<Identities32*>(identities.get())) {
-        std::shared_ptr<Identities32> subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
-        Identities32* rawsubidentities = reinterpret_cast<Identities32*>(subidentities.get());
+      if (Identities32* rawidentities =
+          dynamic_cast<Identities32*>(identities.get())) {
+        std::shared_ptr<Identities32> subidentities =
+          std::make_shared<Identities32>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width(),
+                                         content_.get()->length());
+        Identities32* rawsubidentities =
+          reinterpret_cast<Identities32*>(subidentities.get());
         struct Error err = awkward_identities32_extend(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -141,9 +182,15 @@ namespace awkward {
         util::handle_error(err, classname(), identities_.get());
         content_.get()->setidentities(subidentities);
       }
-      else if (Identities64* rawidentities = dynamic_cast<Identities64*>(identities.get())) {
-        std::shared_ptr<Identities64> subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
-        Identities64* rawsubidentities = reinterpret_cast<Identities64*>(subidentities.get());
+      else if (Identities64* rawidentities =
+               dynamic_cast<Identities64*>(identities.get())) {
+        std::shared_ptr<Identities64> subidentities =
+          std::make_shared<Identities64>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width(),
+                                         content_.get()->length());
+        Identities64* rawsubidentities =
+          reinterpret_cast<Identities64*>(subidentities.get());
         struct Error err = awkward_identities64_extend(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -160,43 +207,69 @@ namespace awkward {
     identities_ = identities;
   }
 
-  void BitMaskedArray::setidentities() {
+  void
+  BitMaskedArraysetidentities() {
     if (length() <= kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err =
+        awkward_new_identities32(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err = awkward_new_identities64(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
   }
 
-  const TypePtr BitMaskedArray::type(const util::TypeStrs& typestrs) const {
-    return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
+  const TypePtr
+  BitMaskedArraytype(const util::TypeStrs& typestrs) const {
+    return std::make_shared<OptionType>(
+      parameters_,
+      util::gettypestr(parameters_, typestrs),
+      content_.get()->type(typestrs));
   }
 
-  const std::string BitMaskedArray::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  BitMaskedArraytostring_part(const std::string& indent,
+                              const std::string& pre,
+                              const std::string& post) const {
     std::stringstream out;
-    out << indent << pre << "<" << classname() << " validwhen=\"" << (validwhen_ ? "true" : "false") << "\" length=\"" << length_ << "\" lsb_order=\"" << (lsb_order_ ? "true" : "false") << "\">\n";
+    out << indent << pre << "<" << classname() << " validwhen=\""
+        << (validwhen_ ? "true" : "false") << "\" length=\"" << length_
+        << "\" lsb_order=\"" << (lsb_order_ ? "true" : "false") << "\">\n";
     if (identities_.get() != nullptr) {
-      out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+      out << identities_.get()->tostring_part(
+               indent + std::string("    "), "", "\n");
     }
     if (!parameters_.empty()) {
       out << parameters_tostring(indent + std::string("    "), "", "\n");
     }
-    out << mask_.tostring_part(indent + std::string("    "), "<mask>", "</mask>\n");
-    out << content_.get()->tostring_part(indent + std::string("    "), "<content>", "</content>\n");
+    out << mask_.tostring_part(
+             indent + std::string("    "), "<mask>", "</mask>\n");
+    out << content_.get()->tostring_part(
+             indent + std::string("    "), "<content>", "</content>\n");
     out << indent << "</" << classname() << ">" << post;
     return out.str();
   }
 
-  void BitMaskedArray::tojson_part(ToJson& builder) const {
+  void
+  BitMaskedArraytojson_part(ToJson& builder) const {
     int64_t len = length();
     check_for_iteration();
     builder.beginlist();
@@ -206,7 +279,8 @@ namespace awkward {
     builder.endlist();
   }
 
-  void BitMaskedArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  BitMaskedArraynbytes_part(std::map<size_t, int64_t>& largest) const {
     mask_.nbytes_part(largest);
     content_.get()->nbytes_part(largest);
     if (identities_.get() != nullptr) {
@@ -214,50 +288,82 @@ namespace awkward {
     }
   }
 
-  int64_t BitMaskedArray::length() const {
+  int64_t
+  BitMaskedArraylength() const {
     return length_;
   }
 
-  const ContentPtr BitMaskedArray::shallow_copy() const {
-    return std::make_shared<BitMaskedArray>(identities_, parameters_, mask_, content_, validwhen_, length_, lsb_order_);
+  const ContentPtr
+  BitMaskedArrayshallow_copy() const {
+    return std::make_shared<BitMaskedArray>(identities_,
+                                            parameters_,
+                                            mask_,
+                                            content_,
+                                            validwhen_,
+                                            length_,
+                                            lsb_order_);
   }
 
-  const ContentPtr BitMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  BitMaskedArraydeep_copy(bool copyarrays,
+                          bool copyindexes,
+                          bool copyidentities) const {
     IndexU8 mask = copyindexes ? mask_.deep_copy() : mask_;
-    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays,
+                                                   copyindexes,
+                                                   copyidentities);
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
-    return std::make_shared<BitMaskedArray>(identities, parameters_, mask, content, validwhen_, length_, lsb_order_);
+    return std::make_shared<BitMaskedArray>(identities,
+                                            parameters_,
+                                            mask,
+                                            content,
+                                            validwhen_,
+                                            length_,
+                                            lsb_order_);
   }
 
-  void BitMaskedArray::check_for_iteration() const {
-    if (identities_.get() != nullptr  &&  identities_.get()->length() < length()) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+  void
+  BitMaskedArraycheck_for_iteration() const {
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < length()) {
+      util::handle_error(
+        failure("len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
-  const ContentPtr BitMaskedArray::getitem_nothing() const {
+  const ContentPtr
+  BitMaskedArraygetitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  const ContentPtr BitMaskedArray::getitem_at(int64_t at) const {
+  const ContentPtr
+  BitMaskedArraygetitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
     }
     if (!(0 <= regular_at  &&  regular_at < length())) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
-  const ContentPtr BitMaskedArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  BitMaskedArraygetitem_at_nowrap(int64_t at) const {
     int64_t bitat = at / 8;
     int64_t shift = at % 8;
     uint8_t byte = mask_.getitem_at_nowrap(bitat);
-    uint8_t asbool = (lsb_order_ ? ((byte >> ((uint8_t)shift)) & ((uint8_t)1)) : ((byte << ((uint8_t)shift)) & ((uint8_t)128)));
+    uint8_t asbool = (lsb_order_
+                          ? ((byte >> ((uint8_t)shift)) & ((uint8_t)1))
+                          : ((byte << ((uint8_t)shift)) & ((uint8_t)128)));
     if ((asbool != 0) == validwhen_) {
       return content_.get()->getitem_at_nowrap(at);
     }
@@ -266,17 +372,24 @@ namespace awkward {
     }
   }
 
-  const ContentPtr BitMaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  BitMaskedArraygetitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
-    if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-      util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), length());
+    if (identities_.get() != nullptr  &&
+        regular_stop > identities_.get()->length()) {
+      util::handle_error(
+        failure("index out of range", kSliceNone, stop),
+        identities_.get()->classname(),
+        nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const ContentPtr BitMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  BitMaskedArraygetitem_range_nowrap(int64_t start, int64_t stop) const {
     int64_t bitstart = start / 8;
     int64_t remainder = start % 8;
     if (remainder == 0) {
@@ -288,30 +401,58 @@ namespace awkward {
       int64_t bitlength = length / 8;
       int64_t remainder = length % 8;
       int64_t bitstop = bitstart + (bitlength + (remainder != 0));
-      return std::make_shared<BitMaskedArray>(identities, parameters_, mask_.getitem_range_nowrap(bitstart, bitstop), content_.get()->getitem_range_nowrap(start, stop), validwhen_, length, lsb_order_);
+      return std::make_shared<BitMaskedArray>(
+        identities,
+        parameters_,
+        mask_.getitem_range_nowrap(bitstart, bitstop),
+        content_.get()->getitem_range_nowrap(start, stop),
+        validwhen_,
+        length,
+        lsb_order_);
     }
     else {
       return toByteMaskedArray().get()->getitem_range_nowrap(start, stop);
     }
   }
 
-  const ContentPtr BitMaskedArray::getitem_field(const std::string& key) const {
-    return std::make_shared<BitMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_field(key), validwhen_, length_, lsb_order_);
+  const ContentPtr
+  BitMaskedArraygetitem_field(const std::string& key) const {
+    return std::make_shared<BitMaskedArray>(
+      identities_,
+      util::Parameters(),
+      mask_,
+      content_.get()->getitem_field(key),
+      validwhen_,
+      length_,
+      lsb_order_);
   }
 
-  const ContentPtr BitMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
-    return std::make_shared<BitMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_fields(keys), validwhen_, length_, lsb_order_);
+  const ContentPtr
+  BitMaskedArraygetitem_fields(const std::vector<std::string>& keys) const {
+    return std::make_shared<BitMaskedArray>(
+      identities_,
+      util::Parameters(),
+      mask_,
+      content_.get()->getitem_fields(keys),
+      validwhen_,
+      length_,
+      lsb_order_);
   }
 
-  const ContentPtr BitMaskedArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  BitMaskedArraygetitem_next(const SliceItemPtr& head,
+                             const Slice& tail,
+                             const Index64& advanced) const {
     return toByteMaskedArray().get()->getitem_next(head, tail, advanced);
   }
 
-  const ContentPtr BitMaskedArray::carry(const Index64& carry) const {
+  const ContentPtr
+  BitMaskedArraycarry(const Index64& carry) const {
     return toByteMaskedArray().get()->carry(carry);
   }
 
-  const std::string BitMaskedArray::purelist_parameter(const std::string& key) const {
+  const std::string
+  BitMaskedArraypurelist_parameter(const std::string& key) const {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       return content_.get()->purelist_parameter(key);
@@ -321,59 +462,73 @@ namespace awkward {
     }
   }
 
-  bool BitMaskedArray::purelist_isregular() const {
+  bool
+  BitMaskedArraypurelist_isregular() const {
     return content_.get()->purelist_isregular();
   }
 
-  int64_t BitMaskedArray::purelist_depth() const {
+  int64_t
+  BitMaskedArraypurelist_depth() const {
     return content_.get()->purelist_depth();
   }
 
-  const std::pair<int64_t, int64_t> BitMaskedArray::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  BitMaskedArrayminmax_depth() const {
     return content_.get()->minmax_depth();
   }
 
-  const std::pair<bool, int64_t> BitMaskedArray::branch_depth() const {
+  const std::pair<bool, int64_t>
+  BitMaskedArraybranch_depth() const {
     return content_.get()->branch_depth();
   }
 
-  int64_t BitMaskedArray::numfields() const {
+  int64_t
+  BitMaskedArraynumfields() const {
     return content_.get()->numfields();
   }
 
-  int64_t BitMaskedArray::fieldindex(const std::string& key) const {
+  int64_t
+  BitMaskedArrayfieldindex(const std::string& key) const {
     return content_.get()->fieldindex(key);
   }
 
-  const std::string BitMaskedArray::key(int64_t fieldindex) const {
+  const std::string
+  BitMaskedArraykey(int64_t fieldindex) const {
     return content_.get()->key(fieldindex);
   }
 
-  bool BitMaskedArray::haskey(const std::string& key) const {
+  bool
+  BitMaskedArrayhaskey(const std::string& key) const {
     return content_.get()->haskey(key);
   }
 
-  const std::vector<std::string> BitMaskedArray::keys() const {
+  const std::vector<std::string>
+  BitMaskedArraykeys() const {
     return content_.get()->keys();
   }
 
-  const std::string BitMaskedArray::validityerror(const std::string& path) const {
+  const std::string
+  BitMaskedArrayvalidityerror(const std::string& path) const {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  const ContentPtr BitMaskedArray::shallow_simplify() const {
+  const ContentPtr
+  BitMaskedArrayshallow_simplify() const {
     return simplify_optiontype();
   }
 
-  const ContentPtr BitMaskedArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  BitMaskedArraynum(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->num(axis, depth);
   }
 
-  const std::pair<Index64, ContentPtr> BitMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  BitMaskedArrayoffsets_and_flattened(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->offsets_and_flattened(axis, depth);
   }
 
-  bool BitMaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  BitMaskedArraymergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -385,28 +540,36 @@ namespace awkward {
       return true;
     }
 
-    if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    if (IndexedArray32* rawother =
+        dynamic_cast<IndexedArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
     else {
@@ -414,70 +577,141 @@ namespace awkward {
     }
   }
 
-  const ContentPtr BitMaskedArray::reverse_merge(const ContentPtr& other) const {
+  const ContentPtr
+  BitMaskedArrayreverse_merge(const ContentPtr& other) const {
     ContentPtr indexedoptionarray = toIndexedOptionArray64();
-    IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
+    IndexedOptionArray64* raw =
+      dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  const ContentPtr BitMaskedArray::merge(const ContentPtr& other) const {
+  const ContentPtr
+  BitMaskedArraymerge(const ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
-  const SliceItemPtr BitMaskedArray::asslice() const {
+  const SliceItemPtr
+  BitMaskedArrayasslice() const {
     return toIndexedOptionArray64().get()->asslice();
   }
 
-  const ContentPtr BitMaskedArray::fillna(const ContentPtr& value) const {
+  const ContentPtr
+  BitMaskedArrayfillna(const ContentPtr& value) const {
     return toIndexedOptionArray64().get()->fillna(value);
   }
 
-  const ContentPtr BitMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  BitMaskedArrayrpad(int64_t target, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->rpad(target, axis, depth);
   }
 
-  const ContentPtr BitMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  BitMaskedArrayrpad_and_clip(int64_t target,
+                              int64_t axis,
+                              int64_t depth) const {
     return toByteMaskedArray().get()->rpad_and_clip(target, axis, depth);
   }
 
-  const ContentPtr BitMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
-    return toByteMaskedArray().get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+  const ContentPtr
+  BitMaskedArrayreduce_next(const Reducer& reducer,
+                            int64_t negaxis,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength,
+                            bool mask,
+                            bool keepdims) const {
+    return toByteMaskedArray().get()->reduce_next(reducer,
+                                                  negaxis,
+                                                  starts,
+                                                  parents,
+                                                  outlength,
+                                                  mask,
+                                                  keepdims);
   }
 
-  const ContentPtr BitMaskedArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  BitMaskedArraylocalindex(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->localindex(axis, depth);
   }
 
-  const ContentPtr BitMaskedArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
-    return toByteMaskedArray().get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
+  const ContentPtr
+  BitMaskedArraychoose(int64_t n,
+                       bool diagonal,
+                       const util::RecordLookupPtr& recordlookup,
+                       const util::Parameters& parameters,
+                       int64_t axis,
+                       int64_t depth) const {
+    return toByteMaskedArray().get()->choose(n,
+                                             diagonal,
+                                             recordlookup,
+                                             parameters,
+                                             axis,
+                                             depth);
   }
 
-  const ContentPtr BitMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(at)");
+  const ContentPtr
+  BitMaskedArraygetitem_next(const SliceAt& at,
+                             const Slice& tail,
+                             const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: BitMaskedArraygetitem_next(at)");
   }
 
-  const ContentPtr BitMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(range)");
+  const ContentPtr
+  BitMaskedArraygetitem_next(const SliceRange& range,
+                             const Slice& tail,
+                             const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: BitMaskedArraygetitem_next(range)");
   }
 
-  const ContentPtr BitMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(array)");
+  const ContentPtr
+  BitMaskedArraygetitem_next(const SliceArray64& array,
+                             const Slice& tail,
+                             const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: BitMaskedArraygetitem_next(array)");
   }
 
-  const ContentPtr BitMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(jagged)");
+  const ContentPtr
+  BitMaskedArraygetitem_next(const SliceJagged64& jagged,
+                             const Slice& tail,
+                             const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: BitMaskedArraygetitem_next(jagged)");
   }
 
-  const ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  BitMaskedArraygetitem_next_jagged(const Index64& slicestarts,
+                                    const Index64& slicestops,
+                                    const SliceArray64& slicecontent,
+                                    const Slice& tail) const {
+    return toByteMaskedArray().get()->getitem_next_jagged(slicestarts,
+                                                          slicestops,
+                                                          slicecontent,
+                                                          tail);
   }
 
-  const ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  BitMaskedArraygetitem_next_jagged(const Index64& slicestarts,
+                                    const Index64& slicestops,
+                                    const SliceMissing64& slicecontent,
+                                    const Slice& tail) const {
+    return toByteMaskedArray().get()->getitem_next_jagged(slicestarts,
+                                                          slicestops,
+                                                          slicecontent,
+                                                          tail);
   }
 
-  const ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  BitMaskedArraygetitem_next_jagged(const Index64& slicestarts,
+                                    const Index64& slicestops,
+                                    const SliceJagged64& slicecontent,
+                                    const Slice& tail) const {
+    return toByteMaskedArray().get()->getitem_next_jagged(slicestarts,
+                                                          slicestops,
+                                                          slicecontent,
+                                                          tail);
   }
 
 }

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -177,7 +177,7 @@ namespace awkward {
     }
   }
 
-  const TypePtr BitMaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr BitMaskedArray::type(const util::TypeStrs& typestrs) const {
     return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
   }
 

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -20,7 +20,7 @@
 #include "awkward/array/BitMaskedArray.h"
 
 namespace awkward {
-  BitMaskedArray::BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, const ContentPtr& content, bool validwhen, int64_t length, bool lsb_order)
+  BitMaskedArray::BitMaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexU8& mask, const ContentPtr& content, bool validwhen, int64_t length, bool lsb_order)
       : Content(identities, parameters)
       , mask_(mask)
       , content_(content)
@@ -121,7 +121,7 @@ namespace awkward {
     return "BitMaskedArray";
   }
 
-  void BitMaskedArray::setidentities(const std::shared_ptr<Identities>& identities) {
+  void BitMaskedArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
@@ -162,14 +162,14 @@ namespace awkward {
 
   void BitMaskedArray::setidentities() {
     if (length() <= kMaxInt32) {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
       struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
       struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
@@ -177,7 +177,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Type> BitMaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr BitMaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
     return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
   }
 
@@ -225,7 +225,7 @@ namespace awkward {
   const ContentPtr BitMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexU8 mask = copyindexes ? mask_.deep_copy() : mask_;
     ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
-    std::shared_ptr<Identities> identities = identities_;
+    IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
@@ -280,7 +280,7 @@ namespace awkward {
     int64_t bitstart = start / 8;
     int64_t remainder = start % 8;
     if (remainder == 0) {
-      std::shared_ptr<Identities> identities(nullptr);
+      IdentitiesPtr identities(nullptr);
       if (identities_.get() != nullptr) {
         identities = identities_.get()->getitem_range_nowrap(start, stop);
       }
@@ -303,7 +303,7 @@ namespace awkward {
     return std::make_shared<BitMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_fields(keys), validwhen_, length_, lsb_order_);
   }
 
-  const ContentPtr BitMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr BitMaskedArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
     return toByteMaskedArray().get()->getitem_next(head, tail, advanced);
   }
 
@@ -424,7 +424,7 @@ namespace awkward {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
-  const std::shared_ptr<SliceItem> BitMaskedArray::asslice() const {
+  const SliceItemPtr BitMaskedArray::asslice() const {
     return toIndexedOptionArray64().get()->asslice();
   }
 
@@ -448,7 +448,7 @@ namespace awkward {
     return toByteMaskedArray().get()->localindex(axis, depth);
   }
 
-  const ContentPtr BitMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr BitMaskedArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
   }
 

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -45,37 +45,37 @@ namespace awkward {
   }
 
   const IndexU8
-  BitMaskedArraymask() const {
+  BitMaskedArray::mask() const {
     return mask_;
   }
 
   const ContentPtr
-  BitMaskedArraycontent() const {
+  BitMaskedArray::content() const {
     return content_;
   }
 
   bool
-  BitMaskedArrayvalidwhen() const {
+  BitMaskedArray::validwhen() const {
     return validwhen_;
   }
 
   bool
-  BitMaskedArraylsb_order() const {
+  BitMaskedArray::lsb_order() const {
     return lsb_order_;
   }
 
   const ContentPtr
-  BitMaskedArrayproject() const {
+  BitMaskedArray::project() const {
     return toByteMaskedArray().get()->project();
   }
 
   const ContentPtr
-  BitMaskedArrayproject(const Index8& mask) const {
+  BitMaskedArray::project(const Index8& mask) const {
     return toByteMaskedArray().get()->project(mask);
   }
 
   const Index8
-  BitMaskedArraybytemask() const {
+  BitMaskedArray::bytemask() const {
     Index8 bytemask(mask_.length() * 8);
     struct Error err = awkward_bitmaskedarray_to_bytemaskedarray(
       bytemask.ptr().get(),
@@ -89,7 +89,7 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraysimplify_optiontype() const {
+  BitMaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -109,7 +109,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<ByteMaskedArray>
-  BitMaskedArraytoByteMaskedArray() const {
+  BitMaskedArray::toByteMaskedArray() const {
     Index8 bytemask(mask_.length() * 8);
     struct Error err = awkward_bitmaskedarray_to_bytemaskedarray(
       bytemask.ptr().get(),
@@ -128,7 +128,7 @@ namespace awkward {
   }
 
   const std::shared_ptr<IndexedOptionArray64>
-  BitMaskedArraytoIndexedOptionArray64() const {
+  BitMaskedArray::toIndexedOptionArray64() const {
     Index64 index(mask_.length() * 8);
     struct Error err = awkward_bitmaskedarray_to_indexedoptionarray_64(
       index.ptr().get(),
@@ -146,12 +146,12 @@ namespace awkward {
   }
 
   const std::string
-  BitMaskedArrayclassname() const {
+  BitMaskedArray::classname() const {
     return "BitMaskedArray";
   }
 
   void
-  BitMaskedArraysetidentities(const IdentitiesPtr& identities) {
+  BitMaskedArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
@@ -208,7 +208,7 @@ namespace awkward {
   }
 
   void
-  BitMaskedArraysetidentities() {
+  BitMaskedArray::setidentities() {
     if (length() <= kMaxInt32) {
       IdentitiesPtr newidentities =
         std::make_shared<Identities32>(Identities::newref(),
@@ -238,7 +238,7 @@ namespace awkward {
   }
 
   const TypePtr
-  BitMaskedArraytype(const util::TypeStrs& typestrs) const {
+  BitMaskedArray::type(const util::TypeStrs& typestrs) const {
     return std::make_shared<OptionType>(
       parameters_,
       util::gettypestr(parameters_, typestrs),
@@ -246,9 +246,9 @@ namespace awkward {
   }
 
   const std::string
-  BitMaskedArraytostring_part(const std::string& indent,
-                              const std::string& pre,
-                              const std::string& post) const {
+  BitMaskedArray::tostring_part(const std::string& indent,
+                                const std::string& pre,
+                                const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << " validwhen=\""
         << (validwhen_ ? "true" : "false") << "\" length=\"" << length_
@@ -269,7 +269,7 @@ namespace awkward {
   }
 
   void
-  BitMaskedArraytojson_part(ToJson& builder) const {
+  BitMaskedArray::tojson_part(ToJson& builder) const {
     int64_t len = length();
     check_for_iteration();
     builder.beginlist();
@@ -280,7 +280,7 @@ namespace awkward {
   }
 
   void
-  BitMaskedArraynbytes_part(std::map<size_t, int64_t>& largest) const {
+  BitMaskedArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
     mask_.nbytes_part(largest);
     content_.get()->nbytes_part(largest);
     if (identities_.get() != nullptr) {
@@ -289,12 +289,12 @@ namespace awkward {
   }
 
   int64_t
-  BitMaskedArraylength() const {
+  BitMaskedArray::length() const {
     return length_;
   }
 
   const ContentPtr
-  BitMaskedArrayshallow_copy() const {
+  BitMaskedArray::shallow_copy() const {
     return std::make_shared<BitMaskedArray>(identities_,
                                             parameters_,
                                             mask_,
@@ -305,9 +305,9 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraydeep_copy(bool copyarrays,
-                          bool copyindexes,
-                          bool copyidentities) const {
+  BitMaskedArray::deep_copy(bool copyarrays,
+                            bool copyindexes,
+                            bool copyidentities) const {
     IndexU8 mask = copyindexes ? mask_.deep_copy() : mask_;
     ContentPtr content = content_.get()->deep_copy(copyarrays,
                                                    copyindexes,
@@ -326,7 +326,7 @@ namespace awkward {
   }
 
   void
-  BitMaskedArraycheck_for_iteration() const {
+  BitMaskedArray::check_for_iteration() const {
     if (identities_.get() != nullptr  &&
         identities_.get()->length() < length()) {
       util::handle_error(
@@ -337,12 +337,12 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_nothing() const {
+  BitMaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_at(int64_t at) const {
+  BitMaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
@@ -357,7 +357,7 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_at_nowrap(int64_t at) const {
+  BitMaskedArray::getitem_at_nowrap(int64_t at) const {
     int64_t bitat = at / 8;
     int64_t shift = at % 8;
     uint8_t byte = mask_.getitem_at_nowrap(bitat);
@@ -373,7 +373,7 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_range(int64_t start, int64_t stop) const {
+  BitMaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop,
@@ -389,7 +389,7 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_range_nowrap(int64_t start, int64_t stop) const {
+  BitMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     int64_t bitstart = start / 8;
     int64_t remainder = start % 8;
     if (remainder == 0) {
@@ -416,7 +416,7 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_field(const std::string& key) const {
+  BitMaskedArray::getitem_field(const std::string& key) const {
     return std::make_shared<BitMaskedArray>(
       identities_,
       util::Parameters(),
@@ -428,7 +428,7 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_fields(const std::vector<std::string>& keys) const {
+  BitMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<BitMaskedArray>(
       identities_,
       util::Parameters(),
@@ -440,19 +440,19 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_next(const SliceItemPtr& head,
-                             const Slice& tail,
-                             const Index64& advanced) const {
+  BitMaskedArray::getitem_next(const SliceItemPtr& head,
+                               const Slice& tail,
+                               const Index64& advanced) const {
     return toByteMaskedArray().get()->getitem_next(head, tail, advanced);
   }
 
   const ContentPtr
-  BitMaskedArraycarry(const Index64& carry) const {
+  BitMaskedArray::carry(const Index64& carry) const {
     return toByteMaskedArray().get()->carry(carry);
   }
 
   const std::string
-  BitMaskedArraypurelist_parameter(const std::string& key) const {
+  BitMaskedArray::purelist_parameter(const std::string& key) const {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       return content_.get()->purelist_parameter(key);
@@ -463,72 +463,72 @@ namespace awkward {
   }
 
   bool
-  BitMaskedArraypurelist_isregular() const {
+  BitMaskedArray::purelist_isregular() const {
     return content_.get()->purelist_isregular();
   }
 
   int64_t
-  BitMaskedArraypurelist_depth() const {
+  BitMaskedArray::purelist_depth() const {
     return content_.get()->purelist_depth();
   }
 
   const std::pair<int64_t, int64_t>
-  BitMaskedArrayminmax_depth() const {
+  BitMaskedArray::minmax_depth() const {
     return content_.get()->minmax_depth();
   }
 
   const std::pair<bool, int64_t>
-  BitMaskedArraybranch_depth() const {
+  BitMaskedArray::branch_depth() const {
     return content_.get()->branch_depth();
   }
 
   int64_t
-  BitMaskedArraynumfields() const {
+  BitMaskedArray::numfields() const {
     return content_.get()->numfields();
   }
 
   int64_t
-  BitMaskedArrayfieldindex(const std::string& key) const {
+  BitMaskedArray::fieldindex(const std::string& key) const {
     return content_.get()->fieldindex(key);
   }
 
   const std::string
-  BitMaskedArraykey(int64_t fieldindex) const {
+  BitMaskedArray::key(int64_t fieldindex) const {
     return content_.get()->key(fieldindex);
   }
 
   bool
-  BitMaskedArrayhaskey(const std::string& key) const {
+  BitMaskedArray::haskey(const std::string& key) const {
     return content_.get()->haskey(key);
   }
 
   const std::vector<std::string>
-  BitMaskedArraykeys() const {
+  BitMaskedArray::keys() const {
     return content_.get()->keys();
   }
 
   const std::string
-  BitMaskedArrayvalidityerror(const std::string& path) const {
+  BitMaskedArray::validityerror(const std::string& path) const {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
   const ContentPtr
-  BitMaskedArrayshallow_simplify() const {
+  BitMaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
   const ContentPtr
-  BitMaskedArraynum(int64_t axis, int64_t depth) const {
+  BitMaskedArray::num(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->num(axis, depth);
   }
 
   const std::pair<Index64, ContentPtr>
-  BitMaskedArrayoffsets_and_flattened(int64_t axis, int64_t depth) const {
+  BitMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->offsets_and_flattened(axis, depth);
   }
 
   bool
-  BitMaskedArraymergeable(const ContentPtr& other, bool mergebool) const {
+  BitMaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -578,7 +578,7 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArrayreverse_merge(const ContentPtr& other) const {
+  BitMaskedArray::reverse_merge(const ContentPtr& other) const {
     ContentPtr indexedoptionarray = toIndexedOptionArray64();
     IndexedOptionArray64* raw =
       dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
@@ -586,40 +586,40 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraymerge(const ContentPtr& other) const {
+  BitMaskedArray::merge(const ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
   const SliceItemPtr
-  BitMaskedArrayasslice() const {
+  BitMaskedArray::asslice() const {
     return toIndexedOptionArray64().get()->asslice();
   }
 
   const ContentPtr
-  BitMaskedArrayfillna(const ContentPtr& value) const {
+  BitMaskedArray::fillna(const ContentPtr& value) const {
     return toIndexedOptionArray64().get()->fillna(value);
   }
 
   const ContentPtr
-  BitMaskedArrayrpad(int64_t target, int64_t axis, int64_t depth) const {
+  BitMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->rpad(target, axis, depth);
   }
 
   const ContentPtr
-  BitMaskedArrayrpad_and_clip(int64_t target,
-                              int64_t axis,
-                              int64_t depth) const {
+  BitMaskedArray::rpad_and_clip(int64_t target,
+                                int64_t axis,
+                                int64_t depth) const {
     return toByteMaskedArray().get()->rpad_and_clip(target, axis, depth);
   }
 
   const ContentPtr
-  BitMaskedArrayreduce_next(const Reducer& reducer,
-                            int64_t negaxis,
-                            const Index64& starts,
-                            const Index64& parents,
-                            int64_t outlength,
-                            bool mask,
-                            bool keepdims) const {
+  BitMaskedArray::reduce_next(const Reducer& reducer,
+                              int64_t negaxis,
+                              const Index64& starts,
+                              const Index64& parents,
+                              int64_t outlength,
+                              bool mask,
+                              bool keepdims) const {
     return toByteMaskedArray().get()->reduce_next(reducer,
                                                   negaxis,
                                                   starts,
@@ -630,17 +630,17 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraylocalindex(int64_t axis, int64_t depth) const {
+  BitMaskedArray::localindex(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->localindex(axis, depth);
   }
 
   const ContentPtr
-  BitMaskedArraychoose(int64_t n,
-                       bool diagonal,
-                       const util::RecordLookupPtr& recordlookup,
-                       const util::Parameters& parameters,
-                       int64_t axis,
-                       int64_t depth) const {
+  BitMaskedArray::choose(int64_t n,
+                         bool diagonal,
+                         const util::RecordLookupPtr& recordlookup,
+                         const util::Parameters& parameters,
+                         int64_t axis,
+                         int64_t depth) const {
     return toByteMaskedArray().get()->choose(n,
                                              diagonal,
                                              recordlookup,
@@ -650,42 +650,42 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_next(const SliceAt& at,
-                             const Slice& tail,
-                             const Index64& advanced) const {
+  BitMaskedArray::getitem_next(const SliceAt& at,
+                               const Slice& tail,
+                               const Index64& advanced) const {
     throw std::runtime_error(
       "undefined operation: BitMaskedArraygetitem_next(at)");
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_next(const SliceRange& range,
-                             const Slice& tail,
-                             const Index64& advanced) const {
+  BitMaskedArray::getitem_next(const SliceRange& range,
+                               const Slice& tail,
+                               const Index64& advanced) const {
     throw std::runtime_error(
       "undefined operation: BitMaskedArraygetitem_next(range)");
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_next(const SliceArray64& array,
-                             const Slice& tail,
-                             const Index64& advanced) const {
+  BitMaskedArray::getitem_next(const SliceArray64& array,
+                               const Slice& tail,
+                               const Index64& advanced) const {
     throw std::runtime_error(
       "undefined operation: BitMaskedArraygetitem_next(array)");
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_next(const SliceJagged64& jagged,
-                             const Slice& tail,
-                             const Index64& advanced) const {
+  BitMaskedArray::getitem_next(const SliceJagged64& jagged,
+                               const Slice& tail,
+                               const Index64& advanced) const {
     throw std::runtime_error(
       "undefined operation: BitMaskedArraygetitem_next(jagged)");
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_next_jagged(const Index64& slicestarts,
-                                    const Index64& slicestops,
-                                    const SliceArray64& slicecontent,
-                                    const Slice& tail) const {
+  BitMaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                      const Index64& slicestops,
+                                      const SliceArray64& slicecontent,
+                                      const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts,
                                                           slicestops,
                                                           slicecontent,
@@ -693,10 +693,10 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_next_jagged(const Index64& slicestarts,
-                                    const Index64& slicestops,
-                                    const SliceMissing64& slicecontent,
-                                    const Slice& tail) const {
+  BitMaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                      const Index64& slicestops,
+                                      const SliceMissing64& slicecontent,
+                                      const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts,
                                                           slicestops,
                                                           slicecontent,
@@ -704,10 +704,10 @@ namespace awkward {
   }
 
   const ContentPtr
-  BitMaskedArraygetitem_next_jagged(const Index64& slicestarts,
-                                    const Index64& slicestops,
-                                    const SliceJagged64& slicecontent,
-                                    const Slice& tail) const {
+  BitMaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                      const Index64& slicestops,
+                                      const SliceJagged64& slicecontent,
+                                      const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts,
                                                           slicestops,
                                                           slicecontent,

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -20,7 +20,7 @@
 #include "awkward/array/BitMaskedArray.h"
 
 namespace awkward {
-  BitMaskedArray::BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, ContentPtr& content, bool validwhen, int64_t length, bool lsb_order)
+  BitMaskedArray::BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, const ContentPtr& content, bool validwhen, int64_t length, bool lsb_order)
       : Content(identities, parameters)
       , mask_(mask)
       , content_(content)
@@ -40,7 +40,7 @@ namespace awkward {
     return mask_;
   }
 
-  ContentPtr BitMaskedArray::content() const {
+  const ContentPtr BitMaskedArray::content() const {
     return content_;
   }
 
@@ -52,11 +52,11 @@ namespace awkward {
     return lsb_order_;
   }
 
-  ContentPtr BitMaskedArray::project() const {
+  const ContentPtr BitMaskedArray::project() const {
     return toByteMaskedArray().get()->project();
   }
 
-  ContentPtr BitMaskedArray::project(const Index8& mask) const {
+  const ContentPtr BitMaskedArray::project(const Index8& mask) const {
     return toByteMaskedArray().get()->project(mask);
   }
 
@@ -73,7 +73,7 @@ namespace awkward {
     return bytemask.getitem_range_nowrap(0, length_);
   }
 
-  ContentPtr BitMaskedArray::simplify_optiontype() const {
+  const ContentPtr BitMaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -82,7 +82,7 @@ namespace awkward {
         dynamic_cast<ByteMaskedArray*>(content_.get())       ||
         dynamic_cast<BitMaskedArray*>(content_.get())        ||
         dynamic_cast<UnmaskedArray*>(content_.get())) {
-      std::shared_ptr<Content> step1 = toIndexedOptionArray64();
+      ContentPtr step1 = toIndexedOptionArray64();
       IndexedOptionArray64* step2 = dynamic_cast<IndexedOptionArray64*>(step1.get());
       return step2->simplify_optiontype();
     }
@@ -218,13 +218,13 @@ namespace awkward {
     return length_;
   }
 
-  ContentPtr BitMaskedArray::shallow_copy() const {
+  const ContentPtr BitMaskedArray::shallow_copy() const {
     return std::make_shared<BitMaskedArray>(identities_, parameters_, mask_, content_, validwhen_, length_, lsb_order_);
   }
 
-  ContentPtr BitMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr BitMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexU8 mask = copyindexes ? mask_.deep_copy() : mask_;
-    std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -238,11 +238,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr BitMaskedArray::getitem_nothing() const {
+  const ContentPtr BitMaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  ContentPtr BitMaskedArray::getitem_at(int64_t at) const {
+  const ContentPtr BitMaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
@@ -253,7 +253,7 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  ContentPtr BitMaskedArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr BitMaskedArray::getitem_at_nowrap(int64_t at) const {
     int64_t bitat = at / 8;
     int64_t shift = at % 8;
     uint8_t byte = mask_.getitem_at_nowrap(bitat);
@@ -266,7 +266,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr BitMaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr BitMaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
@@ -276,7 +276,7 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  ContentPtr BitMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr BitMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     int64_t bitstart = start / 8;
     int64_t remainder = start % 8;
     if (remainder == 0) {
@@ -295,19 +295,19 @@ namespace awkward {
     }
   }
 
-  ContentPtr BitMaskedArray::getitem_field(const std::string& key) const {
+  const ContentPtr BitMaskedArray::getitem_field(const std::string& key) const {
     return std::make_shared<BitMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_field(key), validwhen_, length_, lsb_order_);
   }
 
-  ContentPtr BitMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr BitMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<BitMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_fields(keys), validwhen_, length_, lsb_order_);
   }
 
-  ContentPtr BitMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr BitMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     return toByteMaskedArray().get()->getitem_next(head, tail, advanced);
   }
 
-  ContentPtr BitMaskedArray::carry(const Index64& carry) const {
+  const ContentPtr BitMaskedArray::carry(const Index64& carry) const {
     return toByteMaskedArray().get()->carry(carry);
   }
 
@@ -361,19 +361,19 @@ namespace awkward {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  ContentPtr BitMaskedArray::shallow_simplify() const {
+  const ContentPtr BitMaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
-  ContentPtr BitMaskedArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr BitMaskedArray::num(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->num(axis, depth);
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> BitMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> BitMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->offsets_and_flattened(axis, depth);
   }
 
-  bool BitMaskedArray::mergeable(ContentPtr& other, bool mergebool) const {
+  bool BitMaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -414,13 +414,13 @@ namespace awkward {
     }
   }
 
-  ContentPtr BitMaskedArray::reverse_merge(ContentPtr& other) const {
-    std::shared_ptr<Content> indexedoptionarray = toIndexedOptionArray64();
+  const ContentPtr BitMaskedArray::reverse_merge(const ContentPtr& other) const {
+    ContentPtr indexedoptionarray = toIndexedOptionArray64();
     IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  ContentPtr BitMaskedArray::merge(ContentPtr& other) const {
+  const ContentPtr BitMaskedArray::merge(const ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
@@ -428,55 +428,55 @@ namespace awkward {
     return toIndexedOptionArray64().get()->asslice();
   }
 
-  ContentPtr BitMaskedArray::fillna(ContentPtr& value) const {
+  const ContentPtr BitMaskedArray::fillna(const ContentPtr& value) const {
     return toIndexedOptionArray64().get()->fillna(value);
   }
 
-  ContentPtr BitMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr BitMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->rpad(target, axis, depth);
   }
 
-  ContentPtr BitMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr BitMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->rpad_and_clip(target, axis, depth);
   }
 
-  ContentPtr BitMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr BitMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     return toByteMaskedArray().get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  ContentPtr BitMaskedArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr BitMaskedArray::localindex(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->localindex(axis, depth);
   }
 
-  ContentPtr BitMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr BitMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
   }
 
-  ContentPtr BitMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr BitMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(at)");
   }
 
-  ContentPtr BitMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr BitMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(range)");
   }
 
-  ContentPtr BitMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr BitMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(array)");
   }
 
-  ContentPtr BitMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr BitMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(jagged)");
   }
 
-  ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -20,7 +20,7 @@
 #include "awkward/array/BitMaskedArray.h"
 
 namespace awkward {
-  BitMaskedArray::BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, const std::shared_ptr<Content>& content, bool validwhen, int64_t length, bool lsb_order)
+  BitMaskedArray::BitMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexU8& mask, ContentPtr& content, bool validwhen, int64_t length, bool lsb_order)
       : Content(identities, parameters)
       , mask_(mask)
       , content_(content)
@@ -40,7 +40,7 @@ namespace awkward {
     return mask_;
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::content() const {
+  ContentPtr BitMaskedArray::content() const {
     return content_;
   }
 
@@ -52,11 +52,11 @@ namespace awkward {
     return lsb_order_;
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::project() const {
+  ContentPtr BitMaskedArray::project() const {
     return toByteMaskedArray().get()->project();
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::project(const Index8& mask) const {
+  ContentPtr BitMaskedArray::project(const Index8& mask) const {
     return toByteMaskedArray().get()->project(mask);
   }
 
@@ -73,7 +73,7 @@ namespace awkward {
     return bytemask.getitem_range_nowrap(0, length_);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::simplify_optiontype() const {
+  ContentPtr BitMaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -218,11 +218,11 @@ namespace awkward {
     return length_;
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::shallow_copy() const {
+  ContentPtr BitMaskedArray::shallow_copy() const {
     return std::make_shared<BitMaskedArray>(identities_, parameters_, mask_, content_, validwhen_, length_, lsb_order_);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr BitMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexU8 mask = copyindexes ? mask_.deep_copy() : mask_;
     std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
@@ -238,11 +238,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_nothing() const {
+  ContentPtr BitMaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_at(int64_t at) const {
+  ContentPtr BitMaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
@@ -253,7 +253,7 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_at_nowrap(int64_t at) const {
+  ContentPtr BitMaskedArray::getitem_at_nowrap(int64_t at) const {
     int64_t bitat = at / 8;
     int64_t shift = at % 8;
     uint8_t byte = mask_.getitem_at_nowrap(bitat);
@@ -266,7 +266,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr BitMaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
@@ -276,7 +276,7 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr BitMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     int64_t bitstart = start / 8;
     int64_t remainder = start % 8;
     if (remainder == 0) {
@@ -295,19 +295,19 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_field(const std::string& key) const {
+  ContentPtr BitMaskedArray::getitem_field(const std::string& key) const {
     return std::make_shared<BitMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_field(key), validwhen_, length_, lsb_order_);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr BitMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<BitMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_fields(keys), validwhen_, length_, lsb_order_);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  ContentPtr BitMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     return toByteMaskedArray().get()->getitem_next(head, tail, advanced);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::carry(const Index64& carry) const {
+  ContentPtr BitMaskedArray::carry(const Index64& carry) const {
     return toByteMaskedArray().get()->carry(carry);
   }
 
@@ -361,11 +361,11 @@ namespace awkward {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::shallow_simplify() const {
+  ContentPtr BitMaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::num(int64_t axis, int64_t depth) const {
+  ContentPtr BitMaskedArray::num(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->num(axis, depth);
   }
 
@@ -373,7 +373,7 @@ namespace awkward {
     return toByteMaskedArray().get()->offsets_and_flattened(axis, depth);
   }
 
-  bool BitMaskedArray::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool BitMaskedArray::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -414,13 +414,13 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::reverse_merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr BitMaskedArray::reverse_merge(ContentPtr& other) const {
     std::shared_ptr<Content> indexedoptionarray = toIndexedOptionArray64();
     IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr BitMaskedArray::merge(ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
@@ -428,55 +428,55 @@ namespace awkward {
     return toIndexedOptionArray64().get()->asslice();
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr BitMaskedArray::fillna(ContentPtr& value) const {
     return toIndexedOptionArray64().get()->fillna(value);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr BitMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->rpad(target, axis, depth);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr BitMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->rpad_and_clip(target, axis, depth);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr BitMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     return toByteMaskedArray().get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr BitMaskedArray::localindex(int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->localindex(axis, depth);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr BitMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr BitMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(at)");
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr BitMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(range)");
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr BitMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(array)");
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr BitMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: BitMaskedArray::getitem_next(jagged)");
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
-  const std::shared_ptr<Content> BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr BitMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return toByteMaskedArray().get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -196,7 +196,7 @@ namespace awkward {
     }
   }
 
-  const TypePtr ByteMaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr ByteMaskedArray::type(const util::TypeStrs& typestrs) const {
     return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
   }
 

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -25,7 +25,7 @@
 #include "awkward/array/ByteMaskedArray.h"
 
 namespace awkward {
-  ByteMaskedArray::ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, ContentPtr& content, bool validwhen)
+  ByteMaskedArray::ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, const ContentPtr& content, bool validwhen)
       : Content(identities, parameters)
       , mask_(mask)
       , content_(content)
@@ -39,7 +39,7 @@ namespace awkward {
     return mask_;
   }
 
-  ContentPtr ByteMaskedArray::content() const {
+  const ContentPtr ByteMaskedArray::content() const {
     return content_;
   }
 
@@ -47,7 +47,7 @@ namespace awkward {
     return validwhen_;
   }
 
-  ContentPtr ByteMaskedArray::project() const {
+  const ContentPtr ByteMaskedArray::project() const {
     int64_t numnull;
     struct Error err1 = awkward_bytemaskedarray_numnull(
       &numnull,
@@ -69,7 +69,7 @@ namespace awkward {
     return content_.get()->carry(nextcarry);
   }
 
-  ContentPtr ByteMaskedArray::project(const Index8& mask) const {
+  const ContentPtr ByteMaskedArray::project(const Index8& mask) const {
     if (length() != mask.length()) {
       throw std::invalid_argument(std::string("mask length (") + std::to_string(mask.length()) + std::string(") is not equal to ") + classname() + std::string(" length (") + std::to_string(length()) + std::string(")"));
     }
@@ -106,7 +106,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::simplify_optiontype() const {
+  const ContentPtr ByteMaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -115,7 +115,7 @@ namespace awkward {
         dynamic_cast<ByteMaskedArray*>(content_.get())       ||
         dynamic_cast<BitMaskedArray*>(content_.get())        ||
         dynamic_cast<UnmaskedArray*>(content_.get())) {
-      std::shared_ptr<Content> step1 = toIndexedOptionArray64();
+      ContentPtr step1 = toIndexedOptionArray64();
       IndexedOptionArray64* step2 = dynamic_cast<IndexedOptionArray64*>(step1.get());
       return step2->simplify_optiontype();
     }
@@ -124,7 +124,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::toIndexedOptionArray64() const {
+  const ContentPtr ByteMaskedArray::toIndexedOptionArray64() const {
     Index64 index(length());
     struct Error err = awkward_bytemaskedarray_toindexedarray_64(
       index.ptr().get(),
@@ -237,13 +237,13 @@ namespace awkward {
     return mask_.length();
   }
 
-  ContentPtr ByteMaskedArray::shallow_copy() const {
+  const ContentPtr ByteMaskedArray::shallow_copy() const {
     return std::make_shared<ByteMaskedArray>(identities_, parameters_, mask_, content_, validwhen_);
   }
 
-  ContentPtr ByteMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr ByteMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     Index8 mask = copyindexes ? mask_.deep_copy() : mask_;
-    std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -257,11 +257,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::getitem_nothing() const {
+  const ContentPtr ByteMaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  ContentPtr ByteMaskedArray::getitem_at(int64_t at) const {
+  const ContentPtr ByteMaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
@@ -272,7 +272,7 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  ContentPtr ByteMaskedArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr ByteMaskedArray::getitem_at_nowrap(int64_t at) const {
     bool msk = (mask_.getitem_at_nowrap(at) != 0);
     if (msk == validwhen_) {
       return content_.get()->getitem_at_nowrap(at);
@@ -282,7 +282,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr ByteMaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
@@ -292,7 +292,7 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  ContentPtr ByteMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr ByteMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -300,15 +300,15 @@ namespace awkward {
     return std::make_shared<ByteMaskedArray>(identities, parameters_, mask_.getitem_range_nowrap(start, stop), content_.get()->getitem_range_nowrap(start, stop), validwhen_);
   }
 
-  ContentPtr ByteMaskedArray::getitem_field(const std::string& key) const {
+  const ContentPtr ByteMaskedArray::getitem_field(const std::string& key) const {
     return std::make_shared<ByteMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_field(key), validwhen_);
   }
 
-  ContentPtr ByteMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr ByteMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<ByteMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_fields(keys), validwhen_);
   }
 
-  ContentPtr ByteMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ByteMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -318,9 +318,9 @@ namespace awkward {
       Index64 nextcarry = pair.first;
       Index64 outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
+      ContentPtr next = content_.get()->carry(nextcarry);
 
-      std::shared_ptr<Content> out = next.get()->getitem_next(head, tail, advanced);
+      ContentPtr out = next.get()->getitem_next(head, tail, advanced);
       IndexedOptionArray64 out2(identities_, parameters_, outindex, out);
       return out2.simplify_optiontype();
     }
@@ -344,7 +344,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::carry(const Index64& carry) const {
+  const ContentPtr ByteMaskedArray::carry(const Index64& carry) const {
     Index8 nextmask(carry.length());
     struct Error err = awkward_bytemaskedarray_getitem_carry_64(
       nextmask.ptr().get(),
@@ -411,11 +411,11 @@ namespace awkward {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  ContentPtr ByteMaskedArray::shallow_simplify() const {
+  const ContentPtr ByteMaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
-  ContentPtr ByteMaskedArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr ByteMaskedArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -428,15 +428,15 @@ namespace awkward {
       Index64 nextcarry = pair.first;
       Index64 outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
+      ContentPtr next = content_.get()->carry(nextcarry);
 
-      std::shared_ptr<Content> out = next.get()->num(axis, depth);
+      ContentPtr out = next.get()->num(axis, depth);
       IndexedOptionArray64 out2(Identities::none(), util::Parameters(), outindex, out);
       return out2.simplify_optiontype();
     }
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> ByteMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> ByteMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -447,14 +447,14 @@ namespace awkward {
       Index64 nextcarry = pair.first;
       Index64 outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
+      ContentPtr next = content_.get()->carry(nextcarry);
 
-      std::pair<Index64, std::shared_ptr<Content>> offsets_flattened = next.get()->offsets_and_flattened(axis, depth);
+      std::pair<Index64, ContentPtr> offsets_flattened = next.get()->offsets_and_flattened(axis, depth);
       Index64 offsets = offsets_flattened.first;
-      std::shared_ptr<Content> flattened = offsets_flattened.second;
+      ContentPtr flattened = offsets_flattened.second;
 
       if (offsets.length() == 0) {
-        return std::pair<Index64, std::shared_ptr<Content>>(offsets, std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), outindex, flattened));
+        return std::pair<Index64, ContentPtr>(offsets, std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), outindex, flattened));
       }
       else {
         Index64 outoffsets(offsets.length() + numnull);
@@ -467,12 +467,12 @@ namespace awkward {
           offsets.offset(),
           offsets.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::pair<Index64, std::shared_ptr<Content>>(outoffsets, flattened);
+        return std::pair<Index64, ContentPtr>(outoffsets, flattened);
       }
     }
   }
 
-  bool ByteMaskedArray::mergeable(ContentPtr& other, bool mergebool) const {
+  bool ByteMaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -513,13 +513,13 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::reverse_merge(ContentPtr& other) const {
-    std::shared_ptr<Content> indexedoptionarray = toIndexedOptionArray64();
+  const ContentPtr ByteMaskedArray::reverse_merge(const ContentPtr& other) const {
+    ContentPtr indexedoptionarray = toIndexedOptionArray64();
     IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  ContentPtr ByteMaskedArray::merge(ContentPtr& other) const {
+  const ContentPtr ByteMaskedArray::merge(const ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
@@ -527,11 +527,11 @@ namespace awkward {
     return toIndexedOptionArray64().get()->asslice();
   }
 
-  ContentPtr ByteMaskedArray::fillna(ContentPtr& value) const {
+  const ContentPtr ByteMaskedArray::fillna(const ContentPtr& value) const {
     return toIndexedOptionArray64().get()->fillna(value);
   }
 
-  ContentPtr ByteMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr ByteMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -545,7 +545,7 @@ namespace awkward {
         mask.length());
       util::handle_error(err, classname(), identities_.get());
 
-      std::shared_ptr<Content> next = project().get()->rpad(target, toaxis, depth);
+      ContentPtr next = project().get()->rpad(target, toaxis, depth);
       return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, next).get()->simplify_optiontype();
     }
     else {
@@ -553,7 +553,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr ByteMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -567,7 +567,7 @@ namespace awkward {
         mask.length());
       util::handle_error(err, classname(), identities_.get());
 
-      std::shared_ptr<Content> next = project().get()->rpad_and_clip(target, toaxis, depth);
+      ContentPtr next = project().get()->rpad_and_clip(target, toaxis, depth);
       return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, next).get()->simplify_optiontype();
     }
     else {
@@ -575,7 +575,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr ByteMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     int64_t numnull;
     struct Error err1 = awkward_bytemaskedarray_numnull(
       &numnull,
@@ -600,8 +600,8 @@ namespace awkward {
       validwhen_);
     util::handle_error(err2, classname(), identities_.get());
 
-    std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-    std::shared_ptr<Content> out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
+    ContentPtr next = content_.get()->carry(nextcarry);
+    ContentPtr out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
 
     std::pair<bool, int64_t> branchdepth = branch_depth();
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -632,7 +632,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr ByteMaskedArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr ByteMaskedArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return localindex_axis0();
@@ -643,14 +643,14 @@ namespace awkward {
       Index64 nextcarry = pair.first;
       Index64 outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-      std::shared_ptr<Content> out = next.get()->localindex(axis, depth);
+      ContentPtr next = content_.get()->carry(nextcarry);
+      ContentPtr out = next.get()->localindex(axis, depth);
       IndexedOptionArray64 out2(Identities::none(), util::Parameters(), outindex, out);
       return out2.simplify_optiontype();
     }
   }
 
-  ContentPtr ByteMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr ByteMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -664,50 +664,50 @@ namespace awkward {
       Index64 nextcarry = pair.first;
       Index64 outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-      std::shared_ptr<Content> out = next.get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
+      ContentPtr next = content_.get()->carry(nextcarry);
+      ContentPtr out = next.get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
       IndexedOptionArray64 out2(Identities::none(), util::Parameters(), outindex, out);
       return out2.simplify_optiontype();
     }
   }
 
-  ContentPtr ByteMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ByteMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(at)");
   }
 
-  ContentPtr ByteMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ByteMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(range)");
   }
 
-  ContentPtr ByteMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ByteMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(array)");
   }
 
-  ContentPtr ByteMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ByteMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(jagged)");
   }
 
-  ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename S>
-  ContentPtr ByteMaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  const ContentPtr ByteMaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
       int64_t numnull;
       std::pair<Index64, Index64> pair = nextcarry_outindex(numnull);
       Index64 nextcarry = pair.first;
       Index64 outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-      std::shared_ptr<Content> out = next.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+      ContentPtr next = content_.get()->carry(nextcarry);
+      ContentPtr out = next.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
       IndexedOptionArray64 out2(identities_, parameters_, outindex, out);
       return out2.simplify_optiontype();
   }

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -25,7 +25,7 @@
 #include "awkward/array/ByteMaskedArray.h"
 
 namespace awkward {
-  ByteMaskedArray::ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, const std::shared_ptr<Content>& content, bool validwhen)
+  ByteMaskedArray::ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, ContentPtr& content, bool validwhen)
       : Content(identities, parameters)
       , mask_(mask)
       , content_(content)
@@ -39,7 +39,7 @@ namespace awkward {
     return mask_;
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::content() const {
+  ContentPtr ByteMaskedArray::content() const {
     return content_;
   }
 
@@ -47,7 +47,7 @@ namespace awkward {
     return validwhen_;
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::project() const {
+  ContentPtr ByteMaskedArray::project() const {
     int64_t numnull;
     struct Error err1 = awkward_bytemaskedarray_numnull(
       &numnull,
@@ -69,7 +69,7 @@ namespace awkward {
     return content_.get()->carry(nextcarry);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::project(const Index8& mask) const {
+  ContentPtr ByteMaskedArray::project(const Index8& mask) const {
     if (length() != mask.length()) {
       throw std::invalid_argument(std::string("mask length (") + std::to_string(mask.length()) + std::string(") is not equal to ") + classname() + std::string(" length (") + std::to_string(length()) + std::string(")"));
     }
@@ -106,7 +106,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::simplify_optiontype() const {
+  ContentPtr ByteMaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -124,7 +124,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::toIndexedOptionArray64() const {
+  ContentPtr ByteMaskedArray::toIndexedOptionArray64() const {
     Index64 index(length());
     struct Error err = awkward_bytemaskedarray_toindexedarray_64(
       index.ptr().get(),
@@ -237,11 +237,11 @@ namespace awkward {
     return mask_.length();
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::shallow_copy() const {
+  ContentPtr ByteMaskedArray::shallow_copy() const {
     return std::make_shared<ByteMaskedArray>(identities_, parameters_, mask_, content_, validwhen_);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr ByteMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     Index8 mask = copyindexes ? mask_.deep_copy() : mask_;
     std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
@@ -257,11 +257,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_nothing() const {
+  ContentPtr ByteMaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_at(int64_t at) const {
+  ContentPtr ByteMaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
@@ -272,7 +272,7 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_at_nowrap(int64_t at) const {
+  ContentPtr ByteMaskedArray::getitem_at_nowrap(int64_t at) const {
     bool msk = (mask_.getitem_at_nowrap(at) != 0);
     if (msk == validwhen_) {
       return content_.get()->getitem_at_nowrap(at);
@@ -282,7 +282,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr ByteMaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
@@ -292,7 +292,7 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr ByteMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -300,15 +300,15 @@ namespace awkward {
     return std::make_shared<ByteMaskedArray>(identities, parameters_, mask_.getitem_range_nowrap(start, stop), content_.get()->getitem_range_nowrap(start, stop), validwhen_);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_field(const std::string& key) const {
+  ContentPtr ByteMaskedArray::getitem_field(const std::string& key) const {
     return std::make_shared<ByteMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_field(key), validwhen_);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr ByteMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<ByteMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_fields(keys), validwhen_);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ByteMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -344,7 +344,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::carry(const Index64& carry) const {
+  ContentPtr ByteMaskedArray::carry(const Index64& carry) const {
     Index8 nextmask(carry.length());
     struct Error err = awkward_bytemaskedarray_getitem_carry_64(
       nextmask.ptr().get(),
@@ -411,11 +411,11 @@ namespace awkward {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::shallow_simplify() const {
+  ContentPtr ByteMaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::num(int64_t axis, int64_t depth) const {
+  ContentPtr ByteMaskedArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -472,7 +472,7 @@ namespace awkward {
     }
   }
 
-  bool ByteMaskedArray::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool ByteMaskedArray::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -513,13 +513,13 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::reverse_merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr ByteMaskedArray::reverse_merge(ContentPtr& other) const {
     std::shared_ptr<Content> indexedoptionarray = toIndexedOptionArray64();
     IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr ByteMaskedArray::merge(ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
@@ -527,11 +527,11 @@ namespace awkward {
     return toIndexedOptionArray64().get()->asslice();
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr ByteMaskedArray::fillna(ContentPtr& value) const {
     return toIndexedOptionArray64().get()->fillna(value);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr ByteMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -553,7 +553,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr ByteMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -575,7 +575,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr ByteMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     int64_t numnull;
     struct Error err1 = awkward_bytemaskedarray_numnull(
       &numnull,
@@ -632,7 +632,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr ByteMaskedArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return localindex_axis0();
@@ -650,7 +650,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr ByteMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -671,36 +671,36 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ByteMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(at)");
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ByteMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(range)");
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ByteMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(array)");
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ByteMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(jagged)");
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename S>
-  const std::shared_ptr<Content> ByteMaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  ContentPtr ByteMaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
       int64_t numnull;
       std::pair<Index64, Index64> pair = nextcarry_outindex(numnull);
       Index64 nextcarry = pair.first;

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -25,29 +25,38 @@
 #include "awkward/array/ByteMaskedArray.h"
 
 namespace awkward {
-  ByteMaskedArray::ByteMaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const Index8& mask, const ContentPtr& content, bool validwhen)
+  ByteMaskedArray::ByteMaskedArray(const IdentitiesPtr& identities,
+                                   const util::Parameters& parameters,
+                                   const Index8& mask,
+                                   const ContentPtr& content,
+                                   bool validwhen)
       : Content(identities, parameters)
       , mask_(mask)
       , content_(content)
       , validwhen_(validwhen != 0) {
     if (content.get()->length() < mask.length()) {
-      throw std::invalid_argument("ByteMaskedArray content must not be shorter than its mask");
+      throw std::invalid_argument(
+        "ByteMaskedArray content must not be shorter than its mask");
     }
   }
 
-  const Index8 ByteMaskedArray::mask() const {
+  const Index8
+  ByteMaskedArray::mask() const {
     return mask_;
   }
 
-  const ContentPtr ByteMaskedArray::content() const {
+  const ContentPtr
+  ByteMaskedArray::content() const {
     return content_;
   }
 
-  bool ByteMaskedArray::validwhen() const {
+  bool
+  ByteMaskedArray::validwhen() const {
     return validwhen_;
   }
 
-  const ContentPtr ByteMaskedArray::project() const {
+  const ContentPtr
+  ByteMaskedArray::project() const {
     int64_t numnull;
     struct Error err1 = awkward_bytemaskedarray_numnull(
       &numnull,
@@ -69,9 +78,14 @@ namespace awkward {
     return content_.get()->carry(nextcarry);
   }
 
-  const ContentPtr ByteMaskedArray::project(const Index8& mask) const {
+  const ContentPtr
+  ByteMaskedArray::project(const Index8& mask) const {
     if (length() != mask.length()) {
-      throw std::invalid_argument(std::string("mask length (") + std::to_string(mask.length()) + std::string(") is not equal to ") + classname() + std::string(" length (") + std::to_string(length()) + std::string(")"));
+      throw std::invalid_argument(
+        std::string("mask length (") + std::to_string(mask.length())
+        + std::string(") is not equal to ") + classname()
+        + std::string(" length (") + std::to_string(length())
+        + std::string(")"));
     }
 
     Index8 nextmask(length());
@@ -85,11 +99,13 @@ namespace awkward {
       validwhen_);
     util::handle_error(err, classname(), identities_.get());
 
-    ByteMaskedArray next(identities_, parameters_, nextmask, content_, false);  // validwhen=false
+    //                                                       validwhen=false
+    ByteMaskedArray next(identities_, parameters_, nextmask, content_, false);
     return next.project();
   }
 
-  const Index8 ByteMaskedArray::bytemask() const {
+  const Index8
+  ByteMaskedArray::bytemask() const {
     if (!validwhen_) {
       return mask_;
     }
@@ -106,7 +122,8 @@ namespace awkward {
     }
   }
 
-  const ContentPtr ByteMaskedArray::simplify_optiontype() const {
+  const ContentPtr
+  ByteMaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -116,7 +133,8 @@ namespace awkward {
         dynamic_cast<BitMaskedArray*>(content_.get())        ||
         dynamic_cast<UnmaskedArray*>(content_.get())) {
       ContentPtr step1 = toIndexedOptionArray64();
-      IndexedOptionArray64* step2 = dynamic_cast<IndexedOptionArray64*>(step1.get());
+      IndexedOptionArray64* step2 =
+        dynamic_cast<IndexedOptionArray64*>(step1.get());
       return step2->simplify_optiontype();
     }
     else {
@@ -124,7 +142,8 @@ namespace awkward {
     }
   }
 
-  const ContentPtr ByteMaskedArray::toIndexedOptionArray64() const {
+  const ContentPtr
+  ByteMaskedArray::toIndexedOptionArray64() const {
     Index64 index(length());
     struct Error err = awkward_bytemaskedarray_toindexedarray_64(
       index.ptr().get(),
@@ -133,24 +152,40 @@ namespace awkward {
       mask_.length(),
       validwhen_);
     util::handle_error(err, classname(), identities_.get());
-    return std::make_shared<IndexedOptionArray64>(identities_, parameters_, index, content_);
+    return std::make_shared<IndexedOptionArray64>(identities_,
+                                                  parameters_,
+                                                  index,
+                                                  content_);
   }
 
-  const std::string ByteMaskedArray::classname() const {
+  const std::string
+  ByteMaskedArray::classname() const {
     return "ByteMaskedArray";
   }
 
-  void ByteMaskedArray::setidentities(const IdentitiesPtr& identities) {
+  void
+  ByteMaskedArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
     else {
       if (length() != identities.get()->length()) {
-        util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(
+          failure("content and its identities must have the same length",
+                  kSliceNone,
+                  kSliceNone),
+          classname(),
+          identities_.get());
       }
-      if (Identities32* rawidentities = dynamic_cast<Identities32*>(identities.get())) {
-        std::shared_ptr<Identities32> subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
-        Identities32* rawsubidentities = reinterpret_cast<Identities32*>(subidentities.get());
+      if (Identities32* rawidentities =
+          dynamic_cast<Identities32*>(identities.get())) {
+        std::shared_ptr<Identities32> subidentities =
+          std::make_shared<Identities32>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width(),
+                                         content_.get()->length());
+        Identities32* rawsubidentities =
+          reinterpret_cast<Identities32*>(subidentities.get());
         struct Error err = awkward_identities32_extend(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -160,9 +195,15 @@ namespace awkward {
         util::handle_error(err, classname(), identities_.get());
         content_.get()->setidentities(subidentities);
       }
-      else if (Identities64* rawidentities = dynamic_cast<Identities64*>(identities.get())) {
-        std::shared_ptr<Identities64> subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
-        Identities64* rawsubidentities = reinterpret_cast<Identities64*>(subidentities.get());
+      else if (Identities64* rawidentities =
+               dynamic_cast<Identities64*>(identities.get())) {
+        std::shared_ptr<Identities64> subidentities =
+          std::make_shared<Identities64>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width(),
+                                         content_.get()->length());
+        Identities64* rawsubidentities =
+          reinterpret_cast<Identities64*>(subidentities.get());
         struct Error err = awkward_identities64_extend(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -179,43 +220,68 @@ namespace awkward {
     identities_ = identities;
   }
 
-  void ByteMaskedArray::setidentities() {
+  void
+  ByteMaskedArray::setidentities() {
     if (length() <= kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err = awkward_new_identities32(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err =
+        awkward_new_identities64(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
   }
 
-  const TypePtr ByteMaskedArray::type(const util::TypeStrs& typestrs) const {
-    return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
+  const TypePtr
+  ByteMaskedArray::type(const util::TypeStrs& typestrs) const {
+    return std::make_shared<OptionType>(
+             parameters_,
+             util::gettypestr(parameters_, typestrs),
+             content_.get()->type(typestrs));
   }
 
-  const std::string ByteMaskedArray::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  ByteMaskedArray::tostring_part(const std::string& indent,
+                                 const std::string& pre,
+                                 const std::string& post) const {
     std::stringstream out;
-    out << indent << pre << "<" << classname() << " validwhen=\"" << (validwhen_ ? "true" : "false") << "\">\n";
+    out << indent << pre << "<" << classname() << " validwhen=\""
+        << (validwhen_ ? "true" : "false") << "\">\n";
     if (identities_.get() != nullptr) {
-      out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+      out << identities_.get()->tostring_part(
+               indent + std::string("    "), "", "\n");
     }
     if (!parameters_.empty()) {
       out << parameters_tostring(indent + std::string("    "), "", "\n");
     }
-    out << mask_.tostring_part(indent + std::string("    "), "<mask>", "</mask>\n");
-    out << content_.get()->tostring_part(indent + std::string("    "), "<content>", "</content>\n");
+    out << mask_.tostring_part(
+             indent + std::string("    "), "<mask>", "</mask>\n");
+    out << content_.get()->tostring_part(
+             indent + std::string("    "), "<content>", "</content>\n");
     out << indent << "</" << classname() << ">" << post;
     return out.str();
   }
 
-  void ByteMaskedArray::tojson_part(ToJson& builder) const {
+  void
+  ByteMaskedArray::tojson_part(ToJson& builder) const {
     int64_t len = length();
     check_for_iteration();
     builder.beginlist();
@@ -225,7 +291,8 @@ namespace awkward {
     builder.endlist();
   }
 
-  void ByteMaskedArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  ByteMaskedArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
     mask_.nbytes_part(largest);
     content_.get()->nbytes_part(largest);
     if (identities_.get() != nullptr) {
@@ -233,46 +300,72 @@ namespace awkward {
     }
   }
 
-  int64_t ByteMaskedArray::length() const {
+  int64_t
+  ByteMaskedArray::length() const {
     return mask_.length();
   }
 
-  const ContentPtr ByteMaskedArray::shallow_copy() const {
-    return std::make_shared<ByteMaskedArray>(identities_, parameters_, mask_, content_, validwhen_);
+  const ContentPtr
+  ByteMaskedArray::shallow_copy() const {
+    return std::make_shared<ByteMaskedArray>(identities_,
+                                             parameters_,
+                                             mask_,
+                                             content_,
+                                             validwhen_);
   }
 
-  const ContentPtr ByteMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  ByteMaskedArray::deep_copy(bool copyarrays,
+                             bool copyindexes,
+                             bool copyidentities) const {
     Index8 mask = copyindexes ? mask_.deep_copy() : mask_;
-    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays,
+                                                   copyindexes,
+                                                   copyidentities);
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
-    return std::make_shared<ByteMaskedArray>(identities, parameters_, mask, content, validwhen_);
+    return std::make_shared<ByteMaskedArray>(identities,
+                                             parameters_,
+                                             mask,
+                                             content,
+                                             validwhen_);
   }
 
-  void ByteMaskedArray::check_for_iteration() const {
-    if (identities_.get() != nullptr  &&  identities_.get()->length() < length()) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+  void
+  ByteMaskedArray::check_for_iteration() const {
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < length()) {
+      util::handle_error(
+        failure("len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
-  const ContentPtr ByteMaskedArray::getitem_nothing() const {
+  const ContentPtr
+  ByteMaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_at(int64_t at) const {
+  const ContentPtr
+  ByteMaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
     }
     if (!(0 <= regular_at  &&  regular_at < length())) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  ByteMaskedArray::getitem_at_nowrap(int64_t at) const {
     bool msk = (mask_.getitem_at_nowrap(at) != 0);
     if (msk == validwhen_) {
       return content_.get()->getitem_at_nowrap(at);
@@ -282,37 +375,67 @@ namespace awkward {
     }
   }
 
-  const ContentPtr ByteMaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  ByteMaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
-    if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-      util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), length());
+    if (identities_.get() != nullptr  &&
+        regular_stop > identities_.get()->length()) {
+      util::handle_error(
+        failure("index out of range", kSliceNone, stop),
+        identities_.get()->classname(),
+        nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  ByteMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
-    return std::make_shared<ByteMaskedArray>(identities, parameters_, mask_.getitem_range_nowrap(start, stop), content_.get()->getitem_range_nowrap(start, stop), validwhen_);
+    return std::make_shared<ByteMaskedArray>(
+      identities,
+      parameters_,
+      mask_.getitem_range_nowrap(start, stop),
+      content_.get()->getitem_range_nowrap(start, stop),
+      validwhen_);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_field(const std::string& key) const {
-    return std::make_shared<ByteMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_field(key), validwhen_);
+  const ContentPtr
+  ByteMaskedArray::getitem_field(const std::string& key) const {
+    return std::make_shared<ByteMaskedArray>(
+      identities_,
+      util::Parameters(),
+      mask_,
+      content_.get()->getitem_field(key),
+      validwhen_);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
-    return std::make_shared<ByteMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_fields(keys), validwhen_);
+  const ContentPtr
+  ByteMaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
+    return std::make_shared<ByteMaskedArray>(
+      identities_,
+      util::Parameters(),
+      mask_,
+      content_.get()->getitem_fields(keys),
+      validwhen_);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  ByteMaskedArray::getitem_next(const SliceItemPtr& head,
+                                const Slice& tail,
+                                const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
-    else if (dynamic_cast<SliceAt*>(head.get())  ||  dynamic_cast<SliceRange*>(head.get())  ||  dynamic_cast<SliceArray64*>(head.get())  ||  dynamic_cast<SliceJagged64*>(head.get())) {
+    else if (dynamic_cast<SliceAt*>(head.get())  ||
+             dynamic_cast<SliceRange*>(head.get())  ||
+             dynamic_cast<SliceArray64*>(head.get())  ||
+             dynamic_cast<SliceJagged64*>(head.get())) {
       int64_t numnull;
       std::pair<Index64, Index64> pair = nextcarry_outindex(numnull);
       Index64 nextcarry = pair.first;
@@ -324,19 +447,24 @@ namespace awkward {
       IndexedOptionArray64 out2(identities_, parameters_, outindex, out);
       return out2.simplify_optiontype();
     }
-    else if (SliceEllipsis* ellipsis = dynamic_cast<SliceEllipsis*>(head.get())) {
+    else if (SliceEllipsis* ellipsis =
+             dynamic_cast<SliceEllipsis*>(head.get())) {
       return Content::getitem_next(*ellipsis, tail, advanced);
     }
-    else if (SliceNewAxis* newaxis = dynamic_cast<SliceNewAxis*>(head.get())) {
+    else if (SliceNewAxis* newaxis =
+             dynamic_cast<SliceNewAxis*>(head.get())) {
       return Content::getitem_next(*newaxis, tail, advanced);
     }
-    else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {
+    else if (SliceField* field =
+             dynamic_cast<SliceField*>(head.get())) {
       return Content::getitem_next(*field, tail, advanced);
     }
-    else if (SliceFields* fields = dynamic_cast<SliceFields*>(head.get())) {
+    else if (SliceFields* fields =
+             dynamic_cast<SliceFields*>(head.get())) {
       return Content::getitem_next(*fields, tail, advanced);
     }
-    else if (SliceMissing64* missing = dynamic_cast<SliceMissing64*>(head.get())) {
+    else if (SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(head.get())) {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
@@ -344,7 +472,8 @@ namespace awkward {
     }
   }
 
-  const ContentPtr ByteMaskedArray::carry(const Index64& carry) const {
+  const ContentPtr
+  ByteMaskedArray::carry(const Index64& carry) const {
     Index8 nextmask(carry.length());
     struct Error err = awkward_bytemaskedarray_getitem_carry_64(
       nextmask.ptr().get(),
@@ -358,10 +487,15 @@ namespace awkward {
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
-    return std::make_shared<ByteMaskedArray>(identities, parameters_, nextmask, content_.get()->carry(carry), validwhen_);
+    return std::make_shared<ByteMaskedArray>(identities,
+                                             parameters_,
+                                             nextmask,
+                                             content_.get()->carry(carry),
+                                             validwhen_);
   }
 
-  const std::string ByteMaskedArray::purelist_parameter(const std::string& key) const {
+  const std::string
+  ByteMaskedArray::purelist_parameter(const std::string& key) const {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       return content_.get()->purelist_parameter(key);
@@ -371,51 +505,63 @@ namespace awkward {
     }
   }
 
-  bool ByteMaskedArray::purelist_isregular() const {
+  bool
+  ByteMaskedArray::purelist_isregular() const {
     return content_.get()->purelist_isregular();
   }
 
-  int64_t ByteMaskedArray::purelist_depth() const {
+  int64_t
+  ByteMaskedArray::purelist_depth() const {
     return content_.get()->purelist_depth();
   }
 
-  const std::pair<int64_t, int64_t> ByteMaskedArray::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  ByteMaskedArray::minmax_depth() const {
     return content_.get()->minmax_depth();
   }
 
-  const std::pair<bool, int64_t> ByteMaskedArray::branch_depth() const {
+  const std::pair<bool, int64_t>
+  ByteMaskedArray::branch_depth() const {
     return content_.get()->branch_depth();
   }
 
-  int64_t ByteMaskedArray::numfields() const {
+  int64_t
+  ByteMaskedArray::numfields() const {
     return content_.get()->numfields();
   }
 
-  int64_t ByteMaskedArray::fieldindex(const std::string& key) const {
+  int64_t
+  ByteMaskedArray::fieldindex(const std::string& key) const {
     return content_.get()->fieldindex(key);
   }
 
-  const std::string ByteMaskedArray::key(int64_t fieldindex) const {
+  const std::string
+  ByteMaskedArray::key(int64_t fieldindex) const {
     return content_.get()->key(fieldindex);
   }
 
-  bool ByteMaskedArray::haskey(const std::string& key) const {
+  bool
+  ByteMaskedArray::haskey(const std::string& key) const {
     return content_.get()->haskey(key);
   }
 
-  const std::vector<std::string> ByteMaskedArray::keys() const {
+  const std::vector<std::string>
+  ByteMaskedArray::keys() const {
     return content_.get()->keys();
   }
 
-  const std::string ByteMaskedArray::validityerror(const std::string& path) const {
+  const std::string
+  ByteMaskedArray::validityerror(const std::string& path) const {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  const ContentPtr ByteMaskedArray::shallow_simplify() const {
+  const ContentPtr
+  ByteMaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
-  const ContentPtr ByteMaskedArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ByteMaskedArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -431,12 +577,16 @@ namespace awkward {
       ContentPtr next = content_.get()->carry(nextcarry);
 
       ContentPtr out = next.get()->num(axis, depth);
-      IndexedOptionArray64 out2(Identities::none(), util::Parameters(), outindex, out);
+      IndexedOptionArray64 out2(Identities::none(),
+                                util::Parameters(),
+                                outindex,
+                                out);
       return out2.simplify_optiontype();
     }
   }
 
-  const std::pair<Index64, ContentPtr> ByteMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  ByteMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -449,16 +599,23 @@ namespace awkward {
 
       ContentPtr next = content_.get()->carry(nextcarry);
 
-      std::pair<Index64, ContentPtr> offsets_flattened = next.get()->offsets_and_flattened(axis, depth);
+      std::pair<Index64, ContentPtr> offsets_flattened =
+        next.get()->offsets_and_flattened(axis, depth);
       Index64 offsets = offsets_flattened.first;
       ContentPtr flattened = offsets_flattened.second;
 
       if (offsets.length() == 0) {
-        return std::pair<Index64, ContentPtr>(offsets, std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), outindex, flattened));
+        return std::pair<Index64, ContentPtr>(
+          offsets,
+          std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                                 util::Parameters(),
+                                                 outindex,
+                                                 flattened));
       }
       else {
         Index64 outoffsets(offsets.length() + numnull);
-        struct Error err = util::awkward_indexedarray_flatten_none2empty_64<int64_t>(
+        struct Error err =
+          util::awkward_indexedarray_flatten_none2empty_64<int64_t>(
           outoffsets.ptr().get(),
           outindex.ptr().get(),
           outindex.offset(),
@@ -472,7 +629,8 @@ namespace awkward {
     }
   }
 
-  bool ByteMaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  ByteMaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -484,28 +642,36 @@ namespace awkward {
       return true;
     }
 
-    if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    if (IndexedArray32* rawother =
+        dynamic_cast<IndexedArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
     else {
@@ -513,25 +679,31 @@ namespace awkward {
     }
   }
 
-  const ContentPtr ByteMaskedArray::reverse_merge(const ContentPtr& other) const {
+  const ContentPtr
+  ByteMaskedArray::reverse_merge(const ContentPtr& other) const {
     ContentPtr indexedoptionarray = toIndexedOptionArray64();
-    IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
+    IndexedOptionArray64* raw =
+      dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  const ContentPtr ByteMaskedArray::merge(const ContentPtr& other) const {
+  const ContentPtr
+  ByteMaskedArray::merge(const ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
-  const SliceItemPtr ByteMaskedArray::asslice() const {
+  const SliceItemPtr
+  ByteMaskedArray::asslice() const {
     return toIndexedOptionArray64().get()->asslice();
   }
 
-  const ContentPtr ByteMaskedArray::fillna(const ContentPtr& value) const {
+  const ContentPtr
+  ByteMaskedArray::fillna(const ContentPtr& value) const {
     return toIndexedOptionArray64().get()->fillna(value);
   }
 
-  const ContentPtr ByteMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ByteMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -546,14 +718,26 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
 
       ContentPtr next = project().get()->rpad(target, toaxis, depth);
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, next).get()->simplify_optiontype();
+      return std::make_shared<IndexedOptionArray64>(
+        Identities::none(),
+        util::Parameters(),
+        index,
+        next).get()->simplify_optiontype();
     }
     else {
-      return std::make_shared<ByteMaskedArray>(Identities::none(), parameters_, mask_, content_.get()->rpad(target, toaxis, depth), validwhen_);
+      return std::make_shared<ByteMaskedArray>(
+        Identities::none(),
+        parameters_,
+        mask_,
+        content_.get()->rpad(target, toaxis, depth),
+        validwhen_);
     }
   }
 
-  const ContentPtr ByteMaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ByteMaskedArray::rpad_and_clip(int64_t target,
+                                 int64_t axis,
+                                 int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -561,21 +745,38 @@ namespace awkward {
     else if (toaxis == depth + 1) {
       Index8 mask = bytemask();
       Index64 index(mask.length());
-      struct Error err = awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
+      struct Error err =
+        awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
         index.ptr().get(),
         mask.ptr().get(),
         mask.length());
       util::handle_error(err, classname(), identities_.get());
 
       ContentPtr next = project().get()->rpad_and_clip(target, toaxis, depth);
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, next).get()->simplify_optiontype();
+      return std::make_shared<IndexedOptionArray64>(
+        Identities::none(),
+        util::Parameters(),
+        index,
+        next).get()->simplify_optiontype();
     }
     else {
-      return std::make_shared<ByteMaskedArray>(Identities::none(), parameters_, mask_, content_.get()->rpad_and_clip(target, toaxis, depth), validwhen_);
+      return std::make_shared<ByteMaskedArray>(
+        Identities::none(),
+        parameters_,
+        mask_,
+        content_.get()->rpad_and_clip(target, toaxis, depth),
+        validwhen_);
     }
   }
 
-  const ContentPtr ByteMaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr
+  ByteMaskedArray::reduce_next(const Reducer& reducer,
+                               int64_t negaxis,
+                               const Index64& starts,
+                               const Index64& parents,
+                               int64_t outlength,
+                               bool mask,
+                               bool keepdims) const {
     int64_t numnull;
     struct Error err1 = awkward_bytemaskedarray_numnull(
       &numnull,
@@ -601,7 +802,13 @@ namespace awkward {
     util::handle_error(err2, classname(), identities_.get());
 
     ContentPtr next = content_.get()->carry(nextcarry);
-    ContentPtr out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
+    ContentPtr out = next.get()->reduce_next(reducer,
+                                             negaxis,
+                                             starts,
+                                             nextparents,
+                                             outlength,
+                                             mask,
+                                             keepdims);
 
     std::pair<bool, int64_t> branchdepth = branch_depth();
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -614,7 +821,9 @@ namespace awkward {
       if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
-          throw std::runtime_error("reduce_next with unbranching depth > negaxis expects a ListOffsetArray64 whose offsets start at zero");
+          throw std::runtime_error(
+            "reduce_next with unbranching depth > negaxis expects "
+            "a ListOffsetArray64 whose offsets start at zero");
         }
         struct Error err3 = awkward_indexedarray_reduce_next_fix_offsets_64(
           outoffsets.ptr().get(),
@@ -624,15 +833,27 @@ namespace awkward {
           outindex.length());
         util::handle_error(err3, classname(), identities_.get());
 
-        return std::make_shared<ListOffsetArray64>(raw->identities(), raw->parameters(), outoffsets, std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), outindex, raw->content()));
+        return std::make_shared<ListOffsetArray64>(
+          raw->identities(),
+          raw->parameters(),
+          outoffsets,
+          std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                                 util::Parameters(),
+                                                 outindex,
+                                                 raw->content()));
       }
       else {
-        throw std::runtime_error(std::string("reduce_next with unbranching depth > negaxis is only expected to return RegularArray or ListOffsetArray64; instead, it returned ") + out.get()->classname());
+        throw std::runtime_error(
+          std::string("reduce_next with unbranching depth > negaxis is only "
+                      "expected to return RegularArray or ListOffsetArray64; "
+                      "instead, it returned ")
+          + out.get()->classname());
       }
     }
   }
 
-  const ContentPtr ByteMaskedArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ByteMaskedArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return localindex_axis0();
@@ -645,12 +866,21 @@ namespace awkward {
 
       ContentPtr next = content_.get()->carry(nextcarry);
       ContentPtr out = next.get()->localindex(axis, depth);
-      IndexedOptionArray64 out2(Identities::none(), util::Parameters(), outindex, out);
+      IndexedOptionArray64 out2(Identities::none(),
+                                util::Parameters(),
+                                outindex,
+                                out);
       return out2.simplify_optiontype();
     }
   }
 
-  const ContentPtr ByteMaskedArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ByteMaskedArray::choose(int64_t n,
+                          bool diagonal,
+                          const util::RecordLookupPtr& recordlookup,
+                          const util::Parameters& parameters,
+                          int64_t axis,
+                          int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -665,54 +895,107 @@ namespace awkward {
       Index64 outindex = pair.second;
 
       ContentPtr next = content_.get()->carry(nextcarry);
-      ContentPtr out = next.get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
-      IndexedOptionArray64 out2(Identities::none(), util::Parameters(), outindex, out);
+      ContentPtr out = next.get()->choose(n,
+                                          diagonal,
+                                          recordlookup,
+                                          parameters,
+                                          axis,
+                                          depth);
+      IndexedOptionArray64 out2(Identities::none(),
+                                util::Parameters(),
+                                outindex,
+                                out);
       return out2.simplify_optiontype();
     }
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(at)");
+  const ContentPtr
+  ByteMaskedArray::getitem_next(const SliceAt& at,
+                                const Slice& tail,
+                                const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: ByteMaskedArray::getitem_next(at)");
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(range)");
+  const ContentPtr
+  ByteMaskedArray::getitem_next(const SliceRange& range,
+                                const Slice& tail,
+                                const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: ByteMaskedArray::getitem_next(range)");
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(array)");
+  const ContentPtr
+  ByteMaskedArray::getitem_next(const SliceArray64& array,
+                                const Slice& tail,
+                                const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: ByteMaskedArray::getitem_next(array)");
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: ByteMaskedArray::getitem_next(jagged)");
+  const ContentPtr
+  ByteMaskedArray::getitem_next(const SliceJagged64& jagged,
+                                const Slice& tail,
+                                const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: ByteMaskedArray::getitem_next(jagged)");
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                       const Index64& slicestops,
+                                       const SliceArray64& slicecontent,
+                                       const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceArray64>(slicestarts,
+                                                     slicestops,
+                                                     slicecontent,
+                                                     tail);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                       const Index64& slicestops,
+                                       const SliceMissing64& slicecontent,
+                                       const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceMissing64>(slicestarts,
+                                                       slicestops,
+                                                       slicecontent,
+                                                       tail);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  ByteMaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                       const Index64& slicestops,
+                                       const SliceJagged64& slicecontent,
+                                       const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceJagged64>(slicestarts,
+                                                      slicestops,
+                                                      slicecontent,
+                                                      tail);
   }
 
   template <typename S>
-  const ContentPtr ByteMaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  ByteMaskedArray::getitem_next_jagged_generic(const Index64& slicestarts,
+                                               const Index64& slicestops,
+                                               const S& slicecontent,
+                                               const Slice& tail) const {
       int64_t numnull;
       std::pair<Index64, Index64> pair = nextcarry_outindex(numnull);
       Index64 nextcarry = pair.first;
       Index64 outindex = pair.second;
 
       ContentPtr next = content_.get()->carry(nextcarry);
-      ContentPtr out = next.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+      ContentPtr out = next.get()->getitem_next_jagged(slicestarts,
+                                                       slicestops,
+                                                       slicecontent,
+                                                       tail);
       IndexedOptionArray64 out2(identities_, parameters_, outindex, out);
       return out2.simplify_optiontype();
   }
 
-  const std::pair<Index64, Index64> ByteMaskedArray::nextcarry_outindex(int64_t& numnull) const {
+  const std::pair<Index64, Index64>
+  ByteMaskedArray::nextcarry_outindex(int64_t& numnull) const {
     struct Error err1 = awkward_bytemaskedarray_numnull(
       &numnull,
       mask_.ptr().get(),

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -25,7 +25,7 @@
 #include "awkward/array/ByteMaskedArray.h"
 
 namespace awkward {
-  ByteMaskedArray::ByteMaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const Index8& mask, const ContentPtr& content, bool validwhen)
+  ByteMaskedArray::ByteMaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const Index8& mask, const ContentPtr& content, bool validwhen)
       : Content(identities, parameters)
       , mask_(mask)
       , content_(content)
@@ -140,7 +140,7 @@ namespace awkward {
     return "ByteMaskedArray";
   }
 
-  void ByteMaskedArray::setidentities(const std::shared_ptr<Identities>& identities) {
+  void ByteMaskedArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
@@ -181,14 +181,14 @@ namespace awkward {
 
   void ByteMaskedArray::setidentities() {
     if (length() <= kMaxInt32) {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
       struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
       struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
@@ -196,7 +196,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Type> ByteMaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr ByteMaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
     return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
   }
 
@@ -244,7 +244,7 @@ namespace awkward {
   const ContentPtr ByteMaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     Index8 mask = copyindexes ? mask_.deep_copy() : mask_;
     ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
-    std::shared_ptr<Identities> identities = identities_;
+    IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
@@ -293,7 +293,7 @@ namespace awkward {
   }
 
   const ContentPtr ByteMaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    std::shared_ptr<Identities> identities(nullptr);
+    IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
@@ -308,7 +308,7 @@ namespace awkward {
     return std::make_shared<ByteMaskedArray>(identities_, util::Parameters(), mask_, content_.get()->getitem_fields(keys), validwhen_);
   }
 
-  const ContentPtr ByteMaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ByteMaskedArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -354,7 +354,7 @@ namespace awkward {
       carry.ptr().get(),
       carry.length());
     util::handle_error(err, classname(), identities_.get());
-    std::shared_ptr<Identities> identities(nullptr);
+    IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
@@ -523,7 +523,7 @@ namespace awkward {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
-  const std::shared_ptr<SliceItem> ByteMaskedArray::asslice() const {
+  const SliceItemPtr ByteMaskedArray::asslice() const {
     return toIndexedOptionArray64().get()->asslice();
   }
 
@@ -650,7 +650,7 @@ namespace awkward {
     }
   }
 
-  const ContentPtr ByteMaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr ByteMaskedArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -711,7 +711,8 @@ namespace awkward {
     else if (toaxis == depth + 1) {
       Index8 mask = bytemask();
       Index64 index(mask.length());
-      struct Error err = awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
+      struct Error err =
+        awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
         index.ptr().get(),
         mask.ptr().get(),
         mask.length());
@@ -815,10 +816,12 @@ namespace awkward {
       return out;
     }
     else {
-      if (RegularArray* raw = dynamic_cast<RegularArray*>(out.get())) {
+      if (RegularArray* raw =
+          dynamic_cast<RegularArray*>(out.get())) {
         out = raw->toListOffsetArray64(true);
       }
-      if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
+      if (ListOffsetArray64* raw =
+          dynamic_cast<ListOffsetArray64*>(out.get())) {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
           throw std::runtime_error(

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -37,7 +37,7 @@ namespace awkward {
 
   void EmptyArray::setidentities() { }
 
-  const TypePtr EmptyArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr EmptyArray::type(const util::TypeStrs& typestrs) const {
     return std::make_shared<UnknownType>(parameters_, util::gettypestr(parameters_, typestrs));
   }
 

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -14,7 +14,7 @@
 #include "awkward/array/EmptyArray.h"
 
 namespace awkward {
-  EmptyArray::EmptyArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters)
+  EmptyArray::EmptyArray(const IdentitiesPtr& identities, const util::Parameters& parameters)
       : Content(identities, parameters) { }
 
   const ContentPtr EmptyArray::toNumpyArray(const std::string& format, ssize_t itemsize) const {
@@ -28,7 +28,7 @@ namespace awkward {
     return "EmptyArray";
   }
 
-  void EmptyArray::setidentities(const std::shared_ptr<Identities>& identities) {
+  void EmptyArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() != nullptr  &&  length() != identities.get()->length()) {
       util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
     }
@@ -37,7 +37,7 @@ namespace awkward {
 
   void EmptyArray::setidentities() { }
 
-  const std::shared_ptr<Type> EmptyArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr EmptyArray::type(const std::map<std::string, std::string>& typestrs) const {
     return std::make_shared<UnknownType>(parameters_, util::gettypestr(parameters_, typestrs));
   }
 
@@ -81,7 +81,7 @@ namespace awkward {
   }
 
   const ContentPtr EmptyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
-    std::shared_ptr<Identities> identities = identities_;
+    IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
@@ -202,7 +202,7 @@ namespace awkward {
     return other;
   }
 
-  const std::shared_ptr<SliceItem> EmptyArray::asslice() const {
+  const SliceItemPtr EmptyArray::asslice() const {
     Index64 index(0);
     std::vector<int64_t> shape({ 0 });
     std::vector<int64_t> strides({ 1 });
@@ -242,7 +242,7 @@ namespace awkward {
     return std::make_shared<NumpyArray>(Index64(0));
   }
 
-  const ContentPtr EmptyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr EmptyArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -17,7 +17,7 @@ namespace awkward {
   EmptyArray::EmptyArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters)
       : Content(identities, parameters) { }
 
-  const std::shared_ptr<Content> EmptyArray::toNumpyArray(const std::string& format, ssize_t itemsize) const {
+  ContentPtr EmptyArray::toNumpyArray(const std::string& format, ssize_t itemsize) const {
     std::shared_ptr<void> ptr(new uint8_t[0], util::array_deleter<uint8_t>());
     std::vector<ssize_t> shape({ 0 });
     std::vector<ssize_t> strides({ itemsize });
@@ -76,11 +76,11 @@ namespace awkward {
     return 0;
   }
 
-  const std::shared_ptr<Content> EmptyArray::shallow_copy() const {
+  ContentPtr EmptyArray::shallow_copy() const {
     return std::make_shared<EmptyArray>(identities_, parameters_);
   }
 
-  const std::shared_ptr<Content> EmptyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr EmptyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -90,37 +90,37 @@ namespace awkward {
 
   void EmptyArray::check_for_iteration() const { }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_nothing() const {
+  ContentPtr EmptyArray::getitem_nothing() const {
     return shallow_copy();
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_at(int64_t at) const {
+  ContentPtr EmptyArray::getitem_at(int64_t at) const {
     util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
     return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_at_nowrap(int64_t at) const {
+  ContentPtr EmptyArray::getitem_at_nowrap(int64_t at) const {
     util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
     return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr EmptyArray::getitem_range(int64_t start, int64_t stop) const {
     return shallow_copy();
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr EmptyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     return shallow_copy();
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_field(const std::string& key) const {
+  ContentPtr EmptyArray::getitem_field(const std::string& key) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr EmptyArray::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
   }
 
-  const std::shared_ptr<Content> EmptyArray::carry(const Index64& carry) const {
+  ContentPtr EmptyArray::carry(const Index64& carry) const {
     return shallow_copy();
   }
 
@@ -166,11 +166,11 @@ namespace awkward {
     return std::string();
   }
 
-  const std::shared_ptr<Content> EmptyArray::shallow_simplify() const {
+  ContentPtr EmptyArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const std::shared_ptr<Content> EmptyArray::num(int64_t axis, int64_t depth) const {
+  ContentPtr EmptyArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -194,11 +194,11 @@ namespace awkward {
     }
   }
 
-  bool EmptyArray::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool EmptyArray::mergeable(ContentPtr& other, bool mergebool) const {
     return true;
   }
 
-  const std::shared_ptr<Content> EmptyArray::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr EmptyArray::merge(ContentPtr& other) const {
     return other;
   }
 
@@ -209,11 +209,11 @@ namespace awkward {
     return std::make_shared<SliceArray64>(index, shape, strides, false);
   }
 
-  const std::shared_ptr<Content> EmptyArray::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr EmptyArray::fillna(ContentPtr& value) const {
     return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
   }
 
-  const std::shared_ptr<Content> EmptyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr EmptyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis != depth) {
       throw std::invalid_argument("axis exceeds the depth of this array");
@@ -223,7 +223,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> EmptyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr EmptyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis != depth) {
       throw std::invalid_argument("axis exceeds the depth of this array");
@@ -233,61 +233,61 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> EmptyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr EmptyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     std::shared_ptr<Content> asnumpy = toNumpyArray(reducer.preferred_type(), reducer.preferred_typesize());
     return asnumpy.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  const std::shared_ptr<Content> EmptyArray::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr EmptyArray::localindex(int64_t axis, int64_t depth) const {
     return std::make_shared<NumpyArray>(Index64(0));
   }
 
-  const std::shared_ptr<Content> EmptyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr EmptyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
     return std::make_shared<EmptyArray>(identities_, util::Parameters());
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr EmptyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
     return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr EmptyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
     return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr EmptyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
     return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  ContentPtr EmptyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a field name because it has no fields"));
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  ContentPtr EmptyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field names because it has no fields"));
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr EmptyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
     }
     throw std::runtime_error("FIXME: EmptyArray::getitem_next(jagged)");
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(array)");
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(missing)");
   }
 
-  const std::shared_ptr<Content> EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(jagged)");
   }
 

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -14,7 +14,8 @@
 #include "awkward/array/EmptyArray.h"
 
 namespace awkward {
-  EmptyArray::EmptyArray(const IdentitiesPtr& identities, const util::Parameters& parameters)
+  EmptyArray::EmptyArray(const IdentitiesPtr& identities,
+                         const util::Parameters& parameters)
       : Content(identities, parameters) { }
 
   const ContentPtr

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -17,31 +17,54 @@ namespace awkward {
   EmptyArray::EmptyArray(const IdentitiesPtr& identities, const util::Parameters& parameters)
       : Content(identities, parameters) { }
 
-  const ContentPtr EmptyArray::toNumpyArray(const std::string& format, ssize_t itemsize) const {
+  const ContentPtr
+  EmptyArray::toNumpyArray(const std::string& format, ssize_t itemsize) const {
     std::shared_ptr<void> ptr(new uint8_t[0], util::array_deleter<uint8_t>());
     std::vector<ssize_t> shape({ 0 });
     std::vector<ssize_t> strides({ itemsize });
-    return std::make_shared<NumpyArray>(identities_, parameters_, ptr, shape, strides, 0, itemsize, format);
+    return std::make_shared<NumpyArray>(identities_,
+                                        parameters_,
+                                        ptr,
+                                        shape,
+                                        strides,
+                                        0,
+                                        itemsize,
+                                        format);
   }
 
-  const std::string EmptyArray::classname() const {
+  const std::string
+  EmptyArray::classname() const {
     return "EmptyArray";
   }
 
-  void EmptyArray::setidentities(const IdentitiesPtr& identities) {
-    if (identities.get() != nullptr  &&  length() != identities.get()->length()) {
-      util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+  void
+  EmptyArray::setidentities(const IdentitiesPtr& identities) {
+    if (identities.get() != nullptr  &&
+        length() != identities.get()->length()) {
+      util::handle_error(
+        failure("content and its identities must have the same length",
+                kSliceNone,
+                kSliceNone),
+        classname(),
+        identities_.get());
     }
     identities_ = identities;
   }
 
-  void EmptyArray::setidentities() { }
+  void
+  EmptyArray::setidentities() { }
 
-  const TypePtr EmptyArray::type(const util::TypeStrs& typestrs) const {
-    return std::make_shared<UnknownType>(parameters_, util::gettypestr(parameters_, typestrs));
+  const TypePtr
+  EmptyArray::type(const util::TypeStrs& typestrs) const {
+    return std::make_shared<UnknownType>(parameters_,
+                                         util::gettypestr(parameters_,
+                                                          typestrs));
   }
 
-  const std::string EmptyArray::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  EmptyArray::tostring_part(const std::string& indent,
+                            const std::string& pre,
+                            const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname();
     if (identities_.get() == nullptr  &&  parameters_.empty()) {
@@ -50,7 +73,9 @@ namespace awkward {
     else {
       out << ">\n";
       if (identities_.get() != nullptr) {
-        out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n") << indent << "</" << classname() << ">" << post;
+        out << identities_.get()->tostring_part(
+                 indent + std::string("    "), "", "\n")
+            << indent << "</" << classname() << ">" << post;
       }
       if (!parameters_.empty()) {
         out << parameters_tostring(indent + std::string("    "), "", "\n");
@@ -60,27 +85,34 @@ namespace awkward {
     return out.str();
   }
 
-  void EmptyArray::tojson_part(ToJson& builder) const {
+  void
+  EmptyArray::tojson_part(ToJson& builder) const {
     check_for_iteration();
     builder.beginlist();
     builder.endlist();
   }
 
-  void EmptyArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  EmptyArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
     if (identities_.get() != nullptr) {
       identities_.get()->nbytes_part(largest);
     }
   }
 
-  int64_t EmptyArray::length() const {
+  int64_t
+  EmptyArray::length() const {
     return 0;
   }
 
-  const ContentPtr EmptyArray::shallow_copy() const {
+  const ContentPtr
+  EmptyArray::shallow_copy() const {
     return std::make_shared<EmptyArray>(identities_, parameters_);
   }
 
-  const ContentPtr EmptyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  EmptyArray::deep_copy(bool copyarrays,
+                        bool copyindexes,
+                        bool copyidentities) const {
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -88,89 +120,125 @@ namespace awkward {
     return std::make_shared<EmptyArray>(identities, parameters_);
   }
 
-  void EmptyArray::check_for_iteration() const { }
+  void
+  EmptyArray::check_for_iteration() const { }
 
-  const ContentPtr EmptyArray::getitem_nothing() const {
+  const ContentPtr
+  EmptyArray::getitem_nothing() const {
     return shallow_copy();
   }
 
-  const ContentPtr EmptyArray::getitem_at(int64_t at) const {
-    util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+  const ContentPtr
+  EmptyArray::getitem_at(int64_t at) const {
+    util::handle_error(
+      failure("index out of range", kSliceNone, at),
+      classname(),
+      identities_.get());
     return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  const ContentPtr EmptyArray::getitem_at_nowrap(int64_t at) const {
-    util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+  const ContentPtr
+  EmptyArray::getitem_at_nowrap(int64_t at) const {
+    util::handle_error(
+      failure("index out of range", kSliceNone, at),
+      classname(),
+      identities_.get());
     return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  const ContentPtr EmptyArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  EmptyArray::getitem_range(int64_t start, int64_t stop) const {
     return shallow_copy();
   }
 
-  const ContentPtr EmptyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  EmptyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     return shallow_copy();
   }
 
-  const ContentPtr EmptyArray::getitem_field(const std::string& key) const {
-    throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
+  const ContentPtr
+  EmptyArray::getitem_field(const std::string& key) const {
+    throw std::invalid_argument(
+      std::string("cannot slice ") + classname()
+      + std::string(" by field name"));
   }
 
-  const ContentPtr EmptyArray::getitem_fields(const std::vector<std::string>& keys) const {
-    throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
+  const ContentPtr
+  EmptyArray::getitem_fields(const std::vector<std::string>& keys) const {
+    throw std::invalid_argument(
+      std::string("cannot slice ") + classname()
+      + std::string(" by field name"));
   }
 
-  const ContentPtr EmptyArray::carry(const Index64& carry) const {
+  const ContentPtr
+  EmptyArray::carry(const Index64& carry) const {
     return shallow_copy();
   }
 
-  const std::string EmptyArray::purelist_parameter(const std::string& key) const {
+  const std::string
+  EmptyArray::purelist_parameter(const std::string& key) const {
     return parameter(key);
   }
 
-  bool EmptyArray::purelist_isregular() const {
+  bool
+  EmptyArray::purelist_isregular() const {
     return true;
   }
 
-  int64_t EmptyArray::purelist_depth() const {
+  int64_t
+  EmptyArray::purelist_depth() const {
     return 1;
   }
 
-  const std::pair<int64_t, int64_t> EmptyArray::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  EmptyArray::minmax_depth() const {
     return std::pair<int64_t, int64_t>(1, 1);
   }
 
-  const std::pair<bool, int64_t> EmptyArray::branch_depth() const {
+  const std::pair<bool, int64_t>
+  EmptyArray::branch_depth() const {
     return std::pair<bool, int64_t>(false, 1);
   }
 
-  int64_t EmptyArray::numfields() const { return -1; }
+  int64_t
+  EmptyArray::numfields() const { return -1; }
 
-  int64_t EmptyArray::fieldindex(const std::string& key) const {
-    throw std::invalid_argument(std::string("key ") + util::quote(key, true) + std::string(" does not exist (data might not be records)"));
+  int64_t
+  EmptyArray::fieldindex(const std::string& key) const {
+    throw std::invalid_argument(
+      std::string("key ") + util::quote(key, true)
+      + std::string(" does not exist (data might not be records)"));
   }
 
-  const std::string EmptyArray::key(int64_t fieldindex) const {
-    throw std::invalid_argument(std::string("fieldindex \"") + std::to_string(fieldindex) + std::string("\" does not exist (data might not be records)"));
+  const std::string
+  EmptyArray::key(int64_t fieldindex) const {
+    throw std::invalid_argument(
+      std::string("fieldindex \"") + std::to_string(fieldindex)
+      + std::string("\" does not exist (data might not be records)"));
   }
 
-  bool EmptyArray::haskey(const std::string& key) const {
+  bool
+  EmptyArray::haskey(const std::string& key) const {
     return false;
   }
 
-  const std::vector<std::string> EmptyArray::keys() const {
+  const std::vector<std::string>
+  EmptyArray::keys() const {
     return std::vector<std::string>();
   }
 
-  const std::string EmptyArray::validityerror(const std::string& path) const {
+  const std::string
+  EmptyArray::validityerror(const std::string& path) const {
     return std::string();
   }
 
-  const ContentPtr EmptyArray::shallow_simplify() const {
+  const ContentPtr
+  EmptyArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const ContentPtr EmptyArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  EmptyArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -182,7 +250,8 @@ namespace awkward {
     }
   }
 
-  const std::pair<Index64, ContentPtr> EmptyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  EmptyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -190,30 +259,38 @@ namespace awkward {
     else {
       Index64 offsets(1);
       offsets.setitem_at_nowrap(0, 0);
-      return std::pair<Index64, ContentPtr>(offsets, std::make_shared<EmptyArray>(Identities::none(), util::Parameters()));
+      return std::pair<Index64, ContentPtr>(
+        offsets,
+        std::make_shared<EmptyArray>(Identities::none(), util::Parameters()));
     }
   }
 
-  bool EmptyArray::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  EmptyArray::mergeable(const ContentPtr& other, bool mergebool) const {
     return true;
   }
 
-  const ContentPtr EmptyArray::merge(const ContentPtr& other) const {
+  const ContentPtr
+  EmptyArray::merge(const ContentPtr& other) const {
     return other;
   }
 
-  const SliceItemPtr EmptyArray::asslice() const {
+  const SliceItemPtr
+  EmptyArray::asslice() const {
     Index64 index(0);
     std::vector<int64_t> shape({ 0 });
     std::vector<int64_t> strides({ 1 });
     return std::make_shared<SliceArray64>(index, shape, strides, false);
   }
 
-  const ContentPtr EmptyArray::fillna(const ContentPtr& value) const {
-    return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
+  const ContentPtr
+  EmptyArray::fillna(const ContentPtr& value) const {
+    return std::make_shared<EmptyArray>(Identities::none(),
+                                        util::Parameters());
   }
 
-  const ContentPtr EmptyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  EmptyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis != depth) {
       throw std::invalid_argument("axis exceeds the depth of this array");
@@ -223,7 +300,10 @@ namespace awkward {
     }
   }
 
-  const ContentPtr EmptyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  EmptyArray::rpad_and_clip(int64_t target,
+                            int64_t axis,
+                            int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis != depth) {
       throw std::invalid_argument("axis exceeds the depth of this array");
@@ -233,62 +313,130 @@ namespace awkward {
     }
   }
 
-  const ContentPtr EmptyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
-    ContentPtr asnumpy = toNumpyArray(reducer.preferred_type(), reducer.preferred_typesize());
-    return asnumpy.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+  const ContentPtr
+  EmptyArray::reduce_next(const Reducer& reducer,
+                          int64_t negaxis,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength,
+                          bool mask,
+                          bool keepdims) const {
+    ContentPtr asnumpy = toNumpyArray(reducer.preferred_type(),
+                                      reducer.preferred_typesize());
+    return asnumpy.get()->reduce_next(reducer,
+                                      negaxis,
+                                      starts,
+                                      parents,
+                                      outlength,
+                                      mask,
+                                      keepdims);
   }
 
-  const ContentPtr EmptyArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  EmptyArray::localindex(int64_t axis, int64_t depth) const {
     return std::make_shared<NumpyArray>(Index64(0));
   }
 
-  const ContentPtr EmptyArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  EmptyArray::choose(int64_t n,
+                     bool diagonal,
+                     const util::RecordLookupPtr& recordlookup,
+                     const util::Parameters& parameters,
+                     int64_t axis,
+                     int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
     return std::make_shared<EmptyArray>(identities_, util::Parameters());
   }
 
-  const ContentPtr EmptyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
-    util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
+  const ContentPtr
+  EmptyArray::getitem_next(const SliceAt& at,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    util::handle_error(
+      failure("too many dimensions in slice", kSliceNone, kSliceNone),
+      classname(),
+      identities_.get());
     return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  const ContentPtr EmptyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
+  const ContentPtr
+  EmptyArray::getitem_next(const SliceRange& range,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    util::handle_error(
+      failure("too many dimensions in slice", kSliceNone, kSliceNone),
+      classname(),
+      identities_.get());
     return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  const ContentPtr EmptyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
+  const ContentPtr
+  EmptyArray::getitem_next(const SliceArray64& array,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    util::handle_error(
+      failure("too many dimensions in slice", kSliceNone, kSliceNone),
+      classname(),
+      identities_.get());
     return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  const ContentPtr EmptyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
-    throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a field name because it has no fields"));
+  const ContentPtr
+  EmptyArray::getitem_next(const SliceField& field,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    throw std::invalid_argument(
+      std::string("cannot slice ") + classname()
+      + std::string(" by a field name because it has no fields"));
   }
 
-  const ContentPtr EmptyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
-    throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field names because it has no fields"));
+  const ContentPtr
+  EmptyArray::getitem_next(const SliceFields& fields,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    throw std::invalid_argument(
+      std::string("cannot slice ") + classname()
+      + std::string(" by field names because it has no fields"));
   }
 
-  const ContentPtr EmptyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  EmptyArray::getitem_next(const SliceJagged64& jagged,
+                           const Slice& tail,
+                           const Index64& advanced) const {
     if (advanced.length() != 0) {
-      throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
+      throw std::invalid_argument(
+        "cannot mix jagged slice with NumPy-style advanced indexing");
     }
     throw std::runtime_error("FIXME: EmptyArray::getitem_next(jagged)");
   }
 
-  const ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(array)");
+  const ContentPtr
+  EmptyArray::getitem_next_jagged(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const SliceArray64& slicecontent,
+                                  const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: EmptyArray::getitem_next_jagged(array)");
   }
 
-  const ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(missing)");
+  const ContentPtr
+  EmptyArray::getitem_next_jagged(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const SliceMissing64& slicecontent,
+                                  const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: EmptyArray::getitem_next_jagged(missing)");
   }
 
-  const ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(jagged)");
+  const ContentPtr
+  EmptyArray::getitem_next_jagged(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const SliceJagged64& slicecontent,
+                                  const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: EmptyArray::getitem_next_jagged(jagged)");
   }
 
 }

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -17,7 +17,7 @@ namespace awkward {
   EmptyArray::EmptyArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters)
       : Content(identities, parameters) { }
 
-  ContentPtr EmptyArray::toNumpyArray(const std::string& format, ssize_t itemsize) const {
+  const ContentPtr EmptyArray::toNumpyArray(const std::string& format, ssize_t itemsize) const {
     std::shared_ptr<void> ptr(new uint8_t[0], util::array_deleter<uint8_t>());
     std::vector<ssize_t> shape({ 0 });
     std::vector<ssize_t> strides({ itemsize });
@@ -76,11 +76,11 @@ namespace awkward {
     return 0;
   }
 
-  ContentPtr EmptyArray::shallow_copy() const {
+  const ContentPtr EmptyArray::shallow_copy() const {
     return std::make_shared<EmptyArray>(identities_, parameters_);
   }
 
-  ContentPtr EmptyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr EmptyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -90,37 +90,37 @@ namespace awkward {
 
   void EmptyArray::check_for_iteration() const { }
 
-  ContentPtr EmptyArray::getitem_nothing() const {
+  const ContentPtr EmptyArray::getitem_nothing() const {
     return shallow_copy();
   }
 
-  ContentPtr EmptyArray::getitem_at(int64_t at) const {
+  const ContentPtr EmptyArray::getitem_at(int64_t at) const {
     util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
-    return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
+    return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  ContentPtr EmptyArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr EmptyArray::getitem_at_nowrap(int64_t at) const {
     util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
-    return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
+    return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  ContentPtr EmptyArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr EmptyArray::getitem_range(int64_t start, int64_t stop) const {
     return shallow_copy();
   }
 
-  ContentPtr EmptyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr EmptyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     return shallow_copy();
   }
 
-  ContentPtr EmptyArray::getitem_field(const std::string& key) const {
+  const ContentPtr EmptyArray::getitem_field(const std::string& key) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
   }
 
-  ContentPtr EmptyArray::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr EmptyArray::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
   }
 
-  ContentPtr EmptyArray::carry(const Index64& carry) const {
+  const ContentPtr EmptyArray::carry(const Index64& carry) const {
     return shallow_copy();
   }
 
@@ -166,11 +166,11 @@ namespace awkward {
     return std::string();
   }
 
-  ContentPtr EmptyArray::shallow_simplify() const {
+  const ContentPtr EmptyArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  ContentPtr EmptyArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr EmptyArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -182,7 +182,7 @@ namespace awkward {
     }
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> EmptyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> EmptyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -190,15 +190,15 @@ namespace awkward {
     else {
       Index64 offsets(1);
       offsets.setitem_at_nowrap(0, 0);
-      return std::pair<Index64, std::shared_ptr<Content>>(offsets, std::make_shared<EmptyArray>(Identities::none(), util::Parameters()));
+      return std::pair<Index64, ContentPtr>(offsets, std::make_shared<EmptyArray>(Identities::none(), util::Parameters()));
     }
   }
 
-  bool EmptyArray::mergeable(ContentPtr& other, bool mergebool) const {
+  bool EmptyArray::mergeable(const ContentPtr& other, bool mergebool) const {
     return true;
   }
 
-  ContentPtr EmptyArray::merge(ContentPtr& other) const {
+  const ContentPtr EmptyArray::merge(const ContentPtr& other) const {
     return other;
   }
 
@@ -209,11 +209,11 @@ namespace awkward {
     return std::make_shared<SliceArray64>(index, shape, strides, false);
   }
 
-  ContentPtr EmptyArray::fillna(ContentPtr& value) const {
+  const ContentPtr EmptyArray::fillna(const ContentPtr& value) const {
     return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
   }
 
-  ContentPtr EmptyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr EmptyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis != depth) {
       throw std::invalid_argument("axis exceeds the depth of this array");
@@ -223,7 +223,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr EmptyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr EmptyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis != depth) {
       throw std::invalid_argument("axis exceeds the depth of this array");
@@ -233,61 +233,61 @@ namespace awkward {
     }
   }
 
-  ContentPtr EmptyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
-    std::shared_ptr<Content> asnumpy = toNumpyArray(reducer.preferred_type(), reducer.preferred_typesize());
+  const ContentPtr EmptyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+    ContentPtr asnumpy = toNumpyArray(reducer.preferred_type(), reducer.preferred_typesize());
     return asnumpy.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  ContentPtr EmptyArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr EmptyArray::localindex(int64_t axis, int64_t depth) const {
     return std::make_shared<NumpyArray>(Index64(0));
   }
 
-  ContentPtr EmptyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr EmptyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
     return std::make_shared<EmptyArray>(identities_, util::Parameters());
   }
 
-  ContentPtr EmptyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr EmptyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
-    return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
+    return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  ContentPtr EmptyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr EmptyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
-    return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
+    return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  ContentPtr EmptyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr EmptyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
-    return std::shared_ptr<Content>(nullptr);  // make Windows compiler happy
+    return ContentPtr(nullptr);  // make Windows compiler happy
   }
 
-  ContentPtr EmptyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr EmptyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a field name because it has no fields"));
   }
 
-  ContentPtr EmptyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr EmptyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field names because it has no fields"));
   }
 
-  ContentPtr EmptyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr EmptyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
     }
     throw std::runtime_error("FIXME: EmptyArray::getitem_next(jagged)");
   }
 
-  ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(array)");
   }
 
-  ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(missing)");
   }
 
-  ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr EmptyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: EmptyArray::getitem_next_jagged(jagged)");
   }
 

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -26,7 +26,7 @@
 
 namespace awkward {
   template <typename T, bool ISOPTION>
-  IndexedArrayOf<T, ISOPTION>::IndexedArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, ContentPtr& content)
+  IndexedArrayOf<T, ISOPTION>::IndexedArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, const ContentPtr& content)
       : Content(identities, parameters)
       , index_(index)
       , content_(content) { }
@@ -37,7 +37,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::content() const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::content() const {
     return content_;
   }
 
@@ -47,7 +47,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::project() const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::project() const {
     if (ISOPTION) {
       int64_t numnull;
       struct Error err1 = util::awkward_indexedarray_numnull<T>(
@@ -83,7 +83,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::project(const Index8& mask) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::project(const Index8& mask) const {
     if (index_.length() != mask.length()) {
       throw std::invalid_argument(std::string("mask length (") + std::to_string(mask.length()) + std::string(") is not equal to ") + classname() + std::string(" length (") + std::to_string(index_.length()) + std::string(")"));
     }
@@ -125,7 +125,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::simplify_optiontype() const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::simplify_optiontype() const {
     if (ISOPTION) {
       if (IndexedArray32* rawcontent = dynamic_cast<IndexedArray32*>(content_.get())) {
         Index32 inner = rawcontent->index();
@@ -198,7 +198,7 @@ namespace awkward {
         return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
       }
       else if (ByteMaskedArray* step1 = dynamic_cast<ByteMaskedArray*>(content_.get())) {
-        std::shared_ptr<Content> step2 = step1->toIndexedOptionArray64();
+        ContentPtr step2 = step1->toIndexedOptionArray64();
         IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
@@ -214,7 +214,7 @@ namespace awkward {
         return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
       }
       else if (BitMaskedArray* step1 = dynamic_cast<BitMaskedArray*>(content_.get())) {
-        std::shared_ptr<Content> step2 = step1->toIndexedOptionArray64();
+        ContentPtr step2 = step1->toIndexedOptionArray64();
         IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
@@ -230,7 +230,7 @@ namespace awkward {
         return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
       }
       else if (UnmaskedArray* step1 = dynamic_cast<UnmaskedArray*>(content_.get())) {
-        std::shared_ptr<Content> step2 = step1->toIndexedOptionArray64();
+        ContentPtr step2 = step1->toIndexedOptionArray64();
         IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
@@ -321,7 +321,7 @@ namespace awkward {
         return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
       }
       else if (ByteMaskedArray* step1 = dynamic_cast<ByteMaskedArray*>(content_.get())) {
-        std::shared_ptr<Content> step2 = step1->toIndexedOptionArray64();
+        ContentPtr step2 = step1->toIndexedOptionArray64();
         IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
@@ -337,7 +337,7 @@ namespace awkward {
         return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
       }
       else if (BitMaskedArray* step1 = dynamic_cast<BitMaskedArray*>(content_.get())) {
-        std::shared_ptr<Content> step2 = step1->toIndexedOptionArray64();
+        ContentPtr step2 = step1->toIndexedOptionArray64();
         IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
@@ -353,7 +353,7 @@ namespace awkward {
         return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
       }
       else if (UnmaskedArray* step1 = dynamic_cast<UnmaskedArray*>(content_.get())) {
-        std::shared_ptr<Content> step2 = step1->toIndexedOptionArray64();
+        ContentPtr step2 = step1->toIndexedOptionArray64();
         IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
@@ -539,14 +539,14 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::shallow_copy() const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::shallow_copy() const {
     return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, parameters_, index_, content_);
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexOf<T> index = copyindexes ? index_.deep_copy() : index_;
-    std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -562,12 +562,12 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_nothing() const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_at(int64_t at) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += index_.length();
@@ -579,7 +579,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_at_nowrap(int64_t at) const {
     int64_t index = (int64_t)index_.getitem_at_nowrap(at);
     if (index < 0) {
       if (ISOPTION) {
@@ -597,7 +597,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), index_.length());
@@ -608,7 +608,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -617,17 +617,17 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_field(const std::string& key) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_field(const std::string& key) const {
     return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, util::Parameters(), index_, content_.get()->getitem_field(key));
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, util::Parameters(), index_, content_.get()->getitem_fields(keys));
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -638,8 +638,8 @@ namespace awkward {
         Index64 nextcarry = pair.first;
         IndexOf<T> outindex = pair.second;
 
-        std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-        std::shared_ptr<Content> out = next.get()->getitem_next(head, tail, advanced);
+        ContentPtr next = content_.get()->carry(nextcarry);
+        ContentPtr out = next.get()->getitem_next(head, tail, advanced);
         IndexedArrayOf<T, ISOPTION> out2(identities_, parameters_, outindex, out);
         return out2.simplify_optiontype();
       }
@@ -653,7 +653,7 @@ namespace awkward {
           content_.get()->length());
         util::handle_error(err, classname(), identities_.get());
 
-        std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
+        ContentPtr next = content_.get()->carry(nextcarry);
         return next.get()->getitem_next(head, tail, advanced);
       }
     }
@@ -678,7 +678,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::carry(const Index64& carry) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::carry(const Index64& carry) const {
     IndexOf<T> nextindex(carry.length());
     struct Error err = util::awkward_indexedarray_getitem_carry_64<T>(
       nextindex.ptr().get(),
@@ -768,12 +768,12 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::shallow_simplify() const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::shallow_simplify() const {
     return simplify_optiontype();
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::num(int64_t axis, int64_t depth) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -786,8 +786,8 @@ namespace awkward {
       Index64 nextcarry = pair.first;
       IndexOf<T> outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-      std::shared_ptr<Content> out = next.get()->num(axis, depth);
+      ContentPtr next = content_.get()->carry(nextcarry);
+      ContentPtr out = next.get()->num(axis, depth);
       IndexedArrayOf<T, ISOPTION> out2(Identities::none(), util::Parameters(), outindex, out);
       return out2.simplify_optiontype();
     }
@@ -797,7 +797,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::pair<Index64, std::shared_ptr<Content>> IndexedArrayOf<T, ISOPTION>::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> IndexedArrayOf<T, ISOPTION>::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -808,14 +808,14 @@ namespace awkward {
       Index64 nextcarry = pair.first;
       IndexOf<T> outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
+      ContentPtr next = content_.get()->carry(nextcarry);
 
-      std::pair<Index64, std::shared_ptr<Content>> offsets_flattened = next.get()->offsets_and_flattened(axis, depth);
+      std::pair<Index64, ContentPtr> offsets_flattened = next.get()->offsets_and_flattened(axis, depth);
       Index64 offsets = offsets_flattened.first;
-      std::shared_ptr<Content> flattened = offsets_flattened.second;
+      ContentPtr flattened = offsets_flattened.second;
 
       if (offsets.length() == 0) {
-        return std::pair<Index64, std::shared_ptr<Content>>(offsets, std::make_shared<IndexedArrayOf<T, ISOPTION>>(Identities::none(), util::Parameters(), outindex, flattened));
+        return std::pair<Index64, ContentPtr>(offsets, std::make_shared<IndexedArrayOf<T, ISOPTION>>(Identities::none(), util::Parameters(), outindex, flattened));
       }
       else {
         Index64 outoffsets(offsets.length() + numnull);
@@ -828,7 +828,7 @@ namespace awkward {
           offsets.offset(),
           offsets.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::pair<Index64, std::shared_ptr<Content>>(outoffsets, flattened);
+        return std::pair<Index64, ContentPtr>(outoffsets, flattened);
       }
     }
     else {
@@ -837,7 +837,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  bool IndexedArrayOf<T, ISOPTION>::mergeable(ContentPtr& other, bool mergebool) const {
+  bool IndexedArrayOf<T, ISOPTION>::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -879,12 +879,12 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::reverse_merge(ContentPtr& other) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::reverse_merge(const ContentPtr& other) const {
     int64_t theirlength = other.get()->length();
     int64_t mylength = length();
     Index64 index(theirlength + mylength);
 
-    std::shared_ptr<Content> content = other.get()->merge(content_);
+    ContentPtr content = other.get()->merge(content_);
     struct Error err1 = awkward_indexedarray_fill_to64_count(
       index.ptr().get(),
       0,
@@ -931,7 +931,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::merge(ContentPtr& other) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -988,7 +988,7 @@ namespace awkward {
     }
 
     int64_t mycontentlength = content_.get()->length();
-    std::shared_ptr<Content> content;
+    ContentPtr content;
     bool other_isoption = false;
     if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
@@ -1092,7 +1092,7 @@ namespace awkward {
         content_.get()->length());
       util::handle_error(err2, classname(), identities_.get());
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
+      ContentPtr next = content_.get()->carry(nextcarry);
 
       std::shared_ptr<SliceItem> slicecontent = next.get()->asslice();
       if (SliceArray64* raw = dynamic_cast<SliceArray64*>(slicecontent.get())) {
@@ -1125,12 +1125,12 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::fillna(ContentPtr& value) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::fillna(const ContentPtr& value) const {
     if (value.get()->length() != 1) {
       throw std::invalid_argument(std::string("fillna value length (") + std::to_string(value.get()->length()) + std::string(") is not equal to 1"));
     }
     if (ISOPTION) {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       contents.emplace_back(content());
       contents.emplace_back(value);
 
@@ -1152,7 +1152,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -1167,7 +1167,7 @@ namespace awkward {
           mask.length());
         util::handle_error(err, classname(), identities_.get());
 
-        std::shared_ptr<Content> next = project().get()->rpad(target, toaxis, depth);
+        ContentPtr next = project().get()->rpad(target, toaxis, depth);
         return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, next).get()->simplify_optiontype();
       }
       else {
@@ -1180,7 +1180,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -1195,7 +1195,7 @@ namespace awkward {
           mask.length());
         util::handle_error(err, classname(), identities_.get());
 
-        std::shared_ptr<Content> next = project().get()->rpad_and_clip(target, toaxis, depth);
+        ContentPtr next = project().get()->rpad_and_clip(target, toaxis, depth);
         return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, next).get()->simplify_optiontype();
       }
       else {
@@ -1208,7 +1208,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     int64_t numnull;
     struct Error err1 = util::awkward_indexedarray_numnull<T>(
       &numnull,
@@ -1231,8 +1231,8 @@ namespace awkward {
       index_.length());
     util::handle_error(err2, classname(), identities_.get());
 
-    std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-    std::shared_ptr<Content> out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
+    ContentPtr next = content_.get()->carry(nextcarry);
+    ContentPtr out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
 
     std::pair<bool, int64_t> branchdepth = branch_depth();
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -1266,7 +1266,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1278,8 +1278,8 @@ namespace awkward {
         Index64 nextcarry = pair.first;
         IndexOf<T> outindex = pair.second;
 
-        std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-        std::shared_ptr<Content> out = next.get()->localindex(axis, depth);
+        ContentPtr next = content_.get()->carry(nextcarry);
+        ContentPtr out = next.get()->localindex(axis, depth);
         IndexedArrayOf<T, ISOPTION> out2(identities_, util::Parameters(), outindex, out);
         return out2.simplify_optiontype();
       }
@@ -1290,7 +1290,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1305,8 +1305,8 @@ namespace awkward {
         Index64 nextcarry = pair.first;
         IndexOf<T> outindex = pair.second;
 
-        std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-        std::shared_ptr<Content> out = next.get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
+        ContentPtr next = content_.get()->carry(nextcarry);
+        ContentPtr out = next.get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
         IndexedArrayOf<T, ISOPTION> out2(identities_, util::Parameters(), outindex, out);
         return out2.simplify_optiontype();
       }
@@ -1317,51 +1317,51 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: IndexedArray::getitem_next(at)");
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: IndexedArray::getitem_next(range)");
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: IndexedArray::getitem_next(array)");
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: IndexedArray::getitem_next(jagged)");
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, bool ISOPTION>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, bool ISOPTION>
   template <typename S>
-  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
     if (ISOPTION) {
       int64_t numnull;
       std::pair<Index64, IndexOf<T>> pair = nextcarry_outindex(numnull);
       Index64 nextcarry = pair.first;
       IndexOf<T> outindex = pair.second;
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
-      std::shared_ptr<Content> out = next.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+      ContentPtr next = content_.get()->carry(nextcarry);
+      ContentPtr out = next.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
       IndexedArrayOf<T, ISOPTION> out2(identities_, parameters_, outindex, out);
       return out2.simplify_optiontype();
     }
@@ -1375,7 +1375,7 @@ namespace awkward {
         content_.get()->length());
       util::handle_error(err, classname(), identities_.get());
 
-      std::shared_ptr<Content> next = content_.get()->carry(nextcarry);
+      ContentPtr next = content_.get()->carry(nextcarry);
       return next.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
     }
   }

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -760,7 +760,8 @@ namespace awkward {
 
   template <typename T, bool ISOPTION>
   const ContentPtr
-  IndexedArrayOf<T, ISOPTION>::getitem_range(int64_t start, int64_t stop) const {
+  IndexedArrayOf<T, ISOPTION>::getitem_range(int64_t start,
+                                             int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop,
@@ -1354,7 +1355,8 @@ namespace awkward {
 
       Index64 nextcarry(length() - numnull);
       Index64 outindex(length());
-      struct Error err2 = util::awkward_indexedarray_getitem_nextcarry_outindex_mask_64<T>(
+      struct Error err2 =
+        util::awkward_indexedarray_getitem_nextcarry_outindex_mask_64<T>(
         nextcarry.ptr().get(),
         outindex.ptr().get(),
         index_.ptr().get(),
@@ -1570,10 +1572,12 @@ namespace awkward {
       return out;
     }
     else {
-      if (RegularArray* raw = dynamic_cast<RegularArray*>(out.get())) {
+      if (RegularArray* raw =
+          dynamic_cast<RegularArray*>(out.get())) {
         out = raw->toListOffsetArray64(true);
       }
-      if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
+      if (ListOffsetArray64* raw =
+          dynamic_cast<ListOffsetArray64*>(out.get())) {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
           throw std::runtime_error(

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -26,28 +26,36 @@
 
 namespace awkward {
   template <typename T, bool ISOPTION>
-  IndexedArrayOf<T, ISOPTION>::IndexedArrayOf(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& index, const ContentPtr& content)
+  IndexedArrayOf<T, ISOPTION>::IndexedArrayOf(
+    const IdentitiesPtr& identities,
+    const util::Parameters& parameters,
+    const IndexOf<T>& index,
+    const ContentPtr& content)
       : Content(identities, parameters)
       , index_(index)
       , content_(content) { }
 
   template <typename T, bool ISOPTION>
-  const IndexOf<T> IndexedArrayOf<T, ISOPTION>::index() const {
+  const IndexOf<T>
+  IndexedArrayOf<T, ISOPTION>::index() const {
     return index_;
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::content() const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::content() const {
     return content_;
   }
 
   template <typename T, bool ISOPTION>
-  bool IndexedArrayOf<T, ISOPTION>::isoption() const {
+  bool
+  IndexedArrayOf<T, ISOPTION>::isoption() const {
     return ISOPTION;
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::project() const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::project() const {
     if (ISOPTION) {
       int64_t numnull;
       struct Error err1 = util::awkward_indexedarray_numnull<T>(
@@ -83,9 +91,14 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::project(const Index8& mask) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::project(const Index8& mask) const {
     if (index_.length() != mask.length()) {
-      throw std::invalid_argument(std::string("mask length (") + std::to_string(mask.length()) + std::string(") is not equal to ") + classname() + std::string(" length (") + std::to_string(index_.length()) + std::string(")"));
+      throw std::invalid_argument(
+        std::string("mask length (") + std::to_string(mask.length())
+        + std::string(") is not equal to ") + classname()
+        + std::string(" length (") + std::to_string(index_.length())
+        + std::string(")"));
     }
 
     Index64 nextindex(index_.length());
@@ -103,7 +116,8 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const Index8 IndexedArrayOf<T, ISOPTION>::bytemask() const {
+  const Index8
+  IndexedArrayOf<T, ISOPTION>::bytemask() const {
     if (ISOPTION) {
       Index8 out(index_.length());
       struct Error err = util::awkward_indexedarray_mask8(
@@ -125,9 +139,11 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::simplify_optiontype() const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::simplify_optiontype() const {
     if (ISOPTION) {
-      if (IndexedArray32* rawcontent = dynamic_cast<IndexedArray32*>(content_.get())) {
+      if (IndexedArray32* rawcontent =
+          dynamic_cast<IndexedArray32*>(content_.get())) {
         Index32 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify32_to64(
@@ -139,9 +155,13 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (IndexedArrayU32* rawcontent = dynamic_cast<IndexedArrayU32*>(content_.get())) {
+      else if (IndexedArrayU32* rawcontent =
+               dynamic_cast<IndexedArrayU32*>(content_.get())) {
         IndexU32 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplifyU32_to64(
@@ -153,9 +173,13 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (IndexedArray64* rawcontent = dynamic_cast<IndexedArray64*>(content_.get())) {
+      else if (IndexedArray64* rawcontent =
+               dynamic_cast<IndexedArray64*>(content_.get())) {
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -167,9 +191,13 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (IndexedOptionArray32* rawcontent = dynamic_cast<IndexedOptionArray32*>(content_.get())) {
+      else if (IndexedOptionArray32* rawcontent =
+               dynamic_cast<IndexedOptionArray32*>(content_.get())) {
         Index32 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify32_to64(
@@ -181,9 +209,13 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(content_.get())) {
+      else if (IndexedOptionArray64* rawcontent =
+               dynamic_cast<IndexedOptionArray64*>(content_.get())) {
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -195,11 +227,16 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (ByteMaskedArray* step1 = dynamic_cast<ByteMaskedArray*>(content_.get())) {
+      else if (ByteMaskedArray* step1 =
+               dynamic_cast<ByteMaskedArray*>(content_.get())) {
         ContentPtr step2 = step1->toIndexedOptionArray64();
-        IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
+        IndexedOptionArray64* rawcontent =
+          dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -211,11 +248,16 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (BitMaskedArray* step1 = dynamic_cast<BitMaskedArray*>(content_.get())) {
+      else if (BitMaskedArray* step1 =
+               dynamic_cast<BitMaskedArray*>(content_.get())) {
         ContentPtr step2 = step1->toIndexedOptionArray64();
-        IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
+        IndexedOptionArray64* rawcontent =
+          dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -227,11 +269,16 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (UnmaskedArray* step1 = dynamic_cast<UnmaskedArray*>(content_.get())) {
+      else if (UnmaskedArray* step1 =
+               dynamic_cast<UnmaskedArray*>(content_.get())) {
         ContentPtr step2 = step1->toIndexedOptionArray64();
-        IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
+        IndexedOptionArray64* rawcontent =
+          dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -243,14 +290,18 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
       else {
         return shallow_copy();
       }
     }
     else {
-      if (IndexedArray32* rawcontent = dynamic_cast<IndexedArray32*>(content_.get())) {
+      if (IndexedArray32* rawcontent =
+          dynamic_cast<IndexedArray32*>(content_.get())) {
         Index32 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify32_to64(
@@ -262,9 +313,13 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedArray64>(identities_,
+                                                parameters_,
+                                                result,
+                                                rawcontent->content());
       }
-      else if (IndexedArrayU32* rawcontent = dynamic_cast<IndexedArrayU32*>(content_.get())) {
+      else if (IndexedArrayU32* rawcontent =
+               dynamic_cast<IndexedArrayU32*>(content_.get())) {
         IndexU32 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplifyU32_to64(
@@ -276,9 +331,13 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedArray64>(identities_,
+                                                parameters_,
+                                                result,
+                                                rawcontent->content());
       }
-      else if (IndexedArray64* rawcontent = dynamic_cast<IndexedArray64*>(content_.get())) {
+      else if (IndexedArray64* rawcontent =
+               dynamic_cast<IndexedArray64*>(content_.get())) {
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -290,9 +349,13 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedArray64>(identities_,
+                                                parameters_,
+                                                result,
+                                                rawcontent->content());
       }
-      else if (IndexedOptionArray32* rawcontent = dynamic_cast<IndexedOptionArray32*>(content_.get())) {
+      else if (IndexedOptionArray32* rawcontent =
+               dynamic_cast<IndexedOptionArray32*>(content_.get())) {
         Index32 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify32_to64(
@@ -304,9 +367,13 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(content_.get())) {
+      else if (IndexedOptionArray64* rawcontent =
+               dynamic_cast<IndexedOptionArray64*>(content_.get())) {
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -318,11 +385,16 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (ByteMaskedArray* step1 = dynamic_cast<ByteMaskedArray*>(content_.get())) {
+      else if (ByteMaskedArray* step1 =
+               dynamic_cast<ByteMaskedArray*>(content_.get())) {
         ContentPtr step2 = step1->toIndexedOptionArray64();
-        IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
+        IndexedOptionArray64* rawcontent =
+          dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -334,11 +406,16 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (BitMaskedArray* step1 = dynamic_cast<BitMaskedArray*>(content_.get())) {
+      else if (BitMaskedArray* step1 =
+               dynamic_cast<BitMaskedArray*>(content_.get())) {
         ContentPtr step2 = step1->toIndexedOptionArray64();
-        IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
+        IndexedOptionArray64* rawcontent =
+          dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -350,11 +427,16 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
-      else if (UnmaskedArray* step1 = dynamic_cast<UnmaskedArray*>(content_.get())) {
+      else if (UnmaskedArray* step1 =
+               dynamic_cast<UnmaskedArray*>(content_.get())) {
         ContentPtr step2 = step1->toIndexedOptionArray64();
-        IndexedOptionArray64* rawcontent = dynamic_cast<IndexedOptionArray64*>(step2.get());
+        IndexedOptionArray64* rawcontent =
+          dynamic_cast<IndexedOptionArray64*>(step2.get());
         Index64 inner = rawcontent->index();
         Index64 result(index_.length());
         struct Error err = util::awkward_indexedarray_simplify64_to64(
@@ -366,7 +448,10 @@ namespace awkward {
           inner.offset(),
           inner.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::make_shared<IndexedOptionArray64>(identities_, parameters_, result, rawcontent->content());
+        return std::make_shared<IndexedOptionArray64>(identities_,
+                                                      parameters_,
+                                                      result,
+                                                      rawcontent->content());
       }
       else {
         return shallow_copy();
@@ -375,12 +460,14 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  T IndexedArrayOf<T, ISOPTION>::index_at_nowrap(int64_t at) const {
+  T
+  IndexedArrayOf<T, ISOPTION>::index_at_nowrap(int64_t at) const {
     return index_.getitem_at_nowrap(at);
   }
 
   template <typename T, bool ISOPTION>
-  const std::string IndexedArrayOf<T, ISOPTION>::classname() const {
+  const std::string
+  IndexedArrayOf<T, ISOPTION>::classname() const {
     if (ISOPTION) {
       if (std::is_same<T, int32_t>::value) {
         return "IndexedOptionArray32";
@@ -404,22 +491,35 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  void IndexedArrayOf<T, ISOPTION>::setidentities(const IdentitiesPtr& identities) {
+  void
+  IndexedArrayOf<T, ISOPTION>::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
     else {
       if (length() != identities.get()->length()) {
-        util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(
+          failure("content and its identities must have the same length",
+                  kSliceNone,
+                  kSliceNone),
+          classname(),
+          identities_.get());
       }
       IdentitiesPtr bigidentities = identities;
-      if (content_.get()->length() > kMaxInt32  ||  !std::is_same<T, int32_t>::value) {
+      if (content_.get()->length() > kMaxInt32  ||
+          !std::is_same<T, int32_t>::value) {
         bigidentities = identities.get()->to64();
       }
-      if (Identities32* rawidentities = dynamic_cast<Identities32*>(bigidentities.get())) {
+      if (Identities32* rawidentities =
+          dynamic_cast<Identities32*>(bigidentities.get())) {
         bool uniquecontents;
-        IdentitiesPtr subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
-        Identities32* rawsubidentitites = reinterpret_cast<Identities32*>(subidentities.get());
+        IdentitiesPtr subidentities =
+          std::make_shared<Identities32>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width(),
+                                         content_.get()->length());
+        Identities32* rawsubidentitites =
+          reinterpret_cast<Identities32*>(subidentities.get());
         struct Error err = util::awkward_identities32_from_indexedarray<T>(
           &uniquecontents,
           rawsubidentitites->ptr().get(),
@@ -438,10 +538,16 @@ namespace awkward {
           content_.get()->setidentities(Identities::none());
         }
       }
-      else if (Identities64* rawidentities = dynamic_cast<Identities64*>(bigidentities.get())) {
+      else if (Identities64* rawidentities =
+               dynamic_cast<Identities64*>(bigidentities.get())) {
         bool uniquecontents;
-        IdentitiesPtr subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
-        Identities64* rawsubidentitites = reinterpret_cast<Identities64*>(subidentities.get());
+        IdentitiesPtr subidentities =
+          std::make_shared<Identities64>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width(),
+                                         content_.get()->length());
+        Identities64* rawsubidentitites =
+          reinterpret_cast<Identities64*>(subidentities.get());
         struct Error err = util::awkward_identities64_from_indexedarray<T>(
           &uniquecontents,
           rawsubidentitites->ptr().get(),
@@ -468,27 +574,44 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  void IndexedArrayOf<T, ISOPTION>::setidentities() {
+  void
+  IndexedArrayOf<T, ISOPTION>::setidentities() {
     if (length() <= kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err = awkward_new_identities32(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err = awkward_new_identities64(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
   }
 
   template <typename T, bool ISOPTION>
-  const TypePtr IndexedArrayOf<T, ISOPTION>::type(const util::TypeStrs& typestrs) const {
+  const TypePtr
+  IndexedArrayOf<T, ISOPTION>::type(const util::TypeStrs& typestrs) const {
     if (ISOPTION) {
-      return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
+      return std::make_shared<OptionType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        content_.get()->type(typestrs));
     }
     else {
       TypePtr out = content_.get()->type(typestrs);
@@ -498,23 +621,30 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::string IndexedArrayOf<T, ISOPTION>::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  IndexedArrayOf<T, ISOPTION>::tostring_part(const std::string& indent,
+                                             const std::string& pre,
+                                             const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << ">\n";
     if (identities_.get() != nullptr) {
-      out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+      out << identities_.get()->tostring_part(
+               indent + std::string("    "), "", "\n");
     }
     if (!parameters_.empty()) {
       out << parameters_tostring(indent + std::string("    "), "", "\n");
     }
-    out << index_.tostring_part(indent + std::string("    "), "<index>", "</index>\n");
-    out << content_.get()->tostring_part(indent + std::string("    "), "<content>", "</content>\n");
+    out << index_.tostring_part(
+             indent + std::string("    "), "<index>", "</index>\n");
+    out << content_.get()->tostring_part(
+             indent + std::string("    "), "<content>", "</content>\n");
     out << indent << "</" << classname() << ">" << post;
     return out.str();
   }
 
   template <typename T, bool ISOPTION>
-  void IndexedArrayOf<T, ISOPTION>::tojson_part(ToJson& builder) const {
+  void
+  IndexedArrayOf<T, ISOPTION>::tojson_part(ToJson& builder) const {
     int64_t len = length();
     check_for_iteration();
     builder.beginlist();
@@ -525,7 +655,9 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  void IndexedArrayOf<T, ISOPTION>::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  IndexedArrayOf<T, ISOPTION>::nbytes_part(std::map<size_t,
+                                           int64_t>& largest) const {
     index_.nbytes_part(largest);
     content_.get()->nbytes_part(largest);
     if (identities_.get() != nullptr) {
@@ -534,104 +666,163 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  int64_t IndexedArrayOf<T, ISOPTION>::length() const {
+  int64_t
+  IndexedArrayOf<T, ISOPTION>::length() const {
     return index_.length();
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::shallow_copy() const {
-    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, parameters_, index_, content_);
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::shallow_copy() const {
+    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_,
+                                                         parameters_,
+                                                         index_,
+                                                         content_);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::deep_copy(bool copyarrays,
+                                         bool copyindexes,
+                                         bool copyidentities) const {
     IndexOf<T> index = copyindexes ? index_.deep_copy() : index_;
-    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays,
+                                                   copyindexes,
+                                                   copyidentities);
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
-    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities, parameters_, index, content);
+    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities,
+                                                         parameters_,
+                                                         index,
+                                                         content);
   }
 
   template <typename T, bool ISOPTION>
-  void IndexedArrayOf<T, ISOPTION>::check_for_iteration() const {
-    if (identities_.get() != nullptr  &&  identities_.get()->length() < index_.length()) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+  void
+  IndexedArrayOf<T, ISOPTION>::check_for_iteration() const {
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < index_.length()) {
+      util::handle_error(
+        failure("len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_nothing() const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_at(int64_t at) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += index_.length();
     }
     if (!(0 <= regular_at  &&  regular_at < index_.length())) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_at_nowrap(int64_t at) const {
     int64_t index = (int64_t)index_.getitem_at_nowrap(at);
     if (index < 0) {
       if (ISOPTION) {
         return none;
       }
       else {
-        util::handle_error(failure("index[i] < 0", kSliceNone, at), classname(), identities_.get());
+        util::handle_error(
+          failure("index[i] < 0", kSliceNone, at),
+          classname(),
+          identities_.get());
       }
     }
     int64_t lencontent = content_.get()->length();
     if (index >= lencontent) {
-      util::handle_error(failure("index[i] >= len(content)", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index[i] >= len(content)", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return content_.get()->getitem_at_nowrap(index);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), index_.length());
-    if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-      util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), index_.length());
+    if (identities_.get() != nullptr  &&
+        regular_stop > identities_.get()->length()) {
+      util::handle_error(
+        failure("index out of range", kSliceNone, stop),
+        identities_.get()->classname(),
+        nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_range_nowrap(int64_t start,
+                                                    int64_t stop) const {
     IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
-    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities, parameters_, index_.getitem_range_nowrap(start, stop), content_);
+    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(
+      identities,
+      parameters_,
+      index_.getitem_range_nowrap(start, stop),
+      content_);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_field(const std::string& key) const {
-    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, util::Parameters(), index_, content_.get()->getitem_field(key));
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_field(const std::string& key) const {
+    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(
+      identities_,
+      util::Parameters(),
+      index_,
+      content_.get()->getitem_field(key));
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_fields(const std::vector<std::string>& keys) const {
-    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, util::Parameters(), index_, content_.get()->getitem_fields(keys));
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_fields(
+    const std::vector<std::string>& keys) const {
+    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(
+      identities_,
+      util::Parameters(),
+      index_,
+      content_.get()->getitem_fields(keys));
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceItemPtr& head,
+                                            const Slice& tail,
+                                            const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
-    else if (dynamic_cast<SliceAt*>(head.get())  ||  dynamic_cast<SliceRange*>(head.get())  ||  dynamic_cast<SliceArray64*>(head.get())  ||  dynamic_cast<SliceJagged64*>(head.get())) {
+    else if (dynamic_cast<SliceAt*>(head.get())  ||
+             dynamic_cast<SliceRange*>(head.get())  ||
+             dynamic_cast<SliceArray64*>(head.get())  ||
+             dynamic_cast<SliceJagged64*>(head.get())) {
       if (ISOPTION) {
         int64_t numnull;
         std::pair<Index64, IndexOf<T>> pair = nextcarry_outindex(numnull);
@@ -640,7 +831,10 @@ namespace awkward {
 
         ContentPtr next = content_.get()->carry(nextcarry);
         ContentPtr out = next.get()->getitem_next(head, tail, advanced);
-        IndexedArrayOf<T, ISOPTION> out2(identities_, parameters_, outindex, out);
+        IndexedArrayOf<T, ISOPTION> out2(identities_,
+                                         parameters_,
+                                         outindex,
+                                         out);
         return out2.simplify_optiontype();
       }
       else {
@@ -657,19 +851,24 @@ namespace awkward {
         return next.get()->getitem_next(head, tail, advanced);
       }
     }
-    else if (SliceEllipsis* ellipsis = dynamic_cast<SliceEllipsis*>(head.get())) {
+    else if (SliceEllipsis* ellipsis =
+             dynamic_cast<SliceEllipsis*>(head.get())) {
       return Content::getitem_next(*ellipsis, tail, advanced);
     }
-    else if (SliceNewAxis* newaxis = dynamic_cast<SliceNewAxis*>(head.get())) {
+    else if (SliceNewAxis* newaxis =
+             dynamic_cast<SliceNewAxis*>(head.get())) {
       return Content::getitem_next(*newaxis, tail, advanced);
     }
-    else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {
+    else if (SliceField* field =
+             dynamic_cast<SliceField*>(head.get())) {
       return Content::getitem_next(*field, tail, advanced);
     }
-    else if (SliceFields* fields = dynamic_cast<SliceFields*>(head.get())) {
+    else if (SliceFields* fields =
+             dynamic_cast<SliceFields*>(head.get())) {
       return Content::getitem_next(*fields, tail, advanced);
     }
-    else if (SliceMissing64* missing = dynamic_cast<SliceMissing64*>(head.get())) {
+    else if (SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(head.get())) {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
@@ -678,7 +877,8 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::carry(const Index64& carry) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::carry(const Index64& carry) const {
     IndexOf<T> nextindex(carry.length());
     struct Error err = util::awkward_indexedarray_getitem_carry_64<T>(
       nextindex.ptr().get(),
@@ -692,11 +892,16 @@ namespace awkward {
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
-    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities, parameters_, nextindex, content_);
+    return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities,
+                                                         parameters_,
+                                                         nextindex,
+                                                         content_);
   }
 
   template <typename T, bool ISOPTION>
-  const std::string IndexedArrayOf<T, ISOPTION>::purelist_parameter(const std::string& key) const {
+  const std::string
+  IndexedArrayOf<T, ISOPTION>::purelist_parameter(
+    const std::string& key) const {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       return content_.get()->purelist_parameter(key);
@@ -707,52 +912,62 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  bool IndexedArrayOf<T, ISOPTION>::purelist_isregular() const {
+  bool
+  IndexedArrayOf<T, ISOPTION>::purelist_isregular() const {
     return content_.get()->purelist_isregular();
   }
 
   template <typename T, bool ISOPTION>
-  int64_t IndexedArrayOf<T, ISOPTION>::purelist_depth() const {
+  int64_t
+  IndexedArrayOf<T, ISOPTION>::purelist_depth() const {
     return content_.get()->purelist_depth();
   }
 
   template <typename T, bool ISOPTION>
-  const std::pair<int64_t, int64_t> IndexedArrayOf<T, ISOPTION>::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  IndexedArrayOf<T, ISOPTION>::minmax_depth() const {
     return content_.get()->minmax_depth();
   }
 
   template <typename T, bool ISOPTION>
-  const std::pair<bool, int64_t> IndexedArrayOf<T, ISOPTION>::branch_depth() const {
+  const std::pair<bool, int64_t>
+  IndexedArrayOf<T, ISOPTION>::branch_depth() const {
     return content_.get()->branch_depth();
   }
 
   template <typename T, bool ISOPTION>
-  int64_t IndexedArrayOf<T, ISOPTION>::numfields() const {
+  int64_t
+  IndexedArrayOf<T, ISOPTION>::numfields() const {
     return content_.get()->numfields();
   }
 
   template <typename T, bool ISOPTION>
-  int64_t IndexedArrayOf<T, ISOPTION>::fieldindex(const std::string& key) const {
+  int64_t
+  IndexedArrayOf<T, ISOPTION>::fieldindex(const std::string& key) const {
     return content_.get()->fieldindex(key);
   }
 
   template <typename T, bool ISOPTION>
-  const std::string IndexedArrayOf<T, ISOPTION>::key(int64_t fieldindex) const {
+  const std::string
+  IndexedArrayOf<T, ISOPTION>::key(int64_t fieldindex) const {
     return content_.get()->key(fieldindex);
   }
 
   template <typename T, bool ISOPTION>
-  bool IndexedArrayOf<T, ISOPTION>::haskey(const std::string& key) const {
+  bool
+  IndexedArrayOf<T, ISOPTION>::haskey(const std::string& key) const {
     return content_.get()->haskey(key);
   }
 
   template <typename T, bool ISOPTION>
-  const std::vector<std::string> IndexedArrayOf<T, ISOPTION>::keys() const {
+  const std::vector<std::string>
+  IndexedArrayOf<T, ISOPTION>::keys() const {
     return content_.get()->keys();
   }
 
   template <typename T, bool ISOPTION>
-  const std::string IndexedArrayOf<T, ISOPTION>::validityerror(const std::string& path) const {
+  const std::string
+  IndexedArrayOf<T, ISOPTION>::validityerror(const std::string& path) const {
     struct Error err = util::awkward_indexedarray_validity<T>(
       index_.ptr().get(),
       index_.offset(),
@@ -763,17 +978,21 @@ namespace awkward {
       return content_.get()->validityerror(path + std::string(".content"));
     }
     else {
-      return std::string("at ") + path + std::string(" (") + classname() + std::string("): ") + std::string(err.str) + std::string(" at i=") + std::to_string(err.identity);
+      return (std::string("at ") + path + std::string(" (") + classname()
+              + std::string("): ") + std::string(err.str)
+              + std::string(" at i=") + std::to_string(err.identity));
     }
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::shallow_simplify() const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::shallow_simplify() const {
     return simplify_optiontype();
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -788,7 +1007,10 @@ namespace awkward {
 
       ContentPtr next = content_.get()->carry(nextcarry);
       ContentPtr out = next.get()->num(axis, depth);
-      IndexedArrayOf<T, ISOPTION> out2(Identities::none(), util::Parameters(), outindex, out);
+      IndexedArrayOf<T, ISOPTION> out2(Identities::none(),
+                                       util::Parameters(),
+                                       outindex,
+                                       out);
       return out2.simplify_optiontype();
     }
     else {
@@ -797,7 +1019,9 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::pair<Index64, ContentPtr> IndexedArrayOf<T, ISOPTION>::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  IndexedArrayOf<T, ISOPTION>::offsets_and_flattened(int64_t axis,
+                                                     int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -810,12 +1034,18 @@ namespace awkward {
 
       ContentPtr next = content_.get()->carry(nextcarry);
 
-      std::pair<Index64, ContentPtr> offsets_flattened = next.get()->offsets_and_flattened(axis, depth);
+      std::pair<Index64, ContentPtr> offsets_flattened =
+        next.get()->offsets_and_flattened(axis, depth);
       Index64 offsets = offsets_flattened.first;
       ContentPtr flattened = offsets_flattened.second;
 
       if (offsets.length() == 0) {
-        return std::pair<Index64, ContentPtr>(offsets, std::make_shared<IndexedArrayOf<T, ISOPTION>>(Identities::none(), util::Parameters(), outindex, flattened));
+        return std::pair<Index64, ContentPtr>(
+          offsets,
+          std::make_shared<IndexedArrayOf<T, ISOPTION>>(Identities::none(),
+                                                        util::Parameters(),
+                                                        outindex,
+                                                        flattened));
       }
       else {
         Index64 outoffsets(offsets.length() + numnull);
@@ -837,7 +1067,9 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  bool IndexedArrayOf<T, ISOPTION>::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  IndexedArrayOf<T, ISOPTION>::mergeable(const ContentPtr& other,
+                                         bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -849,28 +1081,36 @@ namespace awkward {
       return true;
     }
 
-    if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    if (IndexedArray32* rawother =
+        dynamic_cast<IndexedArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
     else {
@@ -879,7 +1119,8 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::reverse_merge(const ContentPtr& other) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::reverse_merge(const ContentPtr& other) const {
     int64_t theirlength = other.get()->length();
     int64_t mylength = length();
     Index64 index(theirlength + mylength);
@@ -927,11 +1168,16 @@ namespace awkward {
       throw std::runtime_error("unrecognized IndexedArray specialization");
     }
 
-    return std::make_shared<IndexedArrayOf<int64_t, ISOPTION>>(Identities::none(), util::Parameters(), index, content);
+    return std::make_shared<IndexedArrayOf<int64_t, ISOPTION>>(
+      Identities::none(),
+      util::Parameters(),
+      index,
+      content);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::merge(const ContentPtr& other) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -939,13 +1185,16 @@ namespace awkward {
     if (dynamic_cast<EmptyArray*>(other.get())) {
       return shallow_copy();
     }
-    else if (UnionArray8_32* rawother = dynamic_cast<UnionArray8_32*>(other.get())) {
+    else if (UnionArray8_32* rawother =
+             dynamic_cast<UnionArray8_32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_U32* rawother = dynamic_cast<UnionArray8_U32*>(other.get())) {
+    else if (UnionArray8_U32* rawother =
+             dynamic_cast<UnionArray8_U32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_64* rawother = dynamic_cast<UnionArray8_64*>(other.get())) {
+    else if (UnionArray8_64* rawother =
+             dynamic_cast<UnionArray8_64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
 
@@ -990,7 +1239,8 @@ namespace awkward {
     int64_t mycontentlength = content_.get()->length();
     ContentPtr content;
     bool other_isoption = false;
-    if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    if (IndexedArray32* rawother =
+        dynamic_cast<IndexedArray32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index32 other_index = rawother->index();
       struct Error err = awkward_indexedarray_fill_to64_from32(
@@ -1000,9 +1250,12 @@ namespace awkward {
         other_index.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       IndexU32 other_index = rawother->index();
       struct Error err = awkward_indexedarray_fill_to64_fromU32(
@@ -1012,9 +1265,12 @@ namespace awkward {
         other_index.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index64 other_index = rawother->index();
       struct Error err = awkward_indexedarray_fill_to64_from64(
@@ -1024,9 +1280,12 @@ namespace awkward {
         other_index.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index32 other_index = rawother->index();
       struct Error err = awkward_indexedarray_fill_to64_from32(
@@ -1036,10 +1295,13 @@ namespace awkward {
         other_index.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
       other_isoption = true;
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index64 other_index = rawother->index();
       struct Error err = awkward_indexedarray_fill_to64_from64(
@@ -1049,7 +1311,9 @@ namespace awkward {
         other_index.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
       other_isoption = true;
     }
     else {
@@ -1063,15 +1327,22 @@ namespace awkward {
     }
 
     if (ISOPTION  ||  other_isoption) {
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, content);
+      return std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                                    util::Parameters(),
+                                                    index,
+                                                    content);
     }
     else {
-      return std::make_shared<IndexedArray64>(Identities::none(), util::Parameters(), index, content);
+      return std::make_shared<IndexedArray64>(Identities::none(),
+                                              util::Parameters(),
+                                              index,
+                                              content);
     }
   }
 
   template <typename T, bool ISOPTION>
-  const SliceItemPtr IndexedArrayOf<T, ISOPTION>::asslice() const {
+  const SliceItemPtr
+  IndexedArrayOf<T, ISOPTION>::asslice() const {
     if (ISOPTION) {
       int64_t numnull;
       struct Error err1 = util::awkward_indexedarray_numnull<T>(
@@ -1095,7 +1366,8 @@ namespace awkward {
       ContentPtr next = content_.get()->carry(nextcarry);
 
       SliceItemPtr slicecontent = next.get()->asslice();
-      if (SliceArray64* raw = dynamic_cast<SliceArray64*>(slicecontent.get())) {
+      if (SliceArray64* raw =
+          dynamic_cast<SliceArray64*>(slicecontent.get())) {
         if (raw->frombool()) {
           Index64 nonzero(raw->index());
           Index8 originalmask(length());
@@ -1113,11 +1385,19 @@ namespace awkward {
             nonzero.length());
           util::handle_error(err3, classname(), nullptr);
 
-          SliceItemPtr outcontent = std::make_shared<SliceArray64>(adjustednonzero, raw->shape(), raw->strides(), true);
-          return std::make_shared<SliceMissing64>(adjustedindex, originalmask, outcontent);
+          SliceItemPtr outcontent =
+            std::make_shared<SliceArray64>(adjustednonzero,
+                                           raw->shape(),
+                                           raw->strides(),
+                                           true);
+          return std::make_shared<SliceMissing64>(adjustedindex,
+                                                  originalmask,
+                                                  outcontent);
         }
       }
-      return std::make_shared<SliceMissing64>(outindex, Index8(0), slicecontent);
+      return std::make_shared<SliceMissing64>(outindex,
+                                              Index8(0),
+                                              slicecontent);
     }
     else {
       return project().get()->asslice();
@@ -1125,9 +1405,13 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::fillna(const ContentPtr& value) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::fillna(const ContentPtr& value) const {
     if (value.get()->length() != 1) {
-      throw std::invalid_argument(std::string("fillna value length (") + std::to_string(value.get()->length()) + std::string(") is not equal to 1"));
+      throw std::invalid_argument(
+        std::string("fillna value length (")
+        + std::to_string(value.get()->length())
+        + std::string(") is not equal to 1"));
     }
     if (ISOPTION) {
       ContentPtrVec contents;
@@ -1143,16 +1427,28 @@ namespace awkward {
         tags.length());
       util::handle_error(err, classname(), identities_.get());
 
-      std::shared_ptr<UnionArray8_64> out = std::make_shared<UnionArray8_64>(Identities::none(), parameters_, tags, index, contents);
+      std::shared_ptr<UnionArray8_64> out =
+        std::make_shared<UnionArray8_64>(Identities::none(),
+                                         parameters_,
+                                         tags,
+                                         index,
+                                         contents);
       return out.get()->simplify_uniontype(true);
     }
     else {
-      return std::make_shared<IndexedArrayOf<T, ISOPTION>>(Identities::none(), parameters_, index_, content_.get()->fillna(value));
+      return std::make_shared<IndexedArrayOf<T, ISOPTION>>(
+        Identities::none(),
+        parameters_,
+        index_,
+        content_.get()->fillna(value));
     }
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::rpad(int64_t target,
+                                    int64_t axis,
+                                    int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -1161,26 +1457,38 @@ namespace awkward {
       if (ISOPTION) {
         Index8 mask = bytemask();
         Index64 index(mask.length());
-        struct Error err = awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
+        struct Error err =
+          awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
           index.ptr().get(),
           mask.ptr().get(),
           mask.length());
         util::handle_error(err, classname(), identities_.get());
 
         ContentPtr next = project().get()->rpad(target, toaxis, depth);
-        return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, next).get()->simplify_optiontype();
+        return std::make_shared<IndexedOptionArray64>(
+          Identities::none(),
+          util::Parameters(),
+          index,
+          next).get()->simplify_optiontype();
       }
       else {
         return project().get()->rpad(target, toaxis, depth);
       }
     }
     else {
-      return std::make_shared<IndexedArrayOf<T, ISOPTION>>(Identities::none(), parameters_, index_, content_.get()->rpad(target, toaxis, depth));
+      return std::make_shared<IndexedArrayOf<T, ISOPTION>>(
+        Identities::none(),
+        parameters_,
+        index_,
+        content_.get()->rpad(target, toaxis, depth));
     }
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::rpad_and_clip(int64_t target,
+                                             int64_t axis,
+                                             int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -1189,26 +1497,43 @@ namespace awkward {
       if (ISOPTION) {
         Index8 mask = bytemask();
         Index64 index(mask.length());
-        struct Error err = awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
+        struct Error err =
+          awkward_IndexedOptionArray_rpad_and_clip_mask_axis1_64(
           index.ptr().get(),
           mask.ptr().get(),
           mask.length());
         util::handle_error(err, classname(), identities_.get());
 
-        ContentPtr next = project().get()->rpad_and_clip(target, toaxis, depth);
-        return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, next).get()->simplify_optiontype();
+        ContentPtr next =
+          project().get()->rpad_and_clip(target, toaxis, depth);
+        return std::make_shared<IndexedOptionArray64>(
+          Identities::none(),
+          util::Parameters(),
+          index,
+          next).get()->simplify_optiontype();
       }
       else {
         return project().get()->rpad_and_clip(target, toaxis, depth);
       }
     }
     else {
-      return std::make_shared<IndexedArrayOf<T, ISOPTION>>(Identities::none(), parameters_, index_, content_.get()->rpad_and_clip(target, toaxis, depth));
+      return std::make_shared<IndexedArrayOf<T, ISOPTION>>(
+        Identities::none(),
+        parameters_,
+        index_,
+        content_.get()->rpad_and_clip(target, toaxis, depth));
     }
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::reduce_next(const Reducer& reducer,
+                                           int64_t negaxis,
+                                           const Index64& starts,
+                                           const Index64& parents,
+                                           int64_t outlength,
+                                           bool mask,
+                                           bool keepdims) const {
     int64_t numnull;
     struct Error err1 = util::awkward_indexedarray_numnull<T>(
       &numnull,
@@ -1232,7 +1557,13 @@ namespace awkward {
     util::handle_error(err2, classname(), identities_.get());
 
     ContentPtr next = content_.get()->carry(nextcarry);
-    ContentPtr out = next.get()->reduce_next(reducer, negaxis, starts, nextparents, outlength, mask, keepdims);
+    ContentPtr out = next.get()->reduce_next(reducer,
+                                             negaxis,
+                                             starts,
+                                             nextparents,
+                                             outlength,
+                                             mask,
+                                             keepdims);
 
     std::pair<bool, int64_t> branchdepth = branch_depth();
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -1245,7 +1576,9 @@ namespace awkward {
       if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
-          throw std::runtime_error("reduce_next with unbranching depth > negaxis expects a ListOffsetArray64 whose offsets start at zero");
+          throw std::runtime_error(
+            "reduce_next with unbranching depth > negaxis expects a "
+            "ListOffsetArray64 whose offsets start at zero");
         }
         struct Error err3 = awkward_indexedarray_reduce_next_fix_offsets_64(
           outoffsets.ptr().get(),
@@ -1255,10 +1588,20 @@ namespace awkward {
           outindex.length());
         util::handle_error(err3, classname(), identities_.get());
 
-        return std::make_shared<ListOffsetArray64>(raw->identities(), raw->parameters(), outoffsets, std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), outindex, raw->content()));
+        return std::make_shared<ListOffsetArray64>(
+          raw->identities(),
+          raw->parameters(),
+          outoffsets,
+          std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                                 util::Parameters(),
+                                                 outindex,
+                                                 raw->content()));
       }
       else {
-        throw std::runtime_error(std::string("reduce_next with unbranching depth > negaxis is only expected to return RegularArray or ListOffsetArray64; instead, it returned ") + out.get()->classname());
+        throw std::runtime_error(
+          std::string("reduce_next with unbranching depth > negaxis is only "
+                      "expected to return RegularArray or ListOffsetArray64; "
+                      "instead, it returned ") + out.get()->classname());
       }
     }
 
@@ -1266,7 +1609,8 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1280,7 +1624,9 @@ namespace awkward {
 
         ContentPtr next = content_.get()->carry(nextcarry);
         ContentPtr out = next.get()->localindex(axis, depth);
-        IndexedArrayOf<T, ISOPTION> out2(identities_, util::Parameters(), outindex, out);
+        IndexedArrayOf<T, ISOPTION> out2(identities_,
+                                         util::Parameters(),
+                                         outindex, out);
         return out2.simplify_optiontype();
       }
       else {
@@ -1290,7 +1636,14 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::choose(
+    int64_t n,
+    bool diagonal,
+    const util::RecordLookupPtr& recordlookup,
+    const util::Parameters& parameters,
+    int64_t axis,
+    int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1306,54 +1659,113 @@ namespace awkward {
         IndexOf<T> outindex = pair.second;
 
         ContentPtr next = content_.get()->carry(nextcarry);
-        ContentPtr out = next.get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
-        IndexedArrayOf<T, ISOPTION> out2(identities_, util::Parameters(), outindex, out);
+        ContentPtr out = next.get()->choose(n,
+                                            diagonal,
+                                            recordlookup,
+                                            parameters,
+                                            axis,
+                                            depth);
+        IndexedArrayOf<T, ISOPTION> out2(identities_,
+                                         util::Parameters(),
+                                         outindex,
+                                         out);
         return out2.simplify_optiontype();
       }
       else {
-        return project().get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
+        return project().get()->choose(n,
+                                       diagonal,
+                                       recordlookup,
+                                       parameters,
+                                       axis,
+                                       depth);
       }
     }
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: IndexedArray::getitem_next(at)");
+  const ContentPtr
+  IndexedArrayOf<T,
+                 ISOPTION>::getitem_next(const SliceAt& at,
+                                         const Slice& tail,
+                                         const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: IndexedArray::getitem_next(at)");
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: IndexedArray::getitem_next(range)");
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceRange& range,
+                                            const Slice& tail,
+                                            const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: IndexedArray::getitem_next(range)");
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: IndexedArray::getitem_next(array)");
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceArray64& array,
+                                            const Slice& tail,
+                                            const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: IndexedArray::getitem_next(array)");
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: IndexedArray::getitem_next(jagged)");
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceJagged64& jagged,
+                                            const Slice& tail,
+                                            const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: IndexedArray::getitem_next(jagged)");
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(
+    const Index64& slicestarts,
+    const Index64& slicestops,
+    const SliceArray64& slicecontent,
+    const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceArray64>(slicestarts,
+                                                     slicestops,
+                                                     slicecontent,
+                                                     tail);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(
+    const Index64& slicestarts,
+    const Index64& slicestops,
+    const SliceMissing64& slicecontent,
+    const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceMissing64>(slicestarts,
+                                                       slicestops,
+                                                       slicecontent,
+                                                       tail);
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(
+    const Index64& slicestarts,
+    const Index64& slicestops,
+    const SliceJagged64& slicecontent,
+    const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceJagged64>(slicestarts,
+                                                      slicestops,
+                                                      slicecontent,
+                                                      tail);
   }
 
   template <typename T, bool ISOPTION>
   template <typename S>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::getitem_next_jagged_generic(
+    const Index64& slicestarts,
+    const Index64& slicestops,
+    const S& slicecontent,
+    const Slice& tail) const {
     if (ISOPTION) {
       int64_t numnull;
       std::pair<Index64, IndexOf<T>> pair = nextcarry_outindex(numnull);
@@ -1361,8 +1773,14 @@ namespace awkward {
       IndexOf<T> outindex = pair.second;
 
       ContentPtr next = content_.get()->carry(nextcarry);
-      ContentPtr out = next.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
-      IndexedArrayOf<T, ISOPTION> out2(identities_, parameters_, outindex, out);
+      ContentPtr out = next.get()->getitem_next_jagged(slicestarts,
+                                                       slicestops,
+                                                       slicecontent,
+                                                       tail);
+      IndexedArrayOf<T, ISOPTION> out2(identities_,
+                                       parameters_,
+                                       outindex,
+                                       out);
       return out2.simplify_optiontype();
     }
     else {
@@ -1376,12 +1794,16 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
 
       ContentPtr next = content_.get()->carry(nextcarry);
-      return next.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+      return next.get()->getitem_next_jagged(slicestarts,
+                                             slicestops,
+                                             slicecontent,
+                                             tail);
     }
   }
 
   template <typename T, bool ISOPTION>
-  const std::pair<Index64, IndexOf<T>> IndexedArrayOf<T, ISOPTION>::nextcarry_outindex(int64_t& numnull) const {
+  const std::pair<Index64, IndexOf<T>>
+  IndexedArrayOf<T, ISOPTION>::nextcarry_outindex(int64_t& numnull) const {
     struct Error err1 = util::awkward_indexedarray_numnull<T>(
       &numnull,
       index_.ptr().get(),
@@ -1391,7 +1813,8 @@ namespace awkward {
 
     Index64 nextcarry(length() - numnull);
     IndexOf<T> outindex(length());
-    struct Error err2 = util::awkward_indexedarray_getitem_nextcarry_outindex_64<T>(
+    struct Error err2 =
+      util::awkward_indexedarray_getitem_nextcarry_outindex_64<T>(
       nextcarry.ptr().get(),
       outindex.ptr().get(),
       index_.ptr().get(),

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -1130,7 +1130,7 @@ namespace awkward {
       throw std::invalid_argument(std::string("fillna value length (") + std::to_string(value.get()->length()) + std::string(") is not equal to 1"));
     }
     if (ISOPTION) {
-      std::vector<ContentPtr> contents;
+      ContentPtrVec contents;
       contents.emplace_back(content());
       contents.emplace_back(value);
 

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -486,7 +486,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const TypePtr IndexedArrayOf<T, ISOPTION>::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr IndexedArrayOf<T, ISOPTION>::type(const util::TypeStrs& typestrs) const {
     if (ISOPTION) {
       return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
     }

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -26,7 +26,7 @@
 
 namespace awkward {
   template <typename T, bool ISOPTION>
-  IndexedArrayOf<T, ISOPTION>::IndexedArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, const ContentPtr& content)
+  IndexedArrayOf<T, ISOPTION>::IndexedArrayOf(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& index, const ContentPtr& content)
       : Content(identities, parameters)
       , index_(index)
       , content_(content) { }
@@ -404,7 +404,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  void IndexedArrayOf<T, ISOPTION>::setidentities(const std::shared_ptr<Identities>& identities) {
+  void IndexedArrayOf<T, ISOPTION>::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
@@ -412,13 +412,13 @@ namespace awkward {
       if (length() != identities.get()->length()) {
         util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
       }
-      std::shared_ptr<Identities> bigidentities = identities;
+      IdentitiesPtr bigidentities = identities;
       if (content_.get()->length() > kMaxInt32  ||  !std::is_same<T, int32_t>::value) {
         bigidentities = identities.get()->to64();
       }
       if (Identities32* rawidentities = dynamic_cast<Identities32*>(bigidentities.get())) {
         bool uniquecontents;
-        std::shared_ptr<Identities> subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
+        IdentitiesPtr subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
         Identities32* rawsubidentitites = reinterpret_cast<Identities32*>(subidentities.get());
         struct Error err = util::awkward_identities32_from_indexedarray<T>(
           &uniquecontents,
@@ -440,7 +440,7 @@ namespace awkward {
       }
       else if (Identities64* rawidentities = dynamic_cast<Identities64*>(bigidentities.get())) {
         bool uniquecontents;
-        std::shared_ptr<Identities> subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
+        IdentitiesPtr subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
         Identities64* rawsubidentitites = reinterpret_cast<Identities64*>(subidentities.get());
         struct Error err = util::awkward_identities64_from_indexedarray<T>(
           &uniquecontents,
@@ -470,14 +470,14 @@ namespace awkward {
   template <typename T, bool ISOPTION>
   void IndexedArrayOf<T, ISOPTION>::setidentities() {
     if (length() <= kMaxInt32) {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
       struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
       struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
@@ -486,12 +486,12 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Type> IndexedArrayOf<T, ISOPTION>::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr IndexedArrayOf<T, ISOPTION>::type(const std::map<std::string, std::string>& typestrs) const {
     if (ISOPTION) {
       return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
     }
     else {
-      std::shared_ptr<Type> out = content_.get()->type(typestrs);
+      TypePtr out = content_.get()->type(typestrs);
       out.get()->setparameters(parameters_);
       return out;
     }
@@ -547,7 +547,7 @@ namespace awkward {
   const ContentPtr IndexedArrayOf<T, ISOPTION>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexOf<T> index = copyindexes ? index_.deep_copy() : index_;
     ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
-    std::shared_ptr<Identities> identities = identities_;
+    IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
@@ -609,7 +609,7 @@ namespace awkward {
 
   template <typename T, bool ISOPTION>
   const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    std::shared_ptr<Identities> identities(nullptr);
+    IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
@@ -627,7 +627,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -688,7 +688,7 @@ namespace awkward {
       index_.length(),
       carry.length());
     util::handle_error(err, classname(), identities_.get());
-    std::shared_ptr<Identities> identities(nullptr);
+    IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
@@ -1071,7 +1071,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<SliceItem> IndexedArrayOf<T, ISOPTION>::asslice() const {
+  const SliceItemPtr IndexedArrayOf<T, ISOPTION>::asslice() const {
     if (ISOPTION) {
       int64_t numnull;
       struct Error err1 = util::awkward_indexedarray_numnull<T>(
@@ -1094,7 +1094,7 @@ namespace awkward {
 
       ContentPtr next = content_.get()->carry(nextcarry);
 
-      std::shared_ptr<SliceItem> slicecontent = next.get()->asslice();
+      SliceItemPtr slicecontent = next.get()->asslice();
       if (SliceArray64* raw = dynamic_cast<SliceArray64*>(slicecontent.get())) {
         if (raw->frombool()) {
           Index64 nonzero(raw->index());
@@ -1113,7 +1113,7 @@ namespace awkward {
             nonzero.length());
           util::handle_error(err3, classname(), nullptr);
 
-          std::shared_ptr<SliceItem> outcontent = std::make_shared<SliceArray64>(adjustednonzero, raw->shape(), raw->strides(), true);
+          SliceItemPtr outcontent = std::make_shared<SliceArray64>(adjustednonzero, raw->shape(), raw->strides(), true);
           return std::make_shared<SliceMissing64>(adjustedindex, originalmask, outcontent);
         }
       }
@@ -1290,7 +1290,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const ContentPtr IndexedArrayOf<T, ISOPTION>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr IndexedArrayOf<T, ISOPTION>::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -26,7 +26,7 @@
 
 namespace awkward {
   template <typename T, bool ISOPTION>
-  IndexedArrayOf<T, ISOPTION>::IndexedArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, const std::shared_ptr<Content>& content)
+  IndexedArrayOf<T, ISOPTION>::IndexedArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& index, ContentPtr& content)
       : Content(identities, parameters)
       , index_(index)
       , content_(content) { }
@@ -37,7 +37,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::content() const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::content() const {
     return content_;
   }
 
@@ -47,7 +47,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::project() const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::project() const {
     if (ISOPTION) {
       int64_t numnull;
       struct Error err1 = util::awkward_indexedarray_numnull<T>(
@@ -83,7 +83,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::project(const Index8& mask) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::project(const Index8& mask) const {
     if (index_.length() != mask.length()) {
       throw std::invalid_argument(std::string("mask length (") + std::to_string(mask.length()) + std::string(") is not equal to ") + classname() + std::string(" length (") + std::to_string(index_.length()) + std::string(")"));
     }
@@ -125,7 +125,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::simplify_optiontype() const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::simplify_optiontype() const {
     if (ISOPTION) {
       if (IndexedArray32* rawcontent = dynamic_cast<IndexedArray32*>(content_.get())) {
         Index32 inner = rawcontent->index();
@@ -539,12 +539,12 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::shallow_copy() const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::shallow_copy() const {
     return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, parameters_, index_, content_);
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexOf<T> index = copyindexes ? index_.deep_copy() : index_;
     std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
@@ -562,12 +562,12 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_nothing() const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_at(int64_t at) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += index_.length();
@@ -579,7 +579,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_at_nowrap(int64_t at) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_at_nowrap(int64_t at) const {
     int64_t index = (int64_t)index_.getitem_at_nowrap(at);
     if (index < 0) {
       if (ISOPTION) {
@@ -597,7 +597,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), index_.length());
@@ -608,7 +608,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -617,17 +617,17 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_field(const std::string& key) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_field(const std::string& key) const {
     return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, util::Parameters(), index_, content_.get()->getitem_field(key));
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<IndexedArrayOf<T, ISOPTION>>(identities_, util::Parameters(), index_, content_.get()->getitem_fields(keys));
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -678,7 +678,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::carry(const Index64& carry) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::carry(const Index64& carry) const {
     IndexOf<T> nextindex(carry.length());
     struct Error err = util::awkward_indexedarray_getitem_carry_64<T>(
       nextindex.ptr().get(),
@@ -768,12 +768,12 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::shallow_simplify() const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::shallow_simplify() const {
     return simplify_optiontype();
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::num(int64_t axis, int64_t depth) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -837,7 +837,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  bool IndexedArrayOf<T, ISOPTION>::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool IndexedArrayOf<T, ISOPTION>::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -879,7 +879,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::reverse_merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::reverse_merge(ContentPtr& other) const {
     int64_t theirlength = other.get()->length();
     int64_t mylength = length();
     Index64 index(theirlength + mylength);
@@ -931,7 +931,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::merge(ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -1125,7 +1125,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::fillna(ContentPtr& value) const {
     if (value.get()->length() != 1) {
       throw std::invalid_argument(std::string("fillna value length (") + std::to_string(value.get()->length()) + std::string(") is not equal to 1"));
     }
@@ -1152,7 +1152,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -1180,7 +1180,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -1208,7 +1208,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     int64_t numnull;
     struct Error err1 = util::awkward_indexedarray_numnull<T>(
       &numnull,
@@ -1266,7 +1266,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1290,7 +1290,7 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1317,43 +1317,43 @@ namespace awkward {
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: IndexedArray::getitem_next(at)");
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: IndexedArray::getitem_next(range)");
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: IndexedArray::getitem_next(array)");
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: IndexedArray::getitem_next(jagged)");
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, bool ISOPTION>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, bool ISOPTION>
   template <typename S>
-  const std::shared_ptr<Content> IndexedArrayOf<T, ISOPTION>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  ContentPtr IndexedArrayOf<T, ISOPTION>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
     if (ISOPTION) {
       int64_t numnull;
       std::pair<Index64, IndexOf<T>> pair = nextcarry_outindex(numnull);

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -927,7 +927,7 @@ namespace awkward {
         length());
       util::handle_error(err2, classname(), identities_.get());
 
-      std::vector<ContentPtr> contents;
+      ContentPtrVec contents;
       for (auto ptr : tocarry) {
         contents.push_back(content_.get()->carry(Index64(ptr, 0, totallen)));
       }

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -25,7 +25,7 @@
 
 namespace awkward {
   template <typename T>
-  ListArrayOf<T>::ListArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const ContentPtr& content)
+  ListArrayOf<T>::ListArrayOf(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const ContentPtr& content)
       : Content(identities, parameters)
       , starts_(starts)
       , stops_(stops)
@@ -90,7 +90,7 @@ namespace awkward {
 
     ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
-    std::shared_ptr<Identities> identities;
+    IdentitiesPtr identities;
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(0, offsets.length() - 1);
     }
@@ -128,7 +128,7 @@ namespace awkward {
   }
 
   template <typename T>
-  void ListArrayOf<T>::setidentities(const std::shared_ptr<Identities>& identities) {
+  void ListArrayOf<T>::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
@@ -136,13 +136,13 @@ namespace awkward {
       if (length() != identities.get()->length()) {
         util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
       }
-      std::shared_ptr<Identities> bigidentities = identities;
+      IdentitiesPtr bigidentities = identities;
       if (content_.get()->length() > kMaxInt32  ||  !std::is_same<T, int32_t>::value) {
         bigidentities = identities.get()->to64();
       }
       if (Identities32* rawidentities = dynamic_cast<Identities32*>(bigidentities.get())) {
         bool uniquecontents;
-        std::shared_ptr<Identities> subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width() + 1, content_.get()->length());
+        IdentitiesPtr subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width() + 1, content_.get()->length());
         Identities32* rawsubidentities = reinterpret_cast<Identities32*>(subidentities.get());
         struct Error err = util::awkward_identities32_from_listarray<T>(
           &uniquecontents,
@@ -166,7 +166,7 @@ namespace awkward {
       }
       else if (Identities64* rawidentities = dynamic_cast<Identities64*>(bigidentities.get())) {
         bool uniquecontents;
-        std::shared_ptr<Identities> subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width() + 1, content_.get()->length());
+        IdentitiesPtr subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width() + 1, content_.get()->length());
         Identities64* rawsubidentities = reinterpret_cast<Identities64*>(subidentities.get());
         struct Error err = util::awkward_identities64_from_listarray<T>(
           &uniquecontents,
@@ -198,14 +198,14 @@ namespace awkward {
   template <typename T>
   void ListArrayOf<T>::setidentities() {
     if (length() <= kMaxInt32) {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
       struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
       struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
@@ -214,7 +214,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Type> ListArrayOf<T>::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr ListArrayOf<T>::type(const std::map<std::string, std::string>& typestrs) const {
     return std::make_shared<ListType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
   }
 
@@ -271,7 +271,7 @@ namespace awkward {
     IndexOf<T> starts = copyindexes ? starts_.deep_copy() : starts_;
     IndexOf<T> stops = copyindexes ? stops_.deep_copy() : stops_;
     ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
-    std::shared_ptr<Identities> identities = identities_;
+    IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
@@ -344,7 +344,7 @@ namespace awkward {
 
   template <typename T>
   const ContentPtr ListArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    std::shared_ptr<Identities> identities(nullptr);
+    IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
@@ -380,7 +380,7 @@ namespace awkward {
       lenstarts,
       carry.length());
     util::handle_error(err, classname(), identities_.get());
-    std::shared_ptr<Identities> identities(nullptr);
+    IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
@@ -785,7 +785,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<SliceItem> ListArrayOf<T>::asslice() const {
+  const SliceItemPtr ListArrayOf<T>::asslice() const {
     return toListOffsetArray64(true).get()->asslice();
   }
 
@@ -884,7 +884,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const ContentPtr ListArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr ListArrayOf<T>::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -954,7 +954,7 @@ namespace awkward {
     if (advanced.length() != 0) {
       throw std::runtime_error("ListArray::getitem_next(SliceAt): advanced.length() != 0");
     }
-    std::shared_ptr<SliceItem> nexthead = tail.head();
+    SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
     Index64 nextcarry(lenstarts);
     struct Error err = util::awkward_listarray_getitem_next_at_64<T>(
@@ -977,7 +977,7 @@ namespace awkward {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
     }
 
-    std::shared_ptr<SliceItem> nexthead = tail.head();
+    SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
     int64_t start = range.start();
     int64_t stop = range.stop();
@@ -1043,7 +1043,7 @@ namespace awkward {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
     }
 
-    std::shared_ptr<SliceItem> nexthead = tail.head();
+    SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
     Index64 flathead = array.ravel();
     if (advanced.length() == 0) {

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -25,7 +25,7 @@
 
 namespace awkward {
   template <typename T>
-  ListArrayOf<T>::ListArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const std::shared_ptr<Content>& content)
+  ListArrayOf<T>::ListArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, ContentPtr& content)
       : Content(identities, parameters)
       , starts_(starts)
       , stops_(stops)
@@ -46,7 +46,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::content() const {
+  ContentPtr ListArrayOf<T>::content() const {
     return content_;
   }
 
@@ -66,7 +66,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
+  ContentPtr ListArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
       throw std::invalid_argument("broadcast_tooffsets64 can only be used with offsets that start at 0");
     }
@@ -98,7 +98,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::toRegularArray() const {
+  ContentPtr ListArrayOf<T>::toRegularArray() const {
     Index64 offsets = compact_offsets64(true);
     std::shared_ptr<Content> listoffsetarray64 = broadcast_tooffsets64(offsets);
     ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(listoffsetarray64.get());
@@ -106,7 +106,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
+  ContentPtr ListArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
     Index64 offsets = compact_offsets64(start_at_zero);
     return broadcast_tooffsets64(offsets);
   }
@@ -262,12 +262,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::shallow_copy() const {
+  ContentPtr ListArrayOf<T>::shallow_copy() const {
     return std::make_shared<ListArrayOf<T>>(identities_, parameters_, starts_, stops_, content_);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr ListArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexOf<T> starts = copyindexes ? starts_.deep_copy() : starts_;
     IndexOf<T> stops = copyindexes ? stops_.deep_copy() : stops_;
     std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
@@ -289,12 +289,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_nothing() const {
+  ContentPtr ListArrayOf<T>::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_at(int64_t at) const {
+  ContentPtr ListArrayOf<T>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += starts_.length();
@@ -309,7 +309,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_at_nowrap(int64_t at) const {
+  ContentPtr ListArrayOf<T>::getitem_at_nowrap(int64_t at) const {
     int64_t start = (int64_t)starts_.getitem_at_nowrap(at);
     int64_t stop = (int64_t)stops_.getitem_at_nowrap(at);
     int64_t lencontent = content_.get()->length();
@@ -329,7 +329,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr ListArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), starts_.length());
@@ -343,7 +343,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr ListArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -352,17 +352,17 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_field(const std::string& key) const {
+  ContentPtr ListArrayOf<T>::getitem_field(const std::string& key) const {
     return std::make_shared<ListArrayOf<T>>(identities_, util::Parameters(), starts_, stops_, content_.get()->getitem_field(key));
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr ListArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<ListArrayOf<T>>(identities_, util::Parameters(), starts_, stops_, content_.get()->getitem_fields(keys));
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::carry(const Index64& carry) const {
+  ContentPtr ListArrayOf<T>::carry(const Index64& carry) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -463,12 +463,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::shallow_simplify() const {
+  ContentPtr ListArrayOf<T>::shallow_simplify() const {
     return shallow_copy();
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::num(int64_t axis, int64_t depth) const {
+  ContentPtr ListArrayOf<T>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -498,7 +498,7 @@ namespace awkward {
   }
 
   template <typename T>
-  bool ListArrayOf<T>::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool ListArrayOf<T>::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -561,7 +561,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr ListArrayOf<T>::merge(ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -790,12 +790,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr ListArrayOf<T>::fillna(ContentPtr& value) const {
     return std::make_shared<ListArrayOf<T>>(identities_, parameters_, starts_, stops_, content_.get()->fillna(value));
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr ListArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -851,17 +851,17 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr ListArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     return toListOffsetArray64(true).get()->rpad_and_clip(target, axis, depth);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr ListArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     return toListOffsetArray64(true).get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr ListArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -884,7 +884,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr ListArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -945,7 +945,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ListArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -971,7 +971,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ListArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -1037,7 +1037,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ListArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -1086,7 +1086,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ListArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
     }
@@ -1119,7 +1119,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
       util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
     }
@@ -1165,7 +1165,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
       util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
     }
@@ -1221,7 +1221,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
       util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
     }

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1037,7 +1037,8 @@ namespace awkward {
       }
       else {
         int64_t tolength = 0;
-        struct Error err2 = util::awkward_ListArray_rpad_and_clip_length_axis1<T>(
+        struct Error err2 =
+          util::awkward_ListArray_rpad_and_clip_length_axis1<T>(
           &tolength,
           starts_.ptr().get(),
           stops_.ptr().get(),
@@ -1284,7 +1285,8 @@ namespace awkward {
       step = 1;
     }
     int64_t carrylength;
-    struct Error err1 = util::awkward_listarray_getitem_next_range_carrylength<T>(
+    struct Error err1 =
+      util::awkward_listarray_getitem_next_range_carrylength<T>(
       &carrylength,
       starts_.ptr().get(),
       stops_.ptr().get(),

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -214,7 +214,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const TypePtr ListArrayOf<T>::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr ListArrayOf<T>::type(const util::TypeStrs& typestrs) const {
     return std::make_shared<ListType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
   }
 

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -25,7 +25,7 @@
 
 namespace awkward {
   template <typename T>
-  ListArrayOf<T>::ListArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, ContentPtr& content)
+  ListArrayOf<T>::ListArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& starts, const IndexOf<T>& stops, const ContentPtr& content)
       : Content(identities, parameters)
       , starts_(starts)
       , stops_(stops)
@@ -46,7 +46,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::content() const {
+  const ContentPtr ListArrayOf<T>::content() const {
     return content_;
   }
 
@@ -66,7 +66,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
+  const ContentPtr ListArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
       throw std::invalid_argument("broadcast_tooffsets64 can only be used with offsets that start at 0");
     }
@@ -88,7 +88,7 @@ namespace awkward {
       content_.get()->length());
     util::handle_error(err, classname(), identities_.get());
 
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
     std::shared_ptr<Identities> identities;
     if (identities_.get() != nullptr) {
@@ -98,15 +98,15 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::toRegularArray() const {
+  const ContentPtr ListArrayOf<T>::toRegularArray() const {
     Index64 offsets = compact_offsets64(true);
-    std::shared_ptr<Content> listoffsetarray64 = broadcast_tooffsets64(offsets);
+    ContentPtr listoffsetarray64 = broadcast_tooffsets64(offsets);
     ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(listoffsetarray64.get());
     return raw->toRegularArray();
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
+  const ContentPtr ListArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
     Index64 offsets = compact_offsets64(start_at_zero);
     return broadcast_tooffsets64(offsets);
   }
@@ -262,15 +262,15 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::shallow_copy() const {
+  const ContentPtr ListArrayOf<T>::shallow_copy() const {
     return std::make_shared<ListArrayOf<T>>(identities_, parameters_, starts_, stops_, content_);
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr ListArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexOf<T> starts = copyindexes ? starts_.deep_copy() : starts_;
     IndexOf<T> stops = copyindexes ? stops_.deep_copy() : stops_;
-    std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -289,12 +289,12 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_nothing() const {
+  const ContentPtr ListArrayOf<T>::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_at(int64_t at) const {
+  const ContentPtr ListArrayOf<T>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += starts_.length();
@@ -309,7 +309,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr ListArrayOf<T>::getitem_at_nowrap(int64_t at) const {
     int64_t start = (int64_t)starts_.getitem_at_nowrap(at);
     int64_t stop = (int64_t)stops_.getitem_at_nowrap(at);
     int64_t lencontent = content_.get()->length();
@@ -329,7 +329,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr ListArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), starts_.length());
@@ -343,7 +343,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr ListArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -352,17 +352,17 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_field(const std::string& key) const {
+  const ContentPtr ListArrayOf<T>::getitem_field(const std::string& key) const {
     return std::make_shared<ListArrayOf<T>>(identities_, util::Parameters(), starts_, stops_, content_.get()->getitem_field(key));
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr ListArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<ListArrayOf<T>>(identities_, util::Parameters(), starts_, stops_, content_.get()->getitem_fields(keys));
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::carry(const Index64& carry) const {
+  const ContentPtr ListArrayOf<T>::carry(const Index64& carry) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -463,12 +463,12 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::shallow_simplify() const {
+  const ContentPtr ListArrayOf<T>::shallow_simplify() const {
     return shallow_copy();
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::num(int64_t axis, int64_t depth) const {
+  const ContentPtr ListArrayOf<T>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -493,12 +493,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::pair<Index64, std::shared_ptr<Content>> ListArrayOf<T>::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> ListArrayOf<T>::offsets_and_flattened(int64_t axis, int64_t depth) const {
     return toListOffsetArray64(true).get()->offsets_and_flattened(axis, depth);
   }
 
   template <typename T>
-  bool ListArrayOf<T>::mergeable(ContentPtr& other, bool mergebool) const {
+  bool ListArrayOf<T>::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -561,7 +561,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::merge(ContentPtr& other) const {
+  const ContentPtr ListArrayOf<T>::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -655,7 +655,7 @@ namespace awkward {
     }
 
     int64_t mycontentlength = content_.get()->length();
-    std::shared_ptr<Content> content;
+    ContentPtr content;
     if (ListArray32* rawother = dynamic_cast<ListArray32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index32 other_starts = rawother->starts();
@@ -759,7 +759,7 @@ namespace awkward {
       util::handle_error(err, rawother->classname(), rawother->identities().get());
     }
     else if (RegularArray* rawregulararray = dynamic_cast<RegularArray*>(other.get())) {
-      std::shared_ptr<Content> listoffsetarray = rawregulararray->toListOffsetArray64(true);
+      ContentPtr listoffsetarray = rawregulararray->toListOffsetArray64(true);
       ListOffsetArray64* rawother = dynamic_cast<ListOffsetArray64*>(listoffsetarray.get());
       content = content_.get()->merge(rawother->content());
       Index64 other_starts = rawother->starts();
@@ -790,12 +790,12 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::fillna(ContentPtr& value) const {
+  const ContentPtr ListArrayOf<T>::fillna(const ContentPtr& value) const {
     return std::make_shared<ListArrayOf<T>>(identities_, parameters_, starts_, stops_, content_.get()->fillna(value));
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr ListArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -851,17 +851,17 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr ListArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     return toListOffsetArray64(true).get()->rpad_and_clip(target, axis, depth);
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr ListArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     return toListOffsetArray64(true).get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr ListArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -884,7 +884,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr ListArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -927,25 +927,25 @@ namespace awkward {
         length());
       util::handle_error(err2, classname(), identities_.get());
 
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto ptr : tocarry) {
         contents.push_back(content_.get()->carry(Index64(ptr, 0, totallen)));
       }
-      std::shared_ptr<Content> recordarray = std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
+      ContentPtr recordarray = std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
 
       return std::make_shared<ListOffsetArray64>(identities_, util::Parameters(), offsets, recordarray);
     }
 
     else {
-      std::shared_ptr<Content> compact = toListOffsetArray64(true);
+      ContentPtr compact = toListOffsetArray64(true);
       ListOffsetArray64* rawcompact = dynamic_cast<ListOffsetArray64*>(compact.get());
-      std::shared_ptr<Content> next = rawcompact->content().get()->choose(n, diagonal, recordlookup, parameters, axis, depth + 1);
+      ContentPtr next = rawcompact->content().get()->choose(n, diagonal, recordlookup, parameters, axis, depth + 1);
       return std::make_shared<ListOffsetArray64>(identities_, util::Parameters(), rawcompact->offsets(), next);
     }
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ListArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -966,12 +966,12 @@ namespace awkward {
       stops_.offset(),
       at.at());
     util::handle_error(err, classname(), identities_.get());
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
     return nextcontent.get()->getitem_next(nexthead, nexttail, advanced);
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ListArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -1013,7 +1013,7 @@ namespace awkward {
       stop,
       step);
     util::handle_error(err2, classname(), identities_.get());
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
     if (advanced.length() == 0) {
       return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, nextoffsets, nextcontent.get()->getitem_next(nexthead, nexttail, advanced));
@@ -1037,7 +1037,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ListArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
       util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -1061,7 +1061,7 @@ namespace awkward {
         flathead.length(),
         content_.get()->length());
       util::handle_error(err, classname(), identities_.get());
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
       return getitem_next_array_wrap(nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced), array.shape());
     }
     else {
@@ -1080,13 +1080,13 @@ namespace awkward {
         flathead.length(),
         content_.get()->length());
       util::handle_error(err, classname(), identities_.get());
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
       return nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced);
     }
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ListArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
     }
@@ -1112,14 +1112,14 @@ namespace awkward {
       len);
     util::handle_error(err, classname(), identities_.get());
 
-    std::shared_ptr<Content> carried = content_.get()->carry(nextcarry);
-    std::shared_ptr<Content> down = carried.get()->getitem_next_jagged(multistarts, multistops, jagged.content(), tail);
+    ContentPtr carried = content_.get()->carry(nextcarry);
+    ContentPtr down = carried.get()->getitem_next_jagged(multistarts, multistops, jagged.content(), tail);
 
     return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), down, jagged.length());
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
       util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
     }
@@ -1158,14 +1158,14 @@ namespace awkward {
       content_.get()->length());
     util::handle_error(err2, classname(), nullptr);
 
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
-    std::shared_ptr<Content> outcontent = nextcontent.get()->getitem_next(tail.head(), tail.tail(), Index64(0));
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr outcontent = nextcontent.get()->getitem_next(tail.head(), tail.tail(), Index64(0));
 
     return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), outoffsets, outcontent);
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
       util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
     }
@@ -1200,10 +1200,10 @@ namespace awkward {
       missing.offset());
     util::handle_error(err2, classname(), nullptr);
 
-    std::shared_ptr<Content> out;
+    ContentPtr out;
     if (dynamic_cast<SliceJagged64*>(slicecontent.content().get())) {
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
-      std::shared_ptr<Content> next = std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), smalloffsets, nextcontent);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr next = std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), smalloffsets, nextcontent);
       out = next.get()->getitem_next_jagged(util::make_starts(smalloffsets), util::make_stops(smalloffsets), slicecontent.content(), tail);
     }
     else {
@@ -1211,7 +1211,7 @@ namespace awkward {
     }
 
     if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
-      std::shared_ptr<Content> content = raw->content();
+      ContentPtr content = raw->content();
       IndexedOptionArray64 indexedoptionarray(Identities::none(), util::Parameters(), missing, content);
       return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), largeoffsets, indexedoptionarray.simplify_optiontype());
     }
@@ -1221,7 +1221,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
       util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
     }
@@ -1241,7 +1241,7 @@ namespace awkward {
     util::handle_error(err, classname(), identities_.get());
 
     Index64 sliceoffsets = slicecontent.offsets();
-    std::shared_ptr<Content> outcontent = content_.get()->getitem_next_jagged(util::make_starts(sliceoffsets), util::make_stops(sliceoffsets), slicecontent.content(), tail);
+    ContentPtr outcontent = content_.get()->getitem_next_jagged(util::make_starts(sliceoffsets), util::make_stops(sliceoffsets), slicecontent.content(), tail);
 
     return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), outoffsets, outcontent);
   }

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1314,32 +1314,47 @@ namespace awkward {
     ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
     if (advanced.length() == 0) {
-      return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, nextoffsets, nextcontent.get()->getitem_next(nexthead, nexttail, advanced));
+      return std::make_shared<ListOffsetArrayOf<T>>(
+        identities_,
+        parameters_,
+        nextoffsets,
+        nextcontent.get()->getitem_next(nexthead, nexttail, advanced));
     }
     else {
       int64_t total;
-      struct Error err1 = util::awkward_listarray_getitem_next_range_counts_64<T>(
+      struct Error err1 =
+        util::awkward_listarray_getitem_next_range_counts_64<T>(
         &total,
         nextoffsets.ptr().get(),
         lenstarts);
       util::handle_error(err1, classname(), identities_.get());
       Index64 nextadvanced(total);
-      struct Error err2 = util::awkward_listarray_getitem_next_range_spreadadvanced_64<T>(
+      struct Error err2 =
+        util::awkward_listarray_getitem_next_range_spreadadvanced_64<T>(
         nextadvanced.ptr().get(),
         advanced.ptr().get(),
         nextoffsets.ptr().get(),
         lenstarts);
       util::handle_error(err2, classname(), identities_.get());
-      return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, nextoffsets, nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced));
+      return std::make_shared<ListOffsetArrayOf<T>>(
+        identities_,
+        parameters_,
+        nextoffsets,
+        nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced));
     }
   }
 
   template <typename T>
   const ContentPtr
-  ListArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ListArrayOf<T>::getitem_next(const SliceArray64& array,
+                               const Slice& tail,
+                               const Index64& advanced) const {
     int64_t lenstarts = starts_.length();
     if (stops_.length() < lenstarts) {
-      util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("len(stops) < len(starts)", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
 
     SliceItemPtr nexthead = tail.head();
@@ -1361,12 +1376,17 @@ namespace awkward {
         content_.get()->length());
       util::handle_error(err, classname(), identities_.get());
       ContentPtr nextcontent = content_.get()->carry(nextcarry);
-      return getitem_next_array_wrap(nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced), array.shape());
+      return getitem_next_array_wrap(
+        nextcontent.get()->getitem_next(nexthead,
+                                        nexttail,
+                                        nextadvanced),
+        array.shape());
     }
     else {
       Index64 nextcarry(lenstarts);
       Index64 nextadvanced(lenstarts);
-      struct Error err = util::awkward_listarray_getitem_next_array_advanced_64<T>(
+      struct Error err =
+        util::awkward_listarray_getitem_next_array_advanced_64<T>(
         nextcarry.ptr().get(),
         nextadvanced.ptr().get(),
         starts_.ptr().get(),
@@ -1386,12 +1406,18 @@ namespace awkward {
 
   template <typename T>
   const ContentPtr
-  ListArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ListArrayOf<T>::getitem_next(const SliceJagged64& jagged,
+                               const Slice& tail,
+                               const Index64& advanced) const {
     if (advanced.length() != 0) {
-      throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
+      throw std::invalid_argument(
+        "cannot mix jagged slice with NumPy-style advanced indexing");
     }
     if (stops_.length() < starts_.length()) {
-      util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("len(stops) < len(starts)", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
 
     int64_t len = length();
@@ -1413,19 +1439,35 @@ namespace awkward {
     util::handle_error(err, classname(), identities_.get());
 
     ContentPtr carried = content_.get()->carry(nextcarry);
-    ContentPtr down = carried.get()->getitem_next_jagged(multistarts, multistops, jagged.content(), tail);
+    ContentPtr down = carried.get()->getitem_next_jagged(multistarts,
+                                                         multistops,
+                                                         jagged.content(),
+                                                         tail);
 
-    return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), down, jagged.length());
+    return std::make_shared<RegularArray>(Identities::none(),
+                                          util::Parameters(),
+                                          down, jagged.length());
   }
 
   template <typename T>
   const ContentPtr
-  ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts,
+                                      const Index64& slicestops,
+                                      const SliceArray64& slicecontent,
+                                      const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
-      util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("jagged slice length differs from array length",
+                kSliceNone,
+                kSliceNone),
+        classname(),
+        identities_.get());
     }
     if (stops_.length() < starts_.length()) {
-      util::handle_error(failure("len(stops) < len(starts)", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("len(stops) < len(starts)", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
 
     int64_t carrylen;
@@ -1460,16 +1502,29 @@ namespace awkward {
     util::handle_error(err2, classname(), nullptr);
 
     ContentPtr nextcontent = content_.get()->carry(nextcarry);
-    ContentPtr outcontent = nextcontent.get()->getitem_next(tail.head(), tail.tail(), Index64(0));
+    ContentPtr outcontent = nextcontent.get()->getitem_next(tail.head(),
+                                                            tail.tail(),
+                                                            Index64(0));
 
-    return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), outoffsets, outcontent);
+    return std::make_shared<ListOffsetArray64>(Identities::none(),
+                                               util::Parameters(),
+                                               outoffsets,
+                                               outcontent);
   }
 
   template <typename T>
   const ContentPtr
-  ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts,
+                                      const Index64& slicestops,
+                                      const SliceMissing64& slicecontent,
+                                      const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
-      util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("jagged slice length differs from array length",
+                kSliceNone,
+                kSliceNone),
+        classname(),
+        identities_.get());
     }
 
     Index64 missing = slicecontent.index();
@@ -1505,28 +1560,55 @@ namespace awkward {
     ContentPtr out;
     if (dynamic_cast<SliceJagged64*>(slicecontent.content().get())) {
       ContentPtr nextcontent = content_.get()->carry(nextcarry);
-      ContentPtr next = std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), smalloffsets, nextcontent);
-      out = next.get()->getitem_next_jagged(util::make_starts(smalloffsets), util::make_stops(smalloffsets), slicecontent.content(), tail);
+      ContentPtr next = std::make_shared<ListOffsetArray64>(Identities::none(),
+                                                            util::Parameters(),
+                                                            smalloffsets,
+                                                            nextcontent);
+      out = next.get()->getitem_next_jagged(util::make_starts(smalloffsets),
+                                            util::make_stops(smalloffsets),
+                                            slicecontent.content(),
+                                            tail);
     }
     else {
-      out = Content::getitem_next_jagged(util::make_starts(smalloffsets), util::make_stops(smalloffsets), slicecontent.content(), tail);
+      out = Content::getitem_next_jagged(util::make_starts(smalloffsets),
+                                         util::make_stops(smalloffsets),
+                                         slicecontent.content(),
+                                         tail);
     }
 
     if (ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(out.get())) {
       ContentPtr content = raw->content();
-      IndexedOptionArray64 indexedoptionarray(Identities::none(), util::Parameters(), missing, content);
-      return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), largeoffsets, indexedoptionarray.simplify_optiontype());
+      IndexedOptionArray64 indexedoptionarray(Identities::none(),
+                                              util::Parameters(),
+                                              missing,
+                                              content);
+      return std::make_shared<ListOffsetArray64>(
+        Identities::none(),
+        util::Parameters(),
+        largeoffsets,
+        indexedoptionarray.simplify_optiontype());
     }
     else {
-      throw std::runtime_error(std::string("expected ListOffsetArray64 from ListArray::getitem_next_jagged, got ") + out.get()->classname());
+      throw std::runtime_error(
+        std::string("expected ListOffsetArray64 from "
+                    "ListArray::getitem_next_jagged, got ")
+        + out.get()->classname());
     }
   }
 
   template <typename T>
   const ContentPtr
-  ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ListArrayOf<T>::getitem_next_jagged(const Index64& slicestarts,
+                                      const Index64& slicestops,
+                                      const SliceJagged64& slicecontent,
+                                      const Slice& tail) const {
     if (starts_.length() < slicestarts.length()) {
-      util::handle_error(failure("jagged slice length differs from array length", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("jagged slice length differs from array length",
+                kSliceNone,
+                kSliceNone),
+        classname(),
+        identities_.get());
     }
 
     Index64 outoffsets(slicestarts.length() + 1);
@@ -1544,9 +1626,16 @@ namespace awkward {
     util::handle_error(err, classname(), identities_.get());
 
     Index64 sliceoffsets = slicecontent.offsets();
-    ContentPtr outcontent = content_.get()->getitem_next_jagged(util::make_starts(sliceoffsets), util::make_stops(sliceoffsets), slicecontent.content(), tail);
+    ContentPtr outcontent = content_.get()->getitem_next_jagged(
+      util::make_starts(sliceoffsets),
+      util::make_stops(sliceoffsets),
+      slicecontent.content(),
+      tail);
 
-    return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), outoffsets, outcontent);
+    return std::make_shared<ListOffsetArray64>(Identities::none(),
+                                               util::Parameters(),
+                                               outoffsets,
+                                               outcontent);
   }
 
   template class ListArrayOf<int32_t>;

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -73,7 +73,8 @@ namespace awkward {
     else {
       int64_t len = offsets_.length() - 1;
       Index64 out(len + 1);
-      struct Error err = util::awkward_listoffsetarray_compact_offsets64<int64_t>(
+      struct Error err =
+        util::awkward_listoffsetarray_compact_offsets64<int64_t>(
         out.ptr().get(),
         offsets_.ptr().get(),
         offsets_.offset(),
@@ -1122,7 +1123,8 @@ namespace awkward {
           Index64 adjustedoffsets(offsets.get()->length());
           Index64 adjustednonzero(nonzero.length());
 
-          struct Error err = awkward_listoffsetarray_getitem_adjust_offsets_index_64(
+          struct Error err =
+            awkward_listoffsetarray_getitem_adjust_offsets_index_64(
             adjustedoffsets.ptr().get(),
             adjustednonzero.ptr().get(),
             offsets.get()->ptr().get(),
@@ -1298,7 +1300,8 @@ namespace awkward {
       Index64 nextparents(nextlen);
       int64_t maxnextparents;
       Index64 distincts(maxcount * outlength);
-      struct Error err3 = awkward_listoffsetarray_reduce_nonlocal_preparenext_64(
+      struct Error err3 =
+        awkward_listoffsetarray_reduce_nonlocal_preparenext_64(
         nextcarry.ptr().get(),
         nextparents.ptr().get(),
         nextlen,
@@ -1337,7 +1340,8 @@ namespace awkward {
 
       Index64 outstarts(outlength);
       Index64 outstops(outlength);
-      struct Error err6 = awkward_listoffsetarray_reduce_nonlocal_outstartsstops_64(
+      struct Error err6 =
+        awkward_listoffsetarray_reduce_nonlocal_outstartsstops_64(
         outstarts.ptr().get(),
         outstops.ptr().get(),
         distincts.ptr().get(),

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -26,7 +26,7 @@
 
 namespace awkward {
   template <typename T>
-  ListOffsetArrayOf<T>::ListOffsetArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, const std::shared_ptr<Content>& content)
+  ListOffsetArrayOf<T>::ListOffsetArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, ContentPtr& content)
       : Content(identities, parameters)
       , offsets_(offsets)
       , content_(content) {
@@ -51,7 +51,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::content() const {
+  ContentPtr ListOffsetArrayOf<T>::content() const {
     return content_;
   }
 
@@ -87,7 +87,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
+  ContentPtr ListOffsetArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
       throw std::invalid_argument("broadcast_tooffsets64 can only be used with offsets that start at 0");
     }
@@ -122,7 +122,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::toRegularArray() const {
+  ContentPtr ListOffsetArrayOf<T>::toRegularArray() const {
     int64_t start = (int64_t)offsets_.getitem_at(0);
     int64_t stop = (int64_t)offsets_.getitem_at(offsets_.length() - 1);
     std::shared_ptr<Content> content = content_.get()->getitem_range_nowrap(start, stop);
@@ -139,7 +139,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
+  ContentPtr ListOffsetArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
     if (std::is_same<T, int64_t>::value  &&  (!start_at_zero  ||  offsets_.getitem_at_nowrap(offsets_.offset()) == 0)) {
       return shallow_copy();
     }
@@ -280,12 +280,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::shallow_copy() const {
+  ContentPtr ListOffsetArrayOf<T>::shallow_copy() const {
     return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, offsets_, content_);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr ListOffsetArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexOf<T> offsets = copyindexes ? offsets_.deep_copy() : offsets_;
     std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
@@ -303,12 +303,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_nothing() const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_at(int64_t at) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += offsets_.length() - 1;
@@ -320,7 +320,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_at_nowrap(int64_t at) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_at_nowrap(int64_t at) const {
     int64_t start = (int64_t)offsets_.getitem_at_nowrap(at);
     int64_t stop = (int64_t)offsets_.getitem_at_nowrap(at + 1);
     int64_t lencontent = content_.get()->length();
@@ -340,7 +340,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), offsets_.length() - 1);
@@ -351,7 +351,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -360,23 +360,23 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_field(const std::string& key) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_field(const std::string& key) const {
     return std::make_shared<ListOffsetArrayOf<T>>(identities_, util::Parameters(), offsets_, content_.get()->getitem_field(key));
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<ListOffsetArrayOf<T>>(identities_, util::Parameters(), offsets_, content_.get()->getitem_fields(keys));
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const {
     std::shared_ptr<Content> listarray = std::make_shared<ListArrayOf<T>>(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::carry(const Index64& carry) const {
+  ContentPtr ListOffsetArrayOf<T>::carry(const Index64& carry) const {
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
     IndexOf<T> nextstarts(carry.length());
@@ -477,12 +477,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::shallow_simplify() const {
+  ContentPtr ListOffsetArrayOf<T>::shallow_simplify() const {
     return shallow_copy();
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::num(int64_t axis, int64_t depth) const {
+  ContentPtr ListOffsetArrayOf<T>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -544,7 +544,7 @@ namespace awkward {
   }
 
   template <typename T>
-  bool ListOffsetArrayOf<T>::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool ListOffsetArrayOf<T>::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -607,7 +607,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr ListOffsetArrayOf<T>::merge(ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -913,12 +913,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr ListOffsetArrayOf<T>::fillna(ContentPtr& value) const {
     return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, offsets_, content().get()->fillna(value));
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr ListOffsetArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -953,7 +953,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr ListOffsetArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -987,7 +987,7 @@ namespace awkward {
   }
 
   template <>
-  const std::shared_ptr<Content> ListOffsetArrayOf<int64_t>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr ListOffsetArrayOf<int64_t>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     std::pair<bool, int64_t> branchdepth = branch_depth();
 
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -1109,12 +1109,12 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t length, bool mask, bool keepdims) const {
+  ContentPtr ListOffsetArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t length, bool mask, bool keepdims) const {
     return toListOffsetArray64(true).get()->reduce_next(reducer, negaxis, starts, parents, length, mask, keepdims);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr ListOffsetArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1137,7 +1137,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr ListOffsetArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1201,7 +1201,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::runtime_error("ListOffsetArray::getitem_next(SliceAt): advanced.length() != 0");
     }
@@ -1225,7 +1225,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = offsets_.length() - 1;
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
@@ -1289,7 +1289,7 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = offsets_.length() - 1;
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
@@ -1336,25 +1336,25 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.getitem_next(jagged, tail, advanced);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T>
-  const std::shared_ptr<Content> ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -26,7 +26,7 @@
 
 namespace awkward {
   template <typename T>
-  ListOffsetArrayOf<T>::ListOffsetArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, ContentPtr& content)
+  ListOffsetArrayOf<T>::ListOffsetArrayOf(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, const ContentPtr& content)
       : Content(identities, parameters)
       , offsets_(offsets)
       , content_(content) {
@@ -51,7 +51,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::content() const {
+  const ContentPtr ListOffsetArrayOf<T>::content() const {
     return content_;
   }
 
@@ -87,7 +87,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
+  const ContentPtr ListOffsetArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
       throw std::invalid_argument("broadcast_tooffsets64 can only be used with offsets that start at 0");
     }
@@ -112,7 +112,7 @@ namespace awkward {
       content_.get()->length());
     util::handle_error(err, classname(), identities_.get());
 
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
     std::shared_ptr<Identities> identities;
     if (identities_.get() != nullptr) {
@@ -122,10 +122,10 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::toRegularArray() const {
+  const ContentPtr ListOffsetArrayOf<T>::toRegularArray() const {
     int64_t start = (int64_t)offsets_.getitem_at(0);
     int64_t stop = (int64_t)offsets_.getitem_at(offsets_.length() - 1);
-    std::shared_ptr<Content> content = content_.get()->getitem_range_nowrap(start, stop);
+    ContentPtr content = content_.get()->getitem_range_nowrap(start, stop);
 
     int64_t size;
     struct Error err = util::awkward_listoffsetarray_toRegularArray<T>(
@@ -139,7 +139,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
+  const ContentPtr ListOffsetArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
     if (std::is_same<T, int64_t>::value  &&  (!start_at_zero  ||  offsets_.getitem_at_nowrap(offsets_.offset()) == 0)) {
       return shallow_copy();
     }
@@ -280,14 +280,14 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::shallow_copy() const {
+  const ContentPtr ListOffsetArrayOf<T>::shallow_copy() const {
     return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, offsets_, content_);
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr ListOffsetArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexOf<T> offsets = copyindexes ? offsets_.deep_copy() : offsets_;
-    std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -303,12 +303,12 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_nothing() const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_at(int64_t at) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += offsets_.length() - 1;
@@ -320,7 +320,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_at_nowrap(int64_t at) const {
     int64_t start = (int64_t)offsets_.getitem_at_nowrap(at);
     int64_t stop = (int64_t)offsets_.getitem_at_nowrap(at + 1);
     int64_t lencontent = content_.get()->length();
@@ -340,7 +340,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), offsets_.length() - 1);
@@ -351,7 +351,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -360,23 +360,23 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_field(const std::string& key) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_field(const std::string& key) const {
     return std::make_shared<ListOffsetArrayOf<T>>(identities_, util::Parameters(), offsets_, content_.get()->getitem_field(key));
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<ListOffsetArrayOf<T>>(identities_, util::Parameters(), offsets_, content_.get()->getitem_fields(keys));
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const {
-    std::shared_ptr<Content> listarray = std::make_shared<ListArrayOf<T>>(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
+  const ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const std::shared_ptr<SliceItem>& slicecontent, const Slice& tail) const {
+    ContentPtr listarray = std::make_shared<ListArrayOf<T>>(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::carry(const Index64& carry) const {
+  const ContentPtr ListOffsetArrayOf<T>::carry(const Index64& carry) const {
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
     IndexOf<T> nextstarts(carry.length());
@@ -477,12 +477,12 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::shallow_simplify() const {
+  const ContentPtr ListOffsetArrayOf<T>::shallow_simplify() const {
     return shallow_copy();
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::num(int64_t axis, int64_t depth) const {
+  const ContentPtr ListOffsetArrayOf<T>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -504,28 +504,28 @@ namespace awkward {
       return std::make_shared<NumpyArray>(tonum);
     }
     else {
-      std::shared_ptr<Content> next = content_.get()->num(axis, depth + 1);
+      ContentPtr next = content_.get()->num(axis, depth + 1);
       Index64 offsets = compact_offsets64(true);
       return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), offsets, next);
     }
   }
 
   template <typename T>
-  const std::pair<Index64, std::shared_ptr<Content>> ListOffsetArrayOf<T>::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> ListOffsetArrayOf<T>::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
     }
     else if (toaxis == depth + 1) {
-      std::shared_ptr<Content> listoffsetarray = toListOffsetArray64(true);
+      ContentPtr listoffsetarray = toListOffsetArray64(true);
       ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(listoffsetarray.get());
-      return std::pair<Index64, std::shared_ptr<Content>>(raw->offsets(), raw->content());
+      return std::pair<Index64, ContentPtr>(raw->offsets(), raw->content());
     }
     else {
-      std::pair<Index64, std::shared_ptr<Content>> pair = content_.get()->offsets_and_flattened(axis, depth + 1);
+      std::pair<Index64, ContentPtr> pair = content_.get()->offsets_and_flattened(axis, depth + 1);
       Index64 inneroffsets = pair.first;
       if (inneroffsets.length() == 0) {
-        return std::pair<Index64, std::shared_ptr<Content>>(Index64(0), std::make_shared<ListOffsetArrayOf<T>>(Identities::none(), util::Parameters(), offsets_, pair.second));
+        return std::pair<Index64, ContentPtr>(Index64(0), std::make_shared<ListOffsetArrayOf<T>>(Identities::none(), util::Parameters(), offsets_, pair.second));
       }
       else {
         Index64 tooffsets(offsets_.length());
@@ -538,13 +538,13 @@ namespace awkward {
           inneroffsets.offset(),
           inneroffsets.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::pair<Index64, std::shared_ptr<Content>>(Index64(0), std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), tooffsets, pair.second));
+        return std::pair<Index64, ContentPtr>(Index64(0), std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), tooffsets, pair.second));
       }
     }
   }
 
   template <typename T>
-  bool ListOffsetArrayOf<T>::mergeable(ContentPtr& other, bool mergebool) const {
+  bool ListOffsetArrayOf<T>::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -607,7 +607,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::merge(ContentPtr& other) const {
+  const ContentPtr ListOffsetArrayOf<T>::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -704,7 +704,7 @@ namespace awkward {
     }
 
     int64_t mycontentlength = content_.get()->length();
-    std::shared_ptr<Content> content;
+    ContentPtr content;
     if (ListArray32* rawother = dynamic_cast<ListArray32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index32 other_starts = rawother->starts();
@@ -808,7 +808,7 @@ namespace awkward {
       util::handle_error(err, rawother->classname(), rawother->identities().get());
     }
     else if (RegularArray* rawregulararray = dynamic_cast<RegularArray*>(other.get())) {
-      std::shared_ptr<Content> listoffsetarray = rawregulararray->toListOffsetArray64(true);
+      ContentPtr listoffsetarray = rawregulararray->toListOffsetArray64(true);
       ListOffsetArray64* rawother = dynamic_cast<ListOffsetArray64*>(listoffsetarray.get());
       content = content_.get()->merge(rawother->content());
       Index64 other_starts = rawother->starts();
@@ -837,7 +837,7 @@ namespace awkward {
   const std::shared_ptr<SliceItem> ListOffsetArrayOf<int64_t>::asslice() const {
     int64_t start = offsets_.getitem_at_nowrap(0);
     int64_t stop = offsets_.getitem_at_nowrap(offsets_.length() - 1);
-    std::shared_ptr<Content> next = content_.get()->getitem_range_nowrap(start, stop);
+    ContentPtr next = content_.get()->getitem_range_nowrap(start, stop);
 
     std::shared_ptr<Index64> offsets = std::make_shared<Index64>(offsets_.ptr(), offsets_.offset(), offsets_.length());
     if (start != 0) {
@@ -913,12 +913,12 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::fillna(ContentPtr& value) const {
+  const ContentPtr ListOffsetArrayOf<T>::fillna(const ContentPtr& value) const {
     return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, offsets_, content().get()->fillna(value));
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr ListOffsetArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -953,7 +953,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr ListOffsetArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -987,7 +987,7 @@ namespace awkward {
   }
 
   template <>
-  ContentPtr ListOffsetArrayOf<int64_t>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr ListOffsetArrayOf<int64_t>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     std::pair<bool, int64_t> branchdepth = branch_depth();
 
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -1043,8 +1043,8 @@ namespace awkward {
         nextlen);
       util::handle_error(err4, classname(), identities_.get());
 
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
-      std::shared_ptr<Content> outcontent = nextcontent.get()->reduce_next(reducer, negaxis - 1, nextstarts, nextparents, maxnextparents + 1, mask, false);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr outcontent = nextcontent.get()->reduce_next(reducer, negaxis - 1, nextstarts, nextparents, maxnextparents + 1, mask, false);
 
       Index64 gaps(outlength);
       struct Error err5 = awkward_listoffsetarray_reduce_nonlocal_findgaps_64(
@@ -1064,7 +1064,7 @@ namespace awkward {
         gaps.ptr().get());
       util::handle_error(err6, classname(), identities_.get());
 
-      std::shared_ptr<Content> out = std::make_shared<ListArray64>(Identities::none(), util::Parameters(), outstarts, outstops, outcontent);
+      ContentPtr out = std::make_shared<ListArray64>(Identities::none(), util::Parameters(), outstarts, outstops, outcontent);
 
       if (keepdims) {
         out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out, 1);
@@ -1092,8 +1092,8 @@ namespace awkward {
         offsets_.length() - 1);
       util::handle_error(err2, classname(), identities_.get());
 
-      std::shared_ptr<Content> trimmed = content_.get()->getitem_range_nowrap(globalstart, globalstop);
-      std::shared_ptr<Content> outcontent = trimmed.get()->reduce_next(reducer, negaxis, util::make_starts(offsets_), nextparents, offsets_.length() - 1, mask, keepdims);
+      ContentPtr trimmed = content_.get()->getitem_range_nowrap(globalstart, globalstop);
+      ContentPtr outcontent = trimmed.get()->reduce_next(reducer, negaxis, util::make_starts(offsets_), nextparents, offsets_.length() - 1, mask, keepdims);
 
       Index64 outoffsets(outlength + 1);
       struct Error err3 = awkward_listoffsetarray_reduce_local_outoffsets_64(
@@ -1109,12 +1109,12 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t length, bool mask, bool keepdims) const {
+  const ContentPtr ListOffsetArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t length, bool mask, bool keepdims) const {
     return toListOffsetArray64(true).get()->reduce_next(reducer, negaxis, starts, parents, length, mask, keepdims);
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr ListOffsetArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1137,7 +1137,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr ListOffsetArrayOf<T>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1183,25 +1183,25 @@ namespace awkward {
         length());
       util::handle_error(err2, classname(), identities_.get());
 
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto ptr : tocarry) {
         contents.push_back(content_.get()->carry(Index64(ptr, 0, totallen)));
       }
-      std::shared_ptr<Content> recordarray = std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
+      ContentPtr recordarray = std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
 
       return std::make_shared<ListOffsetArray64>(identities_, util::Parameters(), offsets, recordarray);
     }
 
     else {
-      std::shared_ptr<Content> compact = toListOffsetArray64(true);
+      ContentPtr compact = toListOffsetArray64(true);
       ListOffsetArray64* rawcompact = dynamic_cast<ListOffsetArray64*>(compact.get());
-      std::shared_ptr<Content> next = rawcompact->content().get()->choose(n, diagonal, recordlookup, parameters, axis, depth + 1);
+      ContentPtr next = rawcompact->content().get()->choose(n, diagonal, recordlookup, parameters, axis, depth + 1);
       return std::make_shared<ListOffsetArray64>(identities_, util::Parameters(), rawcompact->offsets(), next);
     }
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::runtime_error("ListOffsetArray::getitem_next(SliceAt): advanced.length() != 0");
     }
@@ -1220,12 +1220,12 @@ namespace awkward {
       stops.offset(),
       at.at());
     util::handle_error(err, classname(), identities_.get());
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
     return nextcontent.get()->getitem_next(nexthead, nexttail, advanced);
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = offsets_.length() - 1;
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
@@ -1265,7 +1265,7 @@ namespace awkward {
       stop,
       step);
     util::handle_error(err2, classname(), identities_.get());
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
     if (advanced.length() == 0) {
       return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, nextoffsets, nextcontent.get()->getitem_next(nexthead, nexttail, advanced));
@@ -1289,7 +1289,7 @@ namespace awkward {
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     int64_t lenstarts = offsets_.length() - 1;
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
@@ -1311,7 +1311,7 @@ namespace awkward {
         flathead.length(),
         content_.get()->length());
       util::handle_error(err, classname(), identities_.get());
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
       return getitem_next_array_wrap(nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced), array.shape());
     }
     else {
@@ -1330,31 +1330,31 @@ namespace awkward {
         flathead.length(),
         content_.get()->length());
       util::handle_error(err, classname(), identities_.get());
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
       return nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced);
     }
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.getitem_next(jagged, tail, advanced);
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T>
-  ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
     return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -26,38 +26,48 @@
 
 namespace awkward {
   template <typename T>
-  ListOffsetArrayOf<T>::ListOffsetArrayOf(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T>& offsets, const ContentPtr& content)
+  ListOffsetArrayOf<T>::ListOffsetArrayOf(const IdentitiesPtr& identities,
+                                          const util::Parameters& parameters,
+                                          const IndexOf<T>& offsets,
+                                          const ContentPtr& content)
       : Content(identities, parameters)
       , offsets_(offsets)
       , content_(content) {
     if (offsets.length() == 0) {
-      throw std::invalid_argument("ListOffsetArray offsets length must be at least 1");
+      throw std::invalid_argument(
+        "ListOffsetArray offsets length must be at least 1");
     }
   }
 
   template <typename T>
-  const IndexOf<T> ListOffsetArrayOf<T>::starts() const {
+  const IndexOf<T>
+  ListOffsetArrayOf<T>::starts() const {
     return util::make_starts(offsets_);
   }
 
   template <typename T>
-  const IndexOf<T> ListOffsetArrayOf<T>::stops() const {
+  const IndexOf<T>
+  ListOffsetArrayOf<T>::stops() const {
     return util::make_stops(offsets_);
   }
 
   template <typename T>
-  const IndexOf<T> ListOffsetArrayOf<T>::offsets() const {
+  const IndexOf<T>
+  ListOffsetArrayOf<T>::offsets() const {
     return offsets_;
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::content() const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::content() const {
     return content_;
   }
 
   template <>
-  Index64 ListOffsetArrayOf<int64_t>::compact_offsets64(bool start_at_zero) const {
-    if (!start_at_zero  ||  offsets_.getitem_at_nowrap(offsets_.offset()) == 0) {
+  Index64
+  ListOffsetArrayOf<int64_t>::compact_offsets64(bool start_at_zero) const {
+    if (!start_at_zero  ||
+        offsets_.getitem_at_nowrap(offsets_.offset()) == 0) {
       return offsets_;
     }
     else {
@@ -74,7 +84,8 @@ namespace awkward {
   }
 
   template <typename T>
-  Index64 ListOffsetArrayOf<T>::compact_offsets64(bool start_at_zero) const {
+  Index64
+  ListOffsetArrayOf<T>::compact_offsets64(bool start_at_zero) const {
     int64_t len = offsets_.length() - 1;
     Index64 out(len + 1);
     struct Error err = util::awkward_listoffsetarray_compact_offsets64<T>(
@@ -87,12 +98,17 @@ namespace awkward {
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
-      throw std::invalid_argument("broadcast_tooffsets64 can only be used with offsets that start at 0");
+      throw std::invalid_argument(
+        "broadcast_tooffsets64 can only be used with offsets that start at 0");
     }
     if (offsets.length() - 1 > offsets_.length() - 1) {
-      throw std::invalid_argument(std::string("cannot broadcast ListOffsetArray of length ") + std::to_string(offsets_.length() - 1) + (" to length ") + std::to_string(offsets.length() - 1));
+      throw std::invalid_argument(
+        std::string("cannot broadcast ListOffsetArray of length ")
+        + std::to_string(offsets_.length() - 1) + (" to length ")
+        + std::to_string(offsets.length() - 1));
     }
 
     IndexOf<T> starts = util::make_starts(offsets_);
@@ -116,13 +132,18 @@ namespace awkward {
 
     IdentitiesPtr identities;
     if (identities_.get() != nullptr) {
-      identities = identities_.get()->getitem_range_nowrap(0, offsets.length() - 1);
+      identities =
+        identities_.get()->getitem_range_nowrap(0, offsets.length() - 1);
     }
-    return std::make_shared<ListOffsetArray64>(identities, parameters_, offsets, nextcontent);
+    return std::make_shared<ListOffsetArray64>(identities,
+                                               parameters_,
+                                               offsets,
+                                               nextcontent);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::toRegularArray() const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::toRegularArray() const {
     int64_t start = (int64_t)offsets_.getitem_at(0);
     int64_t stop = (int64_t)offsets_.getitem_at(offsets_.length() - 1);
     ContentPtr content = content_.get()->getitem_range_nowrap(start, stop);
@@ -135,12 +156,18 @@ namespace awkward {
       offsets_.length());
     util::handle_error(err, classname(), identities_.get());
 
-    return std::make_shared<RegularArray>(identities_, parameters_, content, size);
+    return std::make_shared<RegularArray>(identities_,
+                                          parameters_,
+                                          content,
+                                          size);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
-    if (std::is_same<T, int64_t>::value  &&  (!start_at_zero  ||  offsets_.getitem_at_nowrap(offsets_.offset()) == 0)) {
+  const ContentPtr
+  ListOffsetArrayOf<T>::toListOffsetArray64(bool start_at_zero) const {
+    if (std::is_same<T, int64_t>::value  &&
+        (!start_at_zero  ||
+         offsets_.getitem_at_nowrap(offsets_.offset()) == 0)) {
       return shallow_copy();
     }
     else {
@@ -150,7 +177,8 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::string ListOffsetArrayOf<T>::classname() const {
+  const std::string
+  ListOffsetArrayOf<T>::classname() const {
     if (std::is_same<T, int32_t>::value) {
       return "ListOffsetArray32";
     }
@@ -166,21 +194,34 @@ namespace awkward {
   }
 
   template <typename T>
-  void ListOffsetArrayOf<T>::setidentities(const IdentitiesPtr& identities) {
+  void
+  ListOffsetArrayOf<T>::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
     else {
       if (length() != identities.get()->length()) {
-        util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(failure(
+          "content and its identities must have the same length",
+          kSliceNone,
+          kSliceNone),
+        classname(),
+        identities_.get());
       }
       IdentitiesPtr bigidentities = identities;
-      if (content_.get()->length() > kMaxInt32  ||  !std::is_same<T, int32_t>::value) {
+      if (content_.get()->length() > kMaxInt32  ||
+          !std::is_same<T, int32_t>::value) {
         bigidentities = identities.get()->to64();
       }
-      if (Identities32* rawidentities = dynamic_cast<Identities32*>(bigidentities.get())) {
-        IdentitiesPtr subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width() + 1, content_.get()->length());
-        Identities32* rawsubidentities = reinterpret_cast<Identities32*>(subidentities.get());
+      if (Identities32* rawidentities =
+          dynamic_cast<Identities32*>(bigidentities.get())) {
+        IdentitiesPtr subidentities =
+          std::make_shared<Identities32>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width() + 1,
+                                         content_.get()->length());
+        Identities32* rawsubidentities =
+          reinterpret_cast<Identities32*>(subidentities.get());
         struct Error err = util::awkward_identities32_from_listoffsetarray<T>(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -193,9 +234,15 @@ namespace awkward {
         util::handle_error(err, classname(), identities_.get());
         content_.get()->setidentities(subidentities);
       }
-      else if (Identities64* rawidentities = dynamic_cast<Identities64*>(bigidentities.get())) {
-        IdentitiesPtr subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width() + 1, content_.get()->length());
-        Identities64* rawsubidentities = reinterpret_cast<Identities64*>(subidentities.get());
+      else if (Identities64* rawidentities =
+               dynamic_cast<Identities64*>(bigidentities.get())) {
+        IdentitiesPtr subidentities =
+          std::make_shared<Identities64>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width() + 1,
+                                         content_.get()->length());
+        Identities64* rawsubidentities =
+          reinterpret_cast<Identities64*>(subidentities.get());
         struct Error err = util::awkward_identities64_from_listoffsetarray<T>(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -216,46 +263,70 @@ namespace awkward {
   }
 
   template <typename T>
-  void ListOffsetArrayOf<T>::setidentities() {
+  void
+  ListOffsetArrayOf<T>::setidentities() {
     if (length() <= kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err = awkward_new_identities32(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err = awkward_new_identities64(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
   }
 
   template <typename T>
-  const TypePtr ListOffsetArrayOf<T>::type(const std::map<std::string, std::string>& typestrs) const {
-    return std::make_shared<ListType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
+  const TypePtr
+  ListOffsetArrayOf<T>::type(const util::TypeStrs& typestrs) const {
+    return std::make_shared<ListType>(parameters_,
+                                      util::gettypestr(parameters_, typestrs),
+                                      content_.get()->type(typestrs));
   }
 
   template <typename T>
-  const std::string ListOffsetArrayOf<T>::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  ListOffsetArrayOf<T>::tostring_part(const std::string& indent,
+                                      const std::string& pre,
+                                      const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << ">\n";
     if (identities_.get() != nullptr) {
-      out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+      out << identities_.get()->tostring_part(indent + std::string("    "),
+                                              "",
+                                              "\n");
     }
     if (!parameters_.empty()) {
       out << parameters_tostring(indent + std::string("    "), "", "\n");
     }
-    out << offsets_.tostring_part(indent + std::string("    "), "<offsets>", "</offsets>\n");
-    out << content_.get()->tostring_part(indent + std::string("    "), "<content>", "</content>\n");
+    out << offsets_.tostring_part(
+             indent + std::string("    "), "<offsets>", "</offsets>\n");
+    out << content_.get()->tostring_part(
+             indent + std::string("    "), "<content>", "</content>\n");
     out << indent << "</" << classname() << ">" << post;
     return out.str();
   }
 
   template <typename T>
-  void ListOffsetArrayOf<T>::tojson_part(ToJson& builder) const {
+  void
+  ListOffsetArrayOf<T>::tojson_part(ToJson& builder) const {
     int64_t len = length();
     check_for_iteration();
     builder.beginlist();
@@ -266,7 +337,8 @@ namespace awkward {
   }
 
   template <typename T>
-  void ListOffsetArrayOf<T>::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  ListOffsetArrayOf<T>::nbytes_part(std::map<size_t, int64_t>& largest) const {
     offsets_.nbytes_part(largest);
     content_.get()->nbytes_part(largest);
     if (identities_.get() != nullptr) {
@@ -275,52 +347,75 @@ namespace awkward {
   }
 
   template <typename T>
-  int64_t ListOffsetArrayOf<T>::length() const {
+  int64_t
+  ListOffsetArrayOf<T>::length() const {
     return offsets_.length() - 1;
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::shallow_copy() const {
-    return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, offsets_, content_);
+  const ContentPtr
+  ListOffsetArrayOf<T>::shallow_copy() const {
+    return std::make_shared<ListOffsetArrayOf<T>>(identities_,
+                                                  parameters_,
+                                                  offsets_,
+                                                  content_);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::deep_copy(bool copyarrays,
+                                  bool copyindexes,
+                                  bool copyidentities) const {
     IndexOf<T> offsets = copyindexes ? offsets_.deep_copy() : offsets_;
-    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+    ContentPtr content = content_.get()->deep_copy(copyarrays,
+                                                   copyindexes,
+                                                   copyidentities);
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
-    return std::make_shared<ListOffsetArrayOf<T>>(identities, parameters_, offsets, content);
+    return std::make_shared<ListOffsetArrayOf<T>>(identities,
+                                                  parameters_,
+                                                  offsets,
+                                                  content);
   }
 
   template <typename T>
-  void ListOffsetArrayOf<T>::check_for_iteration() const {
-    if (identities_.get() != nullptr  &&  identities_.get()->length() < offsets_.length() - 1) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+  void
+  ListOffsetArrayOf<T>::check_for_iteration() const {
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < offsets_.length() - 1) {
+      util::handle_error(failure(
+        "len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_nothing() const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_at(int64_t at) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += offsets_.length() - 1;
     }
     if (!(0 <= regular_at  &&  regular_at < offsets_.length() - 1)) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(failure("index out of range", kSliceNone, at),
+                         classname(),
+                         identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_at_nowrap(int64_t at) const {
     int64_t start = (int64_t)offsets_.getitem_at_nowrap(at);
     int64_t stop = (int64_t)offsets_.getitem_at_nowrap(at + 1);
     int64_t lencontent = content_.get()->length();
@@ -328,55 +423,101 @@ namespace awkward {
       start = stop = 0;
     }
     if (start < 0) {
-      util::handle_error(failure("offsets[i] < 0", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(failure(
+                           "offsets[i] < 0", kSliceNone, at),
+                         classname(),
+                         identities_.get());
     }
     if (start > stop) {
-      util::handle_error(failure("offsets[i] > offsets[i + 1]", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(failure(
+                           "offsets[i] > offsets[i + 1]", kSliceNone, at),
+                         classname(),
+                         identities_.get());
     }
     if (stop > lencontent) {
-      util::handle_error(failure("offsets[i] != offsets[i + 1] and offsets[i + 1] > len(content)", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(failure(
+                           "offsets[i] != offsets[i + 1] and "
+                           "offsets[i + 1] > len(content)", kSliceNone, at),
+                         classname(),
+                         identities_.get());
     }
     return content_.get()->getitem_range_nowrap(start, stop);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), offsets_.length() - 1);
-    if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-      util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(),
+      offsets_.length() - 1);
+    if (identities_.get() != nullptr  &&
+        regular_stop > identities_.get()->length()) {
+      util::handle_error(failure("index out of range", kSliceNone, stop),
+                         identities_.get()->classname(),
+                         nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_range_nowrap(int64_t start,
+                                             int64_t stop) const {
     IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
-    return std::make_shared<ListOffsetArrayOf<T>>(identities, parameters_, offsets_.getitem_range_nowrap(start, stop + 1), content_);
+    return std::make_shared<ListOffsetArrayOf<T>>(
+             identities,
+             parameters_,
+             offsets_.getitem_range_nowrap(start, stop + 1),
+             content_);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_field(const std::string& key) const {
-    return std::make_shared<ListOffsetArrayOf<T>>(identities_, util::Parameters(), offsets_, content_.get()->getitem_field(key));
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_field(const std::string& key) const {
+    return std::make_shared<ListOffsetArrayOf<T>>(
+             identities_,
+             util::Parameters(),
+             offsets_,
+             content_.get()->getitem_field(key));
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_fields(const std::vector<std::string>& keys) const {
-    return std::make_shared<ListOffsetArrayOf<T>>(identities_, util::Parameters(), offsets_, content_.get()->getitem_fields(keys));
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_fields(
+    const std::vector<std::string>& keys) const {
+    return std::make_shared<ListOffsetArrayOf<T>>(
+      identities_,
+      util::Parameters(),
+      offsets_,
+      content_.get()->getitem_fields(keys));
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceItemPtr& slicecontent, const Slice& tail) const {
-    ContentPtr listarray = std::make_shared<ListArrayOf<T>>(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
-    return listarray.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts,
+                                            const Index64& slicestops,
+                                            const SliceItemPtr& slicecontent,
+                                            const Slice& tail) const {
+    ContentPtr listarray = std::make_shared<ListArrayOf<T>>(
+                             identities_,
+                             parameters_,
+                             util::make_starts(offsets_),
+                             util::make_stops(offsets_),
+                             content_);
+    return listarray.get()->getitem_next_jagged(slicestarts,
+                                                slicestops,
+                                                slicecontent,
+                                                tail);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::carry(const Index64& carry) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::carry(const Index64& carry) const {
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
     IndexOf<T> nextstarts(carry.length());
@@ -396,11 +537,16 @@ namespace awkward {
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
-    return std::make_shared<ListArrayOf<T>>(identities, parameters_, nextstarts, nextstops, content_);
+    return std::make_shared<ListArrayOf<T>>(identities,
+                                            parameters_,
+                                            nextstarts,
+                                            nextstops,
+                                            content_);
   }
 
   template <typename T>
-  const std::string ListOffsetArrayOf<T>::purelist_parameter(const std::string& key) const {
+  const std::string
+  ListOffsetArrayOf<T>::purelist_parameter(const std::string& key) const {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       return content_.get()->purelist_parameter(key);
@@ -411,54 +557,66 @@ namespace awkward {
   }
 
   template <typename T>
-  bool ListOffsetArrayOf<T>::purelist_isregular() const {
+  bool
+  ListOffsetArrayOf<T>::purelist_isregular() const {
     return false;
   }
 
   template <typename T>
-  int64_t ListOffsetArrayOf<T>::purelist_depth() const {
+  int64_t
+  ListOffsetArrayOf<T>::purelist_depth() const {
     return content_.get()->purelist_depth() + 1;
   }
 
   template <typename T>
-  const std::pair<int64_t, int64_t> ListOffsetArrayOf<T>::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  ListOffsetArrayOf<T>::minmax_depth() const {
     std::pair<int64_t, int64_t> content_depth = content_.get()->minmax_depth();
-    return std::pair<int64_t, int64_t>(content_depth.first + 1, content_depth.second + 1);
+    return std::pair<int64_t, int64_t>(content_depth.first + 1,
+                                       content_depth.second + 1);
   }
 
   template <typename T>
-  const std::pair<bool, int64_t> ListOffsetArrayOf<T>::branch_depth() const {
+  const std::pair<bool, int64_t>
+  ListOffsetArrayOf<T>::branch_depth() const {
     std::pair<bool, int64_t> content_depth = content_.get()->branch_depth();
-    return std::pair<bool, int64_t>(content_depth.first, content_depth.second + 1);
+    return std::pair<bool, int64_t>(content_depth.first,
+                                    content_depth.second + 1);
   }
 
   template <typename T>
-  int64_t ListOffsetArrayOf<T>::numfields() const {
+  int64_t
+  ListOffsetArrayOf<T>::numfields() const {
     return content_.get()->numfields();
   }
 
   template <typename T>
-  int64_t ListOffsetArrayOf<T>::fieldindex(const std::string& key) const {
+  int64_t
+  ListOffsetArrayOf<T>::fieldindex(const std::string& key) const {
     return content_.get()->fieldindex(key);
   }
 
   template <typename T>
-  const std::string ListOffsetArrayOf<T>::key(int64_t fieldindex) const {
+  const std::string
+  ListOffsetArrayOf<T>::key(int64_t fieldindex) const {
     return content_.get()->key(fieldindex);
   }
 
   template <typename T>
-  bool ListOffsetArrayOf<T>::haskey(const std::string& key) const {
+  bool
+  ListOffsetArrayOf<T>::haskey(const std::string& key) const {
     return content_.get()->haskey(key);
   }
 
   template <typename T>
-  const std::vector<std::string> ListOffsetArrayOf<T>::keys() const {
+  const std::vector<std::string>
+  ListOffsetArrayOf<T>::keys() const {
     return content_.get()->keys();
   }
 
   template <typename T>
-  const std::string ListOffsetArrayOf<T>::validityerror(const std::string& path) const {
+  const std::string
+  ListOffsetArrayOf<T>::validityerror(const std::string& path) const {
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
     struct Error err = util::awkward_listarray_validity<T>(
@@ -472,17 +630,21 @@ namespace awkward {
       return content_.get()->validityerror(path + std::string(".content"));
     }
     else {
-      return std::string("at ") + path + std::string(" (") + classname() + std::string("): ") + std::string(err.str) + std::string(" at i=") + std::to_string(err.identity);
+      return (std::string("at ") + path + std::string(" (") + classname()
+              + std::string("): ") + std::string(err.str)
+              + std::string(" at i=") + std::to_string(err.identity));
     }
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::shallow_simplify() const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::shallow_simplify() const {
     return shallow_copy();
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -506,26 +668,38 @@ namespace awkward {
     else {
       ContentPtr next = content_.get()->num(axis, depth + 1);
       Index64 offsets = compact_offsets64(true);
-      return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), offsets, next);
+      return std::make_shared<ListOffsetArray64>(Identities::none(),
+                                                 util::Parameters(),
+                                                 offsets,
+                                                 next);
     }
   }
 
   template <typename T>
-  const std::pair<Index64, ContentPtr> ListOffsetArrayOf<T>::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  ListOffsetArrayOf<T>::offsets_and_flattened(int64_t axis,
+                                              int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
     }
     else if (toaxis == depth + 1) {
       ContentPtr listoffsetarray = toListOffsetArray64(true);
-      ListOffsetArray64* raw = dynamic_cast<ListOffsetArray64*>(listoffsetarray.get());
+      ListOffsetArray64* raw =
+        dynamic_cast<ListOffsetArray64*>(listoffsetarray.get());
       return std::pair<Index64, ContentPtr>(raw->offsets(), raw->content());
     }
     else {
-      std::pair<Index64, ContentPtr> pair = content_.get()->offsets_and_flattened(axis, depth + 1);
+      std::pair<Index64, ContentPtr> pair =
+        content_.get()->offsets_and_flattened(axis, depth + 1);
       Index64 inneroffsets = pair.first;
       if (inneroffsets.length() == 0) {
-        return std::pair<Index64, ContentPtr>(Index64(0), std::make_shared<ListOffsetArrayOf<T>>(Identities::none(), util::Parameters(), offsets_, pair.second));
+        return std::pair<Index64, ContentPtr>(
+                 Index64(0),
+                 std::make_shared<ListOffsetArrayOf<T>>(Identities::none(),
+                                                        util::Parameters(),
+                                                        offsets_,
+                                                        pair.second));
       }
       else {
         Index64 tooffsets(offsets_.length());
@@ -538,13 +712,20 @@ namespace awkward {
           inneroffsets.offset(),
           inneroffsets.length());
         util::handle_error(err, classname(), identities_.get());
-        return std::pair<Index64, ContentPtr>(Index64(0), std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), tooffsets, pair.second));
+        return std::pair<Index64, ContentPtr>(
+                 Index64(0),
+                 std::make_shared<ListOffsetArray64>(Identities::none(),
+                                                     util::Parameters(),
+                                                     tooffsets,
+                                                     pair.second));
       }
     }
   }
 
   template <typename T>
-  bool ListOffsetArrayOf<T>::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  ListOffsetArrayOf<T>::mergeable(const ContentPtr& other,
+                                  bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -555,50 +736,65 @@ namespace awkward {
         dynamic_cast<UnionArray8_64*>(other.get())) {
       return true;
     }
-    else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    else if (IndexedArray32* rawother =
+             dynamic_cast<IndexedArray32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
 
-    if (RegularArray* rawother = dynamic_cast<RegularArray*>(other.get())) {
+    if (RegularArray* rawother =
+        dynamic_cast<RegularArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListArray32* rawother = dynamic_cast<ListArray32*>(other.get())) {
+    else if (ListArray32* rawother =
+             dynamic_cast<ListArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListArrayU32* rawother = dynamic_cast<ListArrayU32*>(other.get())) {
+    else if (ListArrayU32* rawother =
+             dynamic_cast<ListArrayU32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListArray64* rawother = dynamic_cast<ListArray64*>(other.get())) {
+    else if (ListArray64* rawother =
+             dynamic_cast<ListArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListOffsetArray32* rawother = dynamic_cast<ListOffsetArray32*>(other.get())) {
+    else if (ListOffsetArray32* rawother =
+             dynamic_cast<ListOffsetArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListOffsetArrayU32* rawother = dynamic_cast<ListOffsetArrayU32*>(other.get())) {
+    else if (ListOffsetArrayU32* rawother =
+             dynamic_cast<ListOffsetArrayU32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListOffsetArray64* rawother = dynamic_cast<ListOffsetArray64*>(other.get())) {
+    else if (ListOffsetArray64* rawother =
+             dynamic_cast<ListOffsetArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
     else {
@@ -607,7 +803,8 @@ namespace awkward {
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::merge(const ContentPtr& other) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -615,37 +812,48 @@ namespace awkward {
     if (dynamic_cast<EmptyArray*>(other.get())) {
       return shallow_copy();
     }
-    else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    else if (IndexedArray32* rawother =
+             dynamic_cast<IndexedArray32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_32* rawother = dynamic_cast<UnionArray8_32*>(other.get())) {
+    else if (UnionArray8_32* rawother =
+             dynamic_cast<UnionArray8_32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_U32* rawother = dynamic_cast<UnionArray8_U32*>(other.get())) {
+    else if (UnionArray8_U32* rawother =
+             dynamic_cast<UnionArray8_U32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_64* rawother = dynamic_cast<UnionArray8_64*>(other.get())) {
+    else if (UnionArray8_64* rawother =
+             dynamic_cast<UnionArray8_64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
 
@@ -705,7 +913,8 @@ namespace awkward {
 
     int64_t mycontentlength = content_.get()->length();
     ContentPtr content;
-    if (ListArray32* rawother = dynamic_cast<ListArray32*>(other.get())) {
+    if (ListArray32* rawother =
+        dynamic_cast<ListArray32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index32 other_starts = rawother->starts();
       Index32 other_stops = rawother->stops();
@@ -720,9 +929,12 @@ namespace awkward {
         other_stops.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (ListArrayU32* rawother = dynamic_cast<ListArrayU32*>(other.get())) {
+    else if (ListArrayU32* rawother =
+             dynamic_cast<ListArrayU32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       IndexU32 other_starts = rawother->starts();
       IndexU32 other_stops = rawother->stops();
@@ -737,9 +949,12 @@ namespace awkward {
         other_stops.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (ListArray64* rawother = dynamic_cast<ListArray64*>(other.get())) {
+    else if (ListArray64* rawother =
+             dynamic_cast<ListArray64*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index64 other_starts = rawother->starts();
       Index64 other_stops = rawother->stops();
@@ -754,9 +969,12 @@ namespace awkward {
         other_stops.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (ListOffsetArray32* rawother = dynamic_cast<ListOffsetArray32*>(other.get())) {
+    else if (ListOffsetArray32* rawother =
+             dynamic_cast<ListOffsetArray32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index32 other_starts = rawother->starts();
       Index32 other_stops = rawother->stops();
@@ -771,9 +989,12 @@ namespace awkward {
         other_stops.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (ListOffsetArrayU32* rawother = dynamic_cast<ListOffsetArrayU32*>(other.get())) {
+    else if (ListOffsetArrayU32* rawother =
+             dynamic_cast<ListOffsetArrayU32*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       IndexU32 other_starts = rawother->starts();
       IndexU32 other_stops = rawother->stops();
@@ -788,9 +1009,12 @@ namespace awkward {
         other_stops.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (ListOffsetArray64* rawother = dynamic_cast<ListOffsetArray64*>(other.get())) {
+    else if (ListOffsetArray64* rawother =
+             dynamic_cast<ListOffsetArray64*>(other.get())) {
       content = content_.get()->merge(rawother->content());
       Index64 other_starts = rawother->starts();
       Index64 other_stops = rawother->stops();
@@ -805,11 +1029,15 @@ namespace awkward {
         other_stops.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (RegularArray* rawregulararray = dynamic_cast<RegularArray*>(other.get())) {
+    else if (RegularArray* rawregulararray =
+             dynamic_cast<RegularArray*>(other.get())) {
       ContentPtr listoffsetarray = rawregulararray->toListOffsetArray64(true);
-      ListOffsetArray64* rawother = dynamic_cast<ListOffsetArray64*>(listoffsetarray.get());
+      ListOffsetArray64* rawother =
+        dynamic_cast<ListOffsetArray64*>(listoffsetarray.get());
       content = content_.get()->merge(rawother->content());
       Index64 other_starts = rawother->starts();
       Index64 other_stops = rawother->stops();
@@ -824,13 +1052,21 @@ namespace awkward {
         other_stops.offset(),
         theirlength,
         mycontentlength);
-      util::handle_error(err, rawother->classname(), rawother->identities().get());
+      util::handle_error(err,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
     else {
-      throw std::invalid_argument(std::string("cannot merge ") + classname() + std::string(" with ") + other.get()->classname());
+      throw std::invalid_argument(std::string("cannot merge ") + classname()
+                                  + std::string(" with ")
+                                  + other.get()->classname());
     }
 
-    return std::make_shared<ListArray64>(Identities::none(), util::Parameters(), starts, stops, content);
+    return std::make_shared<ListArray64>(Identities::none(),
+                                         util::Parameters(),
+                                         starts,
+                                         stops,
+                                         content);
   }
 
   template <>
@@ -839,7 +1075,8 @@ namespace awkward {
     int64_t stop = offsets_.getitem_at_nowrap(offsets_.length() - 1);
     ContentPtr next = content_.get()->getitem_range_nowrap(start, stop);
 
-    std::shared_ptr<Index64> offsets = std::make_shared<Index64>(offsets_.ptr(), offsets_.offset(), offsets_.length());
+    std::shared_ptr<Index64> offsets = std::make_shared<Index64>(
+      offsets_.ptr(), offsets_.offset(), offsets_.length());
     if (start != 0) {
       offsets = std::make_shared<Index64>(offsets_.length());
       struct Error err = awkward_listoffsetarray64_compact_offsets64(
@@ -851,7 +1088,8 @@ namespace awkward {
     }
 
     SliceItemPtr slicecontent = next.get()->asslice();
-    if (SliceArray64* array = dynamic_cast<SliceArray64*>(slicecontent.get())) {
+    if (SliceArray64* array =
+        dynamic_cast<SliceArray64*>(slicecontent.get())) {
       if (array->frombool()) {
         Index64 nonzero(array->index());
         Index64 adjustedoffsets(offsets.get()->length());
@@ -868,12 +1106,15 @@ namespace awkward {
           nonzero.length());
         util::handle_error(err, classname(), nullptr);
 
-        SliceItemPtr newarray = std::make_shared<SliceArray64>(adjustednonzero, array->shape(), array->strides(), true);
+        SliceItemPtr newarray = std::make_shared<SliceArray64>(
+          adjustednonzero, array->shape(), array->strides(), true);
         return std::make_shared<SliceJagged64>(adjustedoffsets, newarray);
       }
     }
-    else if (SliceMissing64* missing = dynamic_cast<SliceMissing64*>(slicecontent.get())) {
-      if (SliceArray64* array = dynamic_cast<SliceArray64*>(missing->content().get())) {
+    else if (SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(slicecontent.get())) {
+      if (SliceArray64* array =
+          dynamic_cast<SliceArray64*>(missing->content().get())) {
         if (array->frombool()) {
           Index8 originalmask = missing->originalmask();
           Index64 index = missing->index();
@@ -898,27 +1139,38 @@ namespace awkward {
             originalmask.length());
           util::handle_error(err, classname(), nullptr);
 
-          SliceItemPtr newarray = std::make_shared<SliceArray64>(adjustednonzero, array->shape(), array->strides(), true);
-          SliceItemPtr newmissing = std::make_shared<SliceMissing64>(missing->index(), missing->originalmask(), newarray);
+          SliceItemPtr newarray = std::make_shared<SliceArray64>(
+            adjustednonzero, array->shape(), array->strides(), true);
+          SliceItemPtr newmissing = std::make_shared<SliceMissing64>(
+            missing->index(), missing->originalmask(), newarray);
           return std::make_shared<SliceJagged64>(adjustedoffsets, newmissing);
         }
       }
     }
-    return std::make_shared<SliceJagged64>(Index64(offsets.get()->ptr(), offsets.get()->offset(), offsets.get()->length()), slicecontent);
+    return std::make_shared<SliceJagged64>(Index64(offsets.get()->ptr(),
+                                                   offsets.get()->offset(),
+                                                   offsets.get()->length()),
+                                           slicecontent);
   }
 
   template <typename T>
-  const SliceItemPtr ListOffsetArrayOf<T>::asslice() const {
+  const SliceItemPtr
+  ListOffsetArrayOf<T>::asslice() const {
     return toListOffsetArray64(true).get()->asslice();
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::fillna(const ContentPtr& value) const {
-    return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, offsets_, content().get()->fillna(value));
+  const ContentPtr
+  ListOffsetArrayOf<T>::fillna(const ContentPtr& value) const {
+    return std::make_shared<ListOffsetArrayOf<T>>(
+      identities_, parameters_, offsets_, content().get()->fillna(value));
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::rpad(int64_t target,
+                             int64_t axis,
+                             int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -944,16 +1196,26 @@ namespace awkward {
         target);
       util::handle_error(err2, classname(), identities_.get());
 
-      std::shared_ptr<IndexedOptionArray64> next = std::make_shared<IndexedOptionArray64>(identities_, parameters_, outindex, content());
-      return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, offsets, next.get()->simplify_optiontype());
+      std::shared_ptr<IndexedOptionArray64> next =
+        std::make_shared<IndexedOptionArray64>(identities_,
+                                               parameters_,
+                                               outindex,
+                                               content());
+      return std::make_shared<ListOffsetArrayOf<T>>(
+        identities_, parameters_, offsets, next.get()->simplify_optiontype());
     }
     else {
-      return std::make_shared<ListOffsetArrayOf<T>>(Identities::none(), parameters_, offsets_, content_.get()->rpad(target, toaxis, depth + 1));
+      return std::make_shared<ListOffsetArrayOf<T>>(
+        Identities::none(), parameters_, offsets_,
+        content_.get()->rpad(target, toaxis, depth + 1));
     }
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::rpad_and_clip(int64_t target,
+                                      int64_t axis,
+                                      int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -970,7 +1232,8 @@ namespace awkward {
       util::handle_error(err1, classname(), identities_.get());
 
       Index64 outindex(target*(offsets_.length() - 1));
-      struct Error err2 = util::awkward_ListOffsetArray_rpad_and_clip_axis1_64<T>(
+      struct Error err2 =
+        util::awkward_ListOffsetArray_rpad_and_clip_axis1_64<T>(
         outindex.ptr().get(),
         offsets_.ptr().get(),
         offsets_.offset(),
@@ -978,16 +1241,30 @@ namespace awkward {
         target);
       util::handle_error(err2, classname(), identities_.get());
 
-      std::shared_ptr<IndexedOptionArray64> next = std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), outindex, content());
-      return std::make_shared<RegularArray>(Identities::none(), parameters_, next.get()->simplify_optiontype(), target);
+      std::shared_ptr<IndexedOptionArray64> next =
+        std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                               util::Parameters(),
+                                               outindex,
+                                               content());
+      return std::make_shared<RegularArray>(Identities::none(),
+                                            parameters_,
+                                            next.get()->simplify_optiontype(),
+                                            target);
     }
     else {
-      return std::make_shared<ListOffsetArrayOf<T>>(Identities::none(), parameters_, offsets_, content_.get()->rpad_and_clip(target, toaxis, depth + 1));
+      return std::make_shared<ListOffsetArrayOf<T>>(
+        Identities::none(), parameters_, offsets_,
+        content_.get()->rpad_and_clip(target, toaxis, depth + 1));
     }
   }
 
   template <>
-  const ContentPtr ListOffsetArrayOf<int64_t>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr ListOffsetArrayOf<int64_t>::reduce_next(
+    const Reducer& reducer,
+    int64_t negaxis,
+    const Index64& starts,
+    const Index64& parents,
+    int64_t outlength, bool mask, bool keepdims) const {
     std::pair<bool, int64_t> branchdepth = branch_depth();
 
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -1008,7 +1285,8 @@ namespace awkward {
 
       int64_t maxcount;
       Index64 offsetscopy(offsets_.length());
-      struct Error err2 = awkward_listoffsetarray_reduce_nonlocal_maxcount_offsetscopy_64(
+      struct Error err2 =
+        awkward_listoffsetarray_reduce_nonlocal_maxcount_offsetscopy_64(
         &maxcount,
         offsetscopy.ptr().get(),
         offsets_.ptr().get(),
@@ -1037,14 +1315,17 @@ namespace awkward {
       util::handle_error(err3, classname(), identities_.get());
 
       Index64 nextstarts(maxnextparents + 1);
-      struct Error err4 = awkward_listoffsetarray_reduce_nonlocal_nextstarts_64(
+      struct Error err4 =
+        awkward_listoffsetarray_reduce_nonlocal_nextstarts_64(
         nextstarts.ptr().get(),
         nextparents.ptr().get(),
         nextlen);
       util::handle_error(err4, classname(), identities_.get());
 
       ContentPtr nextcontent = content_.get()->carry(nextcarry);
-      ContentPtr outcontent = nextcontent.get()->reduce_next(reducer, negaxis - 1, nextstarts, nextparents, maxnextparents + 1, mask, false);
+      ContentPtr outcontent = nextcontent.get()->reduce_next(
+        reducer, negaxis - 1, nextstarts, nextparents, maxnextparents + 1,
+        mask, false);
 
       Index64 gaps(outlength);
       struct Error err5 = awkward_listoffsetarray_reduce_nonlocal_findgaps_64(
@@ -1064,12 +1345,17 @@ namespace awkward {
         gaps.ptr().get());
       util::handle_error(err6, classname(), identities_.get());
 
-      ContentPtr out = std::make_shared<ListArray64>(Identities::none(), util::Parameters(), outstarts, outstops, outcontent);
-
+      ContentPtr out = std::make_shared<ListArray64>(Identities::none(),
+                                                     util::Parameters(),
+                                                     outstarts,
+                                                     outstops,
+                                                     outcontent);
       if (keepdims) {
-        out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out, 1);
+        out = std::make_shared<RegularArray>(Identities::none(),
+                                             util::Parameters(),
+                                             out,
+                                             1);
       }
-
       return out;
     }
 
@@ -1092,8 +1378,11 @@ namespace awkward {
         offsets_.length() - 1);
       util::handle_error(err2, classname(), identities_.get());
 
-      ContentPtr trimmed = content_.get()->getitem_range_nowrap(globalstart, globalstop);
-      ContentPtr outcontent = trimmed.get()->reduce_next(reducer, negaxis, util::make_starts(offsets_), nextparents, offsets_.length() - 1, mask, keepdims);
+      ContentPtr trimmed = content_.get()->getitem_range_nowrap(globalstart,
+                                                                globalstop);
+      ContentPtr outcontent = trimmed.get()->reduce_next(
+        reducer, negaxis, util::make_starts(offsets_), nextparents,
+        offsets_.length() - 1, mask, keepdims);
 
       Index64 outoffsets(outlength + 1);
       struct Error err3 = awkward_listoffsetarray_reduce_local_outoffsets_64(
@@ -1104,24 +1393,42 @@ namespace awkward {
         outlength);
       util::handle_error(err3, classname(), identities_.get());
 
-      return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), outoffsets, outcontent);
+      return std::make_shared<ListOffsetArray64>(Identities::none(),
+                                                 util::Parameters(),
+                                                 outoffsets,
+                                                 outcontent);
     }
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t length, bool mask, bool keepdims) const {
-    return toListOffsetArray64(true).get()->reduce_next(reducer, negaxis, starts, parents, length, mask, keepdims);
+  const ContentPtr
+  ListOffsetArrayOf<T>::reduce_next(const Reducer& reducer,
+                                    int64_t negaxis,
+                                    const Index64& starts,
+                                    const Index64& parents,
+                                    int64_t length,
+                                    bool mask,
+                                    bool keepdims) const {
+    return toListOffsetArray64(true).get()->reduce_next(reducer,
+                                                        negaxis,
+                                                        starts,
+                                                        parents,
+                                                        length,
+                                                        mask,
+                                                        keepdims);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
     }
     else if (axis == depth + 1) {
       Index64 offsets = compact_offsets64(true);
-      int64_t innerlength = offsets.getitem_at_nowrap(offsets.offset() + offsets.length() - 1);
+      int64_t innerlength = offsets.getitem_at_nowrap(
+        offsets.offset() + offsets.length() - 1);
       Index64 localindex(innerlength);
       struct Error err = util::awkward_listarray_localindex_64(
         localindex.ptr().get(),
@@ -1129,15 +1436,29 @@ namespace awkward {
         offsets.offset(),
         offsets.length() - 1);
       util::handle_error(err, classname(), identities_.get());
-      return std::make_shared<ListOffsetArray64>(identities_, util::Parameters(), offsets, std::make_shared<NumpyArray>(localindex));
+      return std::make_shared<ListOffsetArray64>(
+        identities_,
+        util::Parameters(),
+        offsets,
+        std::make_shared<NumpyArray>(localindex));
     }
     else {
-      return std::make_shared<ListOffsetArrayOf<T>>(identities_, util::Parameters(), offsets_, content_.get()->localindex(axis, depth + 1));
+      return std::make_shared<ListOffsetArrayOf<T>>(
+        identities_,
+        util::Parameters(),
+        offsets_,
+        content_.get()->localindex(axis, depth + 1));
     }
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::choose(int64_t n,
+                               bool diagonal,
+                               const util::RecordLookupPtr& recordlookup,
+                               const util::Parameters& parameters,
+                               int64_t axis,
+                               int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1168,7 +1489,8 @@ namespace awkward {
       std::vector<std::shared_ptr<int64_t>> tocarry;
       std::vector<int64_t*> tocarryraw;
       for (int64_t j = 0;  j < n;  j++) {
-        std::shared_ptr<int64_t> ptr(new int64_t[(size_t)totallen], util::array_deleter<int64_t>());
+        std::shared_ptr<int64_t> ptr(new int64_t[(size_t)totallen],
+                                     util::array_deleter<int64_t>());
         tocarry.push_back(ptr);
         tocarryraw.push_back(ptr.get());
       }
@@ -1187,23 +1509,40 @@ namespace awkward {
       for (auto ptr : tocarry) {
         contents.push_back(content_.get()->carry(Index64(ptr, 0, totallen)));
       }
-      ContentPtr recordarray = std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
+      ContentPtr recordarray = std::make_shared<RecordArray>(
+        Identities::none(), parameters, contents, recordlookup);
 
-      return std::make_shared<ListOffsetArray64>(identities_, util::Parameters(), offsets, recordarray);
+      return std::make_shared<ListOffsetArray64>(identities_,
+                                                 util::Parameters(),
+                                                 offsets,
+                                                 recordarray);
     }
 
     else {
       ContentPtr compact = toListOffsetArray64(true);
-      ListOffsetArray64* rawcompact = dynamic_cast<ListOffsetArray64*>(compact.get());
-      ContentPtr next = rawcompact->content().get()->choose(n, diagonal, recordlookup, parameters, axis, depth + 1);
-      return std::make_shared<ListOffsetArray64>(identities_, util::Parameters(), rawcompact->offsets(), next);
+      ListOffsetArray64* rawcompact =
+        dynamic_cast<ListOffsetArray64*>(compact.get());
+      ContentPtr next = rawcompact->content().get()->choose(n,
+                                                            diagonal,
+                                                            recordlookup,
+                                                            parameters,
+                                                            axis,
+                                                            depth + 1);
+      return std::make_shared<ListOffsetArray64>(identities_,
+                                                 util::Parameters(),
+                                                 rawcompact->offsets(),
+                                                 next);
     }
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_next(const SliceAt& at,
+                                     const Slice& tail,
+                                     const Index64& advanced) const {
     if (advanced.length() != 0) {
-      throw std::runtime_error("ListOffsetArray::getitem_next(SliceAt): advanced.length() != 0");
+      throw std::runtime_error(
+        "ListOffsetArray::getitem_next(SliceAt): advanced.length() != 0");
     }
     int64_t lenstarts = offsets_.length() - 1;
     IndexOf<T> starts = util::make_starts(offsets_);
@@ -1225,7 +1564,10 @@ namespace awkward {
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_next(const SliceRange& range,
+                                     const Slice& tail,
+                                     const Index64& advanced) const {
     int64_t lenstarts = offsets_.length() - 1;
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
@@ -1238,7 +1580,8 @@ namespace awkward {
       step = 1;
     }
     int64_t carrylength;
-    struct Error err1 = util::awkward_listarray_getitem_next_range_carrylength<T>(
+    struct Error err1 =
+      util::awkward_listarray_getitem_next_range_carrylength<T>(
       &carrylength,
       starts.ptr().get(),
       stops.ptr().get(),
@@ -1268,28 +1611,41 @@ namespace awkward {
     ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
     if (advanced.length() == 0) {
-      return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, nextoffsets, nextcontent.get()->getitem_next(nexthead, nexttail, advanced));
+      return std::make_shared<ListOffsetArrayOf<T>>(
+        identities_,
+        parameters_,
+        nextoffsets,
+        nextcontent.get()->getitem_next(nexthead, nexttail, advanced));
     }
     else {
       int64_t total;
-      struct Error err1 = util::awkward_listarray_getitem_next_range_counts_64<T>(
+      struct Error err1 =
+        util::awkward_listarray_getitem_next_range_counts_64<T>(
         &total,
         nextoffsets.ptr().get(),
         lenstarts);
       util::handle_error(err1, classname(), identities_.get());
       Index64 nextadvanced(total);
-      struct Error err2 = util::awkward_listarray_getitem_next_range_spreadadvanced_64<T>(
+      struct Error err2 =
+        util::awkward_listarray_getitem_next_range_spreadadvanced_64<T>(
         nextadvanced.ptr().get(),
         advanced.ptr().get(),
         nextoffsets.ptr().get(),
         lenstarts);
       util::handle_error(err2, classname(), identities_.get());
-      return std::make_shared<ListOffsetArrayOf<T>>(identities_, parameters_, nextoffsets, nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced));
+      return std::make_shared<ListOffsetArrayOf<T>>(
+        identities_,
+        parameters_,
+        nextoffsets,
+        nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced));
     }
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_next(const SliceArray64& array,
+                                     const Slice& tail,
+                                     const Index64& advanced) const {
     int64_t lenstarts = offsets_.length() - 1;
     IndexOf<T> starts = util::make_starts(offsets_);
     IndexOf<T> stops = util::make_stops(offsets_);
@@ -1312,12 +1668,17 @@ namespace awkward {
         content_.get()->length());
       util::handle_error(err, classname(), identities_.get());
       ContentPtr nextcontent = content_.get()->carry(nextcarry);
-      return getitem_next_array_wrap(nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced), array.shape());
+      return getitem_next_array_wrap(
+               nextcontent.get()->getitem_next(nexthead,
+                                               nexttail,
+                                               nextadvanced),
+               array.shape());
     }
     else {
       Index64 nextcarry(lenstarts);
       Index64 nextadvanced(lenstarts);
-      struct Error err = util::awkward_listarray_getitem_next_array_advanced_64<T>(
+      struct Error err =
+        util::awkward_listarray_getitem_next_array_advanced_64<T>(
         nextcarry.ptr().get(),
         nextadvanced.ptr().get(),
         starts.ptr().get(),
@@ -1336,27 +1697,67 @@ namespace awkward {
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_next(const SliceJagged64& jagged,
+                                     const Slice& tail,
+                                     const Index64& advanced) const {
+    ListArrayOf<T> listarray(identities_,
+                             parameters_,
+                             util::make_starts(offsets_),
+                             util::make_stops(offsets_),
+                             content_);
     return listarray.getitem_next(jagged, tail, advanced);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
-    return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts,
+                                            const Index64& slicestops,
+                                            const SliceArray64& slicecontent,
+                                            const Slice& tail) const {
+    ListArrayOf<T> listarray(identities_,
+                             parameters_,
+                             util::make_starts(offsets_),
+                             util::make_stops(offsets_),
+                             content_);
+    return listarray.getitem_next_jagged(slicestarts,
+                                         slicestops,
+                                         slicecontent,
+                                         tail);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
-    return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts,
+                                            const Index64& slicestops,
+                                            const SliceMissing64& slicecontent,
+                                            const Slice& tail) const {
+    ListArrayOf<T> listarray(identities_,
+                             parameters_,
+                             util::make_starts(offsets_),
+                             util::make_stops(offsets_),
+                             content_);
+    return listarray.getitem_next_jagged(slicestarts,
+                                         slicestops,
+                                         slicecontent,
+                                         tail);
   }
 
   template <typename T>
-  const ContentPtr ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    ListArrayOf<T> listarray(identities_, parameters_, util::make_starts(offsets_), util::make_stops(offsets_), content_);
-    return listarray.getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  ListOffsetArrayOf<T>::getitem_next_jagged(const Index64& slicestarts,
+                                            const Index64& slicestops,
+                                            const SliceJagged64& slicecontent,
+                                            const Slice& tail) const {
+    ListArrayOf<T> listarray(identities_,
+                             parameters_,
+                             util::make_starts(offsets_),
+                             util::make_stops(offsets_),
+                             content_);
+    return listarray.getitem_next_jagged(slicestarts,
+                                         slicestops,
+                                         slicecontent,
+                                         tail);
   }
 
   template class ListOffsetArrayOf<int32_t>;

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1183,7 +1183,7 @@ namespace awkward {
         length());
       util::handle_error(err2, classname(), identities_.get());
 
-      std::vector<ContentPtr> contents;
+      ContentPtrVec contents;
       for (auto ptr : tocarry) {
         contents.push_back(content_.get()->carry(Index64(ptr, 0, totallen)));
       }

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -13,212 +13,308 @@ namespace awkward {
   None::None()
       : Content(Identities::none(), util::Parameters()) { }
 
-  bool None::isscalar() const {
+  bool
+  None::isscalar() const {
     return true;
   }
 
-  const std::string None::classname() const {
+  const std::string
+  None::classname() const {
     return "None";
   }
 
-  void None::setidentities(const IdentitiesPtr& identities) {
-    throw std::runtime_error("undefined operation: None::setidentities(identities)");
+  void
+  None::setidentities(const IdentitiesPtr& identities) {
+    throw std::runtime_error(
+      "undefined operation: None::setidentities(identities)");
   }
 
-  void None::setidentities() {
+  void
+  None::setidentities() {
     throw std::runtime_error("undefined operation: None::setidentities()");
   }
 
-  const TypePtr None::type(const util::TypeStrs& typestrs) const {
+  const TypePtr
+  None::type(const util::TypeStrs& typestrs) const {
     throw std::runtime_error("undefined operation: None::type()");
   }
 
-  const std::string None::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  None::tostring_part(const std::string& indent,
+                      const std::string& pre,
+                      const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << "/>" << post;
     return out.str();
   }
 
-  void None::tojson_part(ToJson& builder) const {
+  void
+  None::tojson_part(ToJson& builder) const {
     builder.null();
   }
 
-  void None::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  None::nbytes_part(std::map<size_t, int64_t>& largest) const {
     throw std::runtime_error("undefined operation: None::nbytes_part");
   }
 
-  int64_t None::length() const {
+  int64_t
+  None::length() const {
     return -1;
   }
 
-  const ContentPtr None::shallow_copy() const {
+  const ContentPtr
+  None::shallow_copy() const {
     return std::make_shared<None>();
   }
 
-  const ContentPtr None::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  None::deep_copy(bool copyarrays,
+                  bool copyindexes,
+                  bool copyidentities) const {
     return std::make_shared<None>();
   }
 
-  void None::check_for_iteration() const { }
+  void
+  None::check_for_iteration() const { }
 
-  const ContentPtr None::getitem_nothing() const {
+  const ContentPtr
+  None::getitem_nothing() const {
     throw std::runtime_error("undefined operation: None::getitem_nothing");
   }
 
-  const ContentPtr None::getitem_at(int64_t at) const {
+  const ContentPtr
+  None::getitem_at(int64_t at) const {
     throw std::runtime_error("undefined operation: None::getitem_at");
   }
 
-  const ContentPtr None::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  None::getitem_at_nowrap(int64_t at) const {
     throw std::runtime_error("undefined operation: None::getitem_at_nowrap");
   }
 
-  const ContentPtr None::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  None::getitem_range(int64_t start, int64_t stop) const {
     throw std::runtime_error("undefined operation: None::getitem_range");
   }
 
-  const ContentPtr None::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    throw std::runtime_error("undefined operation: None::getitem_range_nowrap");
+  const ContentPtr
+  None::getitem_range_nowrap(int64_t start, int64_t stop) const {
+    throw std::runtime_error(
+      "undefined operation: None::getitem_range_nowrap");
   }
 
-  const ContentPtr None::getitem_field(const std::string& key) const {
+  const ContentPtr
+  None::getitem_field(const std::string& key) const {
     throw std::runtime_error("undefined operation: None::getitem_field");
   }
 
-  const ContentPtr None::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr
+  None::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::runtime_error("undefined operation: None::getitem_fields");
   }
 
-  const ContentPtr None::carry(const Index64& carry) const {
+  const ContentPtr
+  None::carry(const Index64& carry) const {
     throw std::runtime_error("undefined operation: None::carry");
   }
 
-  const std::string None::purelist_parameter(const std::string& key) const {
+  const std::string
+  None::purelist_parameter(const std::string& key) const {
     throw std::runtime_error("undefined operation: None::purelist_parameter");
   }
 
-  bool None::purelist_isregular() const {
+  bool
+  None::purelist_isregular() const {
     throw std::runtime_error("undefined operation: None::purelist_isregular");
   }
 
-  int64_t None::purelist_depth() const {
+  int64_t
+  None::purelist_depth() const {
     throw std::runtime_error("undefined operation: None::purelist_depth");
   }
 
-  const std::pair<int64_t, int64_t> None::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  None::minmax_depth() const {
     throw std::runtime_error("undefined operation: None::minmax_depth");
   }
 
-  const std::pair<bool, int64_t> None::branch_depth() const {
+  const std::pair<bool, int64_t>
+  None::branch_depth() const {
     throw std::runtime_error("undefined operation: None::branch_depth");
   }
 
-  int64_t None::numfields() const {
+  int64_t
+  None::numfields() const {
     throw std::runtime_error("undefined operation: None::numfields");
   }
 
-  int64_t None::fieldindex(const std::string& key) const {
+  int64_t
+  None::fieldindex(const std::string& key) const {
     throw std::runtime_error("undefined operation: None::fieldindex");
   }
 
-  const std::string None::key(int64_t fieldindex) const {
+  const std::string
+  None::key(int64_t fieldindex) const {
     throw std::runtime_error("undefined operation: None::key");
   }
 
-  bool None::haskey(const std::string& key) const {
+  bool
+  None::haskey(const std::string& key) const {
     throw std::runtime_error("undefined operation: None::haskey");
   }
 
-  const std::vector<std::string> None::keys() const {
+  const std::vector<std::string>
+  None::keys() const {
     throw std::runtime_error("undefined operation: None::keys");
   }
 
-  const std::string None::validityerror(const std::string& path) const {
+  const std::string
+  None::validityerror(const std::string& path) const {
     throw std::runtime_error("undefined operation: None::validityerror");
   }
 
-  const ContentPtr None::shallow_simplify() const {
+  const ContentPtr
+  None::shallow_simplify() const {
     throw std::runtime_error("undefined operation: None::shallow_simplify");
   }
 
-  const ContentPtr None::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  None::num(int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::num");
   }
 
-  const std::pair<Index64, ContentPtr> None::offsets_and_flattened(int64_t axis, int64_t depth) const {
-    throw std::runtime_error("undefined operation: None::offsets_and_flattened");
+  const std::pair<Index64, ContentPtr>
+  None::offsets_and_flattened(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "undefined operation: None::offsets_and_flattened");
   }
 
-  bool None::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  None::mergeable(const ContentPtr& other, bool mergebool) const {
     throw std::runtime_error("undefined operation: None::mergeable");
   }
 
-  const ContentPtr None::merge(const ContentPtr& other) const {
+  const ContentPtr
+  None::merge(const ContentPtr& other) const {
     throw std::runtime_error("undefined operation: None::merge");
   }
 
-  const SliceItemPtr None::asslice() const {
+  const SliceItemPtr
+  None::asslice() const {
     throw std::runtime_error("undefined opteration: None::asslice");
   }
 
-  const ContentPtr None::fillna(const ContentPtr& value) const {
+  const ContentPtr
+  None::fillna(const ContentPtr& value) const {
     throw std::runtime_error("undefined opteration: None::fillna");
   }
 
-  const ContentPtr None::rpad(int64_t length, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  None::rpad(int64_t length, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::rpad");
   }
 
-  const ContentPtr None::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  None::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::rpad_and_clip");
   }
 
-  const ContentPtr None::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr
+  None::reduce_next(const Reducer& reducer,
+                    int64_t negaxis,
+                    const Index64& starts,
+                    const Index64& parents,
+                    int64_t outlength,
+                    bool mask,
+                    bool keepdims) const {
     throw std::runtime_error("undefined operation: None::reduce_next");
   }
 
-  const ContentPtr None::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  None::localindex(int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None:localindex");
   }
 
-  const ContentPtr None::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  None::choose(int64_t n,
+               bool diagonal,
+               const util::RecordLookupPtr& recordlookup,
+               const util::Parameters& parameters,
+               int64_t axis,
+               int64_t depth) const {
     throw std::runtime_error("undefined operation: None::choose");
   }
 
-  const ContentPtr None::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  None::getitem_next(const SliceAt& at,
+                     const Slice& tail,
+                     const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(at)");
   }
 
-  const ContentPtr None::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  None::getitem_next(const SliceRange& range,
+                     const Slice& tail,
+                     const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(range)");
   }
 
-  const ContentPtr None::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  None::getitem_next(const SliceArray64& array,
+                     const Slice& tail,
+                     const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(array)");
   }
 
-  const ContentPtr None::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  None::getitem_next(const SliceField& field,
+                     const Slice& tail,
+                     const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(field)");
   }
 
-  const ContentPtr None::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: None::getitem_next(fields)");
+  const ContentPtr
+  None::getitem_next(const SliceFields& fields,
+                     const Slice& tail,
+                     const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: None::getitem_next(fields)");
   }
 
-  const ContentPtr None::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: None::getitem_next(jagged)");
+  const ContentPtr
+  None::getitem_next(const SliceJagged64& jagged,
+                     const Slice& tail,
+                     const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: None::getitem_next(jagged)");
   }
 
-  const ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: None::getitem_next_jagged(array)");
+  const ContentPtr
+  None::getitem_next_jagged(const Index64& slicestarts,
+                            const Index64& slicestops,
+                            const SliceArray64& slicecontent,
+                            const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: None::getitem_next_jagged(array)");
   }
 
-  const ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: None::getitem_next_jagged(missing)");
+  const ContentPtr
+  None::getitem_next_jagged(const Index64& slicestarts,
+                            const Index64& slicestops,
+                            const SliceMissing64& slicecontent,
+                            const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: None::getitem_next_jagged(missing)");
   }
 
-  const ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: None::getitem_next_jagged(jagged)");
+  const ContentPtr
+  None::getitem_next_jagged(const Index64& slicestarts,
+                            const Index64& slicestops,
+                            const SliceJagged64& slicecontent,
+                            const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: None::getitem_next_jagged(jagged)");
   }
 
   const ContentPtr none = std::make_shared<None>();

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -51,45 +51,45 @@ namespace awkward {
     return -1;
   }
 
-  const std::shared_ptr<Content> None::shallow_copy() const {
+  ContentPtr None::shallow_copy() const {
     return std::make_shared<None>();
   }
 
-  const std::shared_ptr<Content> None::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr None::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     return std::make_shared<None>();
   }
 
   void None::check_for_iteration() const { }
 
-  const std::shared_ptr<Content> None::getitem_nothing() const {
+  ContentPtr None::getitem_nothing() const {
     throw std::runtime_error("undefined operation: None::getitem_nothing");
   }
 
-  const std::shared_ptr<Content> None::getitem_at(int64_t at) const {
+  ContentPtr None::getitem_at(int64_t at) const {
     throw std::runtime_error("undefined operation: None::getitem_at");
   }
 
-  const std::shared_ptr<Content> None::getitem_at_nowrap(int64_t at) const {
+  ContentPtr None::getitem_at_nowrap(int64_t at) const {
     throw std::runtime_error("undefined operation: None::getitem_at_nowrap");
   }
 
-  const std::shared_ptr<Content> None::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr None::getitem_range(int64_t start, int64_t stop) const {
     throw std::runtime_error("undefined operation: None::getitem_range");
   }
 
-  const std::shared_ptr<Content> None::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr None::getitem_range_nowrap(int64_t start, int64_t stop) const {
     throw std::runtime_error("undefined operation: None::getitem_range_nowrap");
   }
 
-  const std::shared_ptr<Content> None::getitem_field(const std::string& key) const {
+  ContentPtr None::getitem_field(const std::string& key) const {
     throw std::runtime_error("undefined operation: None::getitem_field");
   }
 
-  const std::shared_ptr<Content> None::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr None::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::runtime_error("undefined operation: None::getitem_fields");
   }
 
-  const std::shared_ptr<Content> None::carry(const Index64& carry) const {
+  ContentPtr None::carry(const Index64& carry) const {
     throw std::runtime_error("undefined operation: None::carry");
   }
 
@@ -137,11 +137,11 @@ namespace awkward {
     throw std::runtime_error("undefined operation: None::validityerror");
   }
 
-  const std::shared_ptr<Content> None::shallow_simplify() const {
+  ContentPtr None::shallow_simplify() const {
     throw std::runtime_error("undefined operation: None::shallow_simplify");
   }
 
-  const std::shared_ptr<Content> None::num(int64_t axis, int64_t depth) const {
+  ContentPtr None::num(int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::num");
   }
 
@@ -149,11 +149,11 @@ namespace awkward {
     throw std::runtime_error("undefined operation: None::offsets_and_flattened");
   }
 
-  bool None::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool None::mergeable(ContentPtr& other, bool mergebool) const {
     throw std::runtime_error("undefined operation: None::mergeable");
   }
 
-  const std::shared_ptr<Content> None::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr None::merge(ContentPtr& other) const {
     throw std::runtime_error("undefined operation: None::merge");
   }
 
@@ -161,65 +161,65 @@ namespace awkward {
     throw std::runtime_error("undefined opteration: None::asslice");
   }
 
-  const std::shared_ptr<Content> None::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr None::fillna(ContentPtr& value) const {
     throw std::runtime_error("undefined opteration: None::fillna");
   }
 
-  const std::shared_ptr<Content> None::rpad(int64_t length, int64_t axis, int64_t depth) const {
+  ContentPtr None::rpad(int64_t length, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::rpad");
   }
 
-  const std::shared_ptr<Content> None::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
+  ContentPtr None::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::rpad_and_clip");
   }
 
-  const std::shared_ptr<Content> None::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr None::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     throw std::runtime_error("undefined operation: None::reduce_next");
   }
 
-  const std::shared_ptr<Content> None::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr None::localindex(int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None:localindex");
   }
 
-  const std::shared_ptr<Content> None::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr None::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::choose");
   }
 
-  const std::shared_ptr<Content> None::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr None::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(at)");
   }
 
-  const std::shared_ptr<Content> None::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr None::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(range)");
   }
 
-  const std::shared_ptr<Content> None::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr None::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(array)");
   }
 
-  const std::shared_ptr<Content> None::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  ContentPtr None::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(field)");
   }
 
-  const std::shared_ptr<Content> None::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  ContentPtr None::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(fields)");
   }
 
-  const std::shared_ptr<Content> None::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr None::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(jagged)");
   }
 
-  const std::shared_ptr<Content> None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: None::getitem_next_jagged(array)");
   }
 
-  const std::shared_ptr<Content> None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: None::getitem_next_jagged(missing)");
   }
 
-  const std::shared_ptr<Content> None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: None::getitem_next_jagged(jagged)");
   }
 
-  const std::shared_ptr<Content> none = std::make_shared<None>();
+  ContentPtr none = std::make_shared<None>();
 }

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -51,45 +51,45 @@ namespace awkward {
     return -1;
   }
 
-  ContentPtr None::shallow_copy() const {
+  const ContentPtr None::shallow_copy() const {
     return std::make_shared<None>();
   }
 
-  ContentPtr None::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr None::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     return std::make_shared<None>();
   }
 
   void None::check_for_iteration() const { }
 
-  ContentPtr None::getitem_nothing() const {
+  const ContentPtr None::getitem_nothing() const {
     throw std::runtime_error("undefined operation: None::getitem_nothing");
   }
 
-  ContentPtr None::getitem_at(int64_t at) const {
+  const ContentPtr None::getitem_at(int64_t at) const {
     throw std::runtime_error("undefined operation: None::getitem_at");
   }
 
-  ContentPtr None::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr None::getitem_at_nowrap(int64_t at) const {
     throw std::runtime_error("undefined operation: None::getitem_at_nowrap");
   }
 
-  ContentPtr None::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr None::getitem_range(int64_t start, int64_t stop) const {
     throw std::runtime_error("undefined operation: None::getitem_range");
   }
 
-  ContentPtr None::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr None::getitem_range_nowrap(int64_t start, int64_t stop) const {
     throw std::runtime_error("undefined operation: None::getitem_range_nowrap");
   }
 
-  ContentPtr None::getitem_field(const std::string& key) const {
+  const ContentPtr None::getitem_field(const std::string& key) const {
     throw std::runtime_error("undefined operation: None::getitem_field");
   }
 
-  ContentPtr None::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr None::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::runtime_error("undefined operation: None::getitem_fields");
   }
 
-  ContentPtr None::carry(const Index64& carry) const {
+  const ContentPtr None::carry(const Index64& carry) const {
     throw std::runtime_error("undefined operation: None::carry");
   }
 
@@ -137,23 +137,23 @@ namespace awkward {
     throw std::runtime_error("undefined operation: None::validityerror");
   }
 
-  ContentPtr None::shallow_simplify() const {
+  const ContentPtr None::shallow_simplify() const {
     throw std::runtime_error("undefined operation: None::shallow_simplify");
   }
 
-  ContentPtr None::num(int64_t axis, int64_t depth) const {
+  const ContentPtr None::num(int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::num");
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> None::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> None::offsets_and_flattened(int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::offsets_and_flattened");
   }
 
-  bool None::mergeable(ContentPtr& other, bool mergebool) const {
+  bool None::mergeable(const ContentPtr& other, bool mergebool) const {
     throw std::runtime_error("undefined operation: None::mergeable");
   }
 
-  ContentPtr None::merge(ContentPtr& other) const {
+  const ContentPtr None::merge(const ContentPtr& other) const {
     throw std::runtime_error("undefined operation: None::merge");
   }
 
@@ -161,65 +161,65 @@ namespace awkward {
     throw std::runtime_error("undefined opteration: None::asslice");
   }
 
-  ContentPtr None::fillna(ContentPtr& value) const {
+  const ContentPtr None::fillna(const ContentPtr& value) const {
     throw std::runtime_error("undefined opteration: None::fillna");
   }
 
-  ContentPtr None::rpad(int64_t length, int64_t axis, int64_t depth) const {
+  const ContentPtr None::rpad(int64_t length, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::rpad");
   }
 
-  ContentPtr None::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
+  const ContentPtr None::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::rpad_and_clip");
   }
 
-  ContentPtr None::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr None::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     throw std::runtime_error("undefined operation: None::reduce_next");
   }
 
-  ContentPtr None::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr None::localindex(int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None:localindex");
   }
 
-  ContentPtr None::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr None::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::choose");
   }
 
-  ContentPtr None::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr None::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(at)");
   }
 
-  ContentPtr None::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr None::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(range)");
   }
 
-  ContentPtr None::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr None::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(array)");
   }
 
-  ContentPtr None::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr None::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(field)");
   }
 
-  ContentPtr None::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr None::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(fields)");
   }
 
-  ContentPtr None::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr None::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: None::getitem_next(jagged)");
   }
 
-  ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: None::getitem_next_jagged(array)");
   }
 
-  ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: None::getitem_next_jagged(missing)");
   }
 
-  ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr None::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: None::getitem_next_jagged(jagged)");
   }
 
-  ContentPtr none = std::make_shared<None>();
+  const ContentPtr none = std::make_shared<None>();
 }

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -21,7 +21,7 @@ namespace awkward {
     return "None";
   }
 
-  void None::setidentities(const std::shared_ptr<Identities>& identities) {
+  void None::setidentities(const IdentitiesPtr& identities) {
     throw std::runtime_error("undefined operation: None::setidentities(identities)");
   }
 
@@ -29,7 +29,7 @@ namespace awkward {
     throw std::runtime_error("undefined operation: None::setidentities()");
   }
 
-  const std::shared_ptr<Type> None::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr None::type(const std::map<std::string, std::string>& typestrs) const {
     throw std::runtime_error("undefined operation: None::type()");
   }
 
@@ -157,7 +157,7 @@ namespace awkward {
     throw std::runtime_error("undefined operation: None::merge");
   }
 
-  const std::shared_ptr<SliceItem> None::asslice() const {
+  const SliceItemPtr None::asslice() const {
     throw std::runtime_error("undefined opteration: None::asslice");
   }
 
@@ -181,7 +181,7 @@ namespace awkward {
     throw std::runtime_error("undefined operation: None:localindex");
   }
 
-  const ContentPtr None::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr None::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::choose");
   }
 

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -29,7 +29,7 @@ namespace awkward {
     throw std::runtime_error("undefined operation: None::setidentities()");
   }
 
-  const TypePtr None::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr None::type(const util::TypeStrs& typestrs) const {
     throw std::runtime_error("undefined operation: None::type()");
   }
 

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -197,7 +197,7 @@ namespace awkward {
     return *reinterpret_cast<double*>(byteptr(at));
   }
 
-  const std::shared_ptr<Content> NumpyArray::toRegularArray() const {
+  ContentPtr NumpyArray::toRegularArray() const {
     if (isscalar()) {
       return shallow_copy();
     }
@@ -523,11 +523,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::shallow_copy() const {
+  ContentPtr NumpyArray::shallow_copy() const {
     return std::make_shared<NumpyArray>(identities_, parameters_, ptr_, shape_, strides_, byteoffset_, itemsize_, format_);
   }
 
-  const std::shared_ptr<Content> NumpyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr NumpyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     std::shared_ptr<void> ptr = ptr_;
     std::vector<ssize_t> shape = shape_;
     std::vector<ssize_t> strides = strides_;
@@ -552,7 +552,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_nothing() const {
+  ContentPtr NumpyArray::getitem_nothing() const {
     const std::vector<ssize_t> shape({ 0 });
     const std::vector<ssize_t> strides({ itemsize_ });
     std::shared_ptr<Identities> identities;
@@ -562,7 +562,7 @@ namespace awkward {
     return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides, byteoffset_, itemsize_, format_);
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_at(int64_t at) const {
+  ContentPtr NumpyArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += shape_[0];
@@ -573,7 +573,7 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_at_nowrap(int64_t at) const {
+  ContentPtr NumpyArray::getitem_at_nowrap(int64_t at) const {
     ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)at);
     const std::vector<ssize_t> shape(shape_.begin() + 1, shape_.end());
     const std::vector<ssize_t> strides(strides_.begin() + 1, strides_.end());
@@ -587,14 +587,14 @@ namespace awkward {
     return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides, byteoffset, itemsize_, format_);
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr NumpyArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), shape_[0]);
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr NumpyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)start);
     std::vector<ssize_t> shape;
     shape.push_back((ssize_t)(stop - start));
@@ -609,11 +609,11 @@ namespace awkward {
     return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides_, byteoffset, itemsize_, format_);
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_field(const std::string& key) const {
+  ContentPtr NumpyArray::getitem_field(const std::string& key) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr NumpyArray::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
   }
 
@@ -629,7 +629,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem(const Slice& where) const {
+  ContentPtr NumpyArray::getitem(const Slice& where) const {
     if (isscalar()) {
       throw std::runtime_error("cannot get-item on a scalar");
     }
@@ -681,14 +681,14 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  ContentPtr NumpyArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     Index64 carry(shape_[0]);
     struct Error err = awkward_carry_arange_64(carry.ptr().get(), shape_[0]);
     util::handle_error(err, classname(), identities_.get());
     return getitem_next(head, tail, carry, advanced, shape_[0], strides_[0], false).shallow_copy();
   }
 
-  const std::shared_ptr<Content> NumpyArray::carry(const Index64& carry) const {
+  ContentPtr NumpyArray::carry(const Index64& carry) const {
     std::shared_ptr<void> ptr(new uint8_t[(size_t)(carry.length()*strides_[0])], util::array_deleter<uint8_t>());
     struct Error err = awkward_numpyarray_getitem_next_null_64(
       reinterpret_cast<uint8_t*>(ptr.get()),
@@ -764,11 +764,11 @@ namespace awkward {
     return std::string();
   }
 
-  const std::shared_ptr<Content> NumpyArray::shallow_simplify() const {
+  ContentPtr NumpyArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const std::shared_ptr<Content> NumpyArray::num(int64_t axis, int64_t depth) const {
+  ContentPtr NumpyArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -873,7 +873,7 @@ namespace awkward {
     }
   }
 
-  bool NumpyArray::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool NumpyArray::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -943,7 +943,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr NumpyArray::merge(ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -1374,11 +1374,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr NumpyArray::fillna(ContentPtr& value) const {
     return shallow_copy();
   }
 
-  const std::shared_ptr<Content> NumpyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr NumpyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     if (ndim() == 0) {
       throw std::runtime_error("cannot rpad a scalar");
     }
@@ -1397,7 +1397,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr NumpyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     if (ndim() == 0) {
       throw std::runtime_error("cannot rpad a scalar");
     }
@@ -1411,7 +1411,7 @@ namespace awkward {
     return rpad_axis0(target, true);
   }
 
-  const std::shared_ptr<Content> NumpyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr NumpyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     if (shape_.empty()) {
       throw std::runtime_error("attempting to reduce a scalar");
     }
@@ -1499,7 +1499,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr NumpyArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1512,7 +1512,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr NumpyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1531,27 +1531,27 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr NumpyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(at) (without 'length', 'stride', and 'first')");
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr NumpyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(range) (without 'length', 'stride', and 'first')");
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr NumpyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(array) (without 'length', 'stride', and 'first')");
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  ContentPtr NumpyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(field) (without 'length', 'stride', and 'first')");
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  ContentPtr NumpyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(fields) (without 'length', 'stride', and 'first')");
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr NumpyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     if (shape_.size() != 1) {
       throw std::runtime_error("undefined operation: NumpyArray::getitem_next(jagged) with ndim != 1");
     }
@@ -1563,7 +1563,7 @@ namespace awkward {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a jagged array because it is one-dimensional"));
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }
@@ -1572,7 +1572,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }
@@ -1581,7 +1581,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -1380,7 +1380,8 @@ namespace awkward {
     NumpyArray contiguous_self = contiguous();
     if (NumpyArray* rawother = dynamic_cast<NumpyArray*>(other.get())) {
       if (ndim() != rawother->ndim()) {
-        throw std::invalid_argument("cannot merge arrays with different shapes");
+        throw std::invalid_argument(
+          "cannot merge arrays with different shapes");
       }
 
       std::string other_format = rawother->format();
@@ -1673,7 +1674,8 @@ namespace awkward {
                   other_offset,
                   other_flatlength);
         }
-        else if (other_format.compare("B") == 0  ||  format_.compare("c") == 0) {
+        else if (other_format.compare("B") == 0  ||
+                 format_.compare("c") == 0) {
           err = awkward_numpyarray_fill_todouble_fromU8(
                   reinterpret_cast<double*>(ptr.get()),
                   self_flatlength,
@@ -1882,7 +1884,8 @@ namespace awkward {
                   other_offset,
                   other_flatlength);
         }
-        else if (other_format.compare("B") == 0  ||  format_.compare("c") == 0) {
+        else if (other_format.compare("B") == 0  ||
+                 format_.compare("c") == 0) {
           err = awkward_numpyarray_fill_to64_fromU8(
                   reinterpret_cast<int64_t*>(ptr.get()),
                   self_flatlength,
@@ -2112,7 +2115,9 @@ namespace awkward {
   }
 
   const ContentPtr
-  NumpyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  NumpyArray::rpad_and_clip(int64_t target,
+                            int64_t axis,
+                            int64_t depth) const {
     if (ndim() == 0) {
       throw std::runtime_error("cannot rpad a scalar");
     }
@@ -2381,7 +2386,8 @@ namespace awkward {
                            const Slice& tail, const Index64& advanced) const {
     if (shape_.size() != 1) {
       throw std::runtime_error(
-        "undefined operation: NumpyArray::getitem_next(jagged) with ndim != 1");
+        "undefined operation: NumpyArray::getitem_next(jagged) with "
+        "ndim != 1");
     }
 
     if (advanced.length() != 0) {
@@ -2400,7 +2406,8 @@ namespace awkward {
                                   const SliceArray64& slicecontent,
                                   const Slice& tail) const {
     if (ndim() == 1) {
-      throw std::invalid_argument("too many jagged slice dimensions for array");
+      throw std::invalid_argument(
+        "too many jagged slice dimensions for array");
     }
     else {
       throw std::runtime_error(
@@ -2415,7 +2422,8 @@ namespace awkward {
                                   const SliceMissing64& slicecontent,
                                   const Slice& tail) const {
     if (ndim() == 1) {
-      throw std::invalid_argument("too many jagged slice dimensions for array");
+      throw std::invalid_argument(
+        "too many jagged slice dimensions for array");
     }
     else {
       throw std::runtime_error(
@@ -2430,7 +2438,8 @@ namespace awkward {
                                   const SliceJagged64& slicecontent,
                                   const Slice& tail) const {
     if (ndim() == 1) {
-      throw std::invalid_argument("too many jagged slice dimensions for array");
+      throw std::invalid_argument(
+        "too many jagged slice dimensions for array");
     }
     else {
       throw std::runtime_error(
@@ -3194,7 +3203,8 @@ namespace awkward {
       for (auto x = arrayshape.rbegin();  x != arrayshape.rend();  ++x) {
         outstrides.insert(outstrides.begin(), ((ssize_t)(*x))*outstrides[0]);
       }
-      return NumpyArray(arrayshape.size() == 1 ? out.identities_ : Identities::none(),
+      return NumpyArray(arrayshape.size() == 1 ? out.identities_
+                                               : Identities::none(),
                         out.parameters_,
                         out.ptr_,
                         outshape,

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -197,7 +197,7 @@ namespace awkward {
     return *reinterpret_cast<double*>(byteptr(at));
   }
 
-  ContentPtr NumpyArray::toRegularArray() const {
+  const ContentPtr NumpyArray::toRegularArray() const {
     if (isscalar()) {
       return shallow_copy();
     }
@@ -207,7 +207,7 @@ namespace awkward {
       flatshape[0] = flatshape[0] * x;
     }
     std::vector<ssize_t> flatstrides({ itemsize_ });
-    std::shared_ptr<Content> out = std::make_shared<NumpyArray>(identities_, parameters_, contiguous_self.ptr(), flatshape, flatstrides, contiguous_self.byteoffset(), contiguous_self.itemsize(), contiguous_self.format());
+    ContentPtr out = std::make_shared<NumpyArray>(identities_, parameters_, contiguous_self.ptr(), flatshape, flatstrides, contiguous_self.byteoffset(), contiguous_self.itemsize(), contiguous_self.format());
     for (int64_t i = (int64_t)shape_.size() - 1;  i > 0;  i--) {
       out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out, shape_[(size_t)i]);
     }
@@ -523,11 +523,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::shallow_copy() const {
+  const ContentPtr NumpyArray::shallow_copy() const {
     return std::make_shared<NumpyArray>(identities_, parameters_, ptr_, shape_, strides_, byteoffset_, itemsize_, format_);
   }
 
-  ContentPtr NumpyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr NumpyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     std::shared_ptr<void> ptr = ptr_;
     std::vector<ssize_t> shape = shape_;
     std::vector<ssize_t> strides = strides_;
@@ -552,7 +552,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::getitem_nothing() const {
+  const ContentPtr NumpyArray::getitem_nothing() const {
     const std::vector<ssize_t> shape({ 0 });
     const std::vector<ssize_t> strides({ itemsize_ });
     std::shared_ptr<Identities> identities;
@@ -562,7 +562,7 @@ namespace awkward {
     return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides, byteoffset_, itemsize_, format_);
   }
 
-  ContentPtr NumpyArray::getitem_at(int64_t at) const {
+  const ContentPtr NumpyArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += shape_[0];
@@ -573,7 +573,7 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  ContentPtr NumpyArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr NumpyArray::getitem_at_nowrap(int64_t at) const {
     ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)at);
     const std::vector<ssize_t> shape(shape_.begin() + 1, shape_.end());
     const std::vector<ssize_t> strides(strides_.begin() + 1, strides_.end());
@@ -587,14 +587,14 @@ namespace awkward {
     return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides, byteoffset, itemsize_, format_);
   }
 
-  ContentPtr NumpyArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr NumpyArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), shape_[0]);
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  ContentPtr NumpyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr NumpyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)start);
     std::vector<ssize_t> shape;
     shape.push_back((ssize_t)(stop - start));
@@ -609,11 +609,11 @@ namespace awkward {
     return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides_, byteoffset, itemsize_, format_);
   }
 
-  ContentPtr NumpyArray::getitem_field(const std::string& key) const {
+  const ContentPtr NumpyArray::getitem_field(const std::string& key) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
   }
 
-  ContentPtr NumpyArray::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr NumpyArray::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
   }
 
@@ -629,7 +629,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::getitem(const Slice& where) const {
+  const ContentPtr NumpyArray::getitem(const Slice& where) const {
     if (isscalar()) {
       throw std::runtime_error("cannot get-item on a scalar");
     }
@@ -681,14 +681,14 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr NumpyArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     Index64 carry(shape_[0]);
     struct Error err = awkward_carry_arange_64(carry.ptr().get(), shape_[0]);
     util::handle_error(err, classname(), identities_.get());
     return getitem_next(head, tail, carry, advanced, shape_[0], strides_[0], false).shallow_copy();
   }
 
-  ContentPtr NumpyArray::carry(const Index64& carry) const {
+  const ContentPtr NumpyArray::carry(const Index64& carry) const {
     std::shared_ptr<void> ptr(new uint8_t[(size_t)(carry.length()*strides_[0])], util::array_deleter<uint8_t>());
     struct Error err = awkward_numpyarray_getitem_next_null_64(
       reinterpret_cast<uint8_t*>(ptr.get()),
@@ -764,11 +764,11 @@ namespace awkward {
     return std::string();
   }
 
-  ContentPtr NumpyArray::shallow_simplify() const {
+  const ContentPtr NumpyArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  ContentPtr NumpyArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr NumpyArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -860,7 +860,7 @@ namespace awkward {
     }
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> NumpyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> NumpyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -873,7 +873,7 @@ namespace awkward {
     }
   }
 
-  bool NumpyArray::mergeable(ContentPtr& other, bool mergebool) const {
+  bool NumpyArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -943,7 +943,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::merge(ContentPtr& other) const {
+  const ContentPtr NumpyArray::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -1374,11 +1374,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::fillna(ContentPtr& value) const {
+  const ContentPtr NumpyArray::fillna(const ContentPtr& value) const {
     return shallow_copy();
   }
 
-  ContentPtr NumpyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr NumpyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     if (ndim() == 0) {
       throw std::runtime_error("cannot rpad a scalar");
     }
@@ -1397,7 +1397,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr NumpyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     if (ndim() == 0) {
       throw std::runtime_error("cannot rpad a scalar");
     }
@@ -1411,7 +1411,7 @@ namespace awkward {
     return rpad_axis0(target, true);
   }
 
-  ContentPtr NumpyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr NumpyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     if (shape_.empty()) {
       throw std::runtime_error("attempting to reduce a scalar");
     }
@@ -1477,7 +1477,7 @@ namespace awkward {
       ssize_t itemsize = reducer.return_typesize(format_);
       std::vector<ssize_t> shape({ (ssize_t)outlength });
       std::vector<ssize_t> strides({ itemsize });
-      std::shared_ptr<Content> out = std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), ptr, shape, strides, 0, itemsize, format);
+      ContentPtr out = std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), ptr, shape, strides, 0, itemsize, format);
 
       if (mask) {
         Index8 mask(outlength);
@@ -1499,7 +1499,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr NumpyArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1512,7 +1512,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr NumpyArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1531,27 +1531,27 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr NumpyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(at) (without 'length', 'stride', and 'first')");
   }
 
-  ContentPtr NumpyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr NumpyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(range) (without 'length', 'stride', and 'first')");
   }
 
-  ContentPtr NumpyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr NumpyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(array) (without 'length', 'stride', and 'first')");
   }
 
-  ContentPtr NumpyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr NumpyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(field) (without 'length', 'stride', and 'first')");
   }
 
-  ContentPtr NumpyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr NumpyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: NumpyArray::getitem_next(fields) (without 'length', 'stride', and 'first')");
   }
 
-  ContentPtr NumpyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr NumpyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     if (shape_.size() != 1) {
       throw std::runtime_error("undefined operation: NumpyArray::getitem_next(jagged) with ndim != 1");
     }
@@ -1563,7 +1563,7 @@ namespace awkward {
     throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a jagged array because it is one-dimensional"));
   }
 
-  ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }
@@ -1572,7 +1572,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }
@@ -1581,7 +1581,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -24,7 +24,9 @@
 #include "awkward/array/NumpyArray.h"
 
 namespace awkward {
-  const TypePtr NumpyArray::unwrap_regulartype(const TypePtr& type, const std::vector<ssize_t>& shape) {
+  const TypePtr
+  NumpyArray::unwrap_regulartype(const TypePtr& type,
+                                 const std::vector<ssize_t>& shape) {
     TypePtr out = type;
     for (size_t i = 1;  i < shape.size();  i++) {
       if (RegularType* raw = dynamic_cast<RegularType*>(out.get())) {
@@ -32,17 +34,26 @@ namespace awkward {
           out = raw->type();
         }
         else {
-          throw std::invalid_argument(std::string("NumpyArray cannot be converted to type ") + type.get()->tostring() + std::string(" because shape does not match sizes of RegularTypes"));
+          throw std::invalid_argument(
+            std::string("NumpyArray cannot be converted to type ")
+            + type.get()->tostring()
+            + std::string(" because shape does not match sizes of "
+                          "RegularTypes"));
         }
       }
       else {
-        throw std::invalid_argument(std::string("NumpyArray cannot be converted to type ") + type.get()->tostring() + std::string(" because shape does not match level of RegularType nesting"));
+        throw std::invalid_argument(
+          std::string("NumpyArray cannot be converted to type ")
+          + type.get()->tostring()
+          + std::string(" because shape does not match level of RegularType "
+                        "nesting"));
       }
     }
     return out;
   }
 
-  const std::unordered_map<std::type_index, std::string> NumpyArray::format_map = {
+  const std::unordered_map<std::type_index, std::string>
+  NumpyArray::format_map = {
     { typeid(int8_t), "b"},
     { typeid(uint8_t), "B"},
 #if defined _MSC_VER || defined __i386__
@@ -56,7 +67,14 @@ namespace awkward {
 #endif
  };
 
-  NumpyArray::NumpyArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const std::shared_ptr<void>& ptr, const std::vector<ssize_t>& shape, const std::vector<ssize_t>& strides, ssize_t byteoffset, ssize_t itemsize, const std::string format)
+  NumpyArray::NumpyArray(const IdentitiesPtr& identities,
+                         const util::Parameters& parameters,
+                         const std::shared_ptr<void>& ptr,
+                         const std::vector<ssize_t>& shape,
+                         const std::vector<ssize_t>& strides,
+                         ssize_t byteoffset,
+                         ssize_t itemsize,
+                         const std::string format)
       : Content(identities, parameters)
       , ptr_(ptr)
       , shape_(shape)
@@ -65,7 +83,10 @@ namespace awkward {
       , itemsize_(itemsize)
       , format_(format) {
     if (shape.size() != strides.size()) {
-      throw std::invalid_argument(std::string("len(shape), which is ") + std::to_string(shape.size()) + std::string(", must be equal to len(strides), which is ") + std::to_string(strides.size()));
+      throw std::invalid_argument(
+        std::string("len(shape), which is ") + std::to_string(shape.size())
+        + std::string(", must be equal to len(strides), which is ")
+        + std::to_string(strides.size()));
     }
   }
 
@@ -85,49 +106,92 @@ namespace awkward {
     : NumpyArray(index, format_map.at(std::type_index(typeid(int64_t)))) { }
 
   NumpyArray::NumpyArray(const Index8 index, const std::string& format)
-    : NumpyArray(Identities::none(), util::Parameters(), index.ptr(), std::vector<ssize_t>({ (ssize_t)index.length() }), std::vector<ssize_t>({ (ssize_t)sizeof(int8_t) }), 0, sizeof(int8_t), format) { }
+    : NumpyArray(Identities::none(),
+                 util::Parameters(),
+                 index.ptr(),
+                 std::vector<ssize_t>({ (ssize_t)index.length() }),
+                 std::vector<ssize_t>({ (ssize_t)sizeof(int8_t) }),
+                 0,
+                 sizeof(int8_t),
+                 format) { }
 
   NumpyArray::NumpyArray(const IndexU8 index, const std::string& format)
-    : NumpyArray(Identities::none(), util::Parameters(), index.ptr(), std::vector<ssize_t>({ (ssize_t)index.length() }), std::vector<ssize_t>({ (ssize_t)sizeof(uint8_t) }), 0, sizeof(uint8_t), format) { }
+    : NumpyArray(Identities::none(),
+                 util::Parameters(),
+                 index.ptr(),
+                 std::vector<ssize_t>({ (ssize_t)index.length() }),
+                 std::vector<ssize_t>({ (ssize_t)sizeof(uint8_t) }),
+                 0,
+                 sizeof(uint8_t),
+                 format) { }
 
   NumpyArray::NumpyArray(const Index32 index, const std::string& format)
-    : NumpyArray(Identities::none(), util::Parameters(), index.ptr(), std::vector<ssize_t>({ (ssize_t)index.length() }), std::vector<ssize_t>({ (ssize_t)sizeof(int32_t) }), 0, sizeof(int32_t), format) { }
+    : NumpyArray(Identities::none(),
+                 util::Parameters(),
+                 index.ptr(),
+                 std::vector<ssize_t>({ (ssize_t)index.length() }),
+                 std::vector<ssize_t>({ (ssize_t)sizeof(int32_t) }),
+                 0,
+                 sizeof(int32_t),
+                 format) { }
 
   NumpyArray::NumpyArray(const IndexU32 index, const std::string& format)
-    : NumpyArray(Identities::none(), util::Parameters(), index.ptr(), std::vector<ssize_t>({ (ssize_t)index.length() }), std::vector<ssize_t>({ (ssize_t)sizeof(uint32_t) }), 0, sizeof(uint32_t), format) { }
+    : NumpyArray(Identities::none(),
+                 util::Parameters(),
+                 index.ptr(),
+                 std::vector<ssize_t>({ (ssize_t)index.length() }),
+                 std::vector<ssize_t>({ (ssize_t)sizeof(uint32_t) }),
+                 0,
+                 sizeof(uint32_t),
+                 format) { }
 
   NumpyArray::NumpyArray(const Index64 index, const std::string& format)
-    : NumpyArray(Identities::none(), util::Parameters(), index.ptr(), std::vector<ssize_t>({ (ssize_t)index.length() }), std::vector<ssize_t>({ (ssize_t)sizeof(int64_t) }), 0, sizeof(int64_t), format) { }
+    : NumpyArray(Identities::none(),
+                 util::Parameters(),
+                 index.ptr(),
+                 std::vector<ssize_t>({ (ssize_t)index.length() }),
+                 std::vector<ssize_t>({ (ssize_t)sizeof(int64_t) }),
+                 0,
+                 sizeof(int64_t),
+                 format) { }
 
-  const std::shared_ptr<void> NumpyArray::ptr() const {
+  const std::shared_ptr<void>
+  NumpyArray::ptr() const {
     return ptr_;
   }
 
-  const std::vector<ssize_t> NumpyArray::shape() const {
+  const std::vector<ssize_t>
+  NumpyArray::shape() const {
     return shape_;
   }
 
-  const std::vector<ssize_t> NumpyArray::strides() const {
+  const std::vector<ssize_t>
+  NumpyArray::strides() const {
     return strides_;
   }
 
-  ssize_t NumpyArray::byteoffset() const {
+  ssize_t
+  NumpyArray::byteoffset() const {
     return byteoffset_;
   }
 
-  ssize_t NumpyArray::itemsize() const {
+  ssize_t
+  NumpyArray::itemsize() const {
     return itemsize_;
   }
 
-  const std::string NumpyArray::format() const {
+  const std::string
+  NumpyArray::format() const {
     return format_;
   }
 
-  ssize_t NumpyArray::ndim() const {
+  ssize_t
+  NumpyArray::ndim() const {
     return (ssize_t)shape_.size();
   }
 
-  bool NumpyArray::isempty() const {
+  bool
+  NumpyArray::isempty() const {
     for (auto x : shape_) {
       if (x == 0) {
         return true;
@@ -136,15 +200,20 @@ namespace awkward {
     return false;  // false for isscalar(), too
   }
 
-  void* NumpyArray::byteptr() const {
-    return reinterpret_cast<void*>(reinterpret_cast<ssize_t>(ptr_.get()) + byteoffset_);
+  void*
+  NumpyArray::byteptr() const {
+    return reinterpret_cast<void*>(
+      reinterpret_cast<ssize_t>(ptr_.get()) + byteoffset_);
   }
 
-  void* NumpyArray::byteptr(ssize_t at) const {
-    return reinterpret_cast<void*>(reinterpret_cast<ssize_t>(ptr_.get()) + byteoffset_ + at);
+  void*
+  NumpyArray::byteptr(ssize_t at) const {
+    return reinterpret_cast<void*>(
+      reinterpret_cast<ssize_t>(ptr_.get()) + byteoffset_ + at);
   }
 
-  ssize_t NumpyArray::bytelength() const {
+  ssize_t
+  NumpyArray::bytelength() const {
     if (isscalar()) {
       return itemsize_;
     }
@@ -153,51 +222,63 @@ namespace awkward {
     }
   }
 
-  uint8_t NumpyArray::getbyte(ssize_t at) const {
+  uint8_t
+  NumpyArray::getbyte(ssize_t at) const {
     return *reinterpret_cast<uint8_t*>(byteptr(at));
   }
 
-  int8_t NumpyArray::getint8(ssize_t at) const  {
+  int8_t
+  NumpyArray::getint8(ssize_t at) const  {
     return *reinterpret_cast<int8_t*>(byteptr(at));
   }
 
-  uint8_t NumpyArray::getuint8(ssize_t at) const {
+  uint8_t
+  NumpyArray::getuint8(ssize_t at) const {
     return *reinterpret_cast<uint8_t*>(byteptr(at));
   }
 
-  int16_t NumpyArray::getint16(ssize_t at) const {
+  int16_t
+  NumpyArray::getint16(ssize_t at) const {
     return *reinterpret_cast<int16_t*>(byteptr(at));
   }
 
-  uint16_t NumpyArray::getuint16(ssize_t at) const {
+  uint16_t
+  NumpyArray::getuint16(ssize_t at) const {
     return *reinterpret_cast<uint16_t*>(byteptr(at));
   }
 
-  int32_t NumpyArray::getint32(ssize_t at) const {
+  int32_t
+  NumpyArray::getint32(ssize_t at) const {
     return *reinterpret_cast<int32_t*>(byteptr(at));
   }
 
-  uint32_t NumpyArray::getuint32(ssize_t at) const {
+  uint32_t
+  NumpyArray::getuint32(ssize_t at) const {
     return *reinterpret_cast<uint32_t*>(byteptr(at));
   }
 
-  int64_t NumpyArray::getint64(ssize_t at) const {
+  int64_t
+  NumpyArray::getint64(ssize_t at) const {
     return *reinterpret_cast<int64_t*>(byteptr(at));
   }
 
-  uint64_t NumpyArray::getuint64(ssize_t at) const {
+  uint64_t
+  NumpyArray::getuint64(ssize_t at) const {
     return *reinterpret_cast<uint64_t*>(byteptr(at));
   }
 
-  float_t NumpyArray::getfloat(ssize_t at) const {
+  float_t
+  NumpyArray::getfloat(ssize_t at) const {
     return *reinterpret_cast<float*>(byteptr(at));
   }
 
-  double_t NumpyArray::getdouble(ssize_t at) const {
+  double_t
+  NumpyArray::getdouble(ssize_t at) const {
     return *reinterpret_cast<double*>(byteptr(at));
   }
 
-  const ContentPtr NumpyArray::toRegularArray() const {
+  const ContentPtr
+  NumpyArray::toRegularArray() const {
     if (isscalar()) {
       return shallow_copy();
     }
@@ -207,40 +288,73 @@ namespace awkward {
       flatshape[0] = flatshape[0] * x;
     }
     std::vector<ssize_t> flatstrides({ itemsize_ });
-    ContentPtr out = std::make_shared<NumpyArray>(identities_, parameters_, contiguous_self.ptr(), flatshape, flatstrides, contiguous_self.byteoffset(), contiguous_self.itemsize(), contiguous_self.format());
+    ContentPtr out = std::make_shared<NumpyArray>(
+      identities_,
+      parameters_,
+      contiguous_self.ptr(),
+      flatshape,
+      flatstrides,
+      contiguous_self.byteoffset(),
+      contiguous_self.itemsize(),
+      contiguous_self.format());
     for (int64_t i = (int64_t)shape_.size() - 1;  i > 0;  i--) {
-      out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out, shape_[(size_t)i]);
+      out = std::make_shared<RegularArray>(Identities::none(),
+                                           util::Parameters(),
+                                           out,
+                                           shape_[(size_t)i]);
     }
     return out;
   }
 
-  bool NumpyArray::isscalar() const {
+  bool
+  NumpyArray::isscalar() const {
     return ndim() == 0;
   }
 
-  const std::string NumpyArray::classname() const {
+  const std::string
+  NumpyArray::classname() const {
     return "NumpyArray";
   }
 
-  void NumpyArray::setidentities(const IdentitiesPtr& identities) {
-    if (identities.get() != nullptr  &&  length() != identities.get()->length()) {
-      util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+  void
+  NumpyArray::setidentities(const IdentitiesPtr& identities) {
+    if (identities.get() != nullptr  &&
+        length() != identities.get()->length()) {
+      util::handle_error(
+        failure("content and its identities must have the same length",
+                kSliceNone,
+                kSliceNone),
+        classname(),
+        identities_.get());
     }
     identities_ = identities;
   }
 
-  void NumpyArray::setidentities() {
+  void
+  NumpyArray::setidentities() {
     if (length() <= kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err = awkward_new_identities32(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err = awkward_new_identities64(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
@@ -288,69 +402,113 @@ namespace awkward {
     }
   }
 
-  const TypePtr NumpyArray::type(const util::TypeStrs& typestrs) const {
+  const TypePtr
+  NumpyArray::type(const util::TypeStrs& typestrs) const {
     TypePtr out;
     if (format_.compare("d") == 0) {
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::float64);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::float64);
     }
     else if (format_.compare("f") == 0) {
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::float32);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::float32);
     }
 #if defined _MSC_VER || defined __i386__
     else if (format_.compare("q") == 0) {
 #else
     else if (format_.compare("l") == 0) {
 #endif
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::int64);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::int64);
     }
 #if defined _MSC_VER || defined __i386__
     else if (format_.compare("Q") == 0) {
 #else
     else if (format_.compare("L") == 0) {
 #endif
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::uint64);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::uint64);
     }
 #if defined _MSC_VER || defined __i386__
     else if (format_.compare("l") == 0) {
 #else
     else if (format_.compare("i") == 0) {
 #endif
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::int32);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::int32);
     }
 #if defined _MSC_VER || defined __i386__
     else if (format_.compare("L") == 0) {
 #else
     else if (format_.compare("I") == 0) {
 #endif
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::uint32);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::uint32);
     }
     else if (format_.compare("h") == 0) {
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::int16);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::int16);
     }
     else if (format_.compare("H") == 0) {
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::uint16);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::uint16);
     }
     else if (format_.compare("b") == 0) {
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::int8);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::int8);
     }
     else if (format_.compare("B") == 0  ||  format_.compare("c") == 0) {
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::uint8);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::uint8);
     }
     else if (format_.compare("?") == 0) {
-      out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::boolean);
+      out = std::make_shared<PrimitiveType>(
+        parameters_,
+        util::gettypestr(parameters_, typestrs),
+        PrimitiveType::boolean);
     }
     else {
-      throw std::invalid_argument(std::string("Numpy format \"") + format_ + std::string("\" cannot be expressed as a PrimitiveType"));
+      throw std::invalid_argument(
+        std::string("Numpy format \"") + format_
+        + std::string("\" cannot be expressed as a PrimitiveType"));
     }
     for (std::size_t i = shape_.size() - 1;  i > 0;  i--) {
-      out = std::make_shared<RegularType>(util::Parameters(), util::gettypestr(parameters_, typestrs), out, (int64_t)shape_[i]);
+      out = std::make_shared<RegularType>(
+        util::Parameters(),
+        util::gettypestr(parameters_, typestrs),
+        out,
+        (int64_t)shape_[i]);
     }
     return out;
   }
 
-  const std::string NumpyArray::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  NumpyArray::tostring_part(const std::string& indent,
+                            const std::string& pre,
+                            const std::string& post) const {
     std::stringstream out;
-    out << indent << pre << "<" << classname() << " format=" << util::quote(format_, true) << " shape=\"";
+    out << indent << pre << "<" << classname() << " format="
+        << util::quote(format_, true) << " shape=\"";
     for (std::size_t i = 0;  i < shape_.size();  i++) {
       if (i != 0) {
         out << " ";
@@ -374,23 +532,33 @@ namespace awkward {
 #else
     if (ndim() == 1  &&  format_.compare("i") == 0) {
 #endif
-      tostring_as<int32_t>(out, reinterpret_cast<int32_t*>(byteptr()), length());
+      tostring_as<int32_t>(out,
+                           reinterpret_cast<int32_t*>(byteptr()),
+                           length());
     }
 #if defined _MSC_VER || defined __i386__
     else if (ndim() == 1  &&  format_.compare("q") == 0) {
 #else
     else if (ndim() == 1  &&  format_.compare("l") == 0) {
 #endif
-      tostring_as<int64_t>(out, reinterpret_cast<int64_t*>(byteptr()), length());
+      tostring_as<int64_t>(out,
+                           reinterpret_cast<int64_t*>(byteptr()),
+                           length());
     }
     else if (ndim() == 1  &&  format_.compare("f") == 0) {
-      tostring_as<float>(out, reinterpret_cast<float*>(byteptr()), length());
+      tostring_as<float>(out,
+                         reinterpret_cast<float*>(byteptr()),
+                         length());
     }
     else if (ndim() == 1  &&  format_.compare("d") == 0) {
-      tostring_as<double>(out, reinterpret_cast<double*>(byteptr()), length());
+      tostring_as<double>(out,
+                          reinterpret_cast<double*>(byteptr()),
+                          length());
     }
     else if (ndim() == 1  &&  format_.compare("?") == 0) {
-      tostring_as<bool>(out, reinterpret_cast<bool*>(byteptr()), length());
+      tostring_as<bool>(out,
+                        reinterpret_cast<bool*>(byteptr()),
+                        length());
     }
     else {
       out << "0x ";
@@ -400,7 +568,8 @@ namespace awkward {
           if (i != 0  &&  i % 4 == 0) {
             out << " ";
           }
-          out << std::hex << std::setw(2) << std::setfill('0') << int(getbyte(i));
+          out << std::hex << std::setw(2) << std::setfill('0')
+              << int(getbyte(i));
         }
       }
       else {
@@ -408,26 +577,30 @@ namespace awkward {
           if (i != 0  &&  i % 4 == 0) {
             out << " ";
           }
-          out << std::hex << std::setw(2) << std::setfill('0') << int(getbyte(i));
+          out << std::hex << std::setw(2) << std::setfill('0')
+              << int(getbyte(i));
         }
         out << " ... ";
         for (ssize_t i = len - 16;  i < len;  i++) {
           if (i != len - 16  &&  i % 4 == 0) {
             out << " ";
           }
-          out << std::hex << std::setw(2) << std::setfill('0') << int(getbyte(i));
+          out << std::hex << std::setw(2) << std::setfill('0')
+              << int(getbyte(i));
         }
       }
     }
     out << "\" at=\"0x";
-    out << std::hex << std::setw(12) << std::setfill('0') << reinterpret_cast<ssize_t>(ptr_.get());
+    out << std::hex << std::setw(12) << std::setfill('0')
+        << reinterpret_cast<ssize_t>(ptr_.get());
     if (identities_.get() == nullptr  &&  parameters_.empty()) {
       out << "\"/>" << post;
     }
     else {
       out << "\">\n";
       if (identities_.get() != nullptr) {
-        out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+        out << identities_.get()->tostring_part(
+          indent + std::string("    "), "", "\n");
       }
       if (!parameters_.empty()) {
         out << parameters_tostring(indent + std::string("    "), "", "\n");
@@ -437,7 +610,8 @@ namespace awkward {
     return out.str();
   }
 
-  void NumpyArray::tojson_part(ToJson& builder) const {
+  void
+  NumpyArray::tojson_part(ToJson& builder) const {
     check_for_iteration();
     if (parameter_equals("__array__", "\"byte\"")) {
       tojson_string(builder);
@@ -495,11 +669,14 @@ namespace awkward {
       tojson_boolean(builder);
     }
     else {
-      throw std::invalid_argument(std::string("cannot convert Numpy format \"") + format_ + std::string("\" into JSON"));
+      throw std::invalid_argument(
+        std::string("cannot convert Numpy format \"") + format_
+        + std::string("\" into JSON"));
     }
   }
 
-  void NumpyArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  NumpyArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
     int64_t len = 1;
     if (!shape_.empty()) {
       len = shape_[0];
@@ -514,7 +691,8 @@ namespace awkward {
     }
   }
 
-  int64_t NumpyArray::length() const {
+  int64_t
+  NumpyArray::length() const {
     if (isscalar()) {
       return -1;   // just like Record, which is also a scalar
     }
@@ -523,11 +701,22 @@ namespace awkward {
     }
   }
 
-  const ContentPtr NumpyArray::shallow_copy() const {
-    return std::make_shared<NumpyArray>(identities_, parameters_, ptr_, shape_, strides_, byteoffset_, itemsize_, format_);
+  const ContentPtr
+  NumpyArray::shallow_copy() const {
+    return std::make_shared<NumpyArray>(identities_,
+                                        parameters_,
+                                        ptr_,
+                                        shape_,
+                                        strides_,
+                                        byteoffset_,
+                                        itemsize_,
+                                        format_);
   }
 
-  const ContentPtr NumpyArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  NumpyArray::deep_copy(bool copyarrays,
+                        bool copyindexes,
+                        bool copyidentities) const {
     std::shared_ptr<void> ptr = ptr_;
     std::vector<ssize_t> shape = shape_;
     std::vector<ssize_t> strides = strides_;
@@ -543,58 +732,96 @@ namespace awkward {
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
-    return std::make_shared<NumpyArray>(identities, parameters_, ptr, shape, strides, byteoffset, itemsize_, format_);
+    return std::make_shared<NumpyArray>(identities,
+                                        parameters_,
+                                        ptr,
+                                        shape,
+                                        strides,
+                                        byteoffset,
+                                        itemsize_,
+                                        format_);
   }
 
-  void NumpyArray::check_for_iteration() const {
-    if (identities_.get() != nullptr  &&  identities_.get()->length() < shape_[0]) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+  void
+  NumpyArray::check_for_iteration() const {
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < shape_[0]) {
+      util::handle_error(
+        failure("len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
-  const ContentPtr NumpyArray::getitem_nothing() const {
+  const ContentPtr
+  NumpyArray::getitem_nothing() const {
     const std::vector<ssize_t> shape({ 0 });
     const std::vector<ssize_t> strides({ itemsize_ });
     IdentitiesPtr identities;
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(0, 0);
     }
-    return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides, byteoffset_, itemsize_, format_);
+    return std::make_shared<NumpyArray>(identities,
+                                        parameters_,
+                                        ptr_,
+                                        shape,
+                                        strides,
+                                        byteoffset_,
+                                        itemsize_,
+                                        format_);
   }
 
-  const ContentPtr NumpyArray::getitem_at(int64_t at) const {
+  const ContentPtr
+  NumpyArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += shape_[0];
     }
     if (regular_at < 0  ||  regular_at >= shape_[0]) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
-  const ContentPtr NumpyArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  NumpyArray::getitem_at_nowrap(int64_t at) const {
     ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)at);
     const std::vector<ssize_t> shape(shape_.begin() + 1, shape_.end());
     const std::vector<ssize_t> strides(strides_.begin() + 1, strides_.end());
     IdentitiesPtr identities;
     if (identities_.get() != nullptr) {
       if (at >= identities_.get()->length()) {
-        util::handle_error(failure("index out of range", kSliceNone, at), identities_.get()->classname(), nullptr);
+        util::handle_error(
+          failure("index out of range", kSliceNone, at),
+          identities_.get()->classname(),
+          nullptr);
       }
       identities = identities_.get()->getitem_range_nowrap(at, at + 1);
     }
-    return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides, byteoffset, itemsize_, format_);
+    return std::make_shared<NumpyArray>(identities,
+                                        parameters_,
+                                        ptr_,
+                                        shape,
+                                        strides,
+                                        byteoffset,
+                                        itemsize_,
+                                        format_);
   }
 
-  const ContentPtr NumpyArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  NumpyArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), shape_[0]);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), shape_[0]);
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const ContentPtr NumpyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  NumpyArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)start);
     std::vector<ssize_t> shape;
     shape.push_back((ssize_t)(stop - start));
@@ -602,26 +829,43 @@ namespace awkward {
     IdentitiesPtr identities;
     if (identities_.get() != nullptr) {
       if (stop > identities_.get()->length()) {
-        util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+        util::handle_error(
+          failure("index out of range", kSliceNone, stop),
+          identities_.get()->classname(),
+          nullptr);
       }
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
-    return std::make_shared<NumpyArray>(identities, parameters_, ptr_, shape, strides_, byteoffset, itemsize_, format_);
+    return std::make_shared<NumpyArray>(identities,
+                                        parameters_,
+                                        ptr_,
+                                        shape,
+                                        strides_,
+                                        byteoffset,
+                                        itemsize_,
+                                        format_);
   }
 
-  const ContentPtr NumpyArray::getitem_field(const std::string& key) const {
-    throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
+  const ContentPtr
+  NumpyArray::getitem_field(const std::string& key) const {
+    throw std::invalid_argument(
+      std::string("cannot slice ") + classname()
+      + std::string(" by field name"));
   }
 
-  const ContentPtr NumpyArray::getitem_fields(const std::vector<std::string>& keys) const {
-    throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field name"));
+  const ContentPtr
+  NumpyArray::getitem_fields(const std::vector<std::string>& keys) const {
+    throw std::invalid_argument(
+      std::string("cannot slice ") + classname()
+      + std::string(" by field name"));
   }
 
   bool getitem_too_general(const SliceItemPtr& head, const Slice& tail) {
     if (head.get() == nullptr) {
       return false;
     }
-    else if (dynamic_cast<SliceMissing64*>(head.get())  ||  dynamic_cast<SliceJagged64*>(head.get())) {
+    else if (dynamic_cast<SliceMissing64*>(head.get())  ||
+             dynamic_cast<SliceJagged64*>(head.get())) {
       return true;
     }
     else {
@@ -629,7 +873,8 @@ namespace awkward {
     }
   }
 
-  const ContentPtr NumpyArray::getitem(const Slice& where) const {
+  const ContentPtr
+  NumpyArray::getitem(const Slice& where) const {
     if (isscalar()) {
       throw std::runtime_error("cannot get-item on a scalar");
     }
@@ -648,48 +893,100 @@ namespace awkward {
       nextshape.insert(nextshape.end(), shape_.begin(), shape_.end());
       std::vector<ssize_t> nextstrides = { shape_[0]*strides_[0] };
       nextstrides.insert(nextstrides.end(), strides_.begin(), strides_.end());
-      NumpyArray next(identities_, parameters_, ptr_, nextshape, nextstrides, byteoffset_, itemsize_, format_);
+      NumpyArray next(identities_,
+                      parameters_,
+                      ptr_,
+                      nextshape,
+                      nextstrides,
+                      byteoffset_,
+                      itemsize_,
+                      format_);
 
       SliceItemPtr nexthead = where.head();
       Slice nexttail = where.tail();
       NumpyArray out = next.getitem_bystrides(nexthead, nexttail, 1);
 
       std::vector<ssize_t> outshape(out.shape_.begin() + 1, out.shape_.end());
-      std::vector<ssize_t> outstrides(out.strides_.begin() + 1, out.strides_.end());
-      return std::make_shared<NumpyArray>(out.identities_, out.parameters_, out.ptr_, outshape, outstrides, out.byteoffset_, itemsize_, format_);
+      std::vector<ssize_t> outstrides(out.strides_.begin() + 1,
+                                      out.strides_.end());
+      return std::make_shared<NumpyArray>(out.identities_,
+                                          out.parameters_,
+                                          out.ptr_,
+                                          outshape,
+                                          outstrides,
+                                          out.byteoffset_,
+                                          itemsize_,
+                                          format_);
     }
 
     else {
       NumpyArray safe = contiguous();
 
       std::vector<ssize_t> nextshape = { 1 };
-      nextshape.insert(nextshape.end(), safe.shape_.begin(), safe.shape_.end());
+      nextshape.insert(nextshape.end(),
+                       safe.shape_.begin(),
+                       safe.shape_.end());
       std::vector<ssize_t> nextstrides = { safe.shape_[0]*safe.strides_[0] };
-      nextstrides.insert(nextstrides.end(), safe.strides_.begin(), safe.strides_.end());
-      NumpyArray next(safe.identities_, safe.parameters_, safe.ptr_, nextshape, nextstrides, safe.byteoffset_, itemsize_, format_);
+      nextstrides.insert(nextstrides.end(),
+                         safe.strides_.begin(),
+                         safe.strides_.end());
+      NumpyArray next(safe.identities_,
+                      safe.parameters_,
+                      safe.ptr_,
+                      nextshape,
+                      nextstrides,
+                      safe.byteoffset_,
+                      itemsize_,
+                      format_);
 
       SliceItemPtr nexthead = where.head();
       Slice nexttail = where.tail();
       Index64 nextcarry(1);
       nextcarry.setitem_at_nowrap(0, 0);
       Index64 nextadvanced(0);
-      NumpyArray out = next.getitem_next(nexthead, nexttail, nextcarry, nextadvanced, 1, next.strides_[0], true);
+      NumpyArray out = next.getitem_next(nexthead,
+                                         nexttail,
+                                         nextcarry,
+                                         nextadvanced,
+                                         1,
+                                         next.strides_[0],
+                                         true);
 
       std::vector<ssize_t> outshape(out.shape_.begin() + 1, out.shape_.end());
-      std::vector<ssize_t> outstrides(out.strides_.begin() + 1, out.strides_.end());
-      return std::make_shared<NumpyArray>(out.identities_, out.parameters_, out.ptr_, outshape, outstrides, out.byteoffset_, itemsize_, format_);
+      std::vector<ssize_t> outstrides(out.strides_.begin() + 1,
+                                      out.strides_.end());
+      return std::make_shared<NumpyArray>(out.identities_,
+                                          out.parameters_,
+                                          out.ptr_,
+                                          outshape,
+                                          outstrides,
+                                          out.byteoffset_,
+                                          itemsize_,
+                                          format_);
     }
   }
 
-  const ContentPtr NumpyArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  NumpyArray::getitem_next(const SliceItemPtr& head,
+                           const Slice& tail,
+                           const Index64& advanced) const {
     Index64 carry(shape_[0]);
     struct Error err = awkward_carry_arange_64(carry.ptr().get(), shape_[0]);
     util::handle_error(err, classname(), identities_.get());
-    return getitem_next(head, tail, carry, advanced, shape_[0], strides_[0], false).shallow_copy();
+    return getitem_next(head,
+                        tail,
+                        carry,
+                        advanced,
+                        shape_[0],
+                        strides_[0],
+                        false).shallow_copy();
   }
 
-  const ContentPtr NumpyArray::carry(const Index64& carry) const {
-    std::shared_ptr<void> ptr(new uint8_t[(size_t)(carry.length()*strides_[0])], util::array_deleter<uint8_t>());
+  const ContentPtr
+  NumpyArray::carry(const Index64& carry) const {
+    std::shared_ptr<void> ptr(
+      new uint8_t[(size_t)(carry.length()*strides_[0])],
+      util::array_deleter<uint8_t>());
     struct Error err = awkward_numpyarray_getitem_next_null_64(
       reinterpret_cast<uint8_t*>(ptr.get()),
       reinterpret_cast<uint8_t*>(ptr_.get()),
@@ -706,69 +1003,98 @@ namespace awkward {
 
     std::vector<ssize_t> shape = { (ssize_t)carry.length() };
     shape.insert(shape.end(), shape_.begin() + 1, shape_.end());
-    return std::make_shared<NumpyArray>(identities, parameters_, ptr, shape, strides_, 0, itemsize_, format_);
+    return std::make_shared<NumpyArray>(identities,
+                                        parameters_,
+                                        ptr,
+                                        shape,
+                                        strides_,
+                                        0,
+                                        itemsize_,
+                                        format_);
   }
 
-  const std::string NumpyArray::purelist_parameter(const std::string& key) const {
+  const std::string
+  NumpyArray::purelist_parameter(const std::string& key) const {
     return parameter(key);
   }
 
-  bool NumpyArray::purelist_isregular() const {
+  bool
+  NumpyArray::purelist_isregular() const {
     return true;
   }
 
-  int64_t NumpyArray::purelist_depth() const {
+  int64_t
+  NumpyArray::purelist_depth() const {
     return (int64_t)shape_.size();
   }
 
-  const std::pair<int64_t, int64_t> NumpyArray::minmax_depth() const {
-    return std::pair<int64_t, int64_t>((int64_t)shape_.size(), (int64_t)shape_.size());
+  const std::pair<int64_t, int64_t>
+  NumpyArray::minmax_depth() const {
+    return std::pair<int64_t, int64_t>((int64_t)shape_.size(),
+                                       (int64_t)shape_.size());
   }
 
-  const std::pair<bool, int64_t> NumpyArray::branch_depth() const {
+  const std::pair<bool, int64_t>
+  NumpyArray::branch_depth() const {
     return std::pair<bool, int64_t>(false, (int64_t)shape_.size());
   }
 
-  int64_t NumpyArray::numfields() const { return -1; }
+  int64_t
+  NumpyArray::numfields() const { return -1; }
 
-  int64_t NumpyArray::fieldindex(const std::string& key) const {
-    throw std::invalid_argument(std::string("key ") + util::quote(key, true) + std::string(" does not exist (data are not records)"));
+  int64_t
+  NumpyArray::fieldindex(const std::string& key) const {
+    throw std::invalid_argument(
+      std::string("key ") + util::quote(key, true)
+      + std::string(" does not exist (data are not records)"));
   }
 
-  const std::string NumpyArray::key(int64_t fieldindex) const {
-    throw std::invalid_argument(std::string("fieldindex \"") + std::to_string(fieldindex) + std::string("\" does not exist (data are not records)"));
+  const std::string
+  NumpyArray::key(int64_t fieldindex) const {
+    throw std::invalid_argument(
+      std::string("fieldindex \"") + std::to_string(fieldindex)
+      + std::string("\" does not exist (data are not records)"));
   }
 
-  bool NumpyArray::haskey(const std::string& key) const {
+  bool
+  NumpyArray::haskey(const std::string& key) const {
     return false;
   }
 
-  const std::vector<std::string> NumpyArray::keys() const {
+  const std::vector<std::string>
+  NumpyArray::keys() const {
     return std::vector<std::string>();
   }
 
-  const std::string NumpyArray::validityerror(const std::string& path) const {
+  const std::string
+  NumpyArray::validityerror(const std::string& path) const {
     if (shape_.empty()) {
-      return std::string("at ") + path + std::string(" (") + classname() + std::string("): shape is zero-dimensional");
+      return (std::string("at ") + path + std::string(" (") + classname()
+              + std::string("): shape is zero-dimensional"));
     }
     for (size_t i = 0;  i < shape_.size();  i++) {
       if (shape_[i] < 0) {
-        return std::string("at ") + path + std::string(" (") + classname() + std::string("): shape[") + std::to_string(i) + ("] < 0");
+        return (std::string("at ") + path + std::string(" (") + classname()
+                + std::string("): shape[") + std::to_string(i) + ("] < 0"));
       }
     }
     for (size_t i = 0;  i < strides_.size();  i++) {
       if (strides_[i] % itemsize_ != 0) {
-        return std::string("at ") + path + std::string(" (") + classname() + std::string("): shape[") + std::to_string(i) + ("] % itemsize != 0");
+        return (std::string("at ") + path + std::string(" (") + classname()
+                + std::string("): shape[") + std::to_string(i)
+                + ("] % itemsize != 0"));
       }
     }
     return std::string();
   }
 
-  const ContentPtr NumpyArray::shallow_simplify() const {
+  const ContentPtr
+  NumpyArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const ContentPtr NumpyArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  NumpyArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -804,10 +1130,19 @@ namespace awkward {
       reps);
     util::handle_error(err, classname(), identities_.get());
 
-    return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), tonum.ptr(), shape, strides, 0, sizeof(int64_t), format_map.at(std::type_index(typeid(int64_t))));
+    return std::make_shared<NumpyArray>(
+      Identities::none(),
+      util::Parameters(),
+      tonum.ptr(),
+      shape,
+      strides,
+      0,
+      sizeof(int64_t),
+      format_map.at(std::type_index(typeid(int64_t))));
   }
 
-  const std::vector<ssize_t> flatten_shape(const std::vector<ssize_t> shape) {
+  const std::vector<ssize_t>
+  flatten_shape(const std::vector<ssize_t> shape) {
     if (shape.size() == 1) {
       return std::vector<ssize_t>();
     }
@@ -818,7 +1153,8 @@ namespace awkward {
     }
   }
 
-  const std::vector<ssize_t> flatten_strides(const std::vector<ssize_t> strides) {
+  const std::vector<ssize_t>
+  flatten_strides(const std::vector<ssize_t> strides) {
     if (strides.size() == 1) {
       return std::vector<ssize_t>();
     }
@@ -827,7 +1163,8 @@ namespace awkward {
     }
   }
 
-  const std::vector<ssize_t> flatten_shape(const std::vector<ssize_t>& shape, int64_t axis) {
+  const std::vector<ssize_t>
+  flatten_shape(const std::vector<ssize_t>& shape, int64_t axis) {
     if (shape.size() == 1) {
       return std::vector<ssize_t>();
     }
@@ -844,7 +1181,8 @@ namespace awkward {
     }
   }
 
-  const std::vector<ssize_t> flatten_strides(const std::vector<ssize_t>& strides, int64_t axis) {
+  const std::vector<ssize_t>
+  flatten_strides(const std::vector<ssize_t>& strides, int64_t axis) {
     if (strides.size() == 1) {
       return std::vector<ssize_t>();
     }
@@ -860,7 +1198,8 @@ namespace awkward {
     }
   }
 
-  const std::pair<Index64, ContentPtr> NumpyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  NumpyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -873,7 +1212,8 @@ namespace awkward {
     }
   }
 
-  bool NumpyArray::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  NumpyArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -884,28 +1224,36 @@ namespace awkward {
         dynamic_cast<UnionArray8_64*>(other.get())) {
       return true;
     }
-    else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    else if (IndexedArray32* rawother =
+             dynamic_cast<IndexedArray32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
 
@@ -920,12 +1268,40 @@ namespace awkward {
 
       std::string other_format = rawother->format();
 
-      if (!mergebool  &&  ((format_.compare("?") == 0  &&  other_format.compare("?") != 0)  ||  (format_.compare("?") != 0  &&  other_format.compare("?") == 0))) {
+      if (!mergebool  &&
+          ((format_.compare("?") == 0  &&  other_format.compare("?") != 0)  ||
+           (format_.compare("?") != 0  &&  other_format.compare("?") == 0))) {
         return false;
       }
 
-      if (!(format_.compare("d") == 0  ||  format_.compare("f") == 0  ||  format_.compare("q") == 0  ||  format_.compare("Q") == 0  ||  format_.compare("l") == 0  ||  format_.compare("L") == 0  ||  format_.compare("i") == 0  ||  format_.compare("I") == 0  ||  format_.compare("h") == 0  ||  format_.compare("H") == 0  ||  format_.compare("b") == 0  ||  format_.compare("B") == 0  ||  format_.compare("c") == 0  ||  format_.compare("?") == 0  ||
-          other_format.compare("d") == 0  ||  other_format.compare("f") == 0  ||  other_format.compare("q") == 0  ||  other_format.compare("Q") == 0  ||  other_format.compare("l") == 0  ||  other_format.compare("L") == 0  ||  other_format.compare("i") == 0  ||  other_format.compare("I") == 0  ||  other_format.compare("h") == 0  ||  other_format.compare("H") == 0  ||  other_format.compare("b") == 0  ||  other_format.compare("B") == 0  ||  other_format.compare("c") == 0  ||  other_format.compare("?") == 0)) {
+      if (!(format_.compare("d") == 0  ||
+            format_.compare("f") == 0  ||
+            format_.compare("q") == 0  ||
+            format_.compare("Q") == 0  ||
+            format_.compare("l") == 0  ||
+            format_.compare("L") == 0  ||
+            format_.compare("i") == 0  ||
+            format_.compare("I") == 0  ||
+            format_.compare("h") == 0  ||
+            format_.compare("H") == 0  ||
+            format_.compare("b") == 0  ||
+            format_.compare("B") == 0  ||
+            format_.compare("c") == 0  ||
+            format_.compare("?") == 0  ||
+            other_format.compare("d") == 0  ||
+            other_format.compare("f") == 0  ||
+            other_format.compare("q") == 0  ||
+            other_format.compare("Q") == 0  ||
+            other_format.compare("l") == 0  ||
+            other_format.compare("L") == 0  ||
+            other_format.compare("i") == 0  ||
+            other_format.compare("I") == 0  ||
+            other_format.compare("h") == 0  ||
+            other_format.compare("H") == 0  ||
+            other_format.compare("b") == 0  ||
+            other_format.compare("B") == 0  ||
+            other_format.compare("c") == 0  ||
+            other_format.compare("?") == 0)) {
         return false;
       }
 
@@ -943,7 +1319,8 @@ namespace awkward {
     }
   }
 
-  const ContentPtr NumpyArray::merge(const ContentPtr& other) const {
+  const ContentPtr
+  NumpyArray::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -951,37 +1328,48 @@ namespace awkward {
     if (dynamic_cast<EmptyArray*>(other.get())) {
       return shallow_copy();
     }
-    else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    else if (IndexedArray32* rawother =
+             dynamic_cast<IndexedArray32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_32* rawother = dynamic_cast<UnionArray8_32*>(other.get())) {
+    else if (UnionArray8_32* rawother =
+             dynamic_cast<UnionArray8_32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_U32* rawother = dynamic_cast<UnionArray8_U32*>(other.get())) {
+    else if (UnionArray8_U32* rawother =
+             dynamic_cast<UnionArray8_U32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_64* rawother = dynamic_cast<UnionArray8_64*>(other.get())) {
+    else if (UnionArray8_64* rawother =
+             dynamic_cast<UnionArray8_64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
 
@@ -999,7 +1387,10 @@ namespace awkward {
 
       ssize_t itemsize;
       std::string format;
-      if (format_.compare("d") == 0  ||  format_.compare("f") == 0  ||  other_format.compare("d") == 0  ||  other_format.compare("f") == 0) {
+      if (format_.compare("d") == 0  ||
+          format_.compare("f") == 0  ||
+          other_format.compare("d") == 0  ||
+          other_format.compare("f") == 0) {
         itemsize = 8;
         format = "d";
       }
@@ -1013,7 +1404,28 @@ namespace awkward {
         format = "L";
 #endif
       }
-      else if (format_.compare("q") == 0  ||  format_.compare("Q") == 0  ||  format_.compare("l") == 0  ||  format_.compare("L") == 0  ||  format_.compare("i") == 0  ||  format_.compare("I") == 0  ||  format_.compare("h") == 0  ||  format_.compare("H") == 0  ||  format_.compare("b") == 0  ||  format_.compare("B") == 0  ||  format_.compare("c") == 0  ||  other_format.compare("q") == 0  ||  other_format.compare("Q") == 0  ||  other_format.compare("l") == 0  ||  other_format.compare("L") == 0  ||  other_format.compare("i") == 0  ||  other_format.compare("I") == 0  ||  other_format.compare("h") == 0  ||  other_format.compare("H") == 0  ||  other_format.compare("b") == 0  ||  other_format.compare("B") == 0  ||  other_format.compare("c") == 0) {
+      else if (format_.compare("q") == 0  ||
+               format_.compare("Q") == 0  ||
+               format_.compare("l") == 0  ||
+               format_.compare("L") == 0  ||
+               format_.compare("i") == 0  ||
+               format_.compare("I") == 0  ||
+               format_.compare("h") == 0  ||
+               format_.compare("H") == 0  ||
+               format_.compare("b") == 0  ||
+               format_.compare("B") == 0  ||
+               format_.compare("c") == 0  ||
+               other_format.compare("q") == 0  ||
+               other_format.compare("Q") == 0  ||
+               other_format.compare("l") == 0  ||
+               other_format.compare("L") == 0  ||
+               other_format.compare("i") == 0  ||
+               other_format.compare("I") == 0  ||
+               other_format.compare("h") == 0  ||
+               other_format.compare("H") == 0  ||
+               other_format.compare("b") == 0  ||
+               other_format.compare("B") == 0  ||
+               other_format.compare("c") == 0) {
         itemsize = 8;
 #if defined _MSC_VER || defined __i386__
         format = "q";
@@ -1026,7 +1438,9 @@ namespace awkward {
         format = "?";
       }
       else {
-        throw std::invalid_argument(std::string("cannot merge Numpy format \"") + format_ + std::string("\" with \"") + other_format + std::string("\""));
+        throw std::invalid_argument(
+          std::string("cannot merge Numpy format \"") + format_
+          + std::string("\" with \"") + other_format + std::string("\""));
       }
 
       std::vector<ssize_t> other_shape = rawother->shape();
@@ -1038,7 +1452,8 @@ namespace awkward {
       int64_t other_flatlength = other_shape[0];
       for (int64_t i = ((int64_t)shape_.size()) - 1;  i > 0;  i--) {
         if (shape_[(size_t)i] != other_shape[(size_t)i]) {
-          throw std::invalid_argument("cannot merge arrays with different shapes");
+          throw std::invalid_argument(
+            "cannot merge arrays with different shapes");
         }
         shape.insert(shape.begin() + 1, shape_[(size_t)i]);
         strides.insert(strides.begin(), strides[0]*shape_[(size_t)i]);
@@ -1046,128 +1461,256 @@ namespace awkward {
         other_flatlength *= (int64_t)shape_[(size_t)i];
       }
 
-      std::shared_ptr<void> ptr(new uint8_t[(size_t)(itemsize*(self_flatlength + other_flatlength))], util::array_deleter<uint8_t>());
+      std::shared_ptr<void> ptr(
+        new uint8_t[(size_t)(itemsize*(self_flatlength + other_flatlength))],
+        util::array_deleter<uint8_t>());
 
       NumpyArray contiguous_other = rawother->contiguous();
 
-      int64_t self_offset = contiguous_self.byteoffset() / contiguous_self.itemsize();
-      int64_t other_offset = contiguous_other.byteoffset() / contiguous_other.itemsize();
+      int64_t self_offset = (contiguous_self.byteoffset() /
+                             contiguous_self.itemsize());
+      int64_t other_offset = (contiguous_other.byteoffset() /
+                              contiguous_other.itemsize());
 
       struct Error err;
       if (format.compare("d") == 0) {
         if (format_.compare("d") == 0) {
-          err = awkward_numpyarray_fill_todouble_fromdouble(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<double*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromdouble(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<double*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("f") == 0) {
-          err = awkward_numpyarray_fill_todouble_fromfloat(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<float*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromfloat(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<float*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
         else if (format_.compare("q") == 0) {
 #else
         else if (format_.compare("l") == 0) {
 #endif
-          err = awkward_numpyarray_fill_todouble_from64(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<int64_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_from64(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<int64_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (format_.compare("Q") == 0) {
 #else
           else if (format_.compare("L") == 0) {
 #endif
-          err = awkward_numpyarray_fill_todouble_fromU64(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<uint64_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromU64(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<uint64_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (format_.compare("l") == 0) {
 #else
           else if (format_.compare("i") == 0) {
 #endif
-          err = awkward_numpyarray_fill_todouble_from32(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<int32_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_from32(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<int32_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (format_.compare("L") == 0) {
 #else
           else if (format_.compare("I") == 0) {
 #endif
-          err = awkward_numpyarray_fill_todouble_fromU32(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<uint32_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromU32(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<uint32_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("h") == 0) {
-          err = awkward_numpyarray_fill_todouble_from16(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<int16_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_from16(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<int16_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("H") == 0) {
-          err = awkward_numpyarray_fill_todouble_fromU16(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<uint16_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromU16(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<uint16_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("b") == 0) {
-          err = awkward_numpyarray_fill_todouble_from8(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<int8_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_from8(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<int8_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("B") == 0  ||  format_.compare("c") == 0) {
-          err = awkward_numpyarray_fill_todouble_fromU8(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<uint8_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromU8(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<uint8_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("?") == 0) {
-          err = awkward_numpyarray_fill_todouble_frombool(reinterpret_cast<double*>(ptr.get()), 0, reinterpret_cast<bool*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_todouble_frombool(
+                  reinterpret_cast<double*>(ptr.get()),
+                  0,
+                  reinterpret_cast<bool*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else {
-          throw std::invalid_argument(std::string("cannot merge Numpy format \"") + format_ + std::string("\" with \"") + other_format + std::string("\""));
+          throw std::invalid_argument(
+            std::string("cannot merge Numpy format \"") + format_
+            + std::string("\" with \"") + other_format + std::string("\""));
         }
         util::handle_error(err, classname(), nullptr);
 
         if (other_format.compare("d") == 0) {
-          err = awkward_numpyarray_fill_todouble_fromdouble(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<double*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromdouble(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<double*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("f") == 0) {
-          err = awkward_numpyarray_fill_todouble_fromfloat(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<float*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromfloat(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<float*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
         else if (other_format.compare("q") == 0) {
 #else
         else if (other_format.compare("l") == 0) {
 #endif
-          err = awkward_numpyarray_fill_todouble_from64(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<int64_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_from64(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<int64_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (other_format.compare("Q") == 0) {
 #else
           else if (other_format.compare("L") == 0) {
 #endif
-          err = awkward_numpyarray_fill_todouble_fromU64(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<uint64_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromU64(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<uint64_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (other_format.compare("l") == 0) {
 #else
           else if (other_format.compare("i") == 0) {
 #endif
-          err = awkward_numpyarray_fill_todouble_from32(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<int32_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_from32(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<int32_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (other_format.compare("L") == 0) {
 #else
           else if (other_format.compare("I") == 0) {
 #endif
-          err = awkward_numpyarray_fill_todouble_fromU32(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<uint32_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromU32(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<uint32_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("h") == 0) {
-          err = awkward_numpyarray_fill_todouble_from16(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<int16_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_from16(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<int16_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("H") == 0) {
-          err = awkward_numpyarray_fill_todouble_fromU16(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<uint16_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromU16(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<uint16_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("b") == 0) {
-          err = awkward_numpyarray_fill_todouble_from8(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<int8_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_from8(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<int8_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("B") == 0  ||  format_.compare("c") == 0) {
-          err = awkward_numpyarray_fill_todouble_fromU8(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<uint8_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_fromU8(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<uint8_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("?") == 0) {
-          err = awkward_numpyarray_fill_todouble_frombool(reinterpret_cast<double*>(ptr.get()), self_flatlength, reinterpret_cast<bool*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_todouble_frombool(
+                  reinterpret_cast<double*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<bool*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else {
-          throw std::invalid_argument(std::string("cannot merge Numpy format \"") + format_ + std::string("\" with \"") + other_format + std::string("\""));
+          throw std::invalid_argument(
+            std::string("cannot merge Numpy format \"") + format_
+            + std::string("\" with \"") + other_format + std::string("\""));
         }
         util::handle_error(err, classname(), nullptr);
       }
 
       else if (format.compare("Q") == 0  ||  format.compare("L") == 0) {
-        err = awkward_numpyarray_fill_toU64_fromU64(reinterpret_cast<uint64_t*>(ptr.get()), 0, reinterpret_cast<uint64_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+        err = awkward_numpyarray_fill_toU64_fromU64(
+                reinterpret_cast<uint64_t*>(ptr.get()),
+                0,
+                reinterpret_cast<uint64_t*>(contiguous_self.ptr().get()),
+                self_offset,
+                self_flatlength);
         util::handle_error(err, classname(), nullptr);
-        err = awkward_numpyarray_fill_toU64_fromU64(reinterpret_cast<uint64_t*>(ptr.get()), self_flatlength, reinterpret_cast<uint64_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+        err = awkward_numpyarray_fill_toU64_fromU64(
+                reinterpret_cast<uint64_t*>(ptr.get()),
+                self_flatlength,
+                reinterpret_cast<uint64_t*>(contiguous_other.ptr().get()),
+                other_offset,
+                other_flatlength);
         util::handle_error(err, classname(), nullptr);
       }
 
@@ -1177,46 +1720,93 @@ namespace awkward {
 #else
         if (format_.compare("l") == 0) {
 #endif
-          err = awkward_numpyarray_fill_to64_from64(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<int64_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_from64(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<int64_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (format_.compare("Q") == 0) {
 #else
           else if (format_.compare("L") == 0) {
 #endif
-          err = awkward_numpyarray_fill_to64_fromU64(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<uint64_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_fromU64(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<uint64_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (format_.compare("l") == 0) {
 #else
           else if (format_.compare("i") == 0) {
 #endif
-          err = awkward_numpyarray_fill_to64_from32(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<int32_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_from32(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<int32_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (format_.compare("L") == 0) {
 #else
           else if (format_.compare("I") == 0) {
 #endif
-          err = awkward_numpyarray_fill_to64_fromU32(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<uint32_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_fromU32(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<uint32_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("h") == 0) {
-          err = awkward_numpyarray_fill_to64_from16(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<int16_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_from16(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<int16_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("H") == 0) {
-          err = awkward_numpyarray_fill_to64_fromU16(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<uint16_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_fromU16(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<uint16_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("b") == 0) {
-          err = awkward_numpyarray_fill_to64_from8(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<int8_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_from8(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<int8_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("B") == 0  ||  format_.compare("c") == 0) {
-          err = awkward_numpyarray_fill_to64_fromU8(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<uint8_t*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_fromU8(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<uint8_t*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else if (format_.compare("?") == 0) {
-          err = awkward_numpyarray_fill_to64_frombool(reinterpret_cast<int64_t*>(ptr.get()), 0, reinterpret_cast<bool*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+          err = awkward_numpyarray_fill_to64_frombool(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  0,
+                  reinterpret_cast<bool*>(contiguous_self.ptr().get()),
+                  self_offset,
+                  self_flatlength);
         }
         else {
-          throw std::invalid_argument(std::string("cannot merge Numpy format \"") + format_ + std::string("\" with \"") + other_format + std::string("\""));
+          throw std::invalid_argument(
+            std::string("cannot merge Numpy format \"") + format_
+            + std::string("\" with \"") + other_format + std::string("\""));
         }
         util::handle_error(err, classname(), nullptr);
 
@@ -1225,68 +1815,138 @@ namespace awkward {
 #else
         if (other_format.compare("l") == 0) {
 #endif
-          err = awkward_numpyarray_fill_to64_from64(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<int64_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_from64(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<int64_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (other_format.compare("Q") == 0) {
 #else
           else if (other_format.compare("L") == 0) {
 #endif
-          err = awkward_numpyarray_fill_to64_fromU64(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<uint64_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_fromU64(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<uint64_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (other_format.compare("l") == 0) {
 #else
           else if (other_format.compare("i") == 0) {
 #endif
-          err = awkward_numpyarray_fill_to64_from32(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<int32_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_from32(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<int32_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
 #if defined _MSC_VER || defined __i386__
           else if (other_format.compare("L") == 0) {
 #else
           else if (other_format.compare("I") == 0) {
 #endif
-          err = awkward_numpyarray_fill_to64_fromU32(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<uint32_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_fromU32(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<uint32_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("h") == 0) {
-          err = awkward_numpyarray_fill_to64_from16(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<int16_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_from16(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<int16_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("H") == 0) {
-          err = awkward_numpyarray_fill_to64_fromU16(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<uint16_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_fromU16(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<uint16_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("b") == 0) {
-          err = awkward_numpyarray_fill_to64_from8(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<int8_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_from8(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<int8_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("B") == 0  ||  format_.compare("c") == 0) {
-          err = awkward_numpyarray_fill_to64_fromU8(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<uint8_t*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_fromU8(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<uint8_t*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else if (other_format.compare("?") == 0) {
-          err = awkward_numpyarray_fill_to64_frombool(reinterpret_cast<int64_t*>(ptr.get()), self_flatlength, reinterpret_cast<bool*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+          err = awkward_numpyarray_fill_to64_frombool(
+                  reinterpret_cast<int64_t*>(ptr.get()),
+                  self_flatlength,
+                  reinterpret_cast<bool*>(contiguous_other.ptr().get()),
+                  other_offset,
+                  other_flatlength);
         }
         else {
-          throw std::invalid_argument(std::string("cannot merge Numpy format \"") + format_ + std::string("\" with \"") + other_format + std::string("\""));
+          throw std::invalid_argument(
+            std::string("cannot merge Numpy format \"") + format_
+            + std::string("\" with \"") + other_format + std::string("\""));
         }
         util::handle_error(err, classname(), nullptr);
       }
 
       else {
-        err = awkward_numpyarray_fill_tobool_frombool(reinterpret_cast<bool*>(ptr.get()), 0, reinterpret_cast<bool*>(contiguous_self.ptr().get()), self_offset, self_flatlength);
+        err = awkward_numpyarray_fill_tobool_frombool(
+                reinterpret_cast<bool*>(ptr.get()),
+                0,
+                reinterpret_cast<bool*>(contiguous_self.ptr().get()),
+                self_offset,
+                self_flatlength);
         util::handle_error(err, classname(), nullptr);
-        err = awkward_numpyarray_fill_tobool_frombool(reinterpret_cast<bool*>(ptr.get()), self_flatlength, reinterpret_cast<bool*>(contiguous_other.ptr().get()), other_offset, other_flatlength);
+        err = awkward_numpyarray_fill_tobool_frombool(
+                reinterpret_cast<bool*>(ptr.get()),
+                self_flatlength,
+                reinterpret_cast<bool*>(contiguous_other.ptr().get()),
+                other_offset,
+                other_flatlength);
         util::handle_error(err, classname(), nullptr);
       }
 
-      return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), ptr, shape, strides, 0, itemsize, format);
+      return std::make_shared<NumpyArray>(Identities::none(),
+                                          util::Parameters(),
+                                          ptr,
+                                          shape,
+                                          strides,
+                                          0,
+                                          itemsize,
+                                          format);
     }
 
     else {
-      throw std::invalid_argument(std::string("cannot merge ") + classname() + std::string(" with ") + other.get()->classname());
+      throw std::invalid_argument(
+        std::string("cannot merge ") + classname() + std::string(" with ")
+        + other.get()->classname());
     }
   }
 
-  const SliceItemPtr NumpyArray::asslice() const {
+  const SliceItemPtr
+  NumpyArray::asslice() const {
     if (ndim() != 1) {
-      throw std::invalid_argument("slice items can have all fixed-size dimensions (to follow NumPy's slice rules) or they can have all var-sized dimensions (for jagged indexing), but not both in the same slice item");
+      throw std::invalid_argument(
+        "slice items can have all fixed-size dimensions (to follow NumPy's "
+        "slice rules) or they can have all var-sized dimensions (for jagged "
+        "indexing), but not both in the same slice item");
     }
 #if defined _MSC_VER || defined __i386__
     if (format_.compare("q") == 0) {
@@ -1296,12 +1956,28 @@ namespace awkward {
       int64_t* raw = reinterpret_cast<int64_t*>(ptr_.get());
       std::shared_ptr<int64_t> ptr(ptr_, raw);
       std::vector<int64_t> shape({ (int64_t)shape_[0] });
-      std::vector<int64_t> strides({ (int64_t)strides_[0] / (int64_t)itemsize_ });
-      return std::make_shared<SliceArray64>(Index64(ptr, (int64_t)byteoffset_ / (int64_t)itemsize_, length()), shape, strides, false);
+      std::vector<int64_t> strides({ (int64_t)strides_[0] /
+                                     (int64_t)itemsize_ });
+      return std::make_shared<SliceArray64>(
+        Index64(ptr, (int64_t)byteoffset_ / (int64_t)itemsize_, length()),
+        shape,
+        strides,
+        false);
     }
-    else if (format_.compare("q") == 0  ||  format_.compare("Q") == 0  ||  format_.compare("l") == 0  ||  format_.compare("L") == 0  ||  format_.compare("i") == 0  ||  format_.compare("I") == 0  ||  format_.compare("h") == 0  ||  format_.compare("H") == 0  ||  format_.compare("b") == 0  ||  format_.compare("B") == 0  ||  format_.compare("c") == 0) {
+    else if (format_.compare("q") == 0  ||
+             format_.compare("Q") == 0  ||
+             format_.compare("l") == 0  ||
+             format_.compare("L") == 0  ||
+             format_.compare("i") == 0  ||
+             format_.compare("I") == 0  ||
+             format_.compare("h") == 0  ||
+             format_.compare("H") == 0  ||
+             format_.compare("b") == 0  ||
+             format_.compare("B") == 0  ||
+             format_.compare("c") == 0) {
       NumpyArray contiguous_self = contiguous();
-      int64_t offset = (int64_t)contiguous_self.byteoffset() / (int64_t)itemsize_;
+      int64_t offset = ((int64_t)contiguous_self.byteoffset() /
+                        (int64_t)itemsize_);
       Index64 index(length());
       struct Error err;
 #if defined _MSC_VER || defined __i386__
@@ -1309,33 +1985,68 @@ namespace awkward {
 #else
       if (format_.compare("L") == 0) {
 #endif
-        err = awkward_numpyarray_fill_to64_fromU64(index.ptr().get(), 0, reinterpret_cast<uint64_t*>(contiguous_self.ptr().get()), offset, length());
+        err = awkward_numpyarray_fill_to64_fromU64(
+                index.ptr().get(),
+                0,
+                reinterpret_cast<uint64_t*>(contiguous_self.ptr().get()),
+                offset,
+                length());
       }
 #if defined _MSC_VER || defined __i386__
       else if (format_.compare("l") == 0) {
 #else
       else if (format_.compare("i") == 0) {
 #endif
-        err = awkward_numpyarray_fill_to64_from32(index.ptr().get(), 0, reinterpret_cast<int32_t*>(contiguous_self.ptr().get()), offset, length());
+        err = awkward_numpyarray_fill_to64_from32(
+                index.ptr().get(),
+                0,
+                reinterpret_cast<int32_t*>(contiguous_self.ptr().get()),
+                offset,
+                length());
       }
 #if defined _MSC_VER || defined __i386__
       else if (format_.compare("L") == 0) {
 #else
       else if (format_.compare("I") == 0) {
 #endif
-        err = awkward_numpyarray_fill_to64_fromU32(index.ptr().get(), 0, reinterpret_cast<uint32_t*>(contiguous_self.ptr().get()), offset, length());
+        err = awkward_numpyarray_fill_to64_fromU32(
+                index.ptr().get(),
+                0,
+                reinterpret_cast<uint32_t*>(contiguous_self.ptr().get()),
+                offset,
+                length());
       }
       else if (format_.compare("h") == 0) {
-        err = awkward_numpyarray_fill_to64_from16(index.ptr().get(), 0, reinterpret_cast<int16_t*>(contiguous_self.ptr().get()), offset, length());
+        err = awkward_numpyarray_fill_to64_from16(
+                index.ptr().get(),
+                0,
+                reinterpret_cast<int16_t*>(contiguous_self.ptr().get()),
+                offset,
+                length());
       }
       else if (format_.compare("H") == 0) {
-        err = awkward_numpyarray_fill_to64_fromU16(index.ptr().get(), 0, reinterpret_cast<uint16_t*>(contiguous_self.ptr().get()), offset, length());
+        err = awkward_numpyarray_fill_to64_fromU16(
+                index.ptr().get(),
+                0,
+                reinterpret_cast<uint16_t*>(contiguous_self.ptr().get()),
+                offset,
+                length());
       }
       else if (format_.compare("b") == 0) {
-        err = awkward_numpyarray_fill_to64_from8(index.ptr().get(), 0, reinterpret_cast<int8_t*>(contiguous_self.ptr().get()), offset, length());
+        err = awkward_numpyarray_fill_to64_from8(
+                index.ptr().get(),
+                0,
+                reinterpret_cast<int8_t*>(contiguous_self.ptr().get()),
+                offset,
+                length());
       }
       else if (format_.compare("B") == 0  ||  format_.compare("c") == 0) {
-        err = awkward_numpyarray_fill_to64_fromU8(index.ptr().get(), 0, reinterpret_cast<uint8_t*>(contiguous_self.ptr().get()), offset, length());
+        err = awkward_numpyarray_fill_to64_fromU8(
+                index.ptr().get(),
+                0,
+                reinterpret_cast<uint8_t*>(contiguous_self.ptr().get()),
+                offset,
+                length());
       }
       else {
         throw std::runtime_error("oops: check format_.compare cases above");
@@ -1370,15 +2081,18 @@ namespace awkward {
       return std::make_shared<SliceArray64>(index, shape, strides, true);
     }
     else {
-      throw std::invalid_argument("only arrays of integers or booleans may be used as a slice");
+      throw std::invalid_argument(
+        "only arrays of integers or booleans may be used as a slice");
     }
   }
 
-  const ContentPtr NumpyArray::fillna(const ContentPtr& value) const {
+  const ContentPtr
+  NumpyArray::fillna(const ContentPtr& value) const {
     return shallow_copy();
   }
 
-  const ContentPtr NumpyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  NumpyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     if (ndim() == 0) {
       throw std::runtime_error("cannot rpad a scalar");
     }
@@ -1397,7 +2111,8 @@ namespace awkward {
     }
   }
 
-  const ContentPtr NumpyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  NumpyArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     if (ndim() == 0) {
       throw std::runtime_error("cannot rpad a scalar");
     }
@@ -1411,73 +2126,139 @@ namespace awkward {
     return rpad_axis0(target, true);
   }
 
-  const ContentPtr NumpyArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr
+  NumpyArray::reduce_next(const Reducer& reducer,
+                          int64_t negaxis,
+                          const Index64& starts,
+                          const Index64& parents,
+                          int64_t outlength,
+                          bool mask,
+                          bool keepdims) const {
     if (shape_.empty()) {
       throw std::runtime_error("attempting to reduce a scalar");
     }
     else if (shape_.size() != 1  ||  !iscontiguous()) {
-      return toRegularArray().get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+      return toRegularArray().get()->reduce_next(reducer,
+                                                 negaxis,
+                                                 starts,
+                                                 parents,
+                                                 outlength,
+                                                 mask,
+                                                 keepdims);
     }
     else {
       std::shared_ptr<void> ptr;
       if (format_.compare("?") == 0) {
-        ptr = reducer.apply_bool(reinterpret_cast<bool*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_bool(reinterpret_cast<bool*>(ptr_.get()),
+                                 byteoffset_ / itemsize_,
+                                 starts,
+                                 parents,
+                                 outlength);
       }
       else if (format_.compare("b") == 0) {
-        ptr = reducer.apply_int8(reinterpret_cast<int8_t*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_int8(reinterpret_cast<int8_t*>(ptr_.get()),
+                                 byteoffset_ / itemsize_,
+                                 starts,
+                                 parents,
+                                 outlength);
       }
       else if (format_.compare("B") == 0  ||  format_.compare("c") == 0) {
-        ptr = reducer.apply_uint8(reinterpret_cast<uint8_t*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_uint8(reinterpret_cast<uint8_t*>(ptr_.get()),
+                                  byteoffset_ / itemsize_,
+                                  starts,
+                                  parents,
+                                  outlength);
       }
       else if (format_.compare("h") == 0) {
-        ptr = reducer.apply_int16(reinterpret_cast<int16_t*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_int16(reinterpret_cast<int16_t*>(ptr_.get()),
+                                  byteoffset_ / itemsize_,
+                                  starts,
+                                  parents,
+                                  outlength);
       }
       else if (format_.compare("H") == 0) {
-        ptr = reducer.apply_uint16(reinterpret_cast<uint16_t*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_uint16(reinterpret_cast<uint16_t*>(ptr_.get()),
+                                   byteoffset_ / itemsize_,
+                                   starts,
+                                   parents,
+                                   outlength);
       }
 #if defined _MSC_VER || defined __i386__
       else if (format_.compare("l") == 0) {
 #else
       else if (format_.compare("i") == 0) {
 #endif
-        ptr = reducer.apply_int32(reinterpret_cast<int32_t*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_int32(reinterpret_cast<int32_t*>(ptr_.get()),
+                                  byteoffset_ / itemsize_,
+                                  starts,
+                                  parents,
+                                  outlength);
       }
 #if defined _MSC_VER || defined __i386__
       else if (format_.compare("L") == 0) {
 #else
       else if (format_.compare("I") == 0) {
 #endif
-        ptr = reducer.apply_uint32(reinterpret_cast<uint32_t*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_uint32(reinterpret_cast<uint32_t*>(ptr_.get()),
+                                   byteoffset_ / itemsize_,
+                                   starts,
+                                   parents,
+                                   outlength);
       }
 #if defined _MSC_VER || defined __i386__
       else if (format_.compare("q") == 0) {
 #else
       else if (format_.compare("l") == 0) {
 #endif
-        ptr = reducer.apply_int64(reinterpret_cast<int64_t*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_int64(reinterpret_cast<int64_t*>(ptr_.get()),
+                                  byteoffset_ / itemsize_,
+                                  starts,
+                                  parents,
+                                  outlength);
       }
 #if defined _MSC_VER || defined __i386__
       else if (format_.compare("Q") == 0) {
 #else
       else if (format_.compare("L") == 0) {
 #endif
-        ptr = reducer.apply_uint64(reinterpret_cast<uint64_t*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_uint64(reinterpret_cast<uint64_t*>(ptr_.get()),
+                                   byteoffset_ / itemsize_,
+                                   starts,
+                                   parents,
+                                   outlength);
       }
       else if (format_.compare("f") == 0) {
-        ptr = reducer.apply_float32(reinterpret_cast<float*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_float32(reinterpret_cast<float*>(ptr_.get()),
+                                    byteoffset_ / itemsize_,
+                                    starts,
+                                    parents,
+                                    outlength);
       }
       else if (format_.compare("d") == 0) {
-        ptr = reducer.apply_float64(reinterpret_cast<double*>(ptr_.get()), byteoffset_ / itemsize_, starts, parents, outlength);
+        ptr = reducer.apply_float64(reinterpret_cast<double*>(ptr_.get()),
+                                    byteoffset_ / itemsize_,
+                                    starts,
+                                    parents,
+                                    outlength);
       }
       else {
-        throw std::invalid_argument(std::string("cannot apply reducers to NumpyArray with format \"") + format_ + std::string("\""));
+        throw std::invalid_argument(
+          std::string("cannot apply reducers to NumpyArray with format \"")
+          + format_ + std::string("\""));
       }
 
       std::string format = reducer.return_type(format_);
       ssize_t itemsize = reducer.return_typesize(format_);
       std::vector<ssize_t> shape({ (ssize_t)outlength });
       std::vector<ssize_t> strides({ itemsize });
-      ContentPtr out = std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), ptr, shape, strides, 0, itemsize, format);
+      ContentPtr out = std::make_shared<NumpyArray>(Identities::none(),
+                                                    util::Parameters(),
+                                                    ptr,
+                                                    shape,
+                                                    strides,
+                                                    0,
+                                                    itemsize,
+                                                    format);
 
       if (mask) {
         Index8 mask(outlength);
@@ -1488,18 +2269,26 @@ namespace awkward {
           parents.length(),
           outlength);
         util::handle_error(err, classname(), nullptr);
-        out = std::make_shared<ByteMaskedArray>(Identities::none(), util::Parameters(), mask, out, false);
+        out = std::make_shared<ByteMaskedArray>(Identities::none(),
+                                                util::Parameters(),
+                                                mask,
+                                                out,
+                                                false);
       }
 
       if (keepdims) {
-        out = std::make_shared<RegularArray>(Identities::none(), util::Parameters(), out, 1);
+        out = std::make_shared<RegularArray>(Identities::none(),
+                                             util::Parameters(),
+                                             out,
+                                             1);
       }
 
       return out;
     }
   }
 
-  const ContentPtr NumpyArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  NumpyArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1512,7 +2301,13 @@ namespace awkward {
     }
   }
 
-  const ContentPtr NumpyArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  NumpyArray::choose(int64_t n,
+                     bool diagonal,
+                     const util::RecordLookupPtr& recordlookup,
+                     const util::Parameters& parameters,
+                     int64_t axis,
+                     int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1527,70 +2322,125 @@ namespace awkward {
     }
 
     else {
-      return toRegularArray().get()->choose(n, diagonal, recordlookup, parameters, axis, depth);
+      return toRegularArray().get()->choose(n,
+                                            diagonal,
+                                            recordlookup,
+                                            parameters,
+                                            axis,
+                                            depth);
     }
   }
 
-  const ContentPtr NumpyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: NumpyArray::getitem_next(at) (without 'length', 'stride', and 'first')");
+  const ContentPtr
+  NumpyArray::getitem_next(const SliceAt& at,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: NumpyArray::getitem_next(at) "
+      "(without 'length', 'stride', and 'first')");
   }
 
-  const ContentPtr NumpyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: NumpyArray::getitem_next(range) (without 'length', 'stride', and 'first')");
+  const ContentPtr
+  NumpyArray::getitem_next(const SliceRange& range,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: NumpyArray::getitem_next(range) "
+      "(without 'length', 'stride', and 'first')");
   }
 
-  const ContentPtr NumpyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: NumpyArray::getitem_next(array) (without 'length', 'stride', and 'first')");
+  const ContentPtr
+  NumpyArray::getitem_next(const SliceArray64& array,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: NumpyArray::getitem_next(array) "
+      "(without 'length','stride', and 'first')");
   }
 
-  const ContentPtr NumpyArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: NumpyArray::getitem_next(field) (without 'length', 'stride', and 'first')");
+  const ContentPtr
+  NumpyArray::getitem_next(const SliceField& field,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: NumpyArray::getitem_next(field) "
+      "(without 'length', 'stride', and 'first')");
   }
 
-  const ContentPtr NumpyArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: NumpyArray::getitem_next(fields) (without 'length', 'stride', and 'first')");
+  const ContentPtr
+  NumpyArray::getitem_next(const SliceFields& fields,
+                           const Slice& tail,
+                           const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: NumpyArray::getitem_next(fields) "
+      "(without 'length', 'stride', and 'first')");
   }
 
-  const ContentPtr NumpyArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  NumpyArray::getitem_next(const SliceJagged64& jagged,
+                           const Slice& tail, const Index64& advanced) const {
     if (shape_.size() != 1) {
-      throw std::runtime_error("undefined operation: NumpyArray::getitem_next(jagged) with ndim != 1");
+      throw std::runtime_error(
+        "undefined operation: NumpyArray::getitem_next(jagged) with ndim != 1");
     }
 
     if (advanced.length() != 0) {
-      throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
+      throw std::invalid_argument(
+        "cannot mix jagged slice with NumPy-style advanced indexing");
     }
 
-    throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a jagged array because it is one-dimensional"));
+    throw std::invalid_argument(
+      std::string("cannot slice ") + classname()
+      + std::string(" by a jagged array because it is one-dimensional"));
   }
 
-  const ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  NumpyArray::getitem_next_jagged(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const SliceArray64& slicecontent,
+                                  const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }
     else {
-      throw std::runtime_error(std::string("undefined operation: NumpyArray::getitem_next_jagged(array) for ndim == ") + std::to_string(ndim()));
+      throw std::runtime_error(
+        std::string("undefined operation: NumpyArray::getitem_next_jagged("
+                    "array) for ndim == ") + std::to_string(ndim()));
     }
   }
 
-  const ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  NumpyArray::getitem_next_jagged(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const SliceMissing64& slicecontent,
+                                  const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }
     else {
-      throw std::runtime_error(std::string("undefined operation: NumpyArray::getitem_next_jagged(missing) for ndim == ") + std::to_string(ndim()));
+      throw std::runtime_error(
+        std::string("undefined operation: NumpyArray::getitem_next_jagged("
+                    "missing) for ndim == ") + std::to_string(ndim()));
     }
   }
 
-  const ContentPtr NumpyArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  NumpyArray::getitem_next_jagged(const Index64& slicestarts,
+                                  const Index64& slicestops,
+                                  const SliceJagged64& slicecontent,
+                                  const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument("too many jagged slice dimensions for array");
     }
     else {
-      throw std::runtime_error(std::string("undefined operation: NumpyArray::getitem_next_jagged(jagged) for ndim == ") + std::to_string(ndim()));
+      throw std::runtime_error(
+        std::string("undefined operation: NumpyArray::getitem_next_jagged("
+                    "jagged) for ndim == ") + std::to_string(ndim()));
     }
   }
 
-  bool NumpyArray::iscontiguous() const {
+  bool
+  NumpyArray::iscontiguous() const {
     ssize_t x = itemsize_;
     for (ssize_t i = ndim() - 1;  i >= 0;  i--) {
       if (x != strides_[i]) return false;
@@ -1599,21 +2449,35 @@ namespace awkward {
     return true;  // true for isscalar(), too
   }
 
-  const NumpyArray NumpyArray::contiguous() const {
+  const NumpyArray
+  NumpyArray::contiguous() const {
     if (iscontiguous()) {
-      return NumpyArray(identities_, parameters_, ptr_, shape_, strides_, byteoffset_, itemsize_, format_);
+      return NumpyArray(identities_,
+                        parameters_,
+                        ptr_,
+                        shape_,
+                        strides_,
+                        byteoffset_,
+                        itemsize_,
+                        format_);
     }
     else {
       Index64 bytepos(shape_[0]);
-      struct Error err = awkward_numpyarray_contiguous_init_64(bytepos.ptr().get(), shape_[0], strides_[0]);
+      struct Error err =
+        awkward_numpyarray_contiguous_init_64(bytepos.ptr().get(),
+                                              shape_[0],
+                                              strides_[0]);
       util::handle_error(err, classname(), identities_.get());
       return contiguous_next(bytepos);
     }
   }
 
-  const NumpyArray NumpyArray::contiguous_next(const Index64& bytepos) const {
+  const NumpyArray
+  NumpyArray::contiguous_next(const Index64& bytepos) const {
     if (iscontiguous()) {
-      std::shared_ptr<void> ptr(new uint8_t[(size_t)(bytepos.length()*strides_[0])], util::array_deleter<uint8_t>());
+      std::shared_ptr<void> ptr(
+        new uint8_t[(size_t)(bytepos.length()*strides_[0])],
+        util::array_deleter<uint8_t>());
       struct Error err = awkward_numpyarray_contiguous_copy_64(
         reinterpret_cast<uint8_t*>(ptr.get()),
         reinterpret_cast<uint8_t*>(ptr_.get()),
@@ -1622,11 +2486,20 @@ namespace awkward {
         byteoffset_,
         bytepos.ptr().get());
       util::handle_error(err, classname(), identities_.get());
-      return NumpyArray(identities_, parameters_, ptr, shape_, strides_, 0, itemsize_, format_);
+      return NumpyArray(identities_,
+                        parameters_,
+                        ptr,
+                        shape_,
+                        strides_,
+                        0,
+                        itemsize_,
+                        format_);
     }
 
     else if (shape_.size() == 1) {
-      std::shared_ptr<void> ptr(new uint8_t[(size_t)(bytepos.length()*itemsize_)], util::array_deleter<uint8_t>());
+      std::shared_ptr<void> ptr(
+        new uint8_t[(size_t)(bytepos.length()*itemsize_)],
+        util::array_deleter<uint8_t>());
       struct Error err = awkward_numpyarray_contiguous_copy_64(
         reinterpret_cast<uint8_t*>(ptr.get()),
         reinterpret_cast<uint8_t*>(ptr_.get()),
@@ -1636,11 +2509,25 @@ namespace awkward {
         bytepos.ptr().get());
       util::handle_error(err, classname(), identities_.get());
       std::vector<ssize_t> strides = { itemsize_ };
-      return NumpyArray(identities_, parameters_, ptr, shape_, strides, 0, itemsize_, format_);
+      return NumpyArray(identities_,
+                        parameters_,
+                        ptr,
+                        shape_,
+                        strides,
+                        0,
+                        itemsize_,
+                        format_);
     }
 
     else {
-      NumpyArray next(identities_, parameters_, ptr_, flatten_shape(shape_), flatten_strides(strides_), byteoffset_, itemsize_, format_);
+      NumpyArray next(identities_,
+                      parameters_,
+                      ptr_,
+                      flatten_shape(shape_),
+                      flatten_strides(strides_),
+                      byteoffset_,
+                      itemsize_,
+                      format_);
 
       Index64 nextbytepos(bytepos.length()*shape_[1]);
       struct Error err = awkward_numpyarray_contiguous_next_64(
@@ -1653,45 +2540,85 @@ namespace awkward {
 
       NumpyArray out = next.contiguous_next(nextbytepos);
       std::vector<ssize_t> outstrides = { shape_[1]*out.strides_[0] };
-      outstrides.insert(outstrides.end(), out.strides_.begin(), out.strides_.end());
-      return NumpyArray(out.identities_, out.parameters_, out.ptr_, shape_, outstrides, out.byteoffset_, itemsize_, format_);
+      outstrides.insert(outstrides.end(),
+                        out.strides_.begin(),
+                        out.strides_.end());
+      return NumpyArray(out.identities_,
+                        out.parameters_,
+                        out.ptr_,
+                        shape_,
+                        outstrides,
+                        out.byteoffset_,
+                        itemsize_,
+                        format_);
     }
   }
 
-  const NumpyArray NumpyArray::getitem_bystrides(const SliceItemPtr& head, const Slice& tail, int64_t length) const {
+  const NumpyArray
+  NumpyArray::getitem_bystrides(const SliceItemPtr& head,
+                                const Slice& tail,
+                                int64_t length) const {
     if (head.get() == nullptr) {
-      return NumpyArray(identities_, parameters_, ptr_, shape_, strides_, byteoffset_, itemsize_, format_);
+      return NumpyArray(identities_,
+                        parameters_,
+                        ptr_,
+                        shape_,
+                        strides_,
+                        byteoffset_,
+                        itemsize_,
+                        format_);
     }
-    else if (SliceAt* at = dynamic_cast<SliceAt*>(head.get())) {
+    else if (SliceAt* at =
+             dynamic_cast<SliceAt*>(head.get())) {
       return getitem_bystrides(*at, tail, length);
     }
-    else if (SliceRange* range = dynamic_cast<SliceRange*>(head.get())) {
+    else if (SliceRange* range =
+             dynamic_cast<SliceRange*>(head.get())) {
       return getitem_bystrides(*range, tail, length);
     }
-    else if (SliceEllipsis* ellipsis = dynamic_cast<SliceEllipsis*>(head.get())) {
+    else if (SliceEllipsis* ellipsis =
+             dynamic_cast<SliceEllipsis*>(head.get())) {
       return getitem_bystrides(*ellipsis, tail, length);
     }
-    else if (SliceNewAxis* newaxis = dynamic_cast<SliceNewAxis*>(head.get())) {
+    else if (SliceNewAxis* newaxis =
+             dynamic_cast<SliceNewAxis*>(head.get())) {
       return getitem_bystrides(*newaxis, tail, length);
     }
     else {
-      throw std::runtime_error("unrecognized slice item type for NumpyArray::getitem_bystrides");
+      throw std::runtime_error(
+        "unrecognized slice item type for NumpyArray::getitem_bystrides");
     }
   }
 
-  const NumpyArray NumpyArray::getitem_bystrides(const SliceAt& at, const Slice& tail, int64_t length) const {
+  const NumpyArray
+  NumpyArray::getitem_bystrides(const SliceAt& at,
+                                const Slice& tail,
+                                int64_t length) const {
     if (ndim() < 2) {
-      util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("too many dimensions in slice", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
 
     int64_t i = at.at();
     if (i < 0) i += shape_[1];
     if (i < 0  ||  i >= shape_[1]) {
-      util::handle_error(failure("index out of range", kSliceNone, at.at()), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at.at()),
+        classname(),
+        identities_.get());
     }
 
     ssize_t nextbyteoffset = byteoffset_ + ((ssize_t)i)*strides_[1];
-    NumpyArray next(identities_, parameters_, ptr_, flatten_shape(shape_), flatten_strides(strides_), nextbyteoffset, itemsize_, format_);
+    NumpyArray next(identities_,
+                    parameters_,
+                    ptr_,
+                    flatten_shape(shape_),
+                    flatten_strides(strides_),
+                    nextbyteoffset,
+                    itemsize_,
+                    format_);
 
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
@@ -1699,12 +2626,25 @@ namespace awkward {
 
     std::vector<ssize_t> outshape = { (ssize_t)length };
     outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
-    return NumpyArray(out.identities_, out.parameters_, out.ptr_, outshape, out.strides_, out.byteoffset_, itemsize_, format_);
+    return NumpyArray(out.identities_,
+                      out.parameters_,
+                      out.ptr_,
+                      outshape,
+                      out.strides_,
+                      out.byteoffset_,
+                      itemsize_,
+                      format_);
   }
 
-  const NumpyArray NumpyArray::getitem_bystrides(const SliceRange& range, const Slice& tail, int64_t length) const {
+  const NumpyArray
+  NumpyArray::getitem_bystrides(const SliceRange& range,
+                                const Slice& tail,
+                                int64_t length) const {
     if (ndim() < 2) {
-      util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("too many dimensions in slice", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
 
     int64_t start = range.start();
@@ -1713,7 +2653,8 @@ namespace awkward {
     if (step == Slice::none()) {
       step = 1;
     }
-    awkward_regularize_rangeslice(&start, &stop, step > 0, range.hasstart(), range.hasstop(), (int64_t)shape_[1]);
+    awkward_regularize_rangeslice(&start, &stop, step > 0,
+      range.hasstart(), range.hasstop(), (int64_t)shape_[1]);
 
     int64_t numer = std::abs(start - stop);
     int64_t denom = std::abs(step);
@@ -1722,20 +2663,43 @@ namespace awkward {
     int64_t lenhead = d + (m != 0 ? 1 : 0);
 
     ssize_t nextbyteoffset = byteoffset_ + ((ssize_t)start)*strides_[1];
-    NumpyArray next(identities_, parameters_, ptr_, flatten_shape(shape_), flatten_strides(strides_), nextbyteoffset, itemsize_, format_);
+    NumpyArray next(identities_,
+                    parameters_,
+                    ptr_,
+                    flatten_shape(shape_),
+                    flatten_strides(strides_),
+                    nextbyteoffset,
+                    itemsize_,
+                    format_);
 
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
-    NumpyArray out = next.getitem_bystrides(nexthead, nexttail, length*lenhead);
+    NumpyArray out = next.getitem_bystrides(nexthead,
+                                            nexttail,
+                                            length*lenhead);
 
-    std::vector<ssize_t> outshape = { (ssize_t)length, (ssize_t)lenhead };
+    std::vector<ssize_t> outshape = { (ssize_t)length,
+                                      (ssize_t)lenhead };
     outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
-    std::vector<ssize_t> outstrides = { strides_[0], strides_[1]*((ssize_t)step) };
-    outstrides.insert(outstrides.end(), out.strides_.begin() + 1, out.strides_.end());
-    return NumpyArray(out.identities_, out.parameters_, out.ptr_, outshape, outstrides, out.byteoffset_, itemsize_, format_);
+    std::vector<ssize_t> outstrides = { strides_[0],
+                                        strides_[1]*((ssize_t)step) };
+    outstrides.insert(outstrides.end(),
+                      out.strides_.begin() + 1,
+                      out.strides_.end());
+    return NumpyArray(out.identities_,
+                      out.parameters_,
+                      out.ptr_,
+                      outshape,
+                      outstrides,
+                      out.byteoffset_,
+                      itemsize_,
+                      format_);
   }
 
-  const NumpyArray NumpyArray::getitem_bystrides(const SliceEllipsis& ellipsis, const Slice& tail, int64_t length) const {
+  const NumpyArray
+  NumpyArray::getitem_bystrides(const SliceEllipsis& ellipsis,
+                                const Slice& tail,
+                                int64_t length) const {
     std::pair<int64_t, int64_t> minmax = minmax_depth();
     int64_t mindepth = minmax.first;
 
@@ -1749,13 +2713,18 @@ namespace awkward {
       std::vector<SliceItemPtr> items = { std::make_shared<SliceEllipsis>() };
       items.insert(items.end(), tailitems.begin(), tailitems.end());
 
-      SliceItemPtr nexthead = std::make_shared<SliceRange>(Slice::none(), Slice::none(), 1);
+      SliceItemPtr nexthead = std::make_shared<SliceRange>(Slice::none(),
+                                                           Slice::none(),
+                                                           1);
       Slice nexttail(items);
       return getitem_bystrides(nexthead, nexttail, length);
     }
   }
 
-  const NumpyArray NumpyArray::getitem_bystrides(const SliceNewAxis& newaxis, const Slice& tail, int64_t length) const {
+  const NumpyArray
+  NumpyArray::getitem_bystrides(const SliceNewAxis& newaxis,
+                                const Slice& tail,
+                                int64_t length) const {
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
     NumpyArray out = getitem_bystrides(nexthead, nexttail, length);
@@ -1763,13 +2732,30 @@ namespace awkward {
     std::vector<ssize_t> outshape = { (ssize_t)length, 1 };
     outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
     std::vector<ssize_t> outstrides = { out.strides_[0] };
-    outstrides.insert(outstrides.end(), out.strides_.begin(), out.strides_.end());
-    return NumpyArray(out.identities_, out.parameters_, out.ptr_, outshape, outstrides, out.byteoffset_, itemsize_, format_);
+    outstrides.insert(outstrides.end(),
+                      out.strides_.begin(),
+                      out.strides_.end());
+    return NumpyArray(out.identities_,
+                      out.parameters_,
+                      out.ptr_,
+                      outshape,
+                      outstrides,
+                      out.byteoffset_,
+                      itemsize_,
+                      format_);
   }
 
-  const NumpyArray NumpyArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const {
+  const NumpyArray
+  NumpyArray::getitem_next(const SliceItemPtr& head,
+                           const Slice& tail,
+                           const Index64& carry,
+                           const Index64& advanced,
+                           int64_t length,
+                           int64_t stride,
+                           bool first) const {
     if (head.get() == nullptr) {
-      std::shared_ptr<void> ptr(new uint8_t[(size_t)(carry.length()*stride)], util::array_deleter<uint8_t>());
+      std::shared_ptr<void> ptr(new uint8_t[(size_t)(carry.length()*stride)],
+                                util::array_deleter<uint8_t>());
       struct Error err = awkward_numpyarray_getitem_next_null_64(
         reinterpret_cast<uint8_t*>(ptr.get()),
         reinterpret_cast<uint8_t*>(ptr_.get()),
@@ -1788,34 +2774,86 @@ namespace awkward {
       shape.insert(shape.end(), shape_.begin() + 1, shape_.end());
       std::vector<ssize_t> strides = { (ssize_t)stride };
       strides.insert(strides.end(), strides_.begin() + 1, strides_.end());
-      return NumpyArray(identities, parameters_, ptr, shape, strides, 0, itemsize_, format_);
+      return NumpyArray(identities,
+                        parameters_,
+                        ptr,
+                        shape,
+                        strides,
+                        0,
+                        itemsize_,
+                        format_);
     }
 
-    else if (SliceAt* at = dynamic_cast<SliceAt*>(head.get())) {
-      return getitem_next(*at, tail, carry, advanced, length, stride, first);
+    else if (SliceAt* at =
+             dynamic_cast<SliceAt*>(head.get())) {
+      return getitem_next(*at,
+                          tail,
+                          carry,
+                          advanced,
+                          length,
+                          stride,
+                          first);
     }
-    else if (SliceRange* range = dynamic_cast<SliceRange*>(head.get())) {
-      return getitem_next(*range, tail, carry, advanced, length, stride, first);
+    else if (SliceRange* range =
+             dynamic_cast<SliceRange*>(head.get())) {
+      return getitem_next(*range,
+                          tail,
+                          carry,
+                          advanced,
+                          length,
+                          stride,
+                          first);
     }
-    else if (SliceEllipsis* ellipsis = dynamic_cast<SliceEllipsis*>(head.get())) {
-      return getitem_next(*ellipsis, tail, carry, advanced, length, stride, first);
+    else if (SliceEllipsis* ellipsis =
+             dynamic_cast<SliceEllipsis*>(head.get())) {
+      return getitem_next(*ellipsis,
+                          tail,
+                          carry,
+                          advanced,
+                          length,
+                          stride,
+                          first);
     }
-    else if (SliceNewAxis* newaxis = dynamic_cast<SliceNewAxis*>(head.get())) {
-      return getitem_next(*newaxis, tail, carry, advanced, length, stride, first);
+    else if (SliceNewAxis* newaxis =
+             dynamic_cast<SliceNewAxis*>(head.get())) {
+      return getitem_next(*newaxis,
+                          tail,
+                          carry,
+                          advanced,
+                          length,
+                          stride,
+                          first);
     }
-    else if (SliceArray64* array = dynamic_cast<SliceArray64*>(head.get())) {
-      return getitem_next(*array, tail, carry, advanced, length, stride, first);
+    else if (SliceArray64* array =
+             dynamic_cast<SliceArray64*>(head.get())) {
+      return getitem_next(*array,
+                          tail,
+                          carry,
+                          advanced,
+                          length,
+                          stride,
+                          first);
     }
-    else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {
-      throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by a field name because it has no fields"));
+    else if (SliceField* field =
+             dynamic_cast<SliceField*>(head.get())) {
+      throw std::invalid_argument(
+        std::string("cannot slice ") + classname()
+        + std::string(" by a field name because it has no fields"));
     }
-    else if (SliceFields* fields = dynamic_cast<SliceFields*>(head.get())) {
-      throw std::invalid_argument(std::string("cannot slice ") + classname() + std::string(" by field names because it has no fields"));
+    else if (SliceFields* fields =
+             dynamic_cast<SliceFields*>(head.get())) {
+      throw std::invalid_argument(
+        std::string("cannot slice ") + classname()
+        + std::string(" by field names because it has no fields"));
     }
-    else if (SliceMissing64* missing = dynamic_cast<SliceMissing64*>(head.get())) {
-      throw std::runtime_error("undefined operation: NumpyArray::getitem_next(missing) (defer to Content::getitem_next(missing))");
+    else if (SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(head.get())) {
+      throw std::runtime_error(
+        "undefined operation: NumpyArray::getitem_next(missing) "
+        "(defer to Content::getitem_next(missing))");
     }
-    else if (SliceJagged64* jagged = dynamic_cast<SliceJagged64*>(head.get())) {
+    else if (SliceJagged64* jagged =
+             dynamic_cast<SliceJagged64*>(head.get())) {
       throw std::runtime_error("FIXME: NumpyArray::getitem_next(jagged)");
     }
     else {
@@ -1823,12 +2861,29 @@ namespace awkward {
     }
   }
 
-  const NumpyArray NumpyArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const {
+  const NumpyArray
+  NumpyArray::getitem_next(const SliceAt& at,
+                           const Slice& tail,
+                           const Index64& carry,
+                           const Index64& advanced,
+                           int64_t length,
+                           int64_t stride,
+                           bool first) const {
     if (ndim() < 2) {
-      util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("too many dimensions in slice", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
 
-    NumpyArray next(first ? identities_ : Identities::none(), parameters_, ptr_, flatten_shape(shape_), flatten_strides(strides_), byteoffset_, itemsize_, format_);
+    NumpyArray next(first ? identities_ : Identities::none(),
+                    parameters_,
+                    ptr_,
+                    flatten_shape(shape_),
+                    flatten_strides(strides_),
+                    byteoffset_,
+                    itemsize_,
+                    format_);
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
 
@@ -1837,7 +2892,10 @@ namespace awkward {
       regular_at += shape_[1];
     }
     if (!(0 <= regular_at  &&  regular_at < shape_[1])) {
-      util::handle_error(failure("index out of range", kSliceNone, at.at()), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at.at()),
+        classname(),
+        identities_.get());
     }
 
     Index64 nextcarry(carry.length());
@@ -1849,16 +2907,39 @@ namespace awkward {
       regular_at);
     util::handle_error(err, classname(), identities_.get());
 
-    NumpyArray out = next.getitem_next(nexthead, nexttail, nextcarry, advanced, length, next.strides_[0], false);
+    NumpyArray out = next.getitem_next(nexthead,
+                                       nexttail,
+                                       nextcarry,
+                                       advanced,
+                                       length,
+                                       next.strides_[0],
+                                       false);
 
     std::vector<ssize_t> outshape = { (ssize_t)length };
     outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
-    return NumpyArray(out.identities_, out.parameters_, out.ptr_, outshape, out.strides_, out.byteoffset_, itemsize_, format_);
+    return NumpyArray(out.identities_,
+                      out.parameters_,
+                      out.ptr_,
+                      outshape,
+                      out.strides_,
+                      out.byteoffset_,
+                      itemsize_,
+                      format_);
   }
 
-  const NumpyArray NumpyArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const {
+  const NumpyArray
+  NumpyArray::getitem_next(const SliceRange& range,
+                           const Slice& tail,
+                           const Index64& carry,
+                           const Index64& advanced,
+                           int64_t length,
+                           int64_t stride,
+                           bool first) const {
     if (ndim() < 2) {
-      util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("too many dimensions in slice", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
 
     int64_t start = range.start();
@@ -1867,7 +2948,12 @@ namespace awkward {
     if (step == Slice::none()) {
       step = 1;
     }
-    awkward_regularize_rangeslice(&start, &stop, step > 0, range.hasstart(), range.hasstop(), (int64_t)shape_[1]);
+    awkward_regularize_rangeslice(&start,
+                                  &stop,
+                                  step > 0,
+                                  range.hasstart(),
+                                  range.hasstop(),
+                                  (int64_t)shape_[1]);
 
     int64_t numer = std::abs(start - stop);
     int64_t denom = std::abs(step);
@@ -1875,7 +2961,14 @@ namespace awkward {
     int64_t m = numer % denom;
     int64_t lenhead = d + (m != 0 ? 1 : 0);
 
-    NumpyArray next(first ? identities_ : Identities::none(), parameters_, ptr_, flatten_shape(shape_), flatten_strides(strides_), byteoffset_, itemsize_, format_);
+    NumpyArray next(first ? identities_ : Identities::none(),
+                    parameters_,
+                    ptr_,
+                    flatten_shape(shape_),
+                    flatten_strides(strides_),
+                    byteoffset_,
+                    itemsize_,
+                    format_);
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
 
@@ -1891,12 +2984,29 @@ namespace awkward {
         step);
       util::handle_error(err, classname(), identities_.get());
 
-      NumpyArray out = next.getitem_next(nexthead, nexttail, nextcarry, advanced, length*lenhead, next.strides_[0], false);
+      NumpyArray out = next.getitem_next(nexthead,
+                                         nexttail,
+                                         nextcarry,
+                                         advanced,
+                                         length*lenhead,
+                                         next.strides_[0],
+                                         false);
       std::vector<ssize_t> outshape = { (ssize_t)length, (ssize_t)lenhead };
-      outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
+      outshape.insert(outshape.end(),
+                      out.shape_.begin() + 1,
+                      out.shape_.end());
       std::vector<ssize_t> outstrides = { (ssize_t)lenhead*out.strides_[0] };
-      outstrides.insert(outstrides.end(), out.strides_.begin(), out.strides_.end());
-      return NumpyArray(out.identities_, out.parameters_, out.ptr_, outshape, outstrides, out.byteoffset_, itemsize_, format_);
+      outstrides.insert(outstrides.end(),
+                        out.strides_.begin(),
+                        out.strides_.end());
+      return NumpyArray(out.identities_,
+                        out.parameters_,
+                        out.ptr_,
+                        outshape,
+                        outstrides,
+                        out.byteoffset_,
+                        itemsize_,
+                        format_);
     }
 
     else {
@@ -1914,52 +3024,131 @@ namespace awkward {
         step);
       util::handle_error(err, classname(), identities_.get());
 
-      NumpyArray out = next.getitem_next(nexthead, nexttail, nextcarry, nextadvanced, length*lenhead, next.strides_[0], false);
+      NumpyArray out = next.getitem_next(nexthead,
+                                         nexttail,
+                                         nextcarry,
+                                         nextadvanced,
+                                         length*lenhead,
+                                         next.strides_[0],
+                                         false);
       std::vector<ssize_t> outshape = { (ssize_t)length, (ssize_t)lenhead };
-      outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
+      outshape.insert(outshape.end(),
+                      out.shape_.begin() + 1,
+                      out.shape_.end());
       std::vector<ssize_t> outstrides = { (ssize_t)lenhead*out.strides_[0] };
-      outstrides.insert(outstrides.end(), out.strides_.begin(), out.strides_.end());
-      return NumpyArray(out.identities_, out.parameters_, out.ptr_, outshape, outstrides, out.byteoffset_, itemsize_, format_);
+      outstrides.insert(outstrides.end(),
+                        out.strides_.begin(),
+                        out.strides_.end());
+      return NumpyArray(out.identities_,
+                        out.parameters_,
+                        out.ptr_,
+                        outshape,
+                        outstrides,
+                        out.byteoffset_,
+                        itemsize_,
+                        format_);
     }
   }
 
-  const NumpyArray NumpyArray::getitem_next(const SliceEllipsis& ellipsis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const {
+  const NumpyArray
+  NumpyArray::getitem_next(const SliceEllipsis& ellipsis,
+                           const Slice& tail,
+                           const Index64& carry,
+                           const Index64& advanced,
+                           int64_t length,
+                           int64_t stride,
+                           bool first) const {
     std::pair<int64_t, int64_t> minmax = minmax_depth();
     int64_t mindepth = minmax.first;
 
     if (tail.length() == 0  ||  mindepth - 1 == tail.dimlength()) {
       SliceItemPtr nexthead = tail.head();
       Slice nexttail = tail.tail();
-      return getitem_next(nexthead, nexttail, carry, advanced, length, stride, false);
+      return getitem_next(nexthead,
+                          nexttail,
+                          carry,
+                          advanced,
+                          length,
+                          stride,
+                          false);
     }
     else {
       std::vector<SliceItemPtr> tailitems = tail.items();
       std::vector<SliceItemPtr> items = { std::make_shared<SliceEllipsis>() };
       items.insert(items.end(), tailitems.begin(), tailitems.end());
-      SliceItemPtr nexthead = std::make_shared<SliceRange>(Slice::none(), Slice::none(), 1);
+      SliceItemPtr nexthead = std::make_shared<SliceRange>(Slice::none(),
+                                                           Slice::none(),
+                                                           1);
       Slice nexttail(items);
-      return getitem_next(nexthead, nexttail, carry, advanced, length, stride, false);
+      return getitem_next(nexthead,
+                          nexttail,
+                          carry,
+                          advanced,
+                          length,
+                          stride,
+                          false);
     }
   }
 
-  const NumpyArray NumpyArray::getitem_next(const SliceNewAxis& newaxis, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const {
+  const NumpyArray
+  NumpyArray::getitem_next(const SliceNewAxis& newaxis,
+                           const Slice& tail,
+                           const Index64& carry,
+                           const Index64& advanced,
+                           int64_t length,
+                           int64_t stride,
+                           bool first) const {
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
-    NumpyArray out = getitem_next(nexthead, nexttail, carry, advanced, length, stride, false);
+    NumpyArray out = getitem_next(nexthead,
+                                  nexttail,
+                                  carry,
+                                  advanced,
+                                  length,
+                                  stride,
+                                  false);
 
     std::vector<ssize_t> outshape = { (ssize_t)length, 1 };
-    outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
+    outshape.insert(outshape.end(),
+                    out.shape_.begin() + 1,
+                    out.shape_.end());
     std::vector<ssize_t> outstrides = { out.strides_[0] };
-    outstrides.insert(outstrides.end(), out.strides_.begin(), out.strides_.end());
-    return NumpyArray(out.identities_, out.parameters_, out.ptr_, outshape, outstrides, out.byteoffset_, itemsize_, format_);
+    outstrides.insert(outstrides.end(),
+                      out.strides_.begin(),
+                      out.strides_.end());
+    return NumpyArray(out.identities_,
+                      out.parameters_,
+                      out.ptr_,
+                      outshape,
+                      outstrides,
+                      out.byteoffset_,
+                      itemsize_,
+                      format_);
   }
 
-  const NumpyArray NumpyArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& carry, const Index64& advanced, int64_t length, int64_t stride, bool first) const {
+  const NumpyArray
+  NumpyArray::getitem_next(const SliceArray64& array,
+                           const Slice& tail,
+                           const Index64& carry,
+                           const Index64& advanced,
+                           int64_t length,
+                           int64_t stride,
+                           bool first) const {
     if (ndim() < 2) {
-      util::handle_error(failure("too many dimensions in slice", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("too many dimensions in slice", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
 
-    NumpyArray next(first ? identities_ : Identities::none(), parameters_, ptr_, flatten_shape(shape_), flatten_strides(strides_), byteoffset_, itemsize_, format_);
+    NumpyArray next(first ? identities_ : Identities::none(),
+                    parameters_,
+                    ptr_,
+                    flatten_shape(shape_),
+                    flatten_strides(strides_),
+                    byteoffset_,
+                    itemsize_,
+                    format_);
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
 
@@ -1983,20 +3172,36 @@ namespace awkward {
         shape_[1]);   // because this is contiguous
       util::handle_error(err, classname(), identities_.get());
 
-      NumpyArray out = next.getitem_next(nexthead, nexttail, nextcarry, nextadvanced, length*flathead.length(), next.strides_[0], false);
+      NumpyArray out = next.getitem_next(nexthead,
+                                         nexttail,
+                                         nextcarry,
+                                         nextadvanced,
+                                         length*flathead.length(),
+                                         next.strides_[0],
+                                         false);
 
       std::vector<ssize_t> outshape = { (ssize_t)length };
       std::vector<int64_t> arrayshape = array.shape();
       for (auto x = arrayshape.begin();  x != arrayshape.end();  ++x) {
         outshape.push_back((ssize_t)(*x));
       }
-      outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
+      outshape.insert(outshape.end(),
+                      out.shape_.begin() + 1,
+                      out.shape_.end());
 
-      std::vector<ssize_t> outstrides(out.strides_.begin(), out.strides_.end());
+      std::vector<ssize_t> outstrides(out.strides_.begin(),
+                                      out.strides_.end());
       for (auto x = arrayshape.rbegin();  x != arrayshape.rend();  ++x) {
         outstrides.insert(outstrides.begin(), ((ssize_t)(*x))*outstrides[0]);
       }
-      return NumpyArray(arrayshape.size() == 1 ? out.identities_ : Identities::none(), out.parameters_, out.ptr_, outshape, outstrides, out.byteoffset_, itemsize_, format_);
+      return NumpyArray(arrayshape.size() == 1 ? out.identities_ : Identities::none(),
+                        out.parameters_,
+                        out.ptr_,
+                        outshape,
+                        outstrides,
+                        out.byteoffset_,
+                        itemsize_,
+                        format_);
     }
 
     else {
@@ -2010,15 +3215,31 @@ namespace awkward {
         shape_[1]);   // because this is contiguous
       util::handle_error(err, classname(), identities_.get());
 
-      NumpyArray out = next.getitem_next(nexthead, nexttail, nextcarry, advanced, length*array.length(), next.strides_[0], false);
+      NumpyArray out = next.getitem_next(nexthead,
+                                         nexttail,
+                                         nextcarry,
+                                         advanced,
+                                         length*array.length(),
+                                         next.strides_[0],
+                                         false);
 
       std::vector<ssize_t> outshape = { (ssize_t)length };
-      outshape.insert(outshape.end(), out.shape_.begin() + 1, out.shape_.end());
-      return NumpyArray(out.identities_, out.parameters_, out.ptr_, outshape, out.strides_, out.byteoffset_, itemsize_, format_);
+      outshape.insert(outshape.end(),
+                      out.shape_.begin() + 1,
+                      out.shape_.end());
+      return NumpyArray(out.identities_,
+                        out.parameters_,
+                        out.ptr_,
+                        outshape,
+                        out.strides_,
+                        out.byteoffset_,
+                        itemsize_,
+                        format_);
     }
   }
 
-  void NumpyArray::tojson_boolean(ToJson& builder) const {
+  void
+  NumpyArray::tojson_boolean(ToJson& builder) const {
     if (ndim() == 0) {
       bool* array = reinterpret_cast<bool*>(byteptr());
       builder.boolean(array[0]);
@@ -2037,7 +3258,14 @@ namespace awkward {
       builder.beginlist();
       for (int64_t i = 0;  i < length();  i++) {
         ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)i);
-        NumpyArray numpy(Identities::none(), util::Parameters(), ptr_, shape, strides, byteoffset, itemsize_, format_);
+        NumpyArray numpy(Identities::none(),
+                         util::Parameters(),
+                         ptr_,
+                         shape,
+                         strides,
+                         byteoffset,
+                         itemsize_,
+                         format_);
         numpy.tojson_boolean(builder);
       }
       builder.endlist();
@@ -2045,7 +3273,8 @@ namespace awkward {
   }
 
   template <typename T>
-  void NumpyArray::tojson_integer(ToJson& builder) const {
+  void
+  NumpyArray::tojson_integer(ToJson& builder) const {
     if (ndim() == 0) {
       T* array = reinterpret_cast<T*>(byteptr());
       builder.integer(array[0]);
@@ -2064,7 +3293,14 @@ namespace awkward {
       builder.beginlist();
       for (int64_t i = 0;  i < length();  i++) {
         ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)i);
-        NumpyArray numpy(Identities::none(), util::Parameters(), ptr_, shape, strides, byteoffset, itemsize_, format_);
+        NumpyArray numpy(Identities::none(),
+                         util::Parameters(),
+                         ptr_,
+                         shape,
+                         strides,
+                         byteoffset,
+                         itemsize_,
+                         format_);
         numpy.tojson_integer<T>(builder);
       }
       builder.endlist();
@@ -2072,7 +3308,8 @@ namespace awkward {
   }
 
   template <typename T>
-  void NumpyArray::tojson_real(ToJson& builder) const {
+  void
+  NumpyArray::tojson_real(ToJson& builder) const {
     if (ndim() == 0) {
       T* array = reinterpret_cast<T*>(byteptr());
       builder.real(array[0]);
@@ -2091,14 +3328,22 @@ namespace awkward {
       builder.beginlist();
       for (int64_t i = 0;  i < length();  i++) {
         ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)i);
-        NumpyArray numpy(Identities::none(), util::Parameters(), ptr_, shape, strides, byteoffset, itemsize_, format_);
+        NumpyArray numpy(Identities::none(),
+                         util::Parameters(),
+                         ptr_,
+                         shape,
+                         strides,
+                         byteoffset,
+                         itemsize_,
+                         format_);
         numpy.tojson_real<T>(builder);
       }
       builder.endlist();
     }
   }
 
-  void NumpyArray::tojson_string(ToJson& builder) const {
+  void
+  NumpyArray::tojson_string(ToJson& builder) const {
     if (ndim() == 0) {
       char* array = reinterpret_cast<char*>(byteptr());
       builder.string(array, 1);
@@ -2113,7 +3358,14 @@ namespace awkward {
       builder.beginlist();
       for (int64_t i = 0;  i < length();  i++) {
         ssize_t byteoffset = byteoffset_ + strides_[0]*((ssize_t)i);
-        NumpyArray numpy(Identities::none(), util::Parameters(), ptr_, shape, strides, byteoffset, itemsize_, format_);
+        NumpyArray numpy(Identities::none(),
+                         util::Parameters(),
+                         ptr_,
+                         shape,
+                         strides,
+                         byteoffset,
+                         itemsize_,
+                         format_);
         numpy.tojson_string(builder);
       }
       builder.endlist();

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -288,7 +288,7 @@ namespace awkward {
     }
   }
 
-  const TypePtr NumpyArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr NumpyArray::type(const util::TypeStrs& typestrs) const {
     TypePtr out;
     if (format_.compare("d") == 0) {
       out = std::make_shared<PrimitiveType>(parameters_, util::gettypestr(parameters_, typestrs), PrimitiveType::float64);

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -69,7 +69,7 @@ namespace awkward {
     throw std::runtime_error("undefined operation: Record::setidentities");
   }
 
-  const TypePtr Record::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr Record::type(const util::TypeStrs& typestrs) const {
     TypePtr out = array_.get()->type(typestrs);
     out.get()->setparameters(parameters_);
     return out;

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -35,7 +35,7 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<util::RecordLookup> Record::recordlookup() const {
+  const util::RecordLookupPtr Record::recordlookup() const {
     return array_.get()->recordlookup();
   }
 
@@ -51,8 +51,8 @@ namespace awkward {
     return "Record";
   }
 
-  const std::shared_ptr<Identities> Record::identities() const {
-    std::shared_ptr<Identities> recidentities = array_.get()->identities();
+  const IdentitiesPtr Record::identities() const {
+    IdentitiesPtr recidentities = array_.get()->identities();
     if (recidentities.get() == nullptr) {
       return recidentities;
     }
@@ -65,12 +65,12 @@ namespace awkward {
     throw std::runtime_error("undefined operation: Record::setidentities");
   }
 
-  void Record::setidentities(const std::shared_ptr<Identities>& identities) {
+  void Record::setidentities(const IdentitiesPtr& identities) {
     throw std::runtime_error("undefined operation: Record::setidentities");
   }
 
-  const std::shared_ptr<Type> Record::type(const std::map<std::string, std::string>& typestrs) const {
-    std::shared_ptr<Type> out = array_.get()->type(typestrs);
+  const TypePtr Record::type(const std::map<std::string, std::string>& typestrs) const {
+    TypePtr out = array_.get()->type(typestrs);
     out.get()->setparameters(parameters_);
     return out;
   }
@@ -88,7 +88,7 @@ namespace awkward {
 
   void Record::tojson_part(ToJson& builder) const {
     size_t cols = (size_t)numfields();
-    std::shared_ptr<util::RecordLookup> keys = array_.get()->recordlookup();
+    util::RecordLookupPtr keys = array_.get()->recordlookup();
     if (istuple()) {
       keys = std::make_shared<util::RecordLookup>();
       for (size_t j = 0;  j < cols;  j++) {
@@ -233,7 +233,7 @@ namespace awkward {
     throw std::invalid_argument("Record cannot be merged because it is not an array");
   }
 
-  const std::shared_ptr<SliceItem> Record::asslice() const {
+  const SliceItemPtr Record::asslice() const {
     throw std::invalid_argument("cannot use a record as a slice");
   }
 
@@ -266,7 +266,7 @@ namespace awkward {
     }
   }
 
-  const ContentPtr Record::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr Record::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -299,7 +299,7 @@ namespace awkward {
 
   const std::vector<std::pair<std::string, ContentPtr>> Record::fielditems() const {
     std::vector<std::pair<std::string, ContentPtr>> out;
-    std::shared_ptr<util::RecordLookup> keys = array_.get()->recordlookup();
+    util::RecordLookupPtr keys = array_.get()->recordlookup();
     if (istuple()) {
       int64_t cols = numfields();
       for (int64_t j = 0;  j < cols;  j++) {

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -27,8 +27,8 @@ namespace awkward {
     return at_;
   }
 
-  const std::vector<std::shared_ptr<Content>> Record::contents() const {
-    std::vector<std::shared_ptr<Content>> out;
+  const std::vector<ContentPtr> Record::contents() const {
+    std::vector<ContentPtr> out;
     for (auto item : array_.get()->contents()) {
       out.push_back(item.get()->getitem_at_nowrap(at_));
     }
@@ -95,7 +95,7 @@ namespace awkward {
         keys.get()->push_back(std::to_string(j));
       }
     }
-    std::vector<std::shared_ptr<Content>> contents = array_.get()->contents();
+    std::vector<ContentPtr> contents = array_.get()->contents();
     builder.beginrecord();
     for (size_t j = 0;  j < cols;  j++) {
       builder.field(keys.get()->at(j).c_str());
@@ -112,12 +112,12 @@ namespace awkward {
     return -1;   // just like NumpyArray with ndim == 0, which is also a scalar
   }
 
-  ContentPtr Record::shallow_copy() const {
+  const ContentPtr Record::shallow_copy() const {
     return std::make_shared<Record>(array_, at_);
   }
 
-  ContentPtr Record::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
-    std::shared_ptr<Content> out = array_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+  const ContentPtr Record::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+    ContentPtr out = array_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     return std::make_shared<Record>(std::dynamic_pointer_cast<RecordArray>(out), at_);
   }
 
@@ -127,36 +127,36 @@ namespace awkward {
     }
   }
 
-  ContentPtr Record::getitem_nothing() const {
+  const ContentPtr Record::getitem_nothing() const {
     throw std::runtime_error("undefined operation: Record::getitem_nothing");
   }
 
-  ContentPtr Record::getitem_at(int64_t at) const {
+  const ContentPtr Record::getitem_at(int64_t at) const {
     throw std::invalid_argument(std::string("scalar Record can only be sliced by field name (string); try ") + util::quote(std::to_string(at), true));
   }
 
-  ContentPtr Record::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr Record::getitem_at_nowrap(int64_t at) const {
     throw std::invalid_argument(std::string("scalar Record can only be sliced by field name (string); try ") + util::quote(std::to_string(at), true));
   }
 
-  ContentPtr Record::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr Record::getitem_range(int64_t start, int64_t stop) const {
     throw std::invalid_argument("scalar Record can only be sliced by field name (string)");
   }
 
-  ContentPtr Record::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr Record::getitem_range_nowrap(int64_t start, int64_t stop) const {
     throw std::invalid_argument("scalar Record can only be sliced by field name (string)");
   }
 
-  ContentPtr Record::getitem_field(const std::string& key) const {
+  const ContentPtr Record::getitem_field(const std::string& key) const {
     return array_.get()->field(key).get()->getitem_at_nowrap(at_);
   }
 
-  ContentPtr Record::getitem_fields(const std::vector<std::string>& keys) const {
-    std::shared_ptr<Content> recordarray = array_.get()->getitem_fields(keys);
+  const ContentPtr Record::getitem_fields(const std::vector<std::string>& keys) const {
+    ContentPtr recordarray = array_.get()->getitem_fields(keys);
     return recordarray.get()->getitem_at_nowrap(at_);
   }
 
-  ContentPtr Record::carry(const Index64& carry) const {
+  const ContentPtr Record::carry(const Index64& carry) const {
     throw std::runtime_error("undefined operation: Record::carry");
   }
 
@@ -206,30 +206,30 @@ namespace awkward {
     return array_.get()->validityerror(path + std::string(".array"));
   }
 
-  ContentPtr Record::shallow_simplify() const {
+  const ContentPtr Record::shallow_simplify() const {
     return shallow_copy();
   }
 
-  ContentPtr Record::num(int64_t axis, int64_t depth) const {
+  const ContentPtr Record::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("cannot call 'num' with an 'axis' of 0 on a Record");
     }
     else {
-      std::shared_ptr<Content> singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
+      ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
       return singleton.get()->num(axis, depth).get()->getitem_at_nowrap(0);
     }
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> Record::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> Record::offsets_and_flattened(int64_t axis, int64_t depth) const {
     throw std::invalid_argument("Record cannot be flattened because it is not an array");
   }
 
-  bool Record::mergeable(ContentPtr& other, bool mergebool) const {
+  bool Record::mergeable(const ContentPtr& other, bool mergebool) const {
     throw std::invalid_argument("Record cannot be merged because it is not an array");
   }
 
-  ContentPtr Record::merge(ContentPtr& other) const {
+  const ContentPtr Record::merge(const ContentPtr& other) const {
     throw std::invalid_argument("Record cannot be merged because it is not an array");
   }
 
@@ -237,36 +237,36 @@ namespace awkward {
     throw std::invalid_argument("cannot use a record as a slice");
   }
 
-  ContentPtr Record::fillna(ContentPtr& value) const {
+  const ContentPtr Record::fillna(const ContentPtr& value) const {
     //                   get a RecordArray of just this element    fillna               get the only element
     return array_.get()->getitem_range_nowrap(at_, at_ + 1).get()->fillna(value).get()->getitem_at_nowrap(0);
   }
 
-  ContentPtr Record::rpad(int64_t length, int64_t axis, int64_t depth) const {
+  const ContentPtr Record::rpad(int64_t length, int64_t axis, int64_t depth) const {
     throw std::invalid_argument("Record cannot be padded because it is not an array");
   }
 
-  ContentPtr Record::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
+  const ContentPtr Record::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
     throw std::invalid_argument("Record cannot be padded because it is not an array");
   }
 
-  ContentPtr Record::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
-    std::shared_ptr<Content> trimmed = array_.get()->getitem_range_nowrap(at_, at_ + 1);
+  const ContentPtr Record::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+    ContentPtr trimmed = array_.get()->getitem_range_nowrap(at_, at_ + 1);
     return trimmed.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  ContentPtr Record::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr Record::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("cannot call 'localindex' with an 'axis' of 0 on a Record");
     }
     else {
-      std::shared_ptr<Content> singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
+      ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
       return singleton.get()->localindex(axis, depth).get()->getitem_at_nowrap(0);
     }
   }
 
-  ContentPtr Record::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr Record::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -275,21 +275,21 @@ namespace awkward {
       throw std::invalid_argument("cannot call 'choose' with an 'axis' of 0 on a Record");
     }
     else {
-      std::shared_ptr<Content> singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
+      ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
       return singleton.get()->choose(n, diagonal, recordlookup, parameters, axis, depth).get()->getitem_at_nowrap(0);
     }
   }
 
-  ContentPtr Record::field(int64_t fieldindex) const {
+  const ContentPtr Record::field(int64_t fieldindex) const {
     return array_.get()->field(fieldindex).get()->getitem_at_nowrap(at_);
   }
 
-  ContentPtr Record::field(const std::string& key) const {
+  const ContentPtr Record::field(const std::string& key) const {
     return array_.get()->field(key).get()->getitem_at_nowrap(at_);
   }
 
-  const std::vector<std::shared_ptr<Content>> Record::fields() const {
-    std::vector<std::shared_ptr<Content>> out;
+  const std::vector<ContentPtr> Record::fields() const {
+    std::vector<ContentPtr> out;
     int64_t cols = numfields();
     for (int64_t j = 0;  j < cols;  j++) {
       out.push_back(array_.get()->field(j).get()->getitem_at_nowrap(at_));
@@ -297,19 +297,19 @@ namespace awkward {
     return out;
   }
 
-  const std::vector<std::pair<std::string, std::shared_ptr<Content>>> Record::fielditems() const {
-    std::vector<std::pair<std::string, std::shared_ptr<Content>>> out;
+  const std::vector<std::pair<std::string, ContentPtr>> Record::fielditems() const {
+    std::vector<std::pair<std::string, ContentPtr>> out;
     std::shared_ptr<util::RecordLookup> keys = array_.get()->recordlookup();
     if (istuple()) {
       int64_t cols = numfields();
       for (int64_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, std::shared_ptr<Content>>(std::to_string(j), array_.get()->field(j).get()->getitem_at_nowrap(at_)));
+        out.push_back(std::pair<std::string, ContentPtr>(std::to_string(j), array_.get()->field(j).get()->getitem_at_nowrap(at_)));
       }
     }
     else {
       int64_t cols = numfields();
       for (int64_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, std::shared_ptr<Content>>(keys.get()->at((size_t)j), array_.get()->field(j).get()->getitem_at_nowrap(at_)));
+        out.push_back(std::pair<std::string, ContentPtr>(keys.get()->at((size_t)j), array_.get()->field(j).get()->getitem_at_nowrap(at_)));
       }
     }
     return out;
@@ -319,39 +319,39 @@ namespace awkward {
     return std::make_shared<Record>(array_.get()->astuple(), at_);
   }
 
-  ContentPtr Record::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr Record::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(at)");
   }
 
-  ContentPtr Record::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr Record::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(range)");
   }
 
-  ContentPtr Record::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr Record::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(array)");
   }
 
-  ContentPtr Record::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr Record::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(field)");
   }
 
-  ContentPtr Record::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr Record::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(fields)");
   }
 
-  ContentPtr Record::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr Record::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(jagged)");
   }
 
-  ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: Record::getitem_next_jagged(array)");
   }
 
-  ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: Record::getitem_next_jagged(missing)");
   }
 
-  ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: Record::getitem_next_jagged(jagged)");
   }
 

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -112,11 +112,11 @@ namespace awkward {
     return -1;   // just like NumpyArray with ndim == 0, which is also a scalar
   }
 
-  const std::shared_ptr<Content> Record::shallow_copy() const {
+  ContentPtr Record::shallow_copy() const {
     return std::make_shared<Record>(array_, at_);
   }
 
-  const std::shared_ptr<Content> Record::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr Record::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     std::shared_ptr<Content> out = array_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     return std::make_shared<Record>(std::dynamic_pointer_cast<RecordArray>(out), at_);
   }
@@ -127,36 +127,36 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> Record::getitem_nothing() const {
+  ContentPtr Record::getitem_nothing() const {
     throw std::runtime_error("undefined operation: Record::getitem_nothing");
   }
 
-  const std::shared_ptr<Content> Record::getitem_at(int64_t at) const {
+  ContentPtr Record::getitem_at(int64_t at) const {
     throw std::invalid_argument(std::string("scalar Record can only be sliced by field name (string); try ") + util::quote(std::to_string(at), true));
   }
 
-  const std::shared_ptr<Content> Record::getitem_at_nowrap(int64_t at) const {
+  ContentPtr Record::getitem_at_nowrap(int64_t at) const {
     throw std::invalid_argument(std::string("scalar Record can only be sliced by field name (string); try ") + util::quote(std::to_string(at), true));
   }
 
-  const std::shared_ptr<Content> Record::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr Record::getitem_range(int64_t start, int64_t stop) const {
     throw std::invalid_argument("scalar Record can only be sliced by field name (string)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr Record::getitem_range_nowrap(int64_t start, int64_t stop) const {
     throw std::invalid_argument("scalar Record can only be sliced by field name (string)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_field(const std::string& key) const {
+  ContentPtr Record::getitem_field(const std::string& key) const {
     return array_.get()->field(key).get()->getitem_at_nowrap(at_);
   }
 
-  const std::shared_ptr<Content> Record::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr Record::getitem_fields(const std::vector<std::string>& keys) const {
     std::shared_ptr<Content> recordarray = array_.get()->getitem_fields(keys);
     return recordarray.get()->getitem_at_nowrap(at_);
   }
 
-  const std::shared_ptr<Content> Record::carry(const Index64& carry) const {
+  ContentPtr Record::carry(const Index64& carry) const {
     throw std::runtime_error("undefined operation: Record::carry");
   }
 
@@ -206,11 +206,11 @@ namespace awkward {
     return array_.get()->validityerror(path + std::string(".array"));
   }
 
-  const std::shared_ptr<Content> Record::shallow_simplify() const {
+  ContentPtr Record::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const std::shared_ptr<Content> Record::num(int64_t axis, int64_t depth) const {
+  ContentPtr Record::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("cannot call 'num' with an 'axis' of 0 on a Record");
@@ -225,11 +225,11 @@ namespace awkward {
     throw std::invalid_argument("Record cannot be flattened because it is not an array");
   }
 
-  bool Record::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool Record::mergeable(ContentPtr& other, bool mergebool) const {
     throw std::invalid_argument("Record cannot be merged because it is not an array");
   }
 
-  const std::shared_ptr<Content> Record::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr Record::merge(ContentPtr& other) const {
     throw std::invalid_argument("Record cannot be merged because it is not an array");
   }
 
@@ -237,25 +237,25 @@ namespace awkward {
     throw std::invalid_argument("cannot use a record as a slice");
   }
 
-  const std::shared_ptr<Content> Record::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr Record::fillna(ContentPtr& value) const {
     //                   get a RecordArray of just this element    fillna               get the only element
     return array_.get()->getitem_range_nowrap(at_, at_ + 1).get()->fillna(value).get()->getitem_at_nowrap(0);
   }
 
-  const std::shared_ptr<Content> Record::rpad(int64_t length, int64_t axis, int64_t depth) const {
+  ContentPtr Record::rpad(int64_t length, int64_t axis, int64_t depth) const {
     throw std::invalid_argument("Record cannot be padded because it is not an array");
   }
 
-  const std::shared_ptr<Content> Record::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
+  ContentPtr Record::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
     throw std::invalid_argument("Record cannot be padded because it is not an array");
   }
 
-  const std::shared_ptr<Content> Record::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr Record::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     std::shared_ptr<Content> trimmed = array_.get()->getitem_range_nowrap(at_, at_ + 1);
     return trimmed.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  const std::shared_ptr<Content> Record::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr Record::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("cannot call 'localindex' with an 'axis' of 0 on a Record");
@@ -266,7 +266,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> Record::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr Record::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -280,11 +280,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> Record::field(int64_t fieldindex) const {
+  ContentPtr Record::field(int64_t fieldindex) const {
     return array_.get()->field(fieldindex).get()->getitem_at_nowrap(at_);
   }
 
-  const std::shared_ptr<Content> Record::field(const std::string& key) const {
+  ContentPtr Record::field(const std::string& key) const {
     return array_.get()->field(key).get()->getitem_at_nowrap(at_);
   }
 
@@ -319,39 +319,39 @@ namespace awkward {
     return std::make_shared<Record>(array_.get()->astuple(), at_);
   }
 
-  const std::shared_ptr<Content> Record::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Record::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(at)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Record::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(range)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Record::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(array)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Record::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(field)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Record::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(fields)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr Record::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(jagged)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: Record::getitem_next_jagged(array)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: Record::getitem_next_jagged(missing)");
   }
 
-  const std::shared_ptr<Content> Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     throw std::runtime_error("undefined operation: Record::getitem_next_jagged(jagged)");
   }
 

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -15,19 +15,24 @@ namespace awkward {
       , array_(array)
       , at_(at) {
     if (!(0 <= at  &&  at < array.get()->length())) {
-      throw std::invalid_argument(std::string("at=") + std::to_string(at) + std::string(" is out of range for recordarray"));
+      throw std::invalid_argument(
+        std::string("at=") + std::to_string(at)
+        + std::string(" is out of range for recordarray"));
     }
   }
 
-  const std::shared_ptr<const RecordArray> Record::array() const {
+  const std::shared_ptr<const RecordArray>
+  Record::array() const {
     return array_;
   }
 
-  int64_t Record::at() const {
+  int64_t
+  Record::at() const {
     return at_;
   }
 
-  const ContentPtrVec Record::contents() const {
+  const ContentPtrVec
+  Record::contents() const {
     ContentPtrVec out;
     for (auto item : array_.get()->contents()) {
       out.push_back(item.get()->getitem_at_nowrap(at_));
@@ -35,23 +40,28 @@ namespace awkward {
     return out;
   }
 
-  const util::RecordLookupPtr Record::recordlookup() const {
+  const util::RecordLookupPtr
+  Record::recordlookup() const {
     return array_.get()->recordlookup();
   }
 
-  bool Record::istuple() const {
+  bool
+  Record::istuple() const {
     return array_.get()->istuple();
   }
 
-  bool Record::isscalar() const {
+  bool
+  Record::isscalar() const {
     return true;
   }
 
-  const std::string Record::classname() const {
+  const std::string
+  Record::classname() const {
     return "Record";
   }
 
-  const IdentitiesPtr Record::identities() const {
+  const IdentitiesPtr
+  Record::identities() const {
     IdentitiesPtr recidentities = array_.get()->identities();
     if (recidentities.get() == nullptr) {
       return recidentities;
@@ -61,21 +71,27 @@ namespace awkward {
     }
   }
 
-  void Record::setidentities() {
+  void
+  Record::setidentities() {
     throw std::runtime_error("undefined operation: Record::setidentities");
   }
 
-  void Record::setidentities(const IdentitiesPtr& identities) {
+  void
+  Record::setidentities(const IdentitiesPtr& identities) {
     throw std::runtime_error("undefined operation: Record::setidentities");
   }
 
-  const TypePtr Record::type(const util::TypeStrs& typestrs) const {
+  const TypePtr
+  Record::type(const util::TypeStrs& typestrs) const {
     TypePtr out = array_.get()->type(typestrs);
     out.get()->setparameters(parameters_);
     return out;
   }
 
-  const std::string Record::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  Record::tostring_part(const std::string& indent,
+                        const std::string& pre,
+                        const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << " at=\"" << at_ << "\">\n";
     if (!parameters_.empty()) {
@@ -86,7 +102,8 @@ namespace awkward {
     return out.str();
   }
 
-  void Record::tojson_part(ToJson& builder) const {
+  void
+  Record::tojson_part(ToJson& builder) const {
     size_t cols = (size_t)numfields();
     util::RecordLookupPtr keys = array_.get()->recordlookup();
     if (istuple()) {
@@ -104,116 +121,160 @@ namespace awkward {
     builder.endrecord();
   }
 
-  void Record::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  Record::nbytes_part(std::map<size_t, int64_t>& largest) const {
     return array_.get()->nbytes_part(largest);
   }
 
-  int64_t Record::length() const {
+  int64_t
+  Record::length() const {
     return -1;   // just like NumpyArray with ndim == 0, which is also a scalar
   }
 
-  const ContentPtr Record::shallow_copy() const {
+  const ContentPtr
+  Record::shallow_copy() const {
     return std::make_shared<Record>(array_, at_);
   }
 
-  const ContentPtr Record::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
-    ContentPtr out = array_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
-    return std::make_shared<Record>(std::dynamic_pointer_cast<RecordArray>(out), at_);
+  const ContentPtr
+  Record::deep_copy(bool copyarrays,
+                    bool copyindexes,
+                    bool copyidentities) const {
+    ContentPtr out = array_.get()->deep_copy(copyarrays,
+                                             copyindexes,
+                                             copyidentities);
+    return std::make_shared<Record>(
+      std::dynamic_pointer_cast<RecordArray>(out), at_);
   }
 
-  void Record::check_for_iteration() const {
-    if (array_.get()->identities().get() != nullptr  &&  array_.get()->identities().get()->length() != 1) {
-      util::handle_error(failure("len(identities) != 1 for scalar Record", kSliceNone, kSliceNone), array_.get()->identities().get()->classname(), nullptr);
+  void
+  Record::check_for_iteration() const {
+    if (array_.get()->identities().get() != nullptr  &&
+        array_.get()->identities().get()->length() != 1) {
+      util::handle_error(
+        failure("len(identities) != 1 for scalar Record",
+                kSliceNone,
+                kSliceNone),
+        array_.get()->identities().get()->classname(),
+        nullptr);
     }
   }
 
-  const ContentPtr Record::getitem_nothing() const {
+  const ContentPtr
+  Record::getitem_nothing() const {
     throw std::runtime_error("undefined operation: Record::getitem_nothing");
   }
 
-  const ContentPtr Record::getitem_at(int64_t at) const {
-    throw std::invalid_argument(std::string("scalar Record can only be sliced by field name (string); try ") + util::quote(std::to_string(at), true));
+  const ContentPtr
+  Record::getitem_at(int64_t at) const {
+    throw std::invalid_argument(
+      std::string("scalar Record can only be sliced by field name (string); "
+                  "try ") + util::quote(std::to_string(at), true));
   }
 
-  const ContentPtr Record::getitem_at_nowrap(int64_t at) const {
-    throw std::invalid_argument(std::string("scalar Record can only be sliced by field name (string); try ") + util::quote(std::to_string(at), true));
+  const ContentPtr
+  Record::getitem_at_nowrap(int64_t at) const {
+    throw std::invalid_argument(
+      std::string("scalar Record can only be sliced by field name (string); "
+                  "try ") + util::quote(std::to_string(at), true));
   }
 
-  const ContentPtr Record::getitem_range(int64_t start, int64_t stop) const {
-    throw std::invalid_argument("scalar Record can only be sliced by field name (string)");
+  const ContentPtr
+  Record::getitem_range(int64_t start, int64_t stop) const {
+    throw std::invalid_argument(
+      "scalar Record can only be sliced by field name (string)");
   }
 
-  const ContentPtr Record::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    throw std::invalid_argument("scalar Record can only be sliced by field name (string)");
+  const ContentPtr
+  Record::getitem_range_nowrap(int64_t start, int64_t stop) const {
+    throw std::invalid_argument(
+      "scalar Record can only be sliced by field name (string)");
   }
 
-  const ContentPtr Record::getitem_field(const std::string& key) const {
+  const ContentPtr
+  Record::getitem_field(const std::string& key) const {
     return array_.get()->field(key).get()->getitem_at_nowrap(at_);
   }
 
-  const ContentPtr Record::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr
+  Record::getitem_fields(const std::vector<std::string>& keys) const {
     ContentPtr recordarray = array_.get()->getitem_fields(keys);
     return recordarray.get()->getitem_at_nowrap(at_);
   }
 
-  const ContentPtr Record::carry(const Index64& carry) const {
+  const ContentPtr
+  Record::carry(const Index64& carry) const {
     throw std::runtime_error("undefined operation: Record::carry");
   }
 
-  const std::string Record::purelist_parameter(const std::string& key) const {
+  const std::string
+  Record::purelist_parameter(const std::string& key) const {
     return parameter(key);
   }
 
-  bool Record::purelist_isregular() const {
+  bool
+  Record::purelist_isregular() const {
     return true;
   }
 
-  int64_t Record::purelist_depth() const {
+  int64_t
+  Record::purelist_depth() const {
     return 0;
   }
 
-  const std::pair<int64_t, int64_t> Record::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  Record::minmax_depth() const {
     std::pair<int64_t, int64_t> out = array_.get()->minmax_depth();
     return std::pair<int64_t, int64_t>(out.first - 1, out.second - 1);
   }
 
-  const std::pair<bool, int64_t> Record::branch_depth() const {
+  const std::pair<bool, int64_t>
+  Record::branch_depth() const {
     std::pair<bool, int64_t> out = array_.get()->branch_depth();
     return std::pair<bool, int64_t>(out.first, out.second - 1);
   }
 
-  int64_t Record::numfields() const {
+  int64_t
+  Record::numfields() const {
     return array_.get()->numfields();
   }
 
-  int64_t Record::fieldindex(const std::string& key) const {
+  int64_t
+  Record::fieldindex(const std::string& key) const {
     return array_.get()->fieldindex(key);
   }
 
-  const std::string Record::key(int64_t fieldindex) const {
+  const std::string
+  Record::key(int64_t fieldindex) const {
     return array_.get()->key(fieldindex);
   }
 
-  bool Record::haskey(const std::string& key) const {
+  bool
+  Record::haskey(const std::string& key) const {
     return array_.get()->haskey(key);
   }
 
-  const std::vector<std::string> Record::keys() const {
+  const std::vector<std::string>
+  Record::keys() const {
     return array_.get()->keys();
   }
 
-  const std::string Record::validityerror(const std::string& path) const {
+  const std::string
+  Record::validityerror(const std::string& path) const {
     return array_.get()->validityerror(path + std::string(".array"));
   }
 
-  const ContentPtr Record::shallow_simplify() const {
+  const ContentPtr
+  Record::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const ContentPtr Record::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  Record::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
-      throw std::invalid_argument("cannot call 'num' with an 'axis' of 0 on a Record");
+      throw std::invalid_argument(
+        "cannot call 'num' with an 'axis' of 0 on a Record");
     }
     else {
       ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
@@ -221,74 +282,120 @@ namespace awkward {
     }
   }
 
-  const std::pair<Index64, ContentPtr> Record::offsets_and_flattened(int64_t axis, int64_t depth) const {
-    throw std::invalid_argument("Record cannot be flattened because it is not an array");
+  const std::pair<Index64, ContentPtr>
+  Record::offsets_and_flattened(int64_t axis, int64_t depth) const {
+    throw std::invalid_argument(
+      "Record cannot be flattened because it is not an array");
   }
 
-  bool Record::mergeable(const ContentPtr& other, bool mergebool) const {
-    throw std::invalid_argument("Record cannot be merged because it is not an array");
+  bool
+  Record::mergeable(const ContentPtr& other, bool mergebool) const {
+    throw std::invalid_argument(
+      "Record cannot be merged because it is not an array");
   }
 
-  const ContentPtr Record::merge(const ContentPtr& other) const {
-    throw std::invalid_argument("Record cannot be merged because it is not an array");
+  const ContentPtr
+  Record::merge(const ContentPtr& other) const {
+    throw std::invalid_argument(
+      "Record cannot be merged because it is not an array");
   }
 
-  const SliceItemPtr Record::asslice() const {
+  const SliceItemPtr
+  Record::asslice() const {
     throw std::invalid_argument("cannot use a record as a slice");
   }
 
-  const ContentPtr Record::fillna(const ContentPtr& value) const {
-    //                   get a RecordArray of just this element    fillna               get the only element
-    return array_.get()->getitem_range_nowrap(at_, at_ + 1).get()->fillna(value).get()->getitem_at_nowrap(0);
+  const ContentPtr
+  Record::fillna(const ContentPtr& value) const {
+    return array_.get()                                // get RecordArray
+           ->getitem_range_nowrap(at_, at_ + 1).get()  // of just this element
+           ->fillna(value).get()                       // fillna
+           ->getitem_at_nowrap(0);                     // turn into a scalar
   }
 
-  const ContentPtr Record::rpad(int64_t length, int64_t axis, int64_t depth) const {
-    throw std::invalid_argument("Record cannot be padded because it is not an array");
+  const ContentPtr
+  Record::rpad(int64_t length, int64_t axis, int64_t depth) const {
+    throw std::invalid_argument(
+      "Record cannot be padded because it is not an array");
   }
 
-  const ContentPtr Record::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
-    throw std::invalid_argument("Record cannot be padded because it is not an array");
+  const ContentPtr
+  Record::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
+    throw std::invalid_argument(
+      "Record cannot be padded because it is not an array");
   }
 
-  const ContentPtr Record::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr
+  Record::reduce_next(const Reducer& reducer,
+                      int64_t negaxis,
+                      const Index64& starts,
+                      const Index64& parents,
+                      int64_t outlength,
+                      bool mask,
+                      bool keepdims) const {
     ContentPtr trimmed = array_.get()->getitem_range_nowrap(at_, at_ + 1);
-    return trimmed.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+    return trimmed.get()->reduce_next(reducer,
+                                      negaxis,
+                                      starts,
+                                      parents,
+                                      outlength,
+                                      mask,
+                                      keepdims);
   }
 
-  const ContentPtr Record::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  Record::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
-      throw std::invalid_argument("cannot call 'localindex' with an 'axis' of 0 on a Record");
+      throw std::invalid_argument(
+        "cannot call 'localindex' with an 'axis' of 0 on a Record");
     }
     else {
       ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
-      return singleton.get()->localindex(axis, depth).get()->getitem_at_nowrap(0);
+      return singleton.get()
+             ->localindex(axis, depth).get()
+             ->getitem_at_nowrap(0);
     }
   }
 
-  const ContentPtr Record::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  Record::choose(int64_t n,
+                 bool diagonal,
+                 const util::RecordLookupPtr& recordlookup,
+                 const util::Parameters& parameters,
+                 int64_t axis,
+                 int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
-      throw std::invalid_argument("cannot call 'choose' with an 'axis' of 0 on a Record");
+      throw std::invalid_argument(
+        "cannot call 'choose' with an 'axis' of 0 on a Record");
     }
     else {
       ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
-      return singleton.get()->choose(n, diagonal, recordlookup, parameters, axis, depth).get()->getitem_at_nowrap(0);
+      return singleton.get()->choose(n,
+                                     diagonal,
+                                     recordlookup,
+                                     parameters,
+                                     axis,
+                                     depth).get()->getitem_at_nowrap(0);
     }
   }
 
-  const ContentPtr Record::field(int64_t fieldindex) const {
+  const ContentPtr
+  Record::field(int64_t fieldindex) const {
     return array_.get()->field(fieldindex).get()->getitem_at_nowrap(at_);
   }
 
-  const ContentPtr Record::field(const std::string& key) const {
+  const ContentPtr
+  Record::field(const std::string& key) const {
     return array_.get()->field(key).get()->getitem_at_nowrap(at_);
   }
 
-  const ContentPtrVec Record::fields() const {
+  const ContentPtrVec
+  Record::fields() const {
     ContentPtrVec out;
     int64_t cols = numfields();
     for (int64_t j = 0;  j < cols;  j++) {
@@ -297,62 +404,106 @@ namespace awkward {
     return out;
   }
 
-  const std::vector<std::pair<std::string, ContentPtr>> Record::fielditems() const {
+  const std::vector<std::pair<std::string, ContentPtr>>
+  Record::fielditems() const {
     std::vector<std::pair<std::string, ContentPtr>> out;
     util::RecordLookupPtr keys = array_.get()->recordlookup();
     if (istuple()) {
       int64_t cols = numfields();
       for (int64_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, ContentPtr>(std::to_string(j), array_.get()->field(j).get()->getitem_at_nowrap(at_)));
+        out.push_back(std::pair<std::string, ContentPtr>(
+          std::to_string(j),
+          array_.get()->field(j).get()->getitem_at_nowrap(at_)));
       }
     }
     else {
       int64_t cols = numfields();
       for (int64_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, ContentPtr>(keys.get()->at((size_t)j), array_.get()->field(j).get()->getitem_at_nowrap(at_)));
+        out.push_back(std::pair<std::string, ContentPtr>(
+          keys.get()->at((size_t)j),
+          array_.get()->field(j).get()->getitem_at_nowrap(at_)));
       }
     }
     return out;
   }
 
-  const std::shared_ptr<Record> Record::astuple() const {
+  const std::shared_ptr<Record>
+  Record::astuple() const {
     return std::make_shared<Record>(array_.get()->astuple(), at_);
   }
 
-  const ContentPtr Record::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  Record::getitem_next(const SliceAt& at,
+                       const Slice& tail,
+                       const Index64& advanced) const {
     throw std::runtime_error("undefined operation: Record::getitem_next(at)");
   }
 
-  const ContentPtr Record::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next(range)");
+  const ContentPtr
+  Record::getitem_next(const SliceRange& range,
+                       const Slice& tail,
+                       const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: Record::getitem_next(range)");
   }
 
-  const ContentPtr Record::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next(array)");
+  const ContentPtr
+  Record::getitem_next(const SliceArray64& array,
+                       const Slice& tail,
+                       const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: Record::getitem_next(array)");
   }
 
-  const ContentPtr Record::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next(field)");
+  const ContentPtr
+  Record::getitem_next(const SliceField& field,
+                       const Slice& tail,
+                       const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: Record::getitem_next(field)");
   }
 
-  const ContentPtr Record::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next(fields)");
+  const ContentPtr
+  Record::getitem_next(const SliceFields& fields,
+                       const Slice& tail,
+                       const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: Record::getitem_next(fields)");
   }
 
-  const ContentPtr Record::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next(jagged)");
+  const ContentPtr
+  Record::getitem_next(const SliceJagged64& jagged,
+                       const Slice& tail,
+                       const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: Record::getitem_next(jagged)");
   }
 
-  const ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next_jagged(array)");
+  const ContentPtr
+  Record::getitem_next_jagged(const Index64& slicestarts,
+                              const Index64& slicestops,
+                              const SliceArray64& slicecontent,
+                              const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: Record::getitem_next_jagged(array)");
   }
 
-  const ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next_jagged(missing)");
+  const ContentPtr
+  Record::getitem_next_jagged(const Index64& slicestarts,
+                              const Index64& slicestops,
+                              const SliceMissing64& slicecontent,
+                              const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: Record::getitem_next_jagged(missing)");
   }
 
-  const ContentPtr Record::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next_jagged(jagged)");
+  const ContentPtr
+  Record::getitem_next_jagged(const Index64& slicestarts,
+                              const Index64& slicestops,
+                              const SliceJagged64& slicecontent,
+                              const Slice& tail) const {
+    throw std::runtime_error(
+      "undefined operation: Record::getitem_next_jagged(jagged)");
   }
 
 }

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -27,8 +27,8 @@ namespace awkward {
     return at_;
   }
 
-  const std::vector<ContentPtr> Record::contents() const {
-    std::vector<ContentPtr> out;
+  const ContentPtrVec Record::contents() const {
+    ContentPtrVec out;
     for (auto item : array_.get()->contents()) {
       out.push_back(item.get()->getitem_at_nowrap(at_));
     }
@@ -95,7 +95,7 @@ namespace awkward {
         keys.get()->push_back(std::to_string(j));
       }
     }
-    std::vector<ContentPtr> contents = array_.get()->contents();
+    ContentPtrVec contents = array_.get()->contents();
     builder.beginrecord();
     for (size_t j = 0;  j < cols;  j++) {
       builder.field(keys.get()->at(j).c_str());
@@ -288,8 +288,8 @@ namespace awkward {
     return array_.get()->field(key).get()->getitem_at_nowrap(at_);
   }
 
-  const std::vector<ContentPtr> Record::fields() const {
-    std::vector<ContentPtr> out;
+  const ContentPtrVec Record::fields() const {
+    ContentPtrVec out;
     int64_t cols = numfields();
     for (int64_t j = 0;  j < cols;  j++) {
       out.push_back(array_.get()->field(j).get()->getitem_at_nowrap(at_));

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -20,13 +20,19 @@
 #include "awkward/array/RecordArray.h"
 
 namespace awkward {
-  RecordArray::RecordArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const util::RecordLookupPtr& recordlookup, int64_t length)
+  RecordArray::RecordArray(const IdentitiesPtr& identities,
+                           const util::Parameters& parameters,
+                           const ContentPtrVec& contents,
+                           const util::RecordLookupPtr& recordlookup,
+                           int64_t length)
       : Content(identities, parameters)
       , contents_(contents)
       , recordlookup_(recordlookup)
       , length_(length) {
-    if (recordlookup_.get() != nullptr  &&  recordlookup_.get()->size() != contents_.size()) {
-      throw std::invalid_argument("recordlookup and contents must have the same number of fields");
+    if (recordlookup_.get() != nullptr  &&
+        recordlookup_.get()->size() != contents_.size()) {
+      throw std::invalid_argument(
+        "recordlookup and contents must have the same number of fields");
     }
   }
 
@@ -46,27 +52,41 @@ namespace awkward {
     }
   }
 
-  RecordArray::RecordArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtrVec& contents, const util::RecordLookupPtr& recordlookup)
-      : RecordArray(identities, parameters, contents, recordlookup, minlength(contents)) { }
+  RecordArray::RecordArray(const IdentitiesPtr& identities,
+                           const util::Parameters& parameters,
+                           const ContentPtrVec& contents,
+                           const util::RecordLookupPtr& recordlookup)
+      : RecordArray(identities,
+                    parameters,
+                    contents,
+                    recordlookup,
+                    minlength(contents)) { }
 
-  const ContentPtrVec RecordArray::contents() const {
+  const ContentPtrVec
+  RecordArray::contents() const {
     return contents_;
   }
 
-  const util::RecordLookupPtr RecordArray::recordlookup() const {
+  const util::RecordLookupPtr
+  RecordArray::recordlookup() const {
     return recordlookup_;
   }
 
-  bool RecordArray::istuple() const {
+  bool
+  RecordArray::istuple() const {
     return recordlookup_.get() == nullptr;
   }
 
-  const ContentPtr RecordArray::setitem_field(int64_t where, const ContentPtr& what) const {
+  const ContentPtr
+  RecordArray::setitem_field(int64_t where, const ContentPtr& what) const {
     if (where < 0) {
       throw std::invalid_argument("where must be non-negative");
     }
     if (what.get()->length() != length()) {
-      throw std::invalid_argument(std::string("array of length ") + std::to_string(what.get()->length()) + std::string(" cannot be assigned to record array of length ") + std::to_string(length()));
+      throw std::invalid_argument(
+        std::string("array of length ") + std::to_string(what.get()->length())
+        + std::string(" cannot be assigned to record array of length ")
+        + std::to_string(length()));
     }
     ContentPtrVec contents;
     for (size_t i = 0;  i < contents_.size();  i++) {
@@ -91,51 +111,78 @@ namespace awkward {
         recordlookup.get()->push_back(std::to_string(where));
       }
     }
-    return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup);
+    return std::make_shared<RecordArray>(identities_,
+                                         parameters_,
+                                         contents,
+                                         recordlookup);
   }
 
-  const ContentPtr RecordArray::setitem_field(const std::string& where, const ContentPtr& what) const {
+  const ContentPtr
+  RecordArray::setitem_field(const std::string& where,
+                             const ContentPtr& what) const {
     if (what.get()->length() != length()) {
-      throw std::invalid_argument(std::string("array of length ") + std::to_string(what.get()->length()) + std::string(" cannot be assigned to record array of length ") + std::to_string(length()));
+      throw std::invalid_argument(
+        std::string("array of length ") + std::to_string(what.get()->length())
+        + std::string(" cannot be assigned to record array of length ")
+        + std::to_string(length()));
     }
     ContentPtrVec contents(contents_.begin(), contents_.end());
     contents.push_back(what);
     util::RecordLookupPtr recordlookup;
     if (recordlookup_.get() != nullptr) {
       recordlookup = std::make_shared<util::RecordLookup>();
-      recordlookup.get()->insert(recordlookup.get()->end(), recordlookup_.get()->begin(), recordlookup_.get()->end());
+      recordlookup.get()->insert(recordlookup.get()->end(),
+                                 recordlookup_.get()->begin(),
+                                 recordlookup_.get()->end());
       recordlookup.get()->push_back(where);
     }
     else {
       recordlookup = util::init_recordlookup(numfields());
       recordlookup.get()->push_back(where);
     }
-    return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup);
+    return std::make_shared<RecordArray>(identities_,
+                                         parameters_,
+                                         contents,
+                                         recordlookup);
   }
 
-  const std::string RecordArray::classname() const {
+  const std::string
+  RecordArray::classname() const {
     return "RecordArray";
   }
 
-  void RecordArray::setidentities() {
+  void
+  RecordArray::setidentities() {
     int64_t len = length();
     if (len <= kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, len);
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), len);
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       len);
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err = awkward_new_identities32(rawidentities->ptr().get(),
+                                                  len);
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, len);
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), len);
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1, len);
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err =
+        awkward_new_identities64(rawidentities->ptr().get(), len);
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
   }
 
-  void RecordArray::setidentities(const IdentitiesPtr& identities) {
+  void
+  RecordArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       for (auto content : contents_) {
         content.get()->setidentities(identities);
@@ -143,37 +190,54 @@ namespace awkward {
     }
     else {
       if (length() != identities.get()->length()) {
-        util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(
+          failure("content and its identities must have the same length",
+                  kSliceNone,
+                  kSliceNone),
+          classname(),
+          identities_.get());
       }
       if (istuple()) {
         Identities::FieldLoc original = identities.get()->fieldloc();
         for (size_t j = 0;  j < contents_.size();  j++) {
           Identities::FieldLoc fieldloc(original.begin(), original.end());
-          fieldloc.push_back(std::pair<int64_t, std::string>(identities.get()->width() - 1, std::to_string(j)));
-          contents_[j].get()->setidentities(identities.get()->withfieldloc(fieldloc));
+          fieldloc.push_back(
+            std::pair<int64_t, std::string>(identities.get()->width() - 1,
+                                            std::to_string(j)));
+          contents_[j].get()->setidentities(
+            identities.get()->withfieldloc(fieldloc));
         }
       }
       else {
         Identities::FieldLoc original = identities.get()->fieldloc();
         for (size_t j = 0;  j < contents_.size();  j++) {
           Identities::FieldLoc fieldloc(original.begin(), original.end());
-          fieldloc.push_back(std::pair<int64_t, std::string>(identities.get()->width() - 1, recordlookup_.get()->at(j)));
-          contents_[j].get()->setidentities(identities.get()->withfieldloc(fieldloc));
+          fieldloc.push_back(std::pair<int64_t, std::string>(
+            identities.get()->width() - 1, recordlookup_.get()->at(j)));
+          contents_[j].get()->setidentities(
+            identities.get()->withfieldloc(fieldloc));
         }
       }
     }
     identities_ = identities;
   }
 
-  const TypePtr RecordArray::type(const util::TypeStrs& typestrs) const {
+  const TypePtr
+  RecordArray::type(const util::TypeStrs& typestrs) const {
     std::vector<TypePtr> types;
     for (auto item : contents_) {
       types.push_back(item.get()->type(typestrs));
     }
-    return std::make_shared<RecordType>(parameters_, util::gettypestr(parameters_, typestrs), types, recordlookup_);
+    return std::make_shared<RecordType>(
+      parameters_,
+      util::gettypestr(parameters_, typestrs),
+      types, recordlookup_);
   }
 
-  const std::string RecordArray::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  RecordArray::tostring_part(const std::string& indent,
+                             const std::string& pre,
+                             const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname();
     if (contents_.empty()) {
@@ -181,7 +245,8 @@ namespace awkward {
     }
     out << ">\n";
     if (identities_.get() != nullptr) {
-      out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+      out << identities_.get()->tostring_part(
+               indent + std::string("    "), "", "\n");
     }
     if (!parameters_.empty()) {
       out << parameters_tostring(indent + std::string("    "), "", "\n");
@@ -195,14 +260,16 @@ namespace awkward {
         out << ">";
       }
       out << "\n";
-      out << contents_[j].get()->tostring_part(indent + std::string("        "), "", "\n");
+      out << contents_[j].get()->tostring_part(
+               indent + std::string("        "), "", "\n");
       out << indent << "    </field>\n";
     }
     out << indent << "</" << classname() << ">" << post;
     return out.str();
   }
 
-  void RecordArray::tojson_part(ToJson& builder) const {
+  void
+  RecordArray::tojson_part(ToJson& builder) const {
     int64_t rows = length();
     size_t cols = contents_.size();
     util::RecordLookupPtr keys = recordlookup_;
@@ -225,7 +292,8 @@ namespace awkward {
     builder.endlist();
   }
 
-  void RecordArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  RecordArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
     for (auto x : contents_) {
       x.get()->nbytes_part(largest);
     }
@@ -234,80 +302,123 @@ namespace awkward {
     }
   }
 
-  int64_t RecordArray::length() const {
+  int64_t
+  RecordArray::length() const {
     return length_;
   }
 
-  const ContentPtr RecordArray::shallow_copy() const {
-    return std::make_shared<RecordArray>(identities_, parameters_, contents_, recordlookup_, length_);
+  const ContentPtr
+  RecordArray::shallow_copy() const {
+    return std::make_shared<RecordArray>(identities_,
+                                         parameters_,
+                                         contents_,
+                                         recordlookup_,
+                                         length_);
   }
 
-  const ContentPtr RecordArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  RecordArray::deep_copy(bool copyarrays,
+                         bool copyindexes,
+                         bool copyidentities) const {
     ContentPtrVec contents;
     for (auto x : contents_) {
-      contents.push_back(x.get()->deep_copy(copyarrays, copyindexes, copyidentities));
+      contents.push_back(x.get()->deep_copy(copyarrays,
+                                            copyindexes,
+                                            copyidentities));
     }
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
-    return std::make_shared<RecordArray>(identities, parameters_, contents, recordlookup_, length_);
+    return std::make_shared<RecordArray>(identities,
+                                         parameters_,
+                                         contents,
+                                         recordlookup_,
+                                         length_);
   }
 
-  void RecordArray::check_for_iteration() const {
-    if (identities_.get() != nullptr  &&  identities_.get()->length() < length()) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+  void
+  RecordArray::check_for_iteration() const {
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < length()) {
+      util::handle_error(
+        failure("len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
-  const ContentPtr RecordArray::getitem_nothing() const {
+  const ContentPtr
+  RecordArray::getitem_nothing() const {
     return getitem_range_nowrap(0, 0);
   }
 
-  const ContentPtr RecordArray::getitem_at(int64_t at) const {
+  const ContentPtr
+  RecordArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     int64_t len = length();
     if (regular_at < 0) {
       regular_at += len;
     }
     if (!(0 <= regular_at  &&  regular_at < len)) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
-  const ContentPtr RecordArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  RecordArray::getitem_at_nowrap(int64_t at) const {
     return std::make_shared<Record>(shared_from_this(), at);
   }
 
-  const ContentPtr RecordArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  RecordArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
-    if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-      util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), length_);
+    if (identities_.get() != nullptr  &&
+        regular_stop > identities_.get()->length()) {
+      util::handle_error(
+        failure("index out of range", kSliceNone, stop),
+        identities_.get()->classname(),
+        nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const ContentPtr RecordArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  RecordArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     if (contents_.empty()) {
-      return std::make_shared<RecordArray>(identities_, parameters_, contents_, recordlookup_, stop - start);
+      return std::make_shared<RecordArray>(identities_,
+                                           parameters_,
+                                           contents_,
+                                           recordlookup_,
+                                           stop - start);
     }
     else {
       ContentPtrVec contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->getitem_range_nowrap(start, stop));
       }
-      return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_, stop - start);
+      return std::make_shared<RecordArray>(identities_,
+                                           parameters_,
+                                           contents,
+                                           recordlookup_,
+                                           stop - start);
     }
   }
 
-  const ContentPtr RecordArray::getitem_field(const std::string& key) const {
+  const ContentPtr
+  RecordArray::getitem_field(const std::string& key) const {
     return field(key).get()->getitem_range_nowrap(0, length());
   }
 
-  const ContentPtr RecordArray::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr
+  RecordArray::getitem_fields(const std::vector<std::string>& keys) const {
     ContentPtrVec contents;
     util::RecordLookupPtr recordlookup(nullptr);
     if (recordlookup_.get() != nullptr) {
@@ -319,10 +430,14 @@ namespace awkward {
         recordlookup.get()->push_back(key);
       }
     }
-    return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup);
+    return std::make_shared<RecordArray>(identities_,
+                                         parameters_,
+                                         contents,
+                                         recordlookup);
   }
 
-  const ContentPtr RecordArray::carry(const Index64& carry) const {
+  const ContentPtr
+  RecordArray::carry(const Index64& carry) const {
     ContentPtrVec contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->carry(carry));
@@ -331,22 +446,30 @@ namespace awkward {
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
-    return std::make_shared<RecordArray>(identities, parameters_, contents, recordlookup_, carry.length());
+    return std::make_shared<RecordArray>(identities,
+                                         parameters_,
+                                         contents,
+                                         recordlookup_,
+                                         carry.length());
   }
 
-  const std::string RecordArray::purelist_parameter(const std::string& key) const {
+  const std::string
+  RecordArray::purelist_parameter(const std::string& key) const {
     return parameter(key);
   }
 
-  bool RecordArray::purelist_isregular() const {
+  bool
+  RecordArray::purelist_isregular() const {
     return true;
   }
 
-  int64_t RecordArray::purelist_depth() const {
+  int64_t
+  RecordArray::purelist_depth() const {
     return 1;
   }
 
-  const std::pair<int64_t, int64_t> RecordArray::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  RecordArray::minmax_depth() const {
     if (contents_.empty()) {
       return std::pair<int64_t, int64_t>(0, 0);
     }
@@ -364,7 +487,8 @@ namespace awkward {
     return std::pair<int64_t, int64_t>(min, max);
   }
 
-  const std::pair<bool, int64_t> RecordArray::branch_depth() const {
+  const std::pair<bool, int64_t>
+  RecordArray::branch_depth() const {
     if (contents_.empty()) {
       return std::pair<bool, int64_t>(false, 1);
     }
@@ -387,34 +511,43 @@ namespace awkward {
     }
   }
 
-  int64_t RecordArray::numfields() const {
+  int64_t
+  RecordArray::numfields() const {
     return (int64_t)contents_.size();
   }
 
-  int64_t RecordArray::fieldindex(const std::string& key) const {
+  int64_t
+  RecordArray::fieldindex(const std::string& key) const {
     return util::fieldindex(recordlookup_, key, numfields());
   }
 
-  const std::string RecordArray::key(int64_t fieldindex) const {
+  const std::string
+  RecordArray::key(int64_t fieldindex) const {
     return util::key(recordlookup_, fieldindex, numfields());
   }
 
-  bool RecordArray::haskey(const std::string& key) const {
+  bool
+  RecordArray::haskey(const std::string& key) const {
     return util::haskey(recordlookup_, key, numfields());
   }
 
-  const std::vector<std::string> RecordArray::keys() const {
+  const std::vector<std::string>
+  RecordArray::keys() const {
     return util::keys(recordlookup_, numfields());
   }
 
-  const std::string RecordArray::validityerror(const std::string& path) const {
+  const std::string
+  RecordArray::validityerror(const std::string& path) const {
     for (int64_t i = 0;  i < numfields();  i++) {
       if (field(i).get()->length() < length_) {
-        return std::string("at ") + path + std::string(" (") + classname() + std::string("): len(field(") + std::to_string(i) + (")) < len(recordarray)");
+        return (std::string("at ") + path + std::string(" (") + classname()
+                + std::string("): len(field(")
+                + std::to_string(i) + (")) < len(recordarray)"));
       }
     }
     for (int64_t i = 0;  i < numfields();  i++) {
-      std::string sub = field(i).get()->validityerror(path + std::string(".field(") + std::to_string(i) + (")"));
+      std::string sub = field(i).get()->validityerror(
+        path + std::string(".field(") + std::to_string(i) + (")"));
       if (!sub.empty()) {
         return sub;
       }
@@ -422,11 +555,13 @@ namespace awkward {
     return std::string();
   }
 
-  const ContentPtr RecordArray::shallow_simplify() const {
+  const ContentPtr
+  RecordArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const ContentPtr RecordArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RecordArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 single(1);
@@ -436,7 +571,11 @@ namespace awkward {
       for (auto content : contents_) {
         contents.push_back(singleton);
       }
-      ContentPtr record = std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_, 1);
+      ContentPtr record = std::make_shared<RecordArray>(Identities::none(),
+                                                        util::Parameters(),
+                                                        contents,
+                                                        recordlookup_,
+                                                        1);
       return record.get()->getitem_at_nowrap(0);
     }
     else {
@@ -444,33 +583,49 @@ namespace awkward {
       for (auto content : contents_) {
         contents.push_back(content.get()->num(axis, depth));
       }
-      return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_, length_);
+      return std::make_shared<RecordArray>(Identities::none(),
+                                           util::Parameters(),
+                                           contents,
+                                           recordlookup_,
+                                           length_);
     }
   }
 
-  const std::pair<Index64, ContentPtr> RecordArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  RecordArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
     }
     else if (toaxis == depth + 1) {
-      throw std::invalid_argument("arrays of records cannot be flattened (but their contents can be; try a different 'axis')");
+      throw std::invalid_argument(
+        "arrays of records cannot be flattened (but their contents can be; "
+        "try a different 'axis')");
     }
     else {
       ContentPtrVec contents;
       for (auto content : contents_) {
         ContentPtr trimmed = content.get()->getitem_range(0, length());
-        std::pair<Index64, ContentPtr> pair = trimmed.get()->offsets_and_flattened(axis, depth);
+        std::pair<Index64, ContentPtr> pair =
+          trimmed.get()->offsets_and_flattened(axis, depth);
         if (pair.first.length() != 0) {
-          throw std::runtime_error("RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened");
+          throw std::runtime_error(
+            "RecordArray content with axis > depth + 1 returned a non-empty "
+            "offsets from offsets_and_flattened");
         }
         contents.push_back(pair.second);
       }
-      return std::pair<Index64, ContentPtr>(Index64(0), std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_));
+      return std::pair<Index64, ContentPtr>(
+        Index64(0),
+        std::make_shared<RecordArray>(Identities::none(),
+                                      util::Parameters(),
+                                      contents,
+                                      recordlookup_));
     }
   }
 
-  bool RecordArray::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  RecordArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -481,32 +636,41 @@ namespace awkward {
         dynamic_cast<UnionArray8_64*>(other.get())) {
       return true;
     }
-    else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    else if (IndexedArray32* rawother =
+             dynamic_cast<IndexedArray32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
 
-    if (RecordArray* rawother = dynamic_cast<RecordArray*>(other.get())) {
+    if (RecordArray* rawother =
+        dynamic_cast<RecordArray*>(other.get())) {
       if (istuple()  &&  rawother->istuple()) {
         if (numfields() == rawother->numfields()) {
           for (int64_t i = 0;  i < numfields();  i++) {
@@ -524,7 +688,8 @@ namespace awkward {
         std::sort(other_keys.begin(), other_keys.end());
         if (self_keys == other_keys) {
           for (auto key : self_keys) {
-            if (!field(key).get()->mergeable(rawother->field(key), mergebool)) {
+            if (!field(key).get()->mergeable(rawother->field(key),
+                                             mergebool)) {
               return false;
             }
           }
@@ -538,7 +703,8 @@ namespace awkward {
     }
   }
 
-  const ContentPtr RecordArray::merge(const ContentPtr& other) const {
+  const ContentPtr
+  RecordArray::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -546,56 +712,78 @@ namespace awkward {
     if (dynamic_cast<EmptyArray*>(other.get())) {
       return shallow_copy();
     }
-    else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    else if (IndexedArray32* rawother =
+             dynamic_cast<IndexedArray32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_32* rawother = dynamic_cast<UnionArray8_32*>(other.get())) {
+    else if (UnionArray8_32* rawother =
+             dynamic_cast<UnionArray8_32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_U32* rawother = dynamic_cast<UnionArray8_U32*>(other.get())) {
+    else if (UnionArray8_U32* rawother =
+             dynamic_cast<UnionArray8_U32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_64* rawother = dynamic_cast<UnionArray8_64*>(other.get())) {
+    else if (UnionArray8_64* rawother =
+             dynamic_cast<UnionArray8_64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
 
-    if (RecordArray* rawother = dynamic_cast<RecordArray*>(other.get())) {
+    if (RecordArray* rawother =
+        dynamic_cast<RecordArray*>(other.get())) {
       int64_t mylength = length();
       int64_t theirlength = rawother->length();
 
-      if (istuple() == rawother->istuple()  &&  numfields() == 0  &&  rawother->numfields() == 0) {
-        return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents_, util::RecordLookupPtr(nullptr), mylength + theirlength);
+      if (istuple() == rawother->istuple()  &&
+          numfields() == 0  &&  rawother->numfields() == 0) {
+        return std::make_shared<RecordArray>(Identities::none(),
+                                             util::Parameters(),
+                                             contents_,
+                                             util::RecordLookupPtr(nullptr),
+                                             mylength + theirlength);
       }
       if (istuple()  &&  rawother->istuple()) {
         if (numfields() == rawother->numfields()) {
           ContentPtrVec contents;
           for (int64_t i = 0;  i < numfields();  i++) {
-            ContentPtr mine = field(i).get()->getitem_range_nowrap(0, mylength);
-            ContentPtr theirs = rawother->field(i).get()->getitem_range_nowrap(0, theirlength);
+            ContentPtr mine =
+              field(i).get()->getitem_range_nowrap(0, mylength);
+            ContentPtr theirs =
+              rawother->field(i).get()->getitem_range_nowrap(0, theirlength);
             contents.push_back(mine.get()->merge(theirs));
           }
-          return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_);
+          return std::make_shared<RecordArray>(Identities::none(),
+                                               util::Parameters(),
+                                               contents,
+                                               recordlookup_);
         }
       }
       else if (!istuple()  &&  !rawother->istuple()) {
@@ -606,33 +794,48 @@ namespace awkward {
         if (self_keys == other_keys) {
           ContentPtrVec contents;
           for (auto key : keys()) {
-            ContentPtr mine = field(key).get()->getitem_range_nowrap(0, mylength);
-            ContentPtr theirs = rawother->field(key).get()->getitem_range_nowrap(0, theirlength);
+            ContentPtr mine =
+              field(key).get()->getitem_range_nowrap(0, mylength);
+            ContentPtr theirs =
+              rawother->field(key).get()->getitem_range_nowrap(0, theirlength);
             contents.push_back(mine.get()->merge(theirs));
           }
-          return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_);
+          return std::make_shared<RecordArray>(Identities::none(),
+                                               util::Parameters(),
+                                               contents,
+                                               recordlookup_);
         }
       }
-      throw std::invalid_argument("cannot merge records or tuples with different fields");
+      throw std::invalid_argument(
+        "cannot merge records or tuples with different fields");
     }
     else {
-      throw std::invalid_argument(std::string("cannot merge ") + classname() + std::string(" with ") + other.get()->classname());
+      throw std::invalid_argument(
+        std::string("cannot merge ") + classname() + std::string(" with ")
+        + other.get()->classname());
     }
   }
 
-  const SliceItemPtr RecordArray::asslice() const {
+  const SliceItemPtr
+  RecordArray::asslice() const {
     throw std::invalid_argument("cannot use records as a slice");
   }
 
-  const ContentPtr RecordArray::fillna(const ContentPtr& value) const {
+  const ContentPtr
+  RecordArray::fillna(const ContentPtr& value) const {
     ContentPtrVec contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->fillna(value));
     }
-    return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_, length_);
+    return std::make_shared<RecordArray>(identities_,
+                                         parameters_,
+                                         contents,
+                                         recordlookup_,
+                                         length_);
   }
 
-  const ContentPtr RecordArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RecordArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -643,15 +846,25 @@ namespace awkward {
         contents.push_back(content.get()->rpad(target, toaxis, depth));
       }
       if (contents.empty()) {
-        return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_, length_);
+        return std::make_shared<RecordArray>(identities_,
+                                             parameters_,
+                                             contents,
+                                             recordlookup_,
+                                             length_);
       }
       else {
-        return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_);
+        return std::make_shared<RecordArray>(identities_,
+                                             parameters_,
+                                             contents,
+                                             recordlookup_);
       }
     }
   }
 
-  const ContentPtr RecordArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RecordArray::rpad_and_clip(int64_t target,
+                             int64_t axis,
+                             int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -659,28 +872,54 @@ namespace awkward {
     else {
       ContentPtrVec contents;
       for (auto content : contents_) {
-        contents.push_back(content.get()->rpad_and_clip(target, toaxis, depth));
+        contents.push_back(
+          content.get()->rpad_and_clip(target, toaxis, depth));
       }
       if (contents.empty()) {
-        return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_, length_);
+        return std::make_shared<RecordArray>(identities_,
+                                             parameters_,
+                                             contents,
+                                             recordlookup_,
+                                             length_);
       }
       else {
-        return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_);
+        return std::make_shared<RecordArray>(identities_,
+                                             parameters_,
+                                             contents,
+                                             recordlookup_);
       }
     }
   }
 
-  const ContentPtr RecordArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr
+  RecordArray::reduce_next(const Reducer& reducer,
+                           int64_t negaxis,
+                           const Index64& starts,
+                           const Index64& parents,
+                           int64_t outlength,
+                           bool mask,
+                           bool keepdims) const {
     ContentPtrVec contents;
     for (auto content : contents_) {
       ContentPtr trimmed = content.get()->getitem_range_nowrap(0, length());
-      ContentPtr next = trimmed.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+      ContentPtr next = trimmed.get()->reduce_next(reducer,
+                                                   negaxis,
+                                                   starts,
+                                                   parents,
+                                                   outlength,
+                                                   mask,
+                                                   keepdims);
       contents.push_back(next);
     }
-    return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_, outlength);
+    return std::make_shared<RecordArray>(Identities::none(),
+                                         util::Parameters(),
+                                         contents,
+                                         recordlookup_,
+                                         outlength);
   }
 
-  const ContentPtr RecordArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RecordArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -690,11 +929,21 @@ namespace awkward {
       for (auto content : contents_) {
         contents.push_back(content.get()->localindex(axis, depth));
       }
-      return std::make_shared<RecordArray>(identities_, util::Parameters(), contents, recordlookup_, length_);
+      return std::make_shared<RecordArray>(identities_,
+                                           util::Parameters(),
+                                           contents,
+                                           recordlookup_,
+                                           length_);
     }
   }
 
-  const ContentPtr RecordArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RecordArray::choose(int64_t n,
+                      bool diagonal,
+                      const util::RecordLookupPtr& recordlookup,
+                      const util::Parameters& parameters,
+                      int64_t axis,
+                      int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -705,49 +954,76 @@ namespace awkward {
     else {
       ContentPtrVec contents;
       for (auto content : contents_) {
-        contents.push_back(content.get()->choose(n, diagonal, recordlookup, parameters, axis, depth));
+        contents.push_back(content.get()->choose(n,
+                                                 diagonal,
+                                                 recordlookup,
+                                                 parameters,
+                                                 axis,
+                                                 depth));
       }
-      return std::make_shared<RecordArray>(identities_, util::Parameters(), contents, recordlookup_, length_);
+      return std::make_shared<RecordArray>(identities_,
+                                           util::Parameters(),
+                                           contents,
+                                           recordlookup_,
+                                           length_);
     }
   }
 
-  const ContentPtr RecordArray::field(int64_t fieldindex) const {
+  const ContentPtr
+  RecordArray::field(int64_t fieldindex) const {
     if (fieldindex >= numfields()) {
-      throw std::invalid_argument(std::string("fieldindex ") + std::to_string(fieldindex) + std::string(" for record with only " + std::to_string(numfields()) + std::string(" fields")));
+      throw std::invalid_argument(
+        std::string("fieldindex ") + std::to_string(fieldindex)
+        + std::string(" for record with only " + std::to_string(numfields()))
+        + std::string(" fields"));
     }
     return contents_[(size_t)fieldindex];
   }
 
-  const ContentPtr RecordArray::field(const std::string& key) const {
+  const ContentPtr
+  RecordArray::field(const std::string& key) const {
     return contents_[(size_t)fieldindex(key)];
   }
 
-  const ContentPtrVec RecordArray::fields() const {
+  const ContentPtrVec
+  RecordArray::fields() const {
     return ContentPtrVec(contents_);
   }
 
-  const std::vector<std::pair<std::string, ContentPtr>> RecordArray::fielditems() const {
+  const std::vector<std::pair<std::string, ContentPtr>>
+  RecordArray::fielditems() const {
     std::vector<std::pair<std::string, ContentPtr>> out;
     if (istuple()) {
       size_t cols = contents_.size();
       for (size_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, ContentPtr>(std::to_string(j), contents_[j]));
+        out.push_back(
+          std::pair<std::string, ContentPtr>(std::to_string(j), contents_[j]));
       }
     }
     else {
       size_t cols = contents_.size();
       for (size_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, ContentPtr>(recordlookup_.get()->at(j), contents_[j]));
+        out.push_back(
+          std::pair<std::string, ContentPtr>(recordlookup_.get()->at(j),
+                                             contents_[j]));
       }
     }
     return out;
   }
 
-  const std::shared_ptr<RecordArray> RecordArray::astuple() const {
-    return std::make_shared<RecordArray>(identities_, parameters_, contents_, util::RecordLookupPtr(nullptr), length_);
+  const std::shared_ptr<RecordArray>
+  RecordArray::astuple() const {
+    return std::make_shared<RecordArray>(identities_,
+                                         parameters_,
+                                         contents_,
+                                         util::RecordLookupPtr(nullptr),
+                                         length_);
   }
 
-  const ContentPtr RecordArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  RecordArray::getitem_next(const SliceItemPtr& head,
+                            const Slice& tail,
+                            const Index64& advanced) const {
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
     Slice emptytail;
@@ -756,21 +1032,26 @@ namespace awkward {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
-    else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {
+    else if (SliceField* field =
+             dynamic_cast<SliceField*>(head.get())) {
       ContentPtr out = getitem_next(*field, emptytail, advanced);
       return out.get()->getitem_next(nexthead, nexttail, advanced);
     }
-    else if (SliceFields* fields = dynamic_cast<SliceFields*>(head.get())) {
+    else if (SliceFields* fields =
+             dynamic_cast<SliceFields*>(head.get())) {
       ContentPtr out = getitem_next(*fields, emptytail, advanced);
       return out.get()->getitem_next(nexthead, nexttail, advanced);
     }
-    else if (const SliceMissing64* missing = dynamic_cast<SliceMissing64*>(head.get())) {
+    else if (const SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(head.get())) {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
       ContentPtrVec contents;
       for (auto content : contents_) {
-        contents.push_back(content.get()->getitem_next(head, emptytail, advanced));
+        contents.push_back(content.get()->getitem_next(head,
+                                                       emptytail,
+                                                       advanced));
       }
       util::Parameters parameters;
       if (head.get()->preserves_type(advanced)) {
@@ -781,57 +1062,114 @@ namespace awkward {
     }
   }
 
-  const ContentPtr RecordArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
-    throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(at)"));
+  const ContentPtr
+  RecordArray::getitem_next(const SliceAt& at,
+                            const Slice& tail,
+                            const Index64& advanced) const {
+    throw std::invalid_argument(
+      std::string("undefined operation: RecordArray::getitem_next(at)"));
   }
 
-  const ContentPtr RecordArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(range)"));
+  const ContentPtr
+  RecordArray::getitem_next(const SliceRange& range,
+                            const Slice& tail,
+                            const Index64& advanced) const {
+    throw std::invalid_argument(
+      std::string("undefined operation: RecordArray::getitem_next(range)"));
   }
 
-  const ContentPtr RecordArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(array)"));
+  const ContentPtr
+  RecordArray::getitem_next(const SliceArray64& array,
+                            const Slice& tail,
+                            const Index64& advanced) const {
+    throw std::invalid_argument(
+      std::string("undefined operation: RecordArray::getitem_next(array)"));
   }
 
-  const ContentPtr RecordArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  RecordArray::getitem_next(const SliceField& field,
+                            const Slice& tail,
+                            const Index64& advanced) const {
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
-    return getitem_field(field.key()).get()->getitem_next(nexthead, nexttail, advanced);
+    return getitem_field(field.key()).get()->getitem_next(nexthead,
+                                                          nexttail,
+                                                          advanced);
   }
 
-  const ContentPtr RecordArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  RecordArray::getitem_next(const SliceFields& fields,
+                            const Slice& tail,
+                            const Index64& advanced) const {
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
-    return getitem_fields(fields.keys()).get()->getitem_next(nexthead, nexttail, advanced);
+    return getitem_fields(fields.keys()).get()->getitem_next(nexthead,
+                                                             nexttail,
+                                                             advanced);
   }
 
-  const ContentPtr RecordArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(jagged)"));
+  const ContentPtr
+  RecordArray::getitem_next(const SliceJagged64& jagged,
+                            const Slice& tail,
+                            const Index64& advanced) const {
+    throw std::invalid_argument(
+      std::string("undefined operation: RecordArray::getitem_next(jagged)"));
   }
 
-  const ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  RecordArray::getitem_next_jagged(const Index64& slicestarts,
+                                   const Index64& slicestops,
+                                   const SliceArray64& slicecontent,
+                                   const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceArray64>(slicestarts,
+                                                     slicestops,
+                                                     slicecontent,
+                                                     tail);
   }
 
-  const ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  RecordArray::getitem_next_jagged(const Index64& slicestarts,
+                                   const Index64& slicestops,
+                                   const SliceMissing64& slicecontent,
+                                   const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceMissing64>(slicestarts,
+                                                       slicestops,
+                                                       slicecontent,
+                                                       tail);
   }
 
-  const ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  RecordArray::getitem_next_jagged(const Index64& slicestarts,
+                                   const Index64& slicestops,
+                                   const SliceJagged64& slicecontent,
+                                   const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceJagged64>(slicestarts,
+                                                      slicestops,
+                                                      slicecontent,
+                                                      tail);
   }
 
   template <typename S>
-  const ContentPtr RecordArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  RecordArray::getitem_next_jagged_generic(const Index64& slicestarts,
+                                           const Index64& slicestops,
+                                           const S& slicecontent,
+                                           const Slice& tail) const {
     if (contents_.empty()) {
       return shallow_copy();
     }
     else {
       ContentPtrVec contents;
       for (auto content : contents_) {
-        contents.push_back(content.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail));
+        contents.push_back(content.get()->getitem_next_jagged(slicestarts,
+                                                              slicestops,
+                                                              slicecontent,
+                                                              tail));
       }
-      return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_);
+      return std::make_shared<RecordArray>(identities_,
+                                           parameters_,
+                                           contents,
+                                           recordlookup_);
     }
   }
 

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -165,7 +165,7 @@ namespace awkward {
     identities_ = identities;
   }
 
-  const TypePtr RecordArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr RecordArray::type(const util::TypeStrs& typestrs) const {
     std::vector<TypePtr> types;
     for (auto item : contents_) {
       types.push_back(item.get()->type(typestrs));

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -61,7 +61,7 @@ namespace awkward {
     return recordlookup_.get() == nullptr;
   }
 
-  const std::shared_ptr<Content> RecordArray::setitem_field(int64_t where, const std::shared_ptr<Content>& what) const {
+  ContentPtr RecordArray::setitem_field(int64_t where, ContentPtr& what) const {
     if (where < 0) {
       throw std::invalid_argument("where must be non-negative");
     }
@@ -94,7 +94,7 @@ namespace awkward {
     return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup);
   }
 
-  const std::shared_ptr<Content> RecordArray::setitem_field(const std::string& where, const std::shared_ptr<Content>& what) const {
+  ContentPtr RecordArray::setitem_field(const std::string& where, ContentPtr& what) const {
     if (what.get()->length() != length()) {
       throw std::invalid_argument(std::string("array of length ") + std::to_string(what.get()->length()) + std::string(" cannot be assigned to record array of length ") + std::to_string(length()));
     }
@@ -238,11 +238,11 @@ namespace awkward {
     return length_;
   }
 
-  const std::shared_ptr<Content> RecordArray::shallow_copy() const {
+  ContentPtr RecordArray::shallow_copy() const {
     return std::make_shared<RecordArray>(identities_, parameters_, contents_, recordlookup_, length_);
   }
 
-  const std::shared_ptr<Content> RecordArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr RecordArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto x : contents_) {
       contents.push_back(x.get()->deep_copy(copyarrays, copyindexes, copyidentities));
@@ -260,11 +260,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_nothing() const {
+  ContentPtr RecordArray::getitem_nothing() const {
     return getitem_range_nowrap(0, 0);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_at(int64_t at) const {
+  ContentPtr RecordArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     int64_t len = length();
     if (regular_at < 0) {
@@ -276,11 +276,11 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_at_nowrap(int64_t at) const {
+  ContentPtr RecordArray::getitem_at_nowrap(int64_t at) const {
     return std::make_shared<Record>(shared_from_this(), at);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr RecordArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
@@ -290,7 +290,7 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr RecordArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     if (contents_.empty()) {
       return std::make_shared<RecordArray>(identities_, parameters_, contents_, recordlookup_, stop - start);
     }
@@ -303,11 +303,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_field(const std::string& key) const {
+  ContentPtr RecordArray::getitem_field(const std::string& key) const {
     return field(key).get()->getitem_range_nowrap(0, length());
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr RecordArray::getitem_fields(const std::vector<std::string>& keys) const {
     std::vector<std::shared_ptr<Content>> contents;
     std::shared_ptr<util::RecordLookup> recordlookup(nullptr);
     if (recordlookup_.get() != nullptr) {
@@ -322,7 +322,7 @@ namespace awkward {
     return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup);
   }
 
-  const std::shared_ptr<Content> RecordArray::carry(const Index64& carry) const {
+  ContentPtr RecordArray::carry(const Index64& carry) const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->carry(carry));
@@ -422,11 +422,11 @@ namespace awkward {
     return std::string();
   }
 
-  const std::shared_ptr<Content> RecordArray::shallow_simplify() const {
+  ContentPtr RecordArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const std::shared_ptr<Content> RecordArray::num(int64_t axis, int64_t depth) const {
+  ContentPtr RecordArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 single(1);
@@ -470,7 +470,7 @@ namespace awkward {
     }
   }
 
-  bool RecordArray::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool RecordArray::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -538,7 +538,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> RecordArray::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr RecordArray::merge(ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -624,7 +624,7 @@ namespace awkward {
     throw std::invalid_argument("cannot use records as a slice");
   }
 
-  const std::shared_ptr<Content> RecordArray::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr RecordArray::fillna(ContentPtr& value) const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->fillna(value));
@@ -632,7 +632,7 @@ namespace awkward {
     return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_, length_);
   }
 
-  const std::shared_ptr<Content> RecordArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr RecordArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -651,7 +651,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> RecordArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr RecordArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -670,7 +670,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> RecordArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr RecordArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto content : contents_) {
       std::shared_ptr<Content> trimmed = content.get()->getitem_range_nowrap(0, length());
@@ -680,7 +680,7 @@ namespace awkward {
     return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_, outlength);
   }
 
-  const std::shared_ptr<Content> RecordArray::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr RecordArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -694,7 +694,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> RecordArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr RecordArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -711,14 +711,14 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> RecordArray::field(int64_t fieldindex) const {
+  ContentPtr RecordArray::field(int64_t fieldindex) const {
     if (fieldindex >= numfields()) {
       throw std::invalid_argument(std::string("fieldindex ") + std::to_string(fieldindex) + std::string(" for record with only " + std::to_string(numfields()) + std::string(" fields")));
     }
     return contents_[(size_t)fieldindex];
   }
 
-  const std::shared_ptr<Content> RecordArray::field(const std::string& key) const {
+  ContentPtr RecordArray::field(const std::string& key) const {
     return contents_[(size_t)fieldindex(key)];
   }
 
@@ -747,7 +747,7 @@ namespace awkward {
     return std::make_shared<RecordArray>(identities_, parameters_, contents_, std::shared_ptr<util::RecordLookup>(nullptr), length_);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  ContentPtr RecordArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     Slice emptytail;
@@ -781,48 +781,48 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr RecordArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(at)"));
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr RecordArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(range)"));
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr RecordArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(array)"));
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  ContentPtr RecordArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     return getitem_field(field.key()).get()->getitem_next(nexthead, nexttail, advanced);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  ContentPtr RecordArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     return getitem_fields(fields.keys()).get()->getitem_next(nexthead, nexttail, advanced);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr RecordArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(jagged)"));
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  const std::shared_ptr<Content> RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename S>
-  const std::shared_ptr<Content> RecordArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  ContentPtr RecordArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
     if (contents_.empty()) {
       return shallow_copy();
     }

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -20,7 +20,7 @@
 #include "awkward/array/RecordArray.h"
 
 namespace awkward {
-  RecordArray::RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<std::shared_ptr<Content>>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup, int64_t length)
+  RecordArray::RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<ContentPtr>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup, int64_t length)
       : Content(identities, parameters)
       , contents_(contents)
       , recordlookup_(recordlookup)
@@ -30,7 +30,7 @@ namespace awkward {
     }
   }
 
-  int64_t minlength(const std::vector<std::shared_ptr<Content>>& contents) {
+  int64_t minlength(const std::vector<ContentPtr>& contents) {
     if (contents.empty()) {
       return 0;
     }
@@ -46,10 +46,10 @@ namespace awkward {
     }
   }
 
-  RecordArray::RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<std::shared_ptr<Content>>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup)
+  RecordArray::RecordArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::vector<ContentPtr>& contents, const std::shared_ptr<util::RecordLookup>& recordlookup)
       : RecordArray(identities, parameters, contents, recordlookup, minlength(contents)) { }
 
-  const std::vector<std::shared_ptr<Content>> RecordArray::contents() const {
+  const std::vector<ContentPtr> RecordArray::contents() const {
     return contents_;
   }
 
@@ -61,14 +61,14 @@ namespace awkward {
     return recordlookup_.get() == nullptr;
   }
 
-  ContentPtr RecordArray::setitem_field(int64_t where, ContentPtr& what) const {
+  const ContentPtr RecordArray::setitem_field(int64_t where, const ContentPtr& what) const {
     if (where < 0) {
       throw std::invalid_argument("where must be non-negative");
     }
     if (what.get()->length() != length()) {
       throw std::invalid_argument(std::string("array of length ") + std::to_string(what.get()->length()) + std::string(" cannot be assigned to record array of length ") + std::to_string(length()));
     }
-    std::vector<std::shared_ptr<Content>> contents;
+    std::vector<ContentPtr> contents;
     for (size_t i = 0;  i < contents_.size();  i++) {
       if (where == (int64_t)i) {
         contents.push_back(what);
@@ -94,11 +94,11 @@ namespace awkward {
     return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup);
   }
 
-  ContentPtr RecordArray::setitem_field(const std::string& where, ContentPtr& what) const {
+  const ContentPtr RecordArray::setitem_field(const std::string& where, const ContentPtr& what) const {
     if (what.get()->length() != length()) {
       throw std::invalid_argument(std::string("array of length ") + std::to_string(what.get()->length()) + std::string(" cannot be assigned to record array of length ") + std::to_string(length()));
     }
-    std::vector<std::shared_ptr<Content>> contents(contents_.begin(), contents_.end());
+    std::vector<ContentPtr> contents(contents_.begin(), contents_.end());
     contents.push_back(what);
     std::shared_ptr<util::RecordLookup> recordlookup;
     if (recordlookup_.get() != nullptr) {
@@ -238,12 +238,12 @@ namespace awkward {
     return length_;
   }
 
-  ContentPtr RecordArray::shallow_copy() const {
+  const ContentPtr RecordArray::shallow_copy() const {
     return std::make_shared<RecordArray>(identities_, parameters_, contents_, recordlookup_, length_);
   }
 
-  ContentPtr RecordArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
-    std::vector<std::shared_ptr<Content>> contents;
+  const ContentPtr RecordArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+    std::vector<ContentPtr> contents;
     for (auto x : contents_) {
       contents.push_back(x.get()->deep_copy(copyarrays, copyindexes, copyidentities));
     }
@@ -260,11 +260,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr RecordArray::getitem_nothing() const {
+  const ContentPtr RecordArray::getitem_nothing() const {
     return getitem_range_nowrap(0, 0);
   }
 
-  ContentPtr RecordArray::getitem_at(int64_t at) const {
+  const ContentPtr RecordArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     int64_t len = length();
     if (regular_at < 0) {
@@ -276,11 +276,11 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  ContentPtr RecordArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr RecordArray::getitem_at_nowrap(int64_t at) const {
     return std::make_shared<Record>(shared_from_this(), at);
   }
 
-  ContentPtr RecordArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr RecordArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length_);
@@ -290,12 +290,12 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  ContentPtr RecordArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr RecordArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     if (contents_.empty()) {
       return std::make_shared<RecordArray>(identities_, parameters_, contents_, recordlookup_, stop - start);
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->getitem_range_nowrap(start, stop));
       }
@@ -303,12 +303,12 @@ namespace awkward {
     }
   }
 
-  ContentPtr RecordArray::getitem_field(const std::string& key) const {
+  const ContentPtr RecordArray::getitem_field(const std::string& key) const {
     return field(key).get()->getitem_range_nowrap(0, length());
   }
 
-  ContentPtr RecordArray::getitem_fields(const std::vector<std::string>& keys) const {
-    std::vector<std::shared_ptr<Content>> contents;
+  const ContentPtr RecordArray::getitem_fields(const std::vector<std::string>& keys) const {
+    std::vector<ContentPtr> contents;
     std::shared_ptr<util::RecordLookup> recordlookup(nullptr);
     if (recordlookup_.get() != nullptr) {
       recordlookup = std::make_shared<util::RecordLookup>();
@@ -322,8 +322,8 @@ namespace awkward {
     return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup);
   }
 
-  ContentPtr RecordArray::carry(const Index64& carry) const {
-    std::vector<std::shared_ptr<Content>> contents;
+  const ContentPtr RecordArray::carry(const Index64& carry) const {
+    std::vector<ContentPtr> contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->carry(carry));
     }
@@ -422,25 +422,25 @@ namespace awkward {
     return std::string();
   }
 
-  ContentPtr RecordArray::shallow_simplify() const {
+  const ContentPtr RecordArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  ContentPtr RecordArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr RecordArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 single(1);
       single.setitem_at_nowrap(0, length_);
-      std::shared_ptr<Content> singleton = std::make_shared<NumpyArray>(single);
-      std::vector<std::shared_ptr<Content>> contents;
+      ContentPtr singleton = std::make_shared<NumpyArray>(single);
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(singleton);
       }
-      std::shared_ptr<Content> record = std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_, 1);
+      ContentPtr record = std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_, 1);
       return record.get()->getitem_at_nowrap(0);
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->num(axis, depth));
       }
@@ -448,7 +448,7 @@ namespace awkward {
     }
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> RecordArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> RecordArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -457,20 +457,20 @@ namespace awkward {
       throw std::invalid_argument("arrays of records cannot be flattened (but their contents can be; try a different 'axis')");
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
-        std::shared_ptr<Content> trimmed = content.get()->getitem_range(0, length());
-        std::pair<Index64, std::shared_ptr<Content>> pair = trimmed.get()->offsets_and_flattened(axis, depth);
+        ContentPtr trimmed = content.get()->getitem_range(0, length());
+        std::pair<Index64, ContentPtr> pair = trimmed.get()->offsets_and_flattened(axis, depth);
         if (pair.first.length() != 0) {
           throw std::runtime_error("RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened");
         }
         contents.push_back(pair.second);
       }
-      return std::pair<Index64, std::shared_ptr<Content>>(Index64(0), std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_));
+      return std::pair<Index64, ContentPtr>(Index64(0), std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_));
     }
   }
 
-  bool RecordArray::mergeable(ContentPtr& other, bool mergebool) const {
+  bool RecordArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -538,7 +538,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr RecordArray::merge(ContentPtr& other) const {
+  const ContentPtr RecordArray::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -589,10 +589,10 @@ namespace awkward {
       }
       if (istuple()  &&  rawother->istuple()) {
         if (numfields() == rawother->numfields()) {
-          std::vector<std::shared_ptr<Content>> contents;
+          std::vector<ContentPtr> contents;
           for (int64_t i = 0;  i < numfields();  i++) {
-            std::shared_ptr<Content> mine = field(i).get()->getitem_range_nowrap(0, mylength);
-            std::shared_ptr<Content> theirs = rawother->field(i).get()->getitem_range_nowrap(0, theirlength);
+            ContentPtr mine = field(i).get()->getitem_range_nowrap(0, mylength);
+            ContentPtr theirs = rawother->field(i).get()->getitem_range_nowrap(0, theirlength);
             contents.push_back(mine.get()->merge(theirs));
           }
           return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_);
@@ -604,10 +604,10 @@ namespace awkward {
         std::sort(self_keys.begin(), self_keys.end());
         std::sort(other_keys.begin(), other_keys.end());
         if (self_keys == other_keys) {
-          std::vector<std::shared_ptr<Content>> contents;
+          std::vector<ContentPtr> contents;
           for (auto key : keys()) {
-            std::shared_ptr<Content> mine = field(key).get()->getitem_range_nowrap(0, mylength);
-            std::shared_ptr<Content> theirs = rawother->field(key).get()->getitem_range_nowrap(0, theirlength);
+            ContentPtr mine = field(key).get()->getitem_range_nowrap(0, mylength);
+            ContentPtr theirs = rawother->field(key).get()->getitem_range_nowrap(0, theirlength);
             contents.push_back(mine.get()->merge(theirs));
           }
           return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_);
@@ -624,21 +624,21 @@ namespace awkward {
     throw std::invalid_argument("cannot use records as a slice");
   }
 
-  ContentPtr RecordArray::fillna(ContentPtr& value) const {
-    std::vector<std::shared_ptr<Content>> contents;
+  const ContentPtr RecordArray::fillna(const ContentPtr& value) const {
+    std::vector<ContentPtr> contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->fillna(value));
     }
     return std::make_shared<RecordArray>(identities_, parameters_, contents, recordlookup_, length_);
   }
 
-  ContentPtr RecordArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr RecordArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->rpad(target, toaxis, depth));
       }
@@ -651,13 +651,13 @@ namespace awkward {
     }
   }
 
-  ContentPtr RecordArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr RecordArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->rpad_and_clip(target, toaxis, depth));
       }
@@ -670,23 +670,23 @@ namespace awkward {
     }
   }
 
-  ContentPtr RecordArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
-    std::vector<std::shared_ptr<Content>> contents;
+  const ContentPtr RecordArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+    std::vector<ContentPtr> contents;
     for (auto content : contents_) {
-      std::shared_ptr<Content> trimmed = content.get()->getitem_range_nowrap(0, length());
-      std::shared_ptr<Content> next = trimmed.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+      ContentPtr trimmed = content.get()->getitem_range_nowrap(0, length());
+      ContentPtr next = trimmed.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
       contents.push_back(next);
     }
     return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, recordlookup_, outlength);
   }
 
-  ContentPtr RecordArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr RecordArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->localindex(axis, depth));
       }
@@ -694,7 +694,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr RecordArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr RecordArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -703,7 +703,7 @@ namespace awkward {
       return choose_axis0(n, diagonal, recordlookup, parameters);
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->choose(n, diagonal, recordlookup, parameters, axis, depth));
       }
@@ -711,33 +711,33 @@ namespace awkward {
     }
   }
 
-  ContentPtr RecordArray::field(int64_t fieldindex) const {
+  const ContentPtr RecordArray::field(int64_t fieldindex) const {
     if (fieldindex >= numfields()) {
       throw std::invalid_argument(std::string("fieldindex ") + std::to_string(fieldindex) + std::string(" for record with only " + std::to_string(numfields()) + std::string(" fields")));
     }
     return contents_[(size_t)fieldindex];
   }
 
-  ContentPtr RecordArray::field(const std::string& key) const {
+  const ContentPtr RecordArray::field(const std::string& key) const {
     return contents_[(size_t)fieldindex(key)];
   }
 
-  const std::vector<std::shared_ptr<Content>> RecordArray::fields() const {
-    return std::vector<std::shared_ptr<Content>>(contents_);
+  const std::vector<ContentPtr> RecordArray::fields() const {
+    return std::vector<ContentPtr>(contents_);
   }
 
-  const std::vector<std::pair<std::string, std::shared_ptr<Content>>> RecordArray::fielditems() const {
-    std::vector<std::pair<std::string, std::shared_ptr<Content>>> out;
+  const std::vector<std::pair<std::string, ContentPtr>> RecordArray::fielditems() const {
+    std::vector<std::pair<std::string, ContentPtr>> out;
     if (istuple()) {
       size_t cols = contents_.size();
       for (size_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, std::shared_ptr<Content>>(std::to_string(j), contents_[j]));
+        out.push_back(std::pair<std::string, ContentPtr>(std::to_string(j), contents_[j]));
       }
     }
     else {
       size_t cols = contents_.size();
       for (size_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, std::shared_ptr<Content>>(recordlookup_.get()->at(j), contents_[j]));
+        out.push_back(std::pair<std::string, ContentPtr>(recordlookup_.get()->at(j), contents_[j]));
       }
     }
     return out;
@@ -747,7 +747,7 @@ namespace awkward {
     return std::make_shared<RecordArray>(identities_, parameters_, contents_, std::shared_ptr<util::RecordLookup>(nullptr), length_);
   }
 
-  ContentPtr RecordArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RecordArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     Slice emptytail;
@@ -757,18 +757,18 @@ namespace awkward {
       return shallow_copy();
     }
     else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {
-      std::shared_ptr<Content> out = getitem_next(*field, emptytail, advanced);
+      ContentPtr out = getitem_next(*field, emptytail, advanced);
       return out.get()->getitem_next(nexthead, nexttail, advanced);
     }
     else if (SliceFields* fields = dynamic_cast<SliceFields*>(head.get())) {
-      std::shared_ptr<Content> out = getitem_next(*fields, emptytail, advanced);
+      ContentPtr out = getitem_next(*fields, emptytail, advanced);
       return out.get()->getitem_next(nexthead, nexttail, advanced);
     }
     else if (const SliceMissing64* missing = dynamic_cast<SliceMissing64*>(head.get())) {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->getitem_next(head, emptytail, advanced));
       }
@@ -781,53 +781,53 @@ namespace awkward {
     }
   }
 
-  ContentPtr RecordArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RecordArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(at)"));
   }
 
-  ContentPtr RecordArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RecordArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(range)"));
   }
 
-  ContentPtr RecordArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RecordArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(array)"));
   }
 
-  ContentPtr RecordArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RecordArray::getitem_next(const SliceField& field, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     return getitem_field(field.key()).get()->getitem_next(nexthead, nexttail, advanced);
   }
 
-  ContentPtr RecordArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RecordArray::getitem_next(const SliceFields& fields, const Slice& tail, const Index64& advanced) const {
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
     return getitem_fields(fields.keys()).get()->getitem_next(nexthead, nexttail, advanced);
   }
 
-  ContentPtr RecordArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RecordArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::invalid_argument(std::string("undefined operation: RecordArray::getitem_next(jagged)"));
   }
 
-  ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr RecordArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename S>
-  ContentPtr RecordArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  const ContentPtr RecordArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
     if (contents_.empty()) {
       return shallow_copy();
     }
     else {
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto content : contents_) {
         contents.push_back(content.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail));
       }

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -24,7 +24,10 @@
 #include "awkward/array/RegularArray.h"
 
 namespace awkward {
-  RegularArray::RegularArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtr& content, int64_t size)
+  RegularArray::RegularArray(const IdentitiesPtr& identities,
+                             const util::Parameters& parameters,
+                             const ContentPtr& content,
+                             int64_t size)
       : Content(identities, parameters)
       , content_(content)
       , size_(size) {
@@ -33,15 +36,18 @@ namespace awkward {
     }
   }
 
-  const ContentPtr RegularArray::content() const {
+  const ContentPtr
+  RegularArray::content() const {
     return content_;
   }
 
-  int64_t RegularArray::size() const {
+  int64_t
+  RegularArray::size() const {
     return size_;
   }
 
-  Index64 RegularArray::compact_offsets64(bool start_at_zero) const {
+  Index64
+  RegularArray::compact_offsets64(bool start_at_zero) const {
     int64_t len = length();
     Index64 out(len + 1);
     struct Error err = awkward_regulararray_compact_offsets64(
@@ -52,19 +58,25 @@ namespace awkward {
     return out;
   }
 
-  const ContentPtr RegularArray::broadcast_tooffsets64(const Index64& offsets) const {
+  const ContentPtr
+  RegularArray::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
-      throw std::invalid_argument("broadcast_tooffsets64 can only be used with offsets that start at 0");
+      throw std::invalid_argument(
+        "broadcast_tooffsets64 can only be used with offsets that start at 0");
     }
 
     int64_t len = length();
     if (offsets.length() - 1 != len) {
-      throw std::invalid_argument(std::string("cannot broadcast RegularArray of length ") + std::to_string(len) + (" to length ") + std::to_string(offsets.length() - 1));
+      throw std::invalid_argument(
+        std::string("cannot broadcast RegularArray of length ")
+        + std::to_string(len) + (" to length ")
+        + std::to_string(offsets.length() - 1));
     }
 
     IdentitiesPtr identities;
     if (identities_.get() != nullptr) {
-      identities = identities_.get()->getitem_range_nowrap(0, offsets.length() - 1);
+      identities =
+        identities_.get()->getitem_range_nowrap(0, offsets.length() - 1);
     }
 
     if (size_ == 1) {
@@ -77,7 +89,10 @@ namespace awkward {
         offsets.length());
       util::handle_error(err, classname(), identities_.get());
       ContentPtr nextcontent = content_.get()->carry(nextcarry);
-      return std::make_shared<ListOffsetArray64>(identities, parameters_, offsets, nextcontent);
+      return std::make_shared<ListOffsetArray64>(identities,
+                                                 parameters_,
+                                                 offsets,
+                                                 nextcontent);
     }
     else {
       struct Error err = awkward_regulararray_broadcast_tooffsets64(
@@ -86,38 +101,56 @@ namespace awkward {
         offsets.length(),
         size_);
       util::handle_error(err, classname(), identities_.get());
-      return std::make_shared<ListOffsetArray64>(identities, parameters_, offsets, content_);
+      return std::make_shared<ListOffsetArray64>(identities,
+                                                 parameters_,
+                                                 offsets,
+                                                 content_);
     }
   }
 
-  const ContentPtr RegularArray::toRegularArray() const {
+  const ContentPtr
+  RegularArray::toRegularArray() const {
     return shallow_copy();
   }
 
-  const ContentPtr RegularArray::toListOffsetArray64(bool start_at_zero) const {
+  const ContentPtr
+  RegularArray::toListOffsetArray64(bool start_at_zero) const {
     Index64 offsets = compact_offsets64(start_at_zero);
     return broadcast_tooffsets64(offsets);
   }
 
-  const std::string RegularArray::classname() const {
+  const std::string
+  RegularArray::classname() const {
     return "RegularArray";
   }
 
-  void RegularArray::setidentities(const IdentitiesPtr& identities) {
+  void
+  RegularArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
     else {
       if (length() != identities.get()->length()) {
-        util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(
+          failure("content and its identities must have the same length",
+                  kSliceNone,
+                  kSliceNone),
+          classname(),
+          identities_.get());
       }
       IdentitiesPtr bigidentities = identities;
       if (content_.get()->length() > kMaxInt32) {
         bigidentities = identities.get()->to64();
       }
-      if (Identities32* rawidentities = dynamic_cast<Identities32*>(bigidentities.get())) {
-        IdentitiesPtr subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width() + 1, content_.get()->length());
-        Identities32* rawsubidentities = reinterpret_cast<Identities32*>(subidentities.get());
+      if (Identities32* rawidentities =
+          dynamic_cast<Identities32*>(bigidentities.get())) {
+        IdentitiesPtr subidentities =
+          std::make_shared<Identities32>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width() + 1,
+                                         content_.get()->length());
+        Identities32* rawsubidentities =
+          reinterpret_cast<Identities32*>(subidentities.get());
         struct Error err = awkward_identities32_from_regulararray(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -129,9 +162,15 @@ namespace awkward {
         util::handle_error(err, classname(), identities_.get());
         content_.get()->setidentities(subidentities);
       }
-      else if (Identities64* rawidentities = dynamic_cast<Identities64*>(bigidentities.get())) {
-        IdentitiesPtr subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width() + 1, content_.get()->length());
-        Identities64* rawsubidentities = reinterpret_cast<Identities64*>(subidentities.get());
+      else if (Identities64* rawidentities =
+               dynamic_cast<Identities64*>(bigidentities.get())) {
+        IdentitiesPtr subidentities =
+          std::make_shared<Identities64>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width() + 1,
+                                         content_.get()->length());
+        Identities64* rawsubidentities =
+          reinterpret_cast<Identities64*>(subidentities.get());
         struct Error err = awkward_identities64_from_regulararray(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -150,42 +189,67 @@ namespace awkward {
     identities_ = identities;
   }
 
-  void RegularArray::setidentities() {
+  void
+  RegularArray::setidentities() {
     if (length() < kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err = awkward_new_identities32(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err =
+        awkward_new_identities64(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
   }
 
-  const TypePtr RegularArray::type(const util::TypeStrs& typestrs) const {
-    return std::make_shared<RegularType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs), size_);
+  const TypePtr
+  RegularArray::type(const util::TypeStrs& typestrs) const {
+    return std::make_shared<RegularType>(
+      parameters_,
+      util::gettypestr(parameters_, typestrs),
+      content_.get()->type(typestrs),
+      size_);
   }
 
-  const std::string RegularArray::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  RegularArray::tostring_part(const std::string& indent,
+                              const std::string& pre,
+                              const std::string& post) const {
     std::stringstream out;
-    out << indent << pre << "<" << classname() << " size=\"" << size_ << "\">\n";
+    out << indent << pre << "<" << classname() << " size=\"" << size_
+        << "\">\n";
     if (identities_.get() != nullptr) {
-      out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+      out << identities_.get()->tostring_part(
+               indent + std::string("    "), "", "\n");
     }
     if (!parameters_.empty()) {
       out << parameters_tostring(indent + std::string("    "), "", "\n");
     }
-    out << content_.get()->tostring_part(indent + std::string("    "), "<content>", "</content>\n");
+    out << content_.get()->tostring_part(
+             indent + std::string("    "), "<content>", "</content>\n");
     out << indent << "</" << classname() << ">" << post;
     return out.str();
   }
 
-  void RegularArray::tojson_part(ToJson& builder) const {
+  void
+  RegularArray::tojson_part(ToJson& builder) const {
     int64_t len = length();
     check_for_iteration();
     builder.beginlist();
@@ -195,83 +259,129 @@ namespace awkward {
     builder.endlist();
   }
 
-  void RegularArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  RegularArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
     content_.get()->nbytes_part(largest);
     if (identities_.get() != nullptr) {
       identities_.get()->nbytes_part(largest);
     }
   }
 
-  int64_t RegularArray::length() const {
-    return size_ == 0 ? 0 : content_.get()->length() / size_;   // floor of length / size
+  int64_t
+  RegularArray::length() const {
+    return (size_ == 0
+              ? 0
+              : content_.get()->length() / size_);   // floor of length / size
   }
 
-  const ContentPtr RegularArray::shallow_copy() const {
-    return std::make_shared<RegularArray>(identities_, parameters_, content_, size_);
+  const ContentPtr
+  RegularArray::shallow_copy() const {
+    return std::make_shared<RegularArray>(identities_,
+                                          parameters_,
+                                          content_,
+                                          size_);
   }
 
-  const ContentPtr RegularArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
-    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+  const ContentPtr
+  RegularArray::deep_copy(bool copyarrays,
+                          bool copyindexes,
+                          bool copyidentities) const {
+    ContentPtr content = content_.get()->deep_copy(copyarrays,
+                                                   copyindexes,
+                                                   copyidentities);
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
-    return std::make_shared<RegularArray>(identities, parameters_, content, size_);
+    return std::make_shared<RegularArray>(identities,
+                                          parameters_,
+                                          content,
+                                          size_);
   }
 
-  void RegularArray::check_for_iteration() const {
-    if (identities_.get() != nullptr  && identities_.get()->length() < length()) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+  void
+  RegularArray::check_for_iteration() const {
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < length()) {
+      util::handle_error(
+        failure("len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
-  const ContentPtr RegularArray::getitem_nothing() const {
+  const ContentPtr
+  RegularArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  const ContentPtr RegularArray::getitem_at(int64_t at) const {
+  const ContentPtr
+  RegularArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     int64_t len = length();
     if (regular_at < 0) {
       regular_at += len;
     }
     if (!(0 <= regular_at  &&  regular_at < len)) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
-  const ContentPtr RegularArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  RegularArray::getitem_at_nowrap(int64_t at) const {
     return content_.get()->getitem_range_nowrap(at*size_, (at + 1)*size_);
   }
 
-  const ContentPtr RegularArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  RegularArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
-    if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-      util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), length());
+    if (identities_.get() != nullptr  &&
+        regular_stop > identities_.get()->length()) {
+      util::handle_error(
+        failure("index out of range", kSliceNone, stop),
+        identities_.get()->classname(),
+        nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const ContentPtr RegularArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  RegularArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
-    return std::make_shared<RegularArray>(identities_, parameters_, content_.get()->getitem_range_nowrap(start*size_, stop*size_), size_);
+    return std::make_shared<RegularArray>(
+      identities_,
+      parameters_,
+      content_.get()->getitem_range_nowrap(start*size_, stop*size_), size_);
   }
 
-  const ContentPtr RegularArray::getitem_field(const std::string& key) const {
-    return std::make_shared<RegularArray>(identities_, util::Parameters(), content_.get()->getitem_field(key), size_);
+  const ContentPtr
+  RegularArray::getitem_field(const std::string& key) const {
+    return std::make_shared<RegularArray>(
+      identities_,
+      util::Parameters(),
+      content_.get()->getitem_field(key), size_);
   }
 
-  const ContentPtr RegularArray::getitem_fields(const std::vector<std::string>& keys) const {
-    return std::make_shared<RegularArray>(identities_, util::Parameters(), content_.get()->getitem_fields(keys), size_);
+  const ContentPtr
+  RegularArray::getitem_fields(const std::vector<std::string>& keys) const {
+    return std::make_shared<RegularArray>(
+      identities_,
+      util::Parameters(),
+      content_.get()->getitem_fields(keys), size_);
   }
 
-  const ContentPtr RegularArray::carry(const Index64& carry) const {
+  const ContentPtr
+  RegularArray::carry(const Index64& carry) const {
     Index64 nextcarry(carry.length()*size_);
 
     struct Error err = awkward_regulararray_getitem_carry_64(
@@ -285,10 +395,14 @@ namespace awkward {
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
-    return std::make_shared<RegularArray>(identities, parameters_, content_.get()->carry(nextcarry), size_);
+    return std::make_shared<RegularArray>(identities,
+                                          parameters_,
+                                          content_.get()->carry(nextcarry),
+                                          size_);
   }
 
-  const std::string RegularArray::purelist_parameter(const std::string& key) const {
+  const std::string
+  RegularArray::purelist_parameter(const std::string& key) const {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       return content_.get()->purelist_parameter(key);
@@ -298,53 +412,67 @@ namespace awkward {
     }
   }
 
-  bool RegularArray::purelist_isregular() const {
+  bool
+  RegularArray::purelist_isregular() const {
     return content_.get()->purelist_isregular();
   }
 
-  int64_t RegularArray::purelist_depth() const {
+  int64_t
+  RegularArray::purelist_depth() const {
     return content_.get()->purelist_depth() + 1;
   }
 
-  const std::pair<int64_t, int64_t> RegularArray::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  RegularArray::minmax_depth() const {
     std::pair<int64_t, int64_t> content_depth = content_.get()->minmax_depth();
-    return std::pair<int64_t, int64_t>(content_depth.first + 1, content_depth.second + 1);
+    return std::pair<int64_t, int64_t>(content_depth.first + 1,
+                                       content_depth.second + 1);
   }
 
-  const std::pair<bool, int64_t> RegularArray::branch_depth() const {
+  const std::pair<bool, int64_t>
+  RegularArray::branch_depth() const {
     std::pair<bool, int64_t> content_depth = content_.get()->branch_depth();
-    return std::pair<bool, int64_t>(content_depth.first, content_depth.second + 1);
+    return std::pair<bool, int64_t>(content_depth.first,
+                                    content_depth.second + 1);
   }
 
-  int64_t RegularArray::numfields() const {
+  int64_t
+  RegularArray::numfields() const {
     return content_.get()->numfields();
   }
 
-  int64_t RegularArray::fieldindex(const std::string& key) const {
+  int64_t
+  RegularArray::fieldindex(const std::string& key) const {
     return content_.get()->fieldindex(key);
   }
 
-  const std::string RegularArray::key(int64_t fieldindex) const {
+  const std::string
+  RegularArray::key(int64_t fieldindex) const {
     return content_.get()->key(fieldindex);
   }
 
-  bool RegularArray::haskey(const std::string& key) const {
+  bool
+  RegularArray::haskey(const std::string& key) const {
     return content_.get()->haskey(key);
   }
 
-  const std::vector<std::string> RegularArray::keys() const {
+  const std::vector<std::string>
+  RegularArray::keys() const {
     return content_.get()->keys();
   }
 
-  const std::string RegularArray::validityerror(const std::string& path) const {
+  const std::string
+  RegularArray::validityerror(const std::string& path) const {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  const ContentPtr RegularArray::shallow_simplify() const {
+  const ContentPtr
+  RegularArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  const ContentPtr RegularArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RegularArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -362,15 +490,20 @@ namespace awkward {
     }
     else {
       ContentPtr next = content_.get()->num(axis, depth + 1);
-      return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), next, size_);
+      return std::make_shared<RegularArray>(Identities::none(),
+                                            util::Parameters(),
+                                            next,
+                                            size_);
     }
   }
 
-  const std::pair<Index64, ContentPtr> RegularArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  RegularArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     return toListOffsetArray64(true).get()->offsets_and_flattened(axis, depth);
   }
 
-  bool RegularArray::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  RegularArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -381,50 +514,65 @@ namespace awkward {
         dynamic_cast<UnionArray8_64*>(other.get())) {
       return true;
     }
-    else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    else if (IndexedArray32* rawother =
+             dynamic_cast<IndexedArray32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return mergeable(rawother->content(), mergebool);
     }
 
-    if (RegularArray* rawother = dynamic_cast<RegularArray*>(other.get())) {
+    if (RegularArray* rawother =
+        dynamic_cast<RegularArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListArray32* rawother = dynamic_cast<ListArray32*>(other.get())) {
+    else if (ListArray32* rawother =
+             dynamic_cast<ListArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListArrayU32* rawother = dynamic_cast<ListArrayU32*>(other.get())) {
+    else if (ListArrayU32* rawother =
+             dynamic_cast<ListArrayU32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListArray64* rawother = dynamic_cast<ListArray64*>(other.get())) {
+    else if (ListArray64* rawother =
+             dynamic_cast<ListArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListOffsetArray32* rawother = dynamic_cast<ListOffsetArray32*>(other.get())) {
+    else if (ListOffsetArray32* rawother =
+             dynamic_cast<ListOffsetArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListOffsetArrayU32* rawother = dynamic_cast<ListOffsetArrayU32*>(other.get())) {
+    else if (ListOffsetArrayU32* rawother =
+             dynamic_cast<ListOffsetArrayU32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ListOffsetArray64* rawother = dynamic_cast<ListOffsetArray64*>(other.get())) {
+    else if (ListOffsetArray64* rawother =
+             dynamic_cast<ListOffsetArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
     else {
@@ -432,7 +580,8 @@ namespace awkward {
     }
   }
 
-  const ContentPtr RegularArray::merge(const ContentPtr& other) const {
+  const ContentPtr
+  RegularArray::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -440,46 +589,63 @@ namespace awkward {
     if (dynamic_cast<EmptyArray*>(other.get())) {
       return shallow_copy();
     }
-    else if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    else if (IndexedArray32* rawother =
+             dynamic_cast<IndexedArray32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_32* rawother = dynamic_cast<UnionArray8_32*>(other.get())) {
+    else if (UnionArray8_32* rawother =
+             dynamic_cast<UnionArray8_32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_U32* rawother = dynamic_cast<UnionArray8_U32*>(other.get())) {
+    else if (UnionArray8_U32* rawother =
+             dynamic_cast<UnionArray8_U32*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
-    else if (UnionArray8_64* rawother = dynamic_cast<UnionArray8_64*>(other.get())) {
+    else if (UnionArray8_64* rawother =
+             dynamic_cast<UnionArray8_64*>(other.get())) {
       return rawother->reverse_merge(shallow_copy());
     }
 
     if (RegularArray* rawother = dynamic_cast<RegularArray*>(other.get())) {
       if (size_ == rawother->size()) {
-        ContentPtr mine = content_.get()->getitem_range_nowrap(0, size_*length());
-        ContentPtr theirs = rawother->content().get()->getitem_range_nowrap(0, rawother->size()*rawother->length());
+        ContentPtr mine =
+          content_.get()->getitem_range_nowrap(0, size_*length());
+        ContentPtr theirs =
+          rawother->content().get()->getitem_range_nowrap(
+            0, rawother->size()*rawother->length());
         ContentPtr content = mine.get()->merge(theirs);
-        return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), content, size_);
+        return std::make_shared<RegularArray>(Identities::none(),
+                                              util::Parameters(),
+                                              content,
+                                              size_);
       }
       else {
         return toListOffsetArray64(true).get()->merge(other);
@@ -494,19 +660,30 @@ namespace awkward {
       return toListOffsetArray64(true).get()->merge(other);
     }
     else {
-      throw std::invalid_argument(std::string("cannot merge ") + classname() + std::string(" with ") + other.get()->classname());
+      throw std::invalid_argument(
+        std::string("cannot merge ") + classname() + std::string(" with ")
+        + other.get()->classname());
     }
   }
 
-  const SliceItemPtr RegularArray::asslice() const {
-    throw std::invalid_argument("slice items can have all fixed-size dimensions (to follow NumPy's slice rules) or they can have all var-sized dimensions (for jagged indexing), but not both in the same slice item");
+  const SliceItemPtr
+  RegularArray::asslice() const {
+    throw std::invalid_argument(
+      "slice items can have all fixed-size dimensions (to follow NumPy's "
+      "slice rules) or they can have all var-sized dimensions (for jagged "
+      "indexing), but not both in the same slice item");
   }
 
-  const ContentPtr RegularArray::fillna(const ContentPtr& value) const {
-    return std::make_shared<RegularArray>(identities_, parameters_, content().get()->fillna(value), size_);
+  const ContentPtr
+  RegularArray::fillna(const ContentPtr& value) const {
+    return std::make_shared<RegularArray>(identities_,
+                                          parameters_,
+                                          content().get()->fillna(value),
+                                          size_);
   }
 
-  const ContentPtr RegularArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RegularArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -520,11 +697,18 @@ namespace awkward {
       }
     }
     else {
-      return std::make_shared<RegularArray>(Identities::none(), parameters_, content_.get()->rpad(target, axis, depth + 1), size_);
+      return std::make_shared<RegularArray>(
+        Identities::none(),
+        parameters_,
+        content_.get()->rpad(target, axis, depth + 1),
+        size_);
     }
   }
 
-  const ContentPtr RegularArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RegularArray::rpad_and_clip(int64_t target,
+                              int64_t axis,
+                              int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -537,19 +721,45 @@ namespace awkward {
         size_,
         length());
       util::handle_error(err, classname(), identities_.get());
-      std::shared_ptr<IndexedOptionArray64> next = std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, content());
-      return std::make_shared<RegularArray>(Identities::none(), parameters_, next.get()->simplify_optiontype(), target);
+      std::shared_ptr<IndexedOptionArray64> next =
+        std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                               util::Parameters(),
+                                               index,
+                                               content());
+      return std::make_shared<RegularArray>(
+        Identities::none(),
+        parameters_,
+        next.get()->simplify_optiontype(),
+        target);
     }
     else {
-      return std::make_shared<RegularArray>(Identities::none(), parameters_, content_.get()->rpad_and_clip(target, toaxis, depth + 1), size_);
+      return std::make_shared<RegularArray>(
+        Identities::none(),
+        parameters_,
+        content_.get()->rpad_and_clip(target, toaxis, depth + 1),
+        size_);
     }
   }
 
-  const ContentPtr RegularArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
-    return toListOffsetArray64(true).get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+  const ContentPtr
+  RegularArray::reduce_next(const Reducer& reducer,
+                            int64_t negaxis,
+                            const Index64& starts,
+                            const Index64& parents,
+                            int64_t outlength,
+                            bool mask,
+                            bool keepdims) const {
+    return toListOffsetArray64(true).get()->reduce_next(reducer,
+                                                        negaxis,
+                                                        starts,
+                                                        parents,
+                                                        outlength,
+                                                        mask,
+                                                        keepdims);
   }
 
-  const ContentPtr RegularArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RegularArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -561,14 +771,28 @@ namespace awkward {
         size_,
         length());
       util::handle_error(err, classname(), identities_.get());
-      return std::make_shared<RegularArray>(identities_, util::Parameters(), std::make_shared<NumpyArray>(localindex), size_);
+      return std::make_shared<RegularArray>(
+        identities_,
+        util::Parameters(),
+        std::make_shared<NumpyArray>(localindex),
+        size_);
     }
     else {
-      return std::make_shared<RegularArray>(identities_, util::Parameters(), content_.get()->localindex(axis, depth + 1), size_);
+      return std::make_shared<RegularArray>(
+        identities_,
+        util::Parameters(),
+        content_.get()->localindex(axis, depth + 1),
+        size_);
     }
   }
 
-  const ContentPtr RegularArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  RegularArray::choose(int64_t n,
+                       bool diagonal,
+                       const util::RecordLookupPtr& recordlookup,
+                       const util::Parameters& parameters,
+                       int64_t axis,
+                       int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -607,7 +831,8 @@ namespace awkward {
       std::vector<std::shared_ptr<int64_t>> tocarry;
       std::vector<int64_t*> tocarryraw;
       for (int64_t j = 0;  j < n;  j++) {
-        std::shared_ptr<int64_t> ptr(new int64_t[(size_t)totallen], util::array_deleter<int64_t>());
+        std::shared_ptr<int64_t> ptr(new int64_t[(size_t)totallen],
+                                     util::array_deleter<int64_t>());
         tocarry.push_back(ptr);
         tocarryraw.push_back(ptr.get());
       }
@@ -623,20 +848,41 @@ namespace awkward {
       for (auto ptr : tocarry) {
         contents.push_back(content_.get()->carry(Index64(ptr, 0, totallen)));
       }
-      ContentPtr recordarray = std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
+      ContentPtr recordarray =
+        std::make_shared<RecordArray>(Identities::none(),
+                                      parameters,
+                                      contents,
+                                      recordlookup);
 
-      return std::make_shared<RegularArray>(identities_, util::Parameters(), recordarray, chooselen);
+      return std::make_shared<RegularArray>(identities_,
+                                            util::Parameters(),
+                                            recordarray,
+                                            chooselen);
     }
 
     else {
-      ContentPtr next = content_.get()->getitem_range_nowrap(0, length()*size_).get()->choose(n, diagonal, recordlookup, parameters, axis, depth + 1);
-      return std::make_shared<RegularArray>(identities_, util::Parameters(), next, size_);
+      ContentPtr next = content_.get()
+                        ->getitem_range_nowrap(0, length()*size_).get()
+                        ->choose(n,
+                                 diagonal,
+                                 recordlookup,
+                                 parameters,
+                                 axis,
+                                 depth + 1);
+      return std::make_shared<RegularArray>(identities_,
+                                            util::Parameters(),
+                                            next,
+                                            size_);
     }
   }
 
-  const ContentPtr RegularArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  RegularArray::getitem_next(const SliceAt& at,
+                             const Slice& tail,
+                             const Index64& advanced) const {
     if (advanced.length() != 0) {
-      throw std::runtime_error("RegularArray::getitem_next(SliceAt): advanced.length() != 0");
+      throw std::runtime_error(
+        "RegularArray::getitem_next(SliceAt): advanced.length() != 0");
     }
     int64_t len = length();
     SliceItemPtr nexthead = tail.head();
@@ -654,18 +900,27 @@ namespace awkward {
     return nextcontent.get()->getitem_next(nexthead, nexttail, advanced);
   }
 
-  const ContentPtr RegularArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  RegularArray::getitem_next(const SliceRange& range,
+                             const Slice& tail,
+                             const Index64& advanced) const {
     int64_t len = length();
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
 
     if (range.step() == 0) {
-      throw std::runtime_error("RegularArray::getitem_next(SliceRange): range.step() == 0");
+      throw std::runtime_error(
+        "RegularArray::getitem_next(SliceRange): range.step() == 0");
     }
     int64_t regular_start = range.start();
     int64_t regular_stop = range.stop();
     int64_t regular_step = std::abs(range.step());
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, range.step() > 0, range.start() != Slice::none(), range.stop() != Slice::none(), size_);
+    awkward_regularize_rangeslice(&regular_start,
+                                  &regular_stop,
+                                  range.step() > 0,
+                                  range.start() != Slice::none(),
+                                  range.stop() != Slice::none(),
+                                  size_);
     int64_t nextsize = 0;
     if (range.step() > 0  &&  regular_stop - regular_start > 0) {
       int64_t diff = regular_stop - regular_start;
@@ -696,23 +951,35 @@ namespace awkward {
     ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
     if (advanced.length() == 0) {
-      return std::make_shared<RegularArray>(identities_, parameters_, nextcontent.get()->getitem_next(nexthead, nexttail, advanced), nextsize);
+      return std::make_shared<RegularArray>(
+        identities_,
+        parameters_,
+        nextcontent.get()->getitem_next(nexthead, nexttail, advanced),
+        nextsize);
     }
     else {
       Index64 nextadvanced(len*nextsize);
 
-      struct Error err = awkward_regulararray_getitem_next_range_spreadadvanced_64(
+      struct Error err =
+        awkward_regulararray_getitem_next_range_spreadadvanced_64(
         nextadvanced.ptr().get(),
         advanced.ptr().get(),
         len,
         nextsize);
       util::handle_error(err, classname(), identities_.get());
 
-      return std::make_shared<RegularArray>(identities_, parameters_, nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced), nextsize);
+      return std::make_shared<RegularArray>(
+        identities_,
+        parameters_,
+        nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced),
+        nextsize);
     }
   }
 
-  const ContentPtr RegularArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  RegularArray::getitem_next(const SliceArray64& array,
+                             const Slice& tail,
+                             const Index64& advanced) const {
     int64_t len = length();
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
@@ -741,7 +1008,11 @@ namespace awkward {
 
       ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
-      return getitem_next_array_wrap(nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced), array.shape());
+      return getitem_next_array_wrap(
+               nextcontent.get()->getitem_next(nexthead,
+                                               nexttail,
+                                               nextadvanced),
+               array.shape());
     }
     else {
       Index64 nextcarry(len);
@@ -762,13 +1033,20 @@ namespace awkward {
     }
   }
 
-  const ContentPtr RegularArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  RegularArray::getitem_next(const SliceJagged64& jagged,
+                             const Slice& tail,
+                             const Index64& advanced) const {
     if (advanced.length() != 0) {
-      throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
+      throw std::invalid_argument(
+        "cannot mix jagged slice with NumPy-style advanced indexing");
     }
 
     if (jagged.length() != size_) {
-      throw std::invalid_argument(std::string("cannot fit jagged slice with length ") + std::to_string(jagged.length()) + std::string(" into ") + classname() + std::string(" of size ") + std::to_string(size_));
+      throw std::invalid_argument(
+        std::string("cannot fit jagged slice with length ")
+        + std::to_string(jagged.length()) + std::string(" into ")
+        + classname() + std::string(" of size ") + std::to_string(size_));
     }
 
     int64_t regularlength = length();
@@ -783,24 +1061,51 @@ namespace awkward {
       regularlength);
     util::handle_error(err, classname(), identities_.get());
 
-    ContentPtr down = content_.get()->getitem_next_jagged(multistarts, multistops, jagged.content(), tail);
+    ContentPtr down = content_.get()->getitem_next_jagged(multistarts,
+                                                          multistops,
+                                                          jagged.content(),
+                                                          tail);
 
-    return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), down, jagged.length());
+    return std::make_shared<RegularArray>(Identities::none(),
+                                          util::Parameters(),
+                                          down,
+                                          jagged.length());
   }
 
-  const ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  RegularArray::getitem_next_jagged(const Index64& slicestarts,
+                                    const Index64& slicestops,
+                                    const SliceArray64& slicecontent,
+                                    const Slice& tail) const {
     ContentPtr self = toListOffsetArray64(true);
-    return self.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+    return self.get()->getitem_next_jagged(slicestarts,
+                                           slicestops,
+                                           slicecontent,
+                                           tail);
   }
 
-  const ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  RegularArray::getitem_next_jagged(const Index64& slicestarts,
+                                    const Index64& slicestops,
+                                    const SliceMissing64& slicecontent,
+                                    const Slice& tail) const {
     ContentPtr self = toListOffsetArray64(true);
-    return self.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+    return self.get()->getitem_next_jagged(slicestarts,
+                                           slicestops,
+                                           slicecontent,
+                                           tail);
   }
 
-  const ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  RegularArray::getitem_next_jagged(const Index64& slicestarts,
+                                    const Index64& slicestops,
+                                    const SliceJagged64& slicecontent,
+                                    const Slice& tail) const {
     ContentPtr self = toListOffsetArray64(true);
-    return self.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+    return self.get()->getitem_next_jagged(slicestarts,
+                                           slicestops,
+                                           slicecontent,
+                                           tail);
   }
 
 }

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -619,7 +619,7 @@ namespace awkward {
         length());
       util::handle_error(err, classname(), identities_.get());
 
-      std::vector<ContentPtr> contents;
+      ContentPtrVec contents;
       for (auto ptr : tocarry) {
         contents.push_back(content_.get()->carry(Index64(ptr, 0, totallen)));
       }

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -24,7 +24,7 @@
 #include "awkward/array/RegularArray.h"
 
 namespace awkward {
-  RegularArray::RegularArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, ContentPtr& content, int64_t size)
+  RegularArray::RegularArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtr& content, int64_t size)
       : Content(identities, parameters)
       , content_(content)
       , size_(size) {
@@ -33,7 +33,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr RegularArray::content() const {
+  const ContentPtr RegularArray::content() const {
     return content_;
   }
 
@@ -52,7 +52,7 @@ namespace awkward {
     return out;
   }
 
-  ContentPtr RegularArray::broadcast_tooffsets64(const Index64& offsets) const {
+  const ContentPtr RegularArray::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
       throw std::invalid_argument("broadcast_tooffsets64 can only be used with offsets that start at 0");
     }
@@ -76,7 +76,7 @@ namespace awkward {
         offsets.offset(),
         offsets.length());
       util::handle_error(err, classname(), identities_.get());
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
       return std::make_shared<ListOffsetArray64>(identities, parameters_, offsets, nextcontent);
     }
     else {
@@ -90,11 +90,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr RegularArray::toRegularArray() const {
+  const ContentPtr RegularArray::toRegularArray() const {
     return shallow_copy();
   }
 
-  ContentPtr RegularArray::toListOffsetArray64(bool start_at_zero) const {
+  const ContentPtr RegularArray::toListOffsetArray64(bool start_at_zero) const {
     Index64 offsets = compact_offsets64(start_at_zero);
     return broadcast_tooffsets64(offsets);
   }
@@ -206,12 +206,12 @@ namespace awkward {
     return size_ == 0 ? 0 : content_.get()->length() / size_;   // floor of length / size
   }
 
-  ContentPtr RegularArray::shallow_copy() const {
+  const ContentPtr RegularArray::shallow_copy() const {
     return std::make_shared<RegularArray>(identities_, parameters_, content_, size_);
   }
 
-  ContentPtr RegularArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
-    std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+  const ContentPtr RegularArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -225,11 +225,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr RegularArray::getitem_nothing() const {
+  const ContentPtr RegularArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  ContentPtr RegularArray::getitem_at(int64_t at) const {
+  const ContentPtr RegularArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     int64_t len = length();
     if (regular_at < 0) {
@@ -241,11 +241,11 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  ContentPtr RegularArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr RegularArray::getitem_at_nowrap(int64_t at) const {
     return content_.get()->getitem_range_nowrap(at*size_, (at + 1)*size_);
   }
 
-  ContentPtr RegularArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr RegularArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
@@ -255,7 +255,7 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  ContentPtr RegularArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr RegularArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -263,15 +263,15 @@ namespace awkward {
     return std::make_shared<RegularArray>(identities_, parameters_, content_.get()->getitem_range_nowrap(start*size_, stop*size_), size_);
   }
 
-  ContentPtr RegularArray::getitem_field(const std::string& key) const {
+  const ContentPtr RegularArray::getitem_field(const std::string& key) const {
     return std::make_shared<RegularArray>(identities_, util::Parameters(), content_.get()->getitem_field(key), size_);
   }
 
-  ContentPtr RegularArray::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr RegularArray::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<RegularArray>(identities_, util::Parameters(), content_.get()->getitem_fields(keys), size_);
   }
 
-  ContentPtr RegularArray::carry(const Index64& carry) const {
+  const ContentPtr RegularArray::carry(const Index64& carry) const {
     Index64 nextcarry(carry.length()*size_);
 
     struct Error err = awkward_regulararray_getitem_carry_64(
@@ -340,11 +340,11 @@ namespace awkward {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  ContentPtr RegularArray::shallow_simplify() const {
+  const ContentPtr RegularArray::shallow_simplify() const {
     return shallow_copy();
   }
 
-  ContentPtr RegularArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr RegularArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -361,16 +361,16 @@ namespace awkward {
       return std::make_shared<NumpyArray>(tonum);
     }
     else {
-      std::shared_ptr<Content> next = content_.get()->num(axis, depth + 1);
+      ContentPtr next = content_.get()->num(axis, depth + 1);
       return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), next, size_);
     }
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> RegularArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> RegularArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     return toListOffsetArray64(true).get()->offsets_and_flattened(axis, depth);
   }
 
-  bool RegularArray::mergeable(ContentPtr& other, bool mergebool) const {
+  bool RegularArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -432,7 +432,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr RegularArray::merge(ContentPtr& other) const {
+  const ContentPtr RegularArray::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -476,9 +476,9 @@ namespace awkward {
 
     if (RegularArray* rawother = dynamic_cast<RegularArray*>(other.get())) {
       if (size_ == rawother->size()) {
-        std::shared_ptr<Content> mine = content_.get()->getitem_range_nowrap(0, size_*length());
-        std::shared_ptr<Content> theirs = rawother->content().get()->getitem_range_nowrap(0, rawother->size()*rawother->length());
-        std::shared_ptr<Content> content = mine.get()->merge(theirs);
+        ContentPtr mine = content_.get()->getitem_range_nowrap(0, size_*length());
+        ContentPtr theirs = rawother->content().get()->getitem_range_nowrap(0, rawother->size()*rawother->length());
+        ContentPtr content = mine.get()->merge(theirs);
         return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), content, size_);
       }
       else {
@@ -502,11 +502,11 @@ namespace awkward {
     throw std::invalid_argument("slice items can have all fixed-size dimensions (to follow NumPy's slice rules) or they can have all var-sized dimensions (for jagged indexing), but not both in the same slice item");
   }
 
-  ContentPtr RegularArray::fillna(ContentPtr& value) const {
+  const ContentPtr RegularArray::fillna(const ContentPtr& value) const {
     return std::make_shared<RegularArray>(identities_, parameters_, content().get()->fillna(value), size_);
   }
 
-  ContentPtr RegularArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr RegularArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -524,7 +524,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr RegularArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr RegularArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -545,11 +545,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr RegularArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr RegularArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     return toListOffsetArray64(true).get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  ContentPtr RegularArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr RegularArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -568,7 +568,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr RegularArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr RegularArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -619,22 +619,22 @@ namespace awkward {
         length());
       util::handle_error(err, classname(), identities_.get());
 
-      std::vector<std::shared_ptr<Content>> contents;
+      std::vector<ContentPtr> contents;
       for (auto ptr : tocarry) {
         contents.push_back(content_.get()->carry(Index64(ptr, 0, totallen)));
       }
-      std::shared_ptr<Content> recordarray = std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
+      ContentPtr recordarray = std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup);
 
       return std::make_shared<RegularArray>(identities_, util::Parameters(), recordarray, chooselen);
     }
 
     else {
-      std::shared_ptr<Content> next = content_.get()->getitem_range_nowrap(0, length()*size_).get()->choose(n, diagonal, recordlookup, parameters, axis, depth + 1);
+      ContentPtr next = content_.get()->getitem_range_nowrap(0, length()*size_).get()->choose(n, diagonal, recordlookup, parameters, axis, depth + 1);
       return std::make_shared<RegularArray>(identities_, util::Parameters(), next, size_);
     }
   }
 
-  ContentPtr RegularArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RegularArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::runtime_error("RegularArray::getitem_next(SliceAt): advanced.length() != 0");
     }
@@ -650,11 +650,11 @@ namespace awkward {
       size_);
     util::handle_error(err, classname(), identities_.get());
 
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
     return nextcontent.get()->getitem_next(nexthead, nexttail, advanced);
   }
 
-  ContentPtr RegularArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RegularArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     int64_t len = length();
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
@@ -693,7 +693,7 @@ namespace awkward {
       nextsize);
     util::handle_error(err, classname(), identities_.get());
 
-    std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+    ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
     if (advanced.length() == 0) {
       return std::make_shared<RegularArray>(identities_, parameters_, nextcontent.get()->getitem_next(nexthead, nexttail, advanced), nextsize);
@@ -712,7 +712,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr RegularArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RegularArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     int64_t len = length();
     std::shared_ptr<SliceItem> nexthead = tail.head();
     Slice nexttail = tail.tail();
@@ -739,7 +739,7 @@ namespace awkward {
         size_);
       util::handle_error(err, classname(), identities_.get());
 
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
 
       return getitem_next_array_wrap(nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced), array.shape());
     }
@@ -757,12 +757,12 @@ namespace awkward {
         size_);
       util::handle_error(err, classname(), identities_.get());
 
-      std::shared_ptr<Content> nextcontent = content_.get()->carry(nextcarry);
+      ContentPtr nextcontent = content_.get()->carry(nextcarry);
       return nextcontent.get()->getitem_next(nexthead, nexttail, nextadvanced);
     }
   }
 
-  ContentPtr RegularArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr RegularArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument("cannot mix jagged slice with NumPy-style advanced indexing");
     }
@@ -783,23 +783,23 @@ namespace awkward {
       regularlength);
     util::handle_error(err, classname(), identities_.get());
 
-    std::shared_ptr<Content> down = content_.get()->getitem_next_jagged(multistarts, multistops, jagged.content(), tail);
+    ContentPtr down = content_.get()->getitem_next_jagged(multistarts, multistops, jagged.content(), tail);
 
     return std::make_shared<RegularArray>(Identities::none(), util::Parameters(), down, jagged.length());
   }
 
-  ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    std::shared_ptr<Content> self = toListOffsetArray64(true);
+  const ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+    ContentPtr self = toListOffsetArray64(true);
     return self.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    std::shared_ptr<Content> self = toListOffsetArray64(true);
+  const ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+    ContentPtr self = toListOffsetArray64(true);
     return self.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    std::shared_ptr<Content> self = toListOffsetArray64(true);
+  const ContentPtr RegularArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+    ContentPtr self = toListOffsetArray64(true);
     return self.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
   }
 

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -167,7 +167,7 @@ namespace awkward {
     }
   }
 
-  const TypePtr RegularArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr RegularArray::type(const util::TypeStrs& typestrs) const {
     return std::make_shared<RegularType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs), size_);
   }
 

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -66,7 +66,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::content(int64_t index) const {
+  ContentPtr UnionArrayOf<T, I>::content(int64_t index) const {
     if (!(0 <= index  &&  index < numcontents())) {
       throw std::invalid_argument(std::string("index ") + std::to_string(index) + std::string(" out of range for ") + classname() + std::string(" with ") + std::to_string(numcontents()) + std::string(" contents"));
     }
@@ -74,7 +74,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::project(int64_t index) const {
+  ContentPtr UnionArrayOf<T, I>::project(int64_t index) const {
     if (!(0 <= index  &&  index < numcontents())) {
       throw std::invalid_argument(std::string("index ") + std::to_string(index) + std::string(" out of range for ") + classname() + std::string(" with ") + std::to_string(numcontents()) + std::string(" contents"));
     }
@@ -99,7 +99,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::simplify_uniontype(bool mergebool) const {
+  ContentPtr UnionArrayOf<T, I>::simplify_uniontype(bool mergebool) const {
     int64_t len = length();
     if (index_.length() < len) {
       util::handle_error(failure("len(index) < len(tags)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -485,12 +485,12 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::shallow_copy() const {
+  ContentPtr UnionArrayOf<T, I>::shallow_copy() const {
     return std::make_shared<UnionArrayOf<T, I>>(identities_, parameters_, tags_, index_, contents_);
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr UnionArrayOf<T, I>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     IndexOf<T> tags = copyindexes ? tags_.deep_copy() : tags_;
     IndexOf<I> index = copyindexes ? index_.deep_copy() : index_;
     std::vector<std::shared_ptr<Content>> contents;
@@ -515,12 +515,12 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_nothing() const {
+  ContentPtr UnionArrayOf<T, I>::getitem_nothing() const {
     return getitem_range_nowrap(0, 0);
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_at(int64_t at) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     int64_t len = length();
     if (regular_at < 0) {
@@ -533,7 +533,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_at_nowrap(int64_t at) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_at_nowrap(int64_t at) const {
     size_t tag = (size_t)tags_.getitem_at_nowrap(at);
     int64_t index = (int64_t)index_.getitem_at_nowrap(at);
     if (!(0 <= tag  &&  tag < contents_.size())) {
@@ -547,7 +547,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), tags_.length());
@@ -558,7 +558,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -567,7 +567,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_field(const std::string& key) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_field(const std::string& key) const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->getitem_field(key));
@@ -576,7 +576,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_fields(const std::vector<std::string>& keys) const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->getitem_fields(keys));
@@ -585,7 +585,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -620,7 +620,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::carry(const Index64& carry) const {
+  ContentPtr UnionArrayOf<T, I>::carry(const Index64& carry) const {
     int64_t lentags = tags_.length();
     if (index_.length() < lentags) {
       util::handle_error(failure("len(index) < len(tags)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -811,12 +811,12 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::shallow_simplify() const {
+  ContentPtr UnionArrayOf<T, I>::shallow_simplify() const {
     return simplify_uniontype(false);
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::num(int64_t axis, int64_t depth) const {
+  ContentPtr UnionArrayOf<T, I>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -892,7 +892,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  bool UnionArrayOf<T, I>::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool UnionArrayOf<T, I>::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -901,7 +901,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::reverse_merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr UnionArrayOf<T, I>::reverse_merge(ContentPtr& other) const {
     int64_t theirlength = other.get()->length();
     int64_t mylength = length();
     Index8 tags(theirlength + mylength);
@@ -975,7 +975,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr UnionArrayOf<T, I>::merge(ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -1153,7 +1153,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr UnionArrayOf<T, I>::fillna(ContentPtr& value) const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto content : contents_) {
       contents.emplace_back(content.get()->fillna(value));
@@ -1163,7 +1163,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr UnionArrayOf<T, I>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -1179,7 +1179,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr UnionArrayOf<T, I>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -1195,7 +1195,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr UnionArrayOf<T, I>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     std::shared_ptr<Content> simplified = simplify_uniontype(true);
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||
@@ -1206,7 +1206,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr UnionArrayOf<T, I>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1221,7 +1221,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr UnionArrayOf<T, I>::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1239,43 +1239,43 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnionArray::getitem_next(at)");
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnionArray::getitem_next(range)");
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnionArray::getitem_next(array)");
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnionArray::getitem_next(jagged)");
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, typename I>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, typename I>
   template <typename S>
-  const std::shared_ptr<Content> UnionArrayOf<T, I>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  ContentPtr UnionArrayOf<T, I>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
     std::shared_ptr<Content> simplified = simplify_uniontype(false);
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -146,7 +146,8 @@ namespace awkward {
           bool unmerged = true;
           for (size_t k = 0;  k < contents.size();  k++) {
             if (contents[k].get()->mergeable(innercontents[j], mergebool)) {
-              struct Error err = util::awkward_unionarray_simplify8_32_to8_64<T, I>(
+              struct Error err =
+                util::awkward_unionarray_simplify8_32_to8_64<T, I>(
                 tags.ptr().get(),
                 index.ptr().get(),
                 tags_.ptr().get(),
@@ -224,7 +225,8 @@ namespace awkward {
             }
           }
           if (unmerged) {
-            struct Error err = util::awkward_unionarray_simplify8_U32_to8_64<T, I>(
+            struct Error err =
+              util::awkward_unionarray_simplify8_U32_to8_64<T, I>(
               tags.ptr().get(),
               index.ptr().get(),
               tags_.ptr().get(),
@@ -254,7 +256,8 @@ namespace awkward {
           bool unmerged = true;
           for (size_t k = 0;  k < contents.size();  k++) {
             if (contents[k].get()->mergeable(innercontents[j], mergebool)) {
-              struct Error err = util::awkward_unionarray_simplify8_64_to8_64<T, I>(
+              struct Error err =
+                util::awkward_unionarray_simplify8_64_to8_64<T, I>(
                 tags.ptr().get(),
                 index.ptr().get(),
                 tags_.ptr().get(),
@@ -1030,7 +1033,8 @@ namespace awkward {
 
   template <typename T, typename I>
   const std::pair<Index64, ContentPtr>
-  UnionArrayOf<T, I>::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  UnionArrayOf<T, I>::offsets_and_flattened(int64_t axis,
+                                            int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -724,38 +724,57 @@ namespace awkward {
     for (auto content : contents_) {
       contents.push_back(content.get()->getitem_fields(keys));
     }
-    return std::make_shared<UnionArrayOf<T, I>>(identities_, util::Parameters(), tags_, index_, contents);
+    return std::make_shared<UnionArrayOf<T, I>>(identities_,
+                                                util::Parameters(),
+                                                tags_,
+                                                index_,
+                                                contents);
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  UnionArrayOf<T, I>::getitem_next(const SliceItemPtr& head,
+                                   const Slice& tail,
+                                   const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
-    else if (dynamic_cast<SliceAt*>(head.get())  ||  dynamic_cast<SliceRange*>(head.get())  ||  dynamic_cast<SliceArray64*>(head.get())  ||  dynamic_cast<SliceJagged64*>(head.get())) {
+    else if (dynamic_cast<SliceAt*>(head.get())  ||
+             dynamic_cast<SliceRange*>(head.get())  ||
+             dynamic_cast<SliceArray64*>(head.get())  ||
+             dynamic_cast<SliceJagged64*>(head.get())) {
       ContentPtrVec outcontents;
       for (int64_t i = 0;  i < numcontents();  i++) {
         ContentPtr projection = project(i);
-        outcontents.push_back(projection.get()->getitem_next(head, tail, advanced));
+        outcontents.push_back(
+          projection.get()->getitem_next(head, tail, advanced));
       }
       IndexOf<I> outindex = regular_index(tags_);
-      UnionArrayOf<T, I> out(identities_, parameters_, tags_, outindex, outcontents);
+      UnionArrayOf<T, I> out(identities_,
+                             parameters_,
+                             tags_,
+                             outindex,
+                             outcontents);
       return out.simplify_uniontype(false);
     }
-    else if (SliceEllipsis* ellipsis = dynamic_cast<SliceEllipsis*>(head.get())) {
+    else if (SliceEllipsis* ellipsis =
+             dynamic_cast<SliceEllipsis*>(head.get())) {
       return Content::getitem_next(*ellipsis, tail, advanced);
     }
-    else if (SliceNewAxis* newaxis = dynamic_cast<SliceNewAxis*>(head.get())) {
+    else if (SliceNewAxis* newaxis =
+             dynamic_cast<SliceNewAxis*>(head.get())) {
       return Content::getitem_next(*newaxis, tail, advanced);
     }
-    else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {
+    else if (SliceField* field =
+             dynamic_cast<SliceField*>(head.get())) {
       return Content::getitem_next(*field, tail, advanced);
     }
-    else if (SliceFields* fields = dynamic_cast<SliceFields*>(head.get())) {
+    else if (SliceFields* fields =
+             dynamic_cast<SliceFields*>(head.get())) {
       return Content::getitem_next(*fields, tail, advanced);
     }
-    else if (SliceMissing64* missing = dynamic_cast<SliceMissing64*>(head.get())) {
+    else if (SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(head.get())) {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
@@ -768,7 +787,10 @@ namespace awkward {
   UnionArrayOf<T, I>::carry(const Index64& carry) const {
     int64_t lentags = tags_.length();
     if (index_.length() < lentags) {
-      util::handle_error(failure("len(index) < len(tags)", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("len(index) < len(tags)", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
     int64_t lencarry = carry.length();
     IndexOf<T> nexttags(lencarry);
@@ -792,7 +814,11 @@ namespace awkward {
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
-    return std::make_shared<UnionArrayOf<T, I>>(identities, parameters_, nexttags, nextindex, contents_);
+    return std::make_shared<UnionArrayOf<T, I>>(identities,
+                                                parameters_,
+                                                nexttags,
+                                                nextindex,
+                                                contents_);
   }
 
   template <typename T, typename I>
@@ -893,13 +919,17 @@ namespace awkward {
   template <typename T, typename I>
   int64_t
   UnionArrayOf<T, I>::fieldindex(const std::string& key) const {
-    throw std::invalid_argument("UnionArray breaks the one-to-one relationship between fieldindexes and keys");
+    throw std::invalid_argument(
+      "UnionArray breaks the one-to-one relationship "
+      "between fieldindexes and keys");
   }
 
   template <typename T, typename I>
   const std::string
   UnionArrayOf<T, I>::key(int64_t fieldindex) const {
-    throw std::invalid_argument("UnionArray breaks the one-to-one relationship between fieldindexes and keys");
+    throw std::invalid_argument(
+      "UnionArray breaks the one-to-one relationship "
+      "between fieldindexes and keys");
   }
 
   template <typename T, typename I>
@@ -955,10 +985,13 @@ namespace awkward {
       numcontents(),
       lencontents.data());
     if (err.str != nullptr) {
-      return std::string("at ") + path + std::string(" (") + classname() + std::string("): ") + std::string(err.str) + std::string(" at i=") + std::to_string(err.identity);
+      return (std::string("at ") + path + std::string(" (") + classname()
+              + std::string("): ") + std::string(err.str)
+              + std::string(" at i=") + std::to_string(err.identity));
     }
     for (int64_t i = 0;  i < numcontents();  i++) {
-      std::string sub = content(i).get()->validityerror(path + std::string(".content(") + std::to_string(i) + (")"));
+      std::string sub = content(i).get()->validityerror(
+        path + std::string(".content(") + std::to_string(i) + (")"));
       if (!sub.empty()) {
         return sub;
       }
@@ -986,7 +1019,11 @@ namespace awkward {
       for (auto content : contents_) {
         contents.push_back(content.get()->num(axis, depth));
       }
-      UnionArrayOf<T, I> out(Identities::none(), util::Parameters(), tags_, index_, contents);
+      UnionArrayOf<T, I> out(Identities::none(),
+                             util::Parameters(),
+                             tags_,
+                             index_,
+                             contents);
       return out.simplify_uniontype(false);
     }
   }
@@ -1005,7 +1042,8 @@ namespace awkward {
       std::vector<int64_t> offsetsoffsets;
       ContentPtrVec contents;
       for (auto content : contents_) {
-        std::pair<Index64, ContentPtr> pair = content.get()->offsets_and_flattened(axis, depth);
+        std::pair<Index64, ContentPtr> pair =
+          content.get()->offsets_and_flattened(axis, depth);
         Index64 offsets = pair.first;
         offsetsptrs.push_back(offsets.ptr());
         offsetsraws.push_back(offsets.ptr().get());
@@ -1042,21 +1080,33 @@ namespace awkward {
           offsetsraws.data(),
           offsetsoffsets.data());
         util::handle_error(err2, classname(), identities_.get());
-        return std::pair<Index64, ContentPtr>(tooffsets, std::make_shared<UnionArray8_64>(Identities::none(), util::Parameters(), totags, toindex, contents));
+        return std::pair<Index64, ContentPtr>(
+          tooffsets,
+          std::make_shared<UnionArray8_64>(Identities::none(),
+                                           util::Parameters(),
+                                           totags,
+                                           toindex,
+                                           contents));
       }
       else {
-        return std::pair<Index64, ContentPtr>(Index64(0), std::make_shared<UnionArrayOf<T, I>>(Identities::none(), util::Parameters(), tags_, index_, contents));
+        return std::pair<Index64, ContentPtr>(
+          Index64(0),
+          std::make_shared<UnionArrayOf<T, I>>(Identities::none(),
+                                               util::Parameters(),
+                                               tags_,
+                                               index_,
+                                               contents));
       }
     }
   }
 
   template <typename T, typename I>
   bool
-  UnionArrayOf<T, I>::mergeable(const ContentPtr& other, bool mergebool) const {
+  UnionArrayOf<T, I>::mergeable(const ContentPtr& other,
+                                bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
-
     return true;
   }
 
@@ -1129,10 +1179,15 @@ namespace awkward {
     }
 
     if (contents.size() > kMaxInt8) {
-      throw std::runtime_error("FIXME: handle UnionArray with more than 127 contents");
+      throw std::runtime_error(
+        "FIXME: handle UnionArray with more than 127 contents");
     }
 
-    return std::make_shared<UnionArray8_64>(Identities::none(), util::Parameters(), tags, index, contents);
+    return std::make_shared<UnionArray8_64>(Identities::none(),
+                                            util::Parameters(),
+                                            tags,
+                                            index,
+                                            contents);
   }
 
   template <typename T, typename I>
@@ -1197,9 +1252,12 @@ namespace awkward {
     }
 
     ContentPtrVec contents(contents_.begin(), contents_.end());
-    if (UnionArray8_32* rawother = dynamic_cast<UnionArray8_32*>(other.get())) {
+    if (UnionArray8_32* rawother =
+        dynamic_cast<UnionArray8_32*>(other.get())) {
       ContentPtrVec other_contents = rawother->contents();
-      contents.insert(contents.end(), other_contents.begin(), other_contents.end());
+      contents.insert(contents.end(),
+                      other_contents.begin(),
+                      other_contents.end());
       Index8 other_tags = rawother->tags();
       struct Error err1 = awkward_unionarray_filltags_to8_from8(
         tags.ptr().get(),
@@ -1208,7 +1266,9 @@ namespace awkward {
         other_tags.offset(),
         theirlength,
         numcontents());
-      util::handle_error(err1, rawother->classname(), rawother->identities().get());
+      util::handle_error(err1,
+                         rawother->classname(),
+                         rawother->identities().get());
       Index32 other_index = rawother->index();
       struct Error err2 = awkward_unionarray_fillindex_to64_from32(
         index.ptr().get(),
@@ -1216,11 +1276,16 @@ namespace awkward {
         other_index.ptr().get(),
         other_index.offset(),
         theirlength);
-      util::handle_error(err2, rawother->classname(), rawother->identities().get());
+      util::handle_error(err2,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (UnionArray8_U32* rawother = dynamic_cast<UnionArray8_U32*>(other.get())) {
+    else if (UnionArray8_U32* rawother =
+             dynamic_cast<UnionArray8_U32*>(other.get())) {
       ContentPtrVec other_contents = rawother->contents();
-      contents.insert(contents.end(), other_contents.begin(), other_contents.end());
+      contents.insert(contents.end(),
+                      other_contents.begin(),
+                      other_contents.end());
       Index8 other_tags = rawother->tags();
       struct Error err1 = awkward_unionarray_filltags_to8_from8(
         tags.ptr().get(),
@@ -1229,7 +1294,9 @@ namespace awkward {
         other_tags.offset(),
         theirlength,
         numcontents());
-      util::handle_error(err1, rawother->classname(), rawother->identities().get());
+      util::handle_error(err1,
+                         rawother->classname(),
+                         rawother->identities().get());
       IndexU32 other_index = rawother->index();
       struct Error err2 = awkward_unionarray_fillindex_to64_fromU32(
         index.ptr().get(),
@@ -1237,11 +1304,16 @@ namespace awkward {
         other_index.ptr().get(),
         other_index.offset(),
         theirlength);
-      util::handle_error(err2, rawother->classname(), rawother->identities().get());
+      util::handle_error(err2,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
-    else if (UnionArray8_64* rawother = dynamic_cast<UnionArray8_64*>(other.get())) {
+    else if (UnionArray8_64* rawother =
+             dynamic_cast<UnionArray8_64*>(other.get())) {
       ContentPtrVec other_contents = rawother->contents();
-      contents.insert(contents.end(), other_contents.begin(), other_contents.end());
+      contents.insert(contents.end(),
+                      other_contents.begin(),
+                      other_contents.end());
       Index8 other_tags = rawother->tags();
       struct Error err1 = awkward_unionarray_filltags_to8_from8(
         tags.ptr().get(),
@@ -1250,7 +1322,9 @@ namespace awkward {
         other_tags.offset(),
         theirlength,
         numcontents());
-      util::handle_error(err1, rawother->classname(), rawother->identities().get());
+      util::handle_error(err1,
+                         rawother->classname(),
+                         rawother->identities().get());
       Index64 other_index = rawother->index();
       struct Error err2 = awkward_unionarray_fillindex_to64_from64(
         index.ptr().get(),
@@ -1258,7 +1332,9 @@ namespace awkward {
         other_index.ptr().get(),
         other_index.offset(),
         theirlength);
-      util::handle_error(err2, rawother->classname(), rawother->identities().get());
+      util::handle_error(err2,
+                         rawother->classname(),
+                         rawother->identities().get());
     }
     else {
       contents.push_back(other);
@@ -1276,38 +1352,49 @@ namespace awkward {
     }
 
     if (contents.size() > kMaxInt8) {
-      throw std::runtime_error("FIXME: handle UnionArray with more than 127 contents");
+      throw std::runtime_error(
+        "FIXME: handle UnionArray with more than 127 contents");
     }
 
-    return std::make_shared<UnionArray8_64>(Identities::none(), util::Parameters(), tags, index, contents);
+    return std::make_shared<UnionArray8_64>(Identities::none(),
+                                            util::Parameters(),
+                                            tags,
+                                            index,
+                                            contents);
   }
 
   template <typename T, typename I>
   const SliceItemPtr
   UnionArrayOf<T, I>::asslice() const {
     ContentPtr simplified = simplify_uniontype(false);
-    if (UnionArray8_32* raw = dynamic_cast<UnionArray8_32*>(simplified.get())) {
+    if (UnionArray8_32* raw =
+        dynamic_cast<UnionArray8_32*>(simplified.get())) {
       if (raw->numcontents() == 1) {
         return raw->content(0).get()->asslice();
       }
       else {
-        throw std::invalid_argument("cannot use a union of different types as a slice");
+        throw std::invalid_argument(
+          "cannot use a union of different types as a slice");
       }
     }
-    else if (UnionArray8_U32* raw = dynamic_cast<UnionArray8_U32*>(simplified.get())) {
+    else if (UnionArray8_U32* raw =
+             dynamic_cast<UnionArray8_U32*>(simplified.get())) {
       if (raw->numcontents() == 1) {
         return raw->content(0).get()->asslice();
       }
       else {
-        throw std::invalid_argument("cannot use a union of different types as a slice");
+        throw std::invalid_argument(
+          "cannot use a union of different types as a slice");
       }
     }
-    else if (UnionArray8_64* raw = dynamic_cast<UnionArray8_64*>(simplified.get())) {
+    else if (UnionArray8_64* raw =
+             dynamic_cast<UnionArray8_64*>(simplified.get())) {
       if (raw->numcontents() == 1) {
         return raw->content(0).get()->asslice();
       }
       else {
-        throw std::invalid_argument("cannot use a union of different types as a slice");
+        throw std::invalid_argument(
+          "cannot use a union of different types as a slice");
       }
     }
     else {
@@ -1338,14 +1425,20 @@ namespace awkward {
       for (auto content : contents_) {
         contents.emplace_back(content.get()->rpad(target, axis, depth));
       }
-      UnionArrayOf<T, I> out(identities_, parameters_, tags_, index_, contents);
+      UnionArrayOf<T, I> out(identities_,
+                             parameters_,
+                             tags_,
+                             index_,
+                             contents);
       return out.simplify_uniontype(false);
     }
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  UnionArrayOf<T, I>::rpad_and_clip(int64_t target,
+                                    int64_t axis,
+                                    int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -1353,23 +1446,42 @@ namespace awkward {
     else {
       ContentPtrVec contents;
       for (auto content : contents_) {
-        contents.emplace_back(content.get()->rpad_and_clip(target, axis, depth));
+        contents.emplace_back(
+          content.get()->rpad_and_clip(target, axis, depth));
       }
-      UnionArrayOf<T, I> out(identities_, parameters_, tags_, index_, contents);
+      UnionArrayOf<T, I> out(identities_,
+                             parameters_,
+                             tags_,
+                             index_,
+                             contents);
       return out.simplify_uniontype(false);
     }
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  UnionArrayOf<T, I>::reduce_next(const Reducer& reducer,
+                                  int64_t negaxis,
+                                  const Index64& starts,
+                                  const Index64& parents,
+                                  int64_t outlength,
+                                  bool mask,
+                                  bool keepdims) const {
     ContentPtr simplified = simplify_uniontype(true);
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_64*>(simplified.get())) {
-      throw std::invalid_argument(std::string("cannot reduce (call '") + reducer.name() + std::string("' on) an irreducible ") + classname());
+      throw std::invalid_argument(
+        std::string("cannot reduce (call '") + reducer.name()
+        + std::string("' on) an irreducible ") + classname());
     }
-    return simplified.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+    return simplified.get()->reduce_next(reducer,
+                                         negaxis,
+                                         starts,
+                                         parents,
+                                         outlength,
+                                         mask,
+                                         keepdims);
   }
 
   template <typename T, typename I>
@@ -1384,13 +1496,22 @@ namespace awkward {
       for (auto content : contents_) {
         contents.push_back(content.get()->localindex(axis, depth));
       }
-      return std::make_shared<UnionArrayOf<T, I>>(identities_, util::Parameters(), tags_, index_, contents);
+      return std::make_shared<UnionArrayOf<T, I>>(identities_,
+                                                  util::Parameters(),
+                                                  tags_,
+                                                  index_,
+                                                  contents);
     }
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  UnionArrayOf<T, I>::choose(int64_t n,
+                             bool diagonal,
+                             const util::RecordLookupPtr& recordlookup,
+                             const util::Parameters& parameters,
+                             int64_t axis,
+                             int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1401,65 +1522,111 @@ namespace awkward {
     else {
       ContentPtrVec contents;
       for (auto content : contents_) {
-        contents.push_back(content.get()->choose(n, diagonal, recordlookup, parameters, axis, depth));
+        contents.push_back(content.get()->choose(n,
+                                                 diagonal,
+                                                 recordlookup,
+                                                 parameters,
+                                                 axis,
+                                                 depth));
       }
-      return std::make_shared<UnionArrayOf<T, I>>(identities_, util::Parameters(), tags_, index_, contents);
+      return std::make_shared<UnionArrayOf<T, I>>(identities_,
+                                                  util::Parameters(),
+                                                  tags_,
+                                                  index_,
+                                                  contents);
     }
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: UnionArray::getitem_next(at)");
+  UnionArrayOf<T, I>::getitem_next(const SliceAt& at,
+                                   const Slice& tail,
+                                   const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: UnionArray::getitem_next(at)");
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: UnionArray::getitem_next(range)");
+  UnionArrayOf<T, I>::getitem_next(const SliceRange& range,
+                                   const Slice& tail,
+                                   const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: UnionArray::getitem_next(range)");
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: UnionArray::getitem_next(array)");
+  UnionArrayOf<T, I>::getitem_next(const SliceArray64& array,
+                                   const Slice& tail,
+                                   const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: UnionArray::getitem_next(array)");
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: UnionArray::getitem_next(jagged)");
+  UnionArrayOf<T, I>::getitem_next(const SliceJagged64& jagged,
+                                   const Slice& tail,
+                                   const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: UnionArray::getitem_next(jagged)");
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
+  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts,
+                                          const Index64& slicestops,
+                                          const SliceArray64& slicecontent,
+                                          const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceArray64>(slicestarts,
+                                                     slicestops,
+                                                     slicecontent,
+                                                     tail);
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
+  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts,
+                                          const Index64& slicestops,
+                                          const SliceMissing64& slicecontent,
+                                          const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceMissing64>(slicestarts,
+                                                       slicestops,
+                                                       slicecontent,
+                                                       tail);
   }
 
   template <typename T, typename I>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
+  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts,
+                                          const Index64& slicestops,
+                                          const SliceJagged64& slicecontent,
+                                          const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceJagged64>(slicestarts,
+                                                      slicestops,
+                                                      slicecontent,
+                                                      tail);
   }
 
   template <typename T, typename I>
   template <typename S>
   const ContentPtr
-  UnionArrayOf<T, I>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  UnionArrayOf<T, I>::getitem_next_jagged_generic(const Index64& slicestarts,
+                                                  const Index64& slicestops,
+                                                  const S& slicecontent,
+                                                  const Slice& tail) const {
     ContentPtr simplified = simplify_uniontype(false);
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_64*>(simplified.get())) {
-      throw std::invalid_argument("cannot apply jagged slices to irreducible union arrays");
+      throw std::invalid_argument(
+        "cannot apply jagged slices to irreducible union arrays");
     }
-    return simplified.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail);
+    return simplified.get()->getitem_next_jagged(slicestarts,
+                                                 slicestops,
+                                                 slicecontent,
+                                                 tail);
   }
 
   template class UnionArrayOf<int8_t, int32_t>;

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -19,7 +19,8 @@
 
 namespace awkward {
   template <typename T, typename I>
-  const IndexOf<I> UnionArrayOf<T, I>::regular_index(const IndexOf<T>& tags) {
+  const IndexOf<I>
+  UnionArrayOf<T, I>::regular_index(const IndexOf<T>& tags) {
     int64_t lentags = tags.length();
     IndexOf<I> outindex(lentags);
     struct Error err = util::awkward_unionarray_regular_index<T, I>(
@@ -32,7 +33,12 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  UnionArrayOf<T, I>::UnionArrayOf(const IdentitiesPtr& identities, const util::Parameters& parameters, const IndexOf<T> tags, const IndexOf<I>& index, const ContentPtrVec& contents)
+  UnionArrayOf<T,
+               I>::UnionArrayOf(const IdentitiesPtr& identities,
+                                const util::Parameters& parameters,
+                                const IndexOf<T> tags,
+                                const IndexOf<I>& index,
+                                const ContentPtrVec& contents)
       : Content(identities, parameters)
       , tags_(tags)
       , index_(index)
@@ -41,46 +47,64 @@ namespace awkward {
       throw std::invalid_argument("UnionArray must have at least one content");
     }
     if (index.length() < tags.length()) {
-      throw std::invalid_argument("UnionArray index must not be shorter than its tags");
+      throw std::invalid_argument(
+        "UnionArray index must not be shorter than its tags");
     }
   }
 
   template <typename T, typename I>
-  const IndexOf<T> UnionArrayOf<T, I>::tags() const {
+  const IndexOf<T>
+  UnionArrayOf<T, I>::tags() const {
     return tags_;
   }
 
   template <typename T, typename I>
-  const IndexOf<I> UnionArrayOf<T, I>::index() const {
+  const IndexOf<I>
+  UnionArrayOf<T, I>::index() const {
     return index_;
   }
 
   template <typename T, typename I>
-  const ContentPtrVec UnionArrayOf<T, I>::contents() const {
+  const ContentPtrVec
+  UnionArrayOf<T, I>::contents() const {
     return contents_;
   }
 
   template <typename T, typename I>
-  int64_t UnionArrayOf<T, I>::numcontents() const {
+  int64_t
+  UnionArrayOf<T, I>::numcontents() const {
     return (int64_t)contents_.size();
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::content(int64_t index) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::content(int64_t index) const {
     if (!(0 <= index  &&  index < numcontents())) {
-      throw std::invalid_argument(std::string("index ") + std::to_string(index) + std::string(" out of range for ") + classname() + std::string(" with ") + std::to_string(numcontents()) + std::string(" contents"));
+      throw std::invalid_argument(
+        std::string("index ") + std::to_string(index)
+        + std::string(" out of range for ") + classname()
+        + std::string(" with ") + std::to_string(numcontents())
+        + std::string(" contents"));
     }
     return contents_[(size_t)index];
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::project(int64_t index) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::project(int64_t index) const {
     if (!(0 <= index  &&  index < numcontents())) {
-      throw std::invalid_argument(std::string("index ") + std::to_string(index) + std::string(" out of range for ") + classname() + std::string(" with ") + std::to_string(numcontents()) + std::string(" contents"));
+      throw std::invalid_argument(
+        std::string("index ") + std::to_string(index)
+        + std::string(" out of range for ") + classname()
+        + std::string(" with ") + std::to_string(numcontents())
+        + std::string(" contents"));
     }
     int64_t lentags = tags_.length();
     if (index_.length() < lentags) {
-      util::handle_error(failure("len(index) < len(tags)", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("len(index) < len(tags)", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
     int64_t lenout;
     Index64 tmpcarry(lentags);
@@ -99,17 +123,22 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::simplify_uniontype(bool mergebool) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::simplify_uniontype(bool mergebool) const {
     int64_t len = length();
     if (index_.length() < len) {
-      util::handle_error(failure("len(index) < len(tags)", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("len(index) < len(tags)", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
     Index8 tags(len);
     Index64 index(len);
     ContentPtrVec contents;
 
     for (size_t i = 0;  i < contents_.size();  i++) {
-      if (UnionArray8_32* rawcontent = dynamic_cast<UnionArray8_32*>(contents_[i].get())) {
+      if (UnionArray8_32* rawcontent =
+          dynamic_cast<UnionArray8_32*>(contents_[i].get())) {
         Index8 innertags = rawcontent->tags();
         Index32 innerindex = rawcontent->index();
         ContentPtrVec innercontents = rawcontent->contents();
@@ -140,7 +169,8 @@ namespace awkward {
             }
           }
           if (unmerged) {
-            struct Error err = util::awkward_unionarray_simplify8_32_to8_64<T, I>(
+            struct Error err =
+              util::awkward_unionarray_simplify8_32_to8_64<T, I>(
               tags.ptr().get(),
               index.ptr().get(),
               tags_.ptr().get(),
@@ -161,7 +191,8 @@ namespace awkward {
           }
         }
       }
-      else if (UnionArray8_U32* rawcontent = dynamic_cast<UnionArray8_U32*>(contents_[i].get())) {
+      else if (UnionArray8_U32* rawcontent =
+               dynamic_cast<UnionArray8_U32*>(contents_[i].get())) {
         Index8 innertags = rawcontent->tags();
         IndexU32 innerindex = rawcontent->index();
         ContentPtrVec innercontents = rawcontent->contents();
@@ -169,7 +200,8 @@ namespace awkward {
           bool unmerged = true;
           for (size_t k = 0;  k < contents.size();  k++) {
             if (contents[k].get()->mergeable(innercontents[j], mergebool)) {
-              struct Error err = util::awkward_unionarray_simplify8_U32_to8_64<T, I>(
+              struct Error err =
+                util::awkward_unionarray_simplify8_U32_to8_64<T, I>(
                 tags.ptr().get(),
                 index.ptr().get(),
                 tags_.ptr().get(),
@@ -213,7 +245,8 @@ namespace awkward {
           }
         }
       }
-      else if (UnionArray8_64* rawcontent = dynamic_cast<UnionArray8_64*>(contents_[i].get())) {
+      else if (UnionArray8_64* rawcontent =
+               dynamic_cast<UnionArray8_64*>(contents_[i].get())) {
         Index8 innertags = rawcontent->tags();
         Index64 innerindex = rawcontent->index();
         ContentPtrVec innercontents = rawcontent->contents();
@@ -244,7 +277,8 @@ namespace awkward {
             }
           }
           if (unmerged) {
-            struct Error err = util::awkward_unionarray_simplify8_64_to8_64<T, I>(
+            struct Error err =
+              util::awkward_unionarray_simplify8_64_to8_64<T, I>(
               tags.ptr().get(),
               index.ptr().get(),
               tags_.ptr().get(),
@@ -269,7 +303,8 @@ namespace awkward {
         bool unmerged = true;
         for (size_t k = 0;  k < contents.size();  k++) {
           if (contents[k].get()->mergeable(contents_[i], mergebool)) {
-            struct Error err = util::awkward_unionarray_simplify_one_to8_64<T, I>(
+            struct Error err =
+              util::awkward_unionarray_simplify_one_to8_64<T, I>(
               tags.ptr().get(),
               index.ptr().get(),
               tags_.ptr().get(),
@@ -287,7 +322,8 @@ namespace awkward {
           }
         }
         if (unmerged) {
-          struct Error err = util::awkward_unionarray_simplify_one_to8_64<T, I>(
+          struct Error err =
+            util::awkward_unionarray_simplify_one_to8_64<T, I>(
             tags.ptr().get(),
             index.ptr().get(),
             tags_.ptr().get(),
@@ -305,19 +341,25 @@ namespace awkward {
     }
 
     if (contents.size() > kMaxInt8) {
-      throw std::runtime_error("FIXME: handle UnionArray with more than 127 contents");
+      throw std::runtime_error(
+        "FIXME: handle UnionArray with more than 127 contents");
     }
 
     if (contents.size() == 1) {
       return contents[0].get()->carry(index);
     }
     else {
-      return std::make_shared<UnionArray8_64>(identities_, parameters_, tags, index, contents);
+      return std::make_shared<UnionArray8_64>(identities_,
+                                              parameters_,
+                                              tags,
+                                              index,
+                                              contents);
     }
   }
 
   template <typename T, typename I>
-  const std::string UnionArrayOf<T, I>::classname() const {
+  const std::string
+  UnionArrayOf<T, I>::classname() const {
     if (std::is_same<T, int8_t>::value) {
       if (std::is_same<I, int32_t>::value) {
         return "UnionArray8_32";
@@ -333,25 +375,39 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  void UnionArrayOf<T, I>::setidentities() {
+  void
+  UnionArrayOf<T, I>::setidentities() {
     if (length() <= kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err = awkward_new_identities32(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err = awkward_new_identities64(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
   }
 
   template <typename T, typename I>
-  void UnionArrayOf<T, I>::setidentities(const IdentitiesPtr& identities) {
+  void
+  UnionArrayOf<T, I>::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       for (auto content : contents_) {
         content.get()->setidentities(identities);
@@ -359,21 +415,36 @@ namespace awkward {
     }
     else {
       if (index_.length() < tags_.length()) {
-        util::handle_error(failure("len(index) < len(tags)", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(
+          failure("len(index) < len(tags)", kSliceNone, kSliceNone),
+          classname(),
+          identities_.get());
       }
       if (length() != identities.get()->length()) {
-        util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(
+          failure("content and its identities must have the same length",
+                  kSliceNone,
+                  kSliceNone),
+          classname(),
+          identities_.get());
       }
       for (size_t which = 0;  which < contents_.size();  which++) {
         ContentPtr content = contents_[which];
         IdentitiesPtr bigidentities = identities;
-        if (content.get()->length() > kMaxInt32  ||  !std::is_same<I, int32_t>::value) {
+        if (content.get()->length() > kMaxInt32  ||
+            !std::is_same<I, int32_t>::value) {
           bigidentities = identities.get()->to64();
         }
-        if (Identities32* rawidentities = dynamic_cast<Identities32*>(bigidentities.get())) {
+        if (Identities32* rawidentities =
+            dynamic_cast<Identities32*>(bigidentities.get())) {
           bool uniquecontents;
-          IdentitiesPtr subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content.get()->length());
-          Identities32* rawsubidentities = reinterpret_cast<Identities32*>(subidentities.get());
+          IdentitiesPtr subidentities =
+            std::make_shared<Identities32>(Identities::newref(),
+                                           rawidentities->fieldloc(),
+                                           rawidentities->width(),
+                                           content.get()->length());
+          Identities32* rawsubidentities =
+            reinterpret_cast<Identities32*>(subidentities.get());
           struct Error err = util::awkward_identities32_from_unionarray<T, I>(
             &uniquecontents,
             rawsubidentities->ptr().get(),
@@ -395,10 +466,16 @@ namespace awkward {
             content.get()->setidentities(Identities::none());
           }
         }
-        else if (Identities64* rawidentities = dynamic_cast<Identities64*>(bigidentities.get())) {
+        else if (Identities64* rawidentities =
+                 dynamic_cast<Identities64*>(bigidentities.get())) {
           bool uniquecontents;
-          IdentitiesPtr subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content.get()->length());
-          Identities64* rawsubidentities = reinterpret_cast<Identities64*>(subidentities.get());
+          IdentitiesPtr subidentities =
+            std::make_shared<Identities64>(Identities::newref(),
+                                           rawidentities->fieldloc(),
+                                           rawidentities->width(),
+                                           content.get()->length());
+          Identities64* rawsubidentities =
+            reinterpret_cast<Identities64*>(subidentities.get());
           struct Error err = util::awkward_identities64_from_unionarray<T, I>(
             &uniquecontents,
             rawsubidentities->ptr().get(),
@@ -429,29 +506,39 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const TypePtr UnionArrayOf<T, I>::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr
+  UnionArrayOf<T, I>::type(const util::TypeStrs& typestrs) const {
     std::vector<TypePtr> types;
     for (auto item : contents_) {
       types.push_back(item.get()->type(typestrs));
     }
-    return std::make_shared<UnionType>(parameters_, util::gettypestr(parameters_, typestrs), types);
+    return std::make_shared<UnionType>(parameters_,
+                                       util::gettypestr(parameters_, typestrs),
+                                       types);
   }
 
   template <typename T, typename I>
-  const std::string UnionArrayOf<T, I>::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  UnionArrayOf<T, I>::tostring_part(const std::string& indent,
+                                    const std::string& pre,
+                                    const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << ">\n";
     if (identities_.get() != nullptr) {
-      out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+      out << identities_.get()->tostring_part(
+               indent + std::string("    "), "", "\n");
     }
     if (!parameters_.empty()) {
       out << parameters_tostring(indent + std::string("    "), "", "\n");
     }
-    out << tags_.tostring_part(indent + std::string("    "), "<tags>", "</tags>\n");
-    out << index_.tostring_part(indent + std::string("    "), "<index>", "</index>\n");
+    out << tags_.tostring_part(
+             indent + std::string("    "), "<tags>", "</tags>\n");
+    out << index_.tostring_part(
+             indent + std::string("    "), "<index>", "</index>\n");
     for (size_t i = 0;  i < contents_.size();  i++) {
       out << indent << "    <content index=\"" << i << "\">\n";
-      out << contents_[i].get()->tostring_part(indent + std::string("        "), "", "\n");
+      out << contents_[i].get()->tostring_part(
+               indent + std::string("        "), "", "\n");
       out << indent << "    </content>\n";
     }
     out << indent << "</" << classname() << ">" << post;
@@ -459,7 +546,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  void UnionArrayOf<T, I>::tojson_part(ToJson& builder) const {
+  void
+  UnionArrayOf<T, I>::tojson_part(ToJson& builder) const {
     int64_t len = length();
     check_for_iteration();
     builder.beginlist();
@@ -470,7 +558,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  void UnionArrayOf<T, I>::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  UnionArrayOf<T, I>::nbytes_part(std::map<size_t, int64_t>& largest) const {
     for (auto x : contents_) {
       x.get()->nbytes_part(largest);
     }
@@ -480,103 +569,157 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  int64_t UnionArrayOf<T, I>::length() const {
+  int64_t
+  UnionArrayOf<T, I>::length() const {
     return tags_.length();
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::shallow_copy() const {
-    return std::make_shared<UnionArrayOf<T, I>>(identities_, parameters_, tags_, index_, contents_);
+  const ContentPtr
+  UnionArrayOf<T, I>::shallow_copy() const {
+    return std::make_shared<UnionArrayOf<T, I>>(identities_,
+                                                parameters_,
+                                                tags_,
+                                                index_,
+                                                contents_);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::deep_copy(bool copyarrays,
+                                bool copyindexes,
+                                bool copyidentities) const {
     IndexOf<T> tags = copyindexes ? tags_.deep_copy() : tags_;
     IndexOf<I> index = copyindexes ? index_.deep_copy() : index_;
     ContentPtrVec contents;
     for (auto x : contents_) {
-      contents.push_back(x.get()->deep_copy(copyarrays, copyindexes, copyidentities));
+      contents.push_back(x.get()->deep_copy(copyarrays,
+                                            copyindexes,
+                                            copyidentities));
     }
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
-    return std::make_shared<UnionArrayOf<T, I>>(identities, parameters_, tags, index, contents);
+    return std::make_shared<UnionArrayOf<T, I>>(identities,
+                                                parameters_,
+                                                tags,
+                                                index,
+                                                contents);
   }
 
   template <typename T, typename I>
-  void UnionArrayOf<T, I>::check_for_iteration() const {
+  void
+  UnionArrayOf<T, I>::check_for_iteration() const {
     if (index_.length() < tags_.length()) {
-      util::handle_error(failure("len(index) < len(tags)", kSliceNone, kSliceNone), classname(), identities_.get());
+      util::handle_error(
+        failure("len(index) < len(tags)", kSliceNone, kSliceNone),
+        classname(),
+        identities_.get());
     }
-    if (identities_.get() != nullptr  &&  identities_.get()->length() < index_.length()) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < index_.length()) {
+      util::handle_error(
+        failure("len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_nothing() const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_nothing() const {
     return getitem_range_nowrap(0, 0);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_at(int64_t at) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     int64_t len = length();
     if (regular_at < 0) {
       regular_at += len;
     }
     if (!(0 <= regular_at  &&  regular_at < len)) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_at_nowrap(int64_t at) const {
     size_t tag = (size_t)tags_.getitem_at_nowrap(at);
     int64_t index = (int64_t)index_.getitem_at_nowrap(at);
     if (!(0 <= tag  &&  tag < contents_.size())) {
-      util::handle_error(failure("not 0 <= tag[i] < numcontents", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("not 0 <= tag[i] < numcontents", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     ContentPtr content = contents_[tag];
     if (!(0 <= index  &&  index < content.get()->length())) {
-      util::handle_error(failure("index[i] > len(content(tag))", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index[i] > len(content(tag))", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return content.get()->getitem_at_nowrap(index);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), tags_.length());
-    if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-      util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), tags_.length());
+    if (identities_.get() != nullptr  &&
+        regular_stop > identities_.get()->length()) {
+      util::handle_error(
+        failure("index out of range", kSliceNone, stop),
+        identities_.get()->classname(),
+        nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_range_nowrap(int64_t start, int64_t stop) const {
     IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
-    return std::make_shared<UnionArrayOf<T, I>>(identities, parameters_, tags_.getitem_range_nowrap(start, stop), index_.getitem_range_nowrap(start, stop), contents_);
+    return std::make_shared<UnionArrayOf<T, I>>(
+      identities,
+      parameters_,
+      tags_.getitem_range_nowrap(start, stop),
+      index_.getitem_range_nowrap(start, stop),
+      contents_);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_field(const std::string& key) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_field(const std::string& key) const {
     ContentPtrVec contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->getitem_field(key));
     }
-    return std::make_shared<UnionArrayOf<T, I>>(identities_, util::Parameters(), tags_, index_, contents);
+    return std::make_shared<UnionArrayOf<T, I>>(identities_,
+                                                util::Parameters(),
+                                                tags_,
+                                                index_,
+                                                contents);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_fields(
+    const std::vector<std::string>& keys) const {
     ContentPtrVec contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->getitem_fields(keys));
@@ -585,7 +728,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -620,7 +764,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::carry(const Index64& carry) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::carry(const Index64& carry) const {
     int64_t lentags = tags_.length();
     if (index_.length() < lentags) {
       util::handle_error(failure("len(index) < len(tags)", kSliceNone, kSliceNone), classname(), identities_.get());
@@ -651,7 +796,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::string UnionArrayOf<T, I>::purelist_parameter(const std::string& key) const {
+  const std::string
+  UnionArrayOf<T, I>::purelist_parameter(const std::string& key) const {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       if (contents_.empty()) {
@@ -671,7 +817,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  bool UnionArrayOf<T, I>::purelist_isregular() const {
+  bool
+  UnionArrayOf<T, I>::purelist_isregular() const {
     for (auto content : contents_) {
       if (!content.get()->purelist_isregular()) {
         return false;
@@ -681,7 +828,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  int64_t UnionArrayOf<T, I>::purelist_depth() const {
+  int64_t
+  UnionArrayOf<T, I>::purelist_depth() const {
     bool first = true;
     int64_t out = -1;
     for (auto content : contents_) {
@@ -697,7 +845,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::pair<int64_t, int64_t> UnionArrayOf<T, I>::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  UnionArrayOf<T, I>::minmax_depth() const {
     if (contents_.empty()) {
       return std::pair<int64_t, int64_t>(0, 0);
     }
@@ -716,7 +865,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::pair<bool, int64_t> UnionArrayOf<T, I>::branch_depth() const {
+  const std::pair<bool, int64_t>
+  UnionArrayOf<T, I>::branch_depth() const {
     bool anybranch = false;
     int64_t mindepth = -1;
     for (auto content : contents_) {
@@ -735,22 +885,26 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  int64_t UnionArrayOf<T, I>::numfields() const {
+  int64_t
+  UnionArrayOf<T, I>::numfields() const {
     return (int64_t)keys().size();
   }
 
   template <typename T, typename I>
-  int64_t UnionArrayOf<T, I>::fieldindex(const std::string& key) const {
+  int64_t
+  UnionArrayOf<T, I>::fieldindex(const std::string& key) const {
     throw std::invalid_argument("UnionArray breaks the one-to-one relationship between fieldindexes and keys");
   }
 
   template <typename T, typename I>
-  const std::string UnionArrayOf<T, I>::key(int64_t fieldindex) const {
+  const std::string
+  UnionArrayOf<T, I>::key(int64_t fieldindex) const {
     throw std::invalid_argument("UnionArray breaks the one-to-one relationship between fieldindexes and keys");
   }
 
   template <typename T, typename I>
-  bool UnionArrayOf<T, I>::haskey(const std::string& key) const {
+  bool
+  UnionArrayOf<T, I>::haskey(const std::string& key) const {
     for (auto x : keys()) {
       if (x == key) {
         return true;
@@ -760,7 +914,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::vector<std::string> UnionArrayOf<T, I>::keys() const {
+  const std::vector<std::string>
+  UnionArrayOf<T, I>::keys() const {
     std::vector<std::string> out;
     if (contents_.empty()) {
       return out;
@@ -785,7 +940,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::string UnionArrayOf<T, I>::validityerror(const std::string& path) const {
+  const std::string
+  UnionArrayOf<T, I>::validityerror(const std::string& path) const {
     std::vector<int64_t> lencontents;
     for (int64_t i = 0;  i < numcontents();  i++) {
       lencontents.push_back(content(i).get()->length());
@@ -811,12 +967,14 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::shallow_simplify() const {
+  const ContentPtr
+  UnionArrayOf<T, I>::shallow_simplify() const {
     return simplify_uniontype(false);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -834,7 +992,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::pair<Index64, ContentPtr> UnionArrayOf<T, I>::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  UnionArrayOf<T, I>::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
@@ -892,7 +1051,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  bool UnionArrayOf<T, I>::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  UnionArrayOf<T, I>::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -901,7 +1061,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::reverse_merge(const ContentPtr& other) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::reverse_merge(const ContentPtr& other) const {
     int64_t theirlength = other.get()->length();
     int64_t mylength = length();
     Index8 tags(theirlength + mylength);
@@ -975,7 +1136,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::merge(const ContentPtr& other) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::merge(const ContentPtr& other) const {
     if (!parameters_equal(other.get()->parameters())) {
       return merge_as_union(other);
     }
@@ -1121,7 +1283,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const SliceItemPtr UnionArrayOf<T, I>::asslice() const {
+  const SliceItemPtr
+  UnionArrayOf<T, I>::asslice() const {
     ContentPtr simplified = simplify_uniontype(false);
     if (UnionArray8_32* raw = dynamic_cast<UnionArray8_32*>(simplified.get())) {
       if (raw->numcontents() == 1) {
@@ -1153,7 +1316,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::fillna(const ContentPtr& value) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::fillna(const ContentPtr& value) const {
     ContentPtrVec contents;
     for (auto content : contents_) {
       contents.emplace_back(content.get()->fillna(value));
@@ -1163,7 +1327,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -1179,7 +1344,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, true);
@@ -1195,7 +1361,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     ContentPtr simplified = simplify_uniontype(true);
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||
@@ -1206,7 +1373,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -1221,7 +1389,8 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -1239,43 +1408,51 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnionArray::getitem_next(at)");
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnionArray::getitem_next(range)");
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnionArray::getitem_next(array)");
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnionArray::getitem_next(jagged)");
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, typename I>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename T, typename I>
   template <typename S>
-  const ContentPtr UnionArrayOf<T, I>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  const ContentPtr
+  UnionArrayOf<T, I>::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
     ContentPtr simplified = simplify_uniontype(false);
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -21,23 +21,33 @@
 #include "awkward/array/UnmaskedArray.h"
 
 namespace awkward {
-  UnmaskedArray::UnmaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtr& content)
+  UnmaskedArray::UnmaskedArray(const IdentitiesPtr& identities,
+                               const util::Parameters& parameters,
+                               const ContentPtr& content)
       : Content(identities, parameters)
       , content_(content) { }
 
-  const ContentPtr UnmaskedArray::content() const {
+  const ContentPtr
+  UnmaskedArray::content() const {
     return content_;
   }
 
-  const ContentPtr UnmaskedArray::project() const {
+  const ContentPtr
+  UnmaskedArray::project() const {
     return content_;
   }
 
-  const ContentPtr UnmaskedArray::project(const Index8& mask) const {
-    return std::make_shared<ByteMaskedArray>(Identities::none(), util::Parameters(), mask, content_, false).get()->project();
+  const ContentPtr
+  UnmaskedArray::project(const Index8& mask) const {
+    return std::make_shared<ByteMaskedArray>(Identities::none(),
+                                             util::Parameters(),
+                                             mask,
+                                             content_,
+                                             false).get()->project();
   }
 
-  const Index8 UnmaskedArray::bytemask() const {
+  const Index8
+  UnmaskedArray::bytemask() const {
     Index8 out(length());
     struct Error err = awkward_zero_mask8(
       out.ptr().get(),
@@ -46,7 +56,8 @@ namespace awkward {
     return out;
   }
 
-  const ContentPtr UnmaskedArray::simplify_optiontype() const {
+  const ContentPtr
+  UnmaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -62,30 +73,47 @@ namespace awkward {
     }
   }
 
-  const ContentPtr UnmaskedArray::toIndexedOptionArray64() const {
+  const ContentPtr
+  UnmaskedArray::toIndexedOptionArray64() const {
     Index64 index(length());
     struct Error err = awkward_carry_arange_64(
       index.ptr().get(),
       length());
     util::handle_error(err, classname(), identities_.get());
-    return std::make_shared<IndexedOptionArray64>(identities_, parameters_, index, content_);
+    return std::make_shared<IndexedOptionArray64>(identities_,
+                                                  parameters_,
+                                                  index,
+                                                  content_);
   }
 
-  const std::string UnmaskedArray::classname() const {
+  const std::string
+  UnmaskedArray::classname() const {
     return "UnmaskedArray";
   }
 
-  void UnmaskedArray::setidentities(const IdentitiesPtr& identities) {
+  void
+  UnmaskedArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
     else {
       if (length() != identities.get()->length()) {
-        util::handle_error(failure("content and its identities must have the same length", kSliceNone, kSliceNone), classname(), identities_.get());
+        util::handle_error(
+          failure("content and its identities must have the same length",
+                  kSliceNone,
+                  kSliceNone),
+          classname(),
+          identities_.get());
       }
-      if (Identities32* rawidentities = dynamic_cast<Identities32*>(identities.get())) {
-        std::shared_ptr<Identities32> subidentities = std::make_shared<Identities32>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
-        Identities32* rawsubidentities = reinterpret_cast<Identities32*>(subidentities.get());
+      if (Identities32* rawidentities =
+          dynamic_cast<Identities32*>(identities.get())) {
+        std::shared_ptr<Identities32> subidentities =
+          std::make_shared<Identities32>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width(),
+                                         content_.get()->length());
+        Identities32* rawsubidentities =
+          reinterpret_cast<Identities32*>(subidentities.get());
         struct Error err = awkward_identities32_extend(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -95,9 +123,15 @@ namespace awkward {
         util::handle_error(err, classname(), identities_.get());
         content_.get()->setidentities(subidentities);
       }
-      else if (Identities64* rawidentities = dynamic_cast<Identities64*>(identities.get())) {
-        std::shared_ptr<Identities64> subidentities = std::make_shared<Identities64>(Identities::newref(), rawidentities->fieldloc(), rawidentities->width(), content_.get()->length());
-        Identities64* rawsubidentities = reinterpret_cast<Identities64*>(subidentities.get());
+      else if (Identities64* rawidentities =
+               dynamic_cast<Identities64*>(identities.get())) {
+        std::shared_ptr<Identities64> subidentities =
+          std::make_shared<Identities64>(Identities::newref(),
+                                         rawidentities->fieldloc(),
+                                         rawidentities->width(),
+                                         content_.get()->length());
+        Identities64* rawsubidentities =
+          reinterpret_cast<Identities64*>(subidentities.get());
         struct Error err = awkward_identities64_extend(
           rawsubidentities->ptr().get(),
           rawidentities->ptr().get(),
@@ -114,59 +148,91 @@ namespace awkward {
     identities_ = identities;
   }
 
-  void UnmaskedArray::setidentities() {
+  void
+  UnmaskedArray::setidentities() {
     if (length() <= kMaxInt32) {
-      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
-      struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities32>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities32* rawidentities =
+        reinterpret_cast<Identities32*>(newidentities.get());
+      struct Error err = awkward_new_identities32(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
-      Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
-      struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
+      IdentitiesPtr newidentities =
+        std::make_shared<Identities64>(Identities::newref(),
+                                       Identities::FieldLoc(),
+                                       1,
+                                       length());
+      Identities64* rawidentities =
+        reinterpret_cast<Identities64*>(newidentities.get());
+      struct Error err = awkward_new_identities64(rawidentities->ptr().get(),
+                                                  length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
   }
 
-  const TypePtr UnmaskedArray::type(const util::TypeStrs& typestrs) const {
-    return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
+  const TypePtr
+  UnmaskedArray::type(const std::map<std::string,
+                      std::string>& typestrs) const {
+    return std::make_shared<OptionType>(
+      parameters_,
+      util::gettypestr(parameters_, typestrs),
+      content_.get()->type(typestrs));
   }
 
-  const std::string UnmaskedArray::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  const std::string
+  UnmaskedArray::tostring_part(const std::string& indent,
+                               const std::string& pre,
+                               const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << ">\n";
     if (identities_.get() != nullptr) {
-      out << identities_.get()->tostring_part(indent + std::string("    "), "", "\n");
+      out << identities_.get()->tostring_part(
+               indent + std::string("    "), "", "\n");
     }
     if (!parameters_.empty()) {
       out << parameters_tostring(indent + std::string("    "), "", "\n");
     }
-    out << content_.get()->tostring_part(indent + std::string("    "), "<content>", "</content>\n");
+    out << content_.get()->tostring_part(
+             indent + std::string("    "), "<content>", "</content>\n");
     out << indent << "</" << classname() << ">" << post;
     return out.str();
   }
 
-  void UnmaskedArray::tojson_part(ToJson& builder) const {
+  void
+  UnmaskedArray::tojson_part(ToJson& builder) const {
     content_.get()->tojson_part(builder);
   }
 
-  void UnmaskedArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
+  void
+  UnmaskedArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
     content_.get()->nbytes_part(largest);
   }
 
-  int64_t UnmaskedArray::length() const {
+  int64_t
+  UnmaskedArray::length() const {
     return content_.get()->length();
   }
 
-  const ContentPtr UnmaskedArray::shallow_copy() const {
+  const ContentPtr
+  UnmaskedArray::shallow_copy() const {
     return std::make_shared<UnmaskedArray>(identities_, parameters_, content_);
   }
 
-  const ContentPtr UnmaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
-    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+  const ContentPtr
+  UnmaskedArray::deep_copy(bool copyarrays,
+                           bool copyindexes,
+                           bool copyidentities) const {
+    ContentPtr content = content_.get()->deep_copy(copyarrays,
+                                                   copyindexes,
+                                                   copyidentities);
     IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -174,78 +240,120 @@ namespace awkward {
     return std::make_shared<UnmaskedArray>(identities, parameters_, content);
   }
 
-  void UnmaskedArray::check_for_iteration() const {
-    if (identities_.get() != nullptr  &&  identities_.get()->length() < length()) {
-      util::handle_error(failure("len(identities) < len(array)", kSliceNone, kSliceNone), identities_.get()->classname(), nullptr);
+  void
+  UnmaskedArray::check_for_iteration() const {
+    if (identities_.get() != nullptr  &&
+        identities_.get()->length() < length()) {
+      util::handle_error(
+        failure("len(identities) < len(array)", kSliceNone, kSliceNone),
+        identities_.get()->classname(),
+        nullptr);
     }
   }
 
-  const ContentPtr UnmaskedArray::getitem_nothing() const {
+  const ContentPtr
+  UnmaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  const ContentPtr UnmaskedArray::getitem_at(int64_t at) const {
+  const ContentPtr
+  UnmaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
     }
     if (!(0 <= regular_at  &&  regular_at < length())) {
-      util::handle_error(failure("index out of range", kSliceNone, at), classname(), identities_.get());
+      util::handle_error(
+        failure("index out of range", kSliceNone, at),
+        classname(),
+        identities_.get());
     }
     return getitem_at_nowrap(regular_at);
   }
 
-  const ContentPtr UnmaskedArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr
+  UnmaskedArray::getitem_at_nowrap(int64_t at) const {
     return content_.get()->getitem_at_nowrap(at);
   }
 
-  const ContentPtr UnmaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  UnmaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
-    awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
-    if (identities_.get() != nullptr  &&  regular_stop > identities_.get()->length()) {
-      util::handle_error(failure("index out of range", kSliceNone, stop), identities_.get()->classname(), nullptr);
+    awkward_regularize_rangeslice(&regular_start, &regular_stop,
+      true, start != Slice::none(), stop != Slice::none(), length());
+    if (identities_.get() != nullptr  &&
+        regular_stop > identities_.get()->length()) {
+      util::handle_error(
+        failure("index out of range", kSliceNone, stop),
+        identities_.get()->classname(),
+        nullptr);
     }
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const ContentPtr UnmaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr
+  UnmaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
-    return std::make_shared<UnmaskedArray>(identities, parameters_, content_.get()->getitem_range_nowrap(start, stop));
+    return std::make_shared<UnmaskedArray>(
+      identities,
+      parameters_,
+      content_.get()->getitem_range_nowrap(start, stop));
   }
 
-  const ContentPtr UnmaskedArray::getitem_field(const std::string& key) const {
-    return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->getitem_field(key));
+  const ContentPtr
+  UnmaskedArray::getitem_field(const std::string& key) const {
+    return std::make_shared<UnmaskedArray>(
+      identities_,
+      util::Parameters(),
+      content_.get()->getitem_field(key));
   }
 
-  const ContentPtr UnmaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
-    return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->getitem_fields(keys));
+  const ContentPtr
+  UnmaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
+    return std::make_shared<UnmaskedArray>(
+      identities_,
+      util::Parameters(),
+      content_.get()->getitem_fields(keys));
   }
 
-  const ContentPtr UnmaskedArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr
+  UnmaskedArray::getitem_next(const SliceItemPtr& head,
+                              const Slice& tail,
+                              const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
-    else if (dynamic_cast<SliceAt*>(head.get())  ||  dynamic_cast<SliceRange*>(head.get())  ||  dynamic_cast<SliceArray64*>(head.get())  ||  dynamic_cast<SliceJagged64*>(head.get())) {
-      UnmaskedArray out2(identities_, parameters_, content_.get()->getitem_next(head, tail, advanced));
+    else if (dynamic_cast<SliceAt*>(head.get())  ||
+             dynamic_cast<SliceRange*>(head.get())  ||
+             dynamic_cast<SliceArray64*>(head.get())  ||
+             dynamic_cast<SliceJagged64*>(head.get())) {
+      UnmaskedArray out2(identities_,
+                         parameters_,
+                         content_.get()->getitem_next(head, tail, advanced));
       return out2.simplify_optiontype();
     }
-    else if (SliceEllipsis* ellipsis = dynamic_cast<SliceEllipsis*>(head.get())) {
+    else if (SliceEllipsis* ellipsis =
+             dynamic_cast<SliceEllipsis*>(head.get())) {
       return Content::getitem_next(*ellipsis, tail, advanced);
     }
-    else if (SliceNewAxis* newaxis = dynamic_cast<SliceNewAxis*>(head.get())) {
+    else if (SliceNewAxis* newaxis =
+             dynamic_cast<SliceNewAxis*>(head.get())) {
       return Content::getitem_next(*newaxis, tail, advanced);
     }
-    else if (SliceField* field = dynamic_cast<SliceField*>(head.get())) {
+    else if (SliceField* field =
+             dynamic_cast<SliceField*>(head.get())) {
       return Content::getitem_next(*field, tail, advanced);
     }
-    else if (SliceFields* fields = dynamic_cast<SliceFields*>(head.get())) {
+    else if (SliceFields* fields =
+             dynamic_cast<SliceFields*>(head.get())) {
       return Content::getitem_next(*fields, tail, advanced);
     }
-    else if (SliceMissing64* missing = dynamic_cast<SliceMissing64*>(head.get())) {
+    else if (SliceMissing64* missing =
+             dynamic_cast<SliceMissing64*>(head.get())) {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
@@ -253,15 +361,19 @@ namespace awkward {
     }
   }
 
-  const ContentPtr UnmaskedArray::carry(const Index64& carry) const {
+  const ContentPtr
+  UnmaskedArray::carry(const Index64& carry) const {
     IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
-    return std::make_shared<UnmaskedArray>(identities, parameters_, content_.get()->carry(carry));
+    return std::make_shared<UnmaskedArray>(identities,
+                                           parameters_,
+                                           content_.get()->carry(carry));
   }
 
-  const std::string UnmaskedArray::purelist_parameter(const std::string& key) const {
+  const std::string
+  UnmaskedArray::purelist_parameter(const std::string& key) const {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       return content_.get()->purelist_parameter(key);
@@ -271,51 +383,63 @@ namespace awkward {
     }
   }
 
-  bool UnmaskedArray::purelist_isregular() const {
+  bool
+  UnmaskedArray::purelist_isregular() const {
     return content_.get()->purelist_isregular();
   }
 
-  int64_t UnmaskedArray::purelist_depth() const {
+  int64_t
+  UnmaskedArray::purelist_depth() const {
     return content_.get()->purelist_depth();
   }
 
-  const std::pair<int64_t, int64_t> UnmaskedArray::minmax_depth() const {
+  const std::pair<int64_t, int64_t>
+  UnmaskedArray::minmax_depth() const {
     return content_.get()->minmax_depth();
   }
 
-  const std::pair<bool, int64_t> UnmaskedArray::branch_depth() const {
+  const std::pair<bool, int64_t>
+  UnmaskedArray::branch_depth() const {
     return content_.get()->branch_depth();
   }
 
-  int64_t UnmaskedArray::numfields() const {
+  int64_t
+  UnmaskedArray::numfields() const {
     return content_.get()->numfields();
   }
 
-  int64_t UnmaskedArray::fieldindex(const std::string& key) const {
+  int64_t
+  UnmaskedArray::fieldindex(const std::string& key) const {
     return content_.get()->fieldindex(key);
   }
 
-  const std::string UnmaskedArray::key(int64_t fieldindex) const {
+  const std::string
+  UnmaskedArray::key(int64_t fieldindex) const {
     return content_.get()->key(fieldindex);
   }
 
-  bool UnmaskedArray::haskey(const std::string& key) const {
+  bool
+  UnmaskedArray::haskey(const std::string& key) const {
     return content_.get()->haskey(key);
   }
 
-  const std::vector<std::string> UnmaskedArray::keys() const {
+  const std::vector<std::string>
+  UnmaskedArray::keys() const {
     return content_.get()->keys();
   }
 
-  const std::string UnmaskedArray::validityerror(const std::string& path) const {
+  const std::string
+  UnmaskedArray::validityerror(const std::string& path) const {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  const ContentPtr UnmaskedArray::shallow_simplify() const {
+  const ContentPtr
+  UnmaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
-  const ContentPtr UnmaskedArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnmaskedArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -323,21 +447,29 @@ namespace awkward {
       return NumpyArray(out).getitem_at_nowrap(0);
     }
     else {
-      return std::make_shared<UnmaskedArray>(Identities::none(), util::Parameters(), content_.get()->num(axis, depth));
+      return std::make_shared<UnmaskedArray>(Identities::none(),
+                                             util::Parameters(),
+                                             content_.get()->num(axis, depth));
     }
   }
 
-  const std::pair<Index64, ContentPtr> UnmaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr>
+  UnmaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
     }
     else {
-      std::pair<Index64, ContentPtr> offsets_flattened = content_.get()->offsets_and_flattened(axis, depth);
+      std::pair<Index64, ContentPtr> offsets_flattened =
+        content_.get()->offsets_and_flattened(axis, depth);
       Index64 offsets = offsets_flattened.first;
       ContentPtr flattened = offsets_flattened.second;
       if (offsets.length() == 0) {
-        return std::pair<Index64, ContentPtr>(offsets, std::make_shared<UnmaskedArray>(Identities::none(), util::Parameters(), flattened));
+        return std::pair<Index64, ContentPtr>(
+          offsets,
+          std::make_shared<UnmaskedArray>(Identities::none(),
+                                          util::Parameters(),
+                                          flattened));
       }
       else {
         return offsets_flattened;
@@ -345,7 +477,8 @@ namespace awkward {
     }
   }
 
-  bool UnmaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
+  bool
+  UnmaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -357,28 +490,36 @@ namespace awkward {
       return true;
     }
 
-    if (IndexedArray32* rawother = dynamic_cast<IndexedArray32*>(other.get())) {
+    if (IndexedArray32* rawother =
+        dynamic_cast<IndexedArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArrayU32* rawother = dynamic_cast<IndexedArrayU32*>(other.get())) {
+    else if (IndexedArrayU32* rawother =
+             dynamic_cast<IndexedArrayU32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedArray64* rawother = dynamic_cast<IndexedArray64*>(other.get())) {
+    else if (IndexedArray64* rawother =
+             dynamic_cast<IndexedArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray32* rawother = dynamic_cast<IndexedOptionArray32*>(other.get())) {
+    else if (IndexedOptionArray32* rawother =
+             dynamic_cast<IndexedOptionArray32*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (IndexedOptionArray64* rawother = dynamic_cast<IndexedOptionArray64*>(other.get())) {
+    else if (IndexedOptionArray64* rawother =
+             dynamic_cast<IndexedOptionArray64*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (ByteMaskedArray* rawother = dynamic_cast<ByteMaskedArray*>(other.get())) {
+    else if (ByteMaskedArray* rawother =
+             dynamic_cast<ByteMaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (BitMaskedArray* rawother = dynamic_cast<BitMaskedArray*>(other.get())) {
+    else if (BitMaskedArray* rawother =
+             dynamic_cast<BitMaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
-    else if (UnmaskedArray* rawother = dynamic_cast<UnmaskedArray*>(other.get())) {
+    else if (UnmaskedArray* rawother =
+             dynamic_cast<UnmaskedArray*>(other.get())) {
       return content_.get()->mergeable(rawother->content(), mergebool);
     }
     else {
@@ -386,25 +527,31 @@ namespace awkward {
     }
   }
 
-  const ContentPtr UnmaskedArray::reverse_merge(const ContentPtr& other) const {
+  const ContentPtr
+  UnmaskedArray::reverse_merge(const ContentPtr& other) const {
     ContentPtr indexedoptionarray = toIndexedOptionArray64();
-    IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
+    IndexedOptionArray64* raw =
+      dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  const ContentPtr UnmaskedArray::merge(const ContentPtr& other) const {
+  const ContentPtr
+  UnmaskedArray::merge(const ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
-  const SliceItemPtr UnmaskedArray::asslice() const {
+  const SliceItemPtr
+  UnmaskedArray::asslice() const {
     return content_.get()->asslice();
   }
 
-  const ContentPtr UnmaskedArray::fillna(const ContentPtr& value) const {
+  const ContentPtr
+  UnmaskedArray::fillna(const ContentPtr& value) const {
     return content_.get()->fillna(value);
   }
 
-  const ContentPtr UnmaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnmaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -413,11 +560,17 @@ namespace awkward {
       return content_.get()->rpad(target, axis, depth);
     }
     else {
-      return std::make_shared<UnmaskedArray>(Identities::none(), parameters_, content_.get()->rpad(target, axis, depth));
+      return std::make_shared<UnmaskedArray>(
+        Identities::none(),
+        parameters_,
+        content_.get()->rpad(target, axis, depth));
     }
   }
 
-  const ContentPtr UnmaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnmaskedArray::rpad_and_clip(int64_t target,
+                               int64_t axis,
+                               int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -426,25 +579,51 @@ namespace awkward {
       return content_.get()->rpad_and_clip(target, axis, depth);
     }
     else {
-      return std::make_shared<UnmaskedArray>(Identities::none(), parameters_, content_.get()->rpad_and_clip(target, axis, depth));
+      return std::make_shared<UnmaskedArray>(
+        Identities::none(),
+        parameters_,
+        content_.get()->rpad_and_clip(target, axis, depth));
     }
   }
 
-  const ContentPtr UnmaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
-    return content_.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
+  const ContentPtr
+  UnmaskedArray::reduce_next(const Reducer& reducer,
+                             int64_t negaxis,
+                             const Index64& starts,
+                             const Index64& parents,
+                             int64_t outlength,
+                             bool mask,
+                             bool keepdims) const {
+    return content_.get()->reduce_next(reducer,
+                                       negaxis,
+                                       starts,
+                                       parents,
+                                       outlength,
+                                       mask,
+                                       keepdims);
   }
 
-  const ContentPtr UnmaskedArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnmaskedArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
     }
     else {
-      return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->localindex(axis, depth));
+      return std::make_shared<UnmaskedArray>(
+        identities_,
+        util::Parameters(),
+        content_.get()->localindex(axis, depth));
     }
   }
 
-  const ContentPtr UnmaskedArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr
+  UnmaskedArray::choose(int64_t n,
+                        bool diagonal,
+                        const util::RecordLookupPtr& recordlookup,
+                        const util::Parameters& parameters,
+                        int64_t axis,
+                        int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -453,41 +632,95 @@ namespace awkward {
       return choose_axis0(n, diagonal, recordlookup, parameters);
     }
     else {
-      return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->choose(n, diagonal, recordlookup, parameters, axis, depth));
+      return std::make_shared<UnmaskedArray>(
+        identities_,
+        util::Parameters(),
+        content_.get()->choose(n,
+                               diagonal,
+                               recordlookup,
+                               parameters,
+                               axis,
+                               depth));
     }
   }
 
-  const ContentPtr UnmaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(at)");
+  const ContentPtr
+  UnmaskedArray::getitem_next(const SliceAt& at,
+                              const Slice& tail,
+                              const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: UnmaskedArray::getitem_next(at)");
   }
 
-  const ContentPtr UnmaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(range)");
+  const ContentPtr
+  UnmaskedArray::getitem_next(const SliceRange& range,
+                              const Slice& tail,
+                              const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: UnmaskedArray::getitem_next(range)");
   }
 
-  const ContentPtr UnmaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(array)");
+  const ContentPtr
+  UnmaskedArray::getitem_next(const SliceArray64& array,
+                              const Slice& tail,
+                              const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: UnmaskedArray::getitem_next(array)");
   }
 
-  const ContentPtr UnmaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(jagged)");
+  const ContentPtr
+  UnmaskedArray::getitem_next(const SliceJagged64& jagged,
+                              const Slice& tail,
+                              const Index64& advanced) const {
+    throw std::runtime_error(
+      "undefined operation: UnmaskedArray::getitem_next(jagged)");
   }
 
-  const ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  UnmaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                     const Index64& slicestops,
+                                     const SliceArray64& slicecontent,
+                                     const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceArray64>(slicestarts,
+                                                     slicestops,
+                                                     slicecontent,
+                                                     tail);
   }
 
-  const ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  UnmaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                     const Index64& slicestops,
+                                     const SliceMissing64& slicecontent,
+                                     const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceMissing64>(slicestarts,
+                                                       slicestops,
+                                                       slicecontent,
+                                                       tail);
   }
 
-  const ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
-    return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
+  const ContentPtr
+  UnmaskedArray::getitem_next_jagged(const Index64& slicestarts,
+                                     const Index64& slicestops,
+                                     const SliceJagged64& slicecontent,
+                                     const Slice& tail) const {
+    return getitem_next_jagged_generic<SliceJagged64>(slicestarts,
+                                                      slicestops,
+                                                      slicecontent,
+                                                      tail);
   }
 
   template <typename S>
-  const ContentPtr UnmaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
-    UnmaskedArray out2(identities_, parameters_, content_.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail));
+  const ContentPtr
+  UnmaskedArray::getitem_next_jagged_generic(const Index64& slicestarts,
+                                             const Index64& slicestops,
+                                             const S& slicecontent,
+                                             const Slice& tail) const {
+    UnmaskedArray out2(identities_,
+                       parameters_,
+                       content_.get()->getitem_next_jagged(slicestarts,
+                                                           slicestops,
+                                                           slicecontent,
+                                                           tail));
     return out2.simplify_optiontype();
   }
 

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -21,19 +21,19 @@
 #include "awkward/array/UnmaskedArray.h"
 
 namespace awkward {
-  UnmaskedArray::UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const std::shared_ptr<Content>& content)
+  UnmaskedArray::UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, ContentPtr& content)
       : Content(identities, parameters)
       , content_(content) { }
 
-  const std::shared_ptr<Content> UnmaskedArray::content() const {
+  ContentPtr UnmaskedArray::content() const {
     return content_;
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::project() const {
+  ContentPtr UnmaskedArray::project() const {
     return content_;
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::project(const Index8& mask) const {
+  ContentPtr UnmaskedArray::project(const Index8& mask) const {
     return std::make_shared<ByteMaskedArray>(Identities::none(), util::Parameters(), mask, content_, false).get()->project();
   }
 
@@ -46,7 +46,7 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::simplify_optiontype() const {
+  ContentPtr UnmaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -62,7 +62,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::toIndexedOptionArray64() const {
+  ContentPtr UnmaskedArray::toIndexedOptionArray64() const {
     Index64 index(length());
     struct Error err = awkward_carry_arange_64(
       index.ptr().get(),
@@ -161,11 +161,11 @@ namespace awkward {
     return content_.get()->length();
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::shallow_copy() const {
+  ContentPtr UnmaskedArray::shallow_copy() const {
     return std::make_shared<UnmaskedArray>(identities_, parameters_, content_);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+  ContentPtr UnmaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
@@ -180,11 +180,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_nothing() const {
+  ContentPtr UnmaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_at(int64_t at) const {
+  ContentPtr UnmaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
@@ -195,11 +195,11 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_at_nowrap(int64_t at) const {
+  ContentPtr UnmaskedArray::getitem_at_nowrap(int64_t at) const {
     return content_.get()->getitem_at_nowrap(at);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr UnmaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
@@ -209,7 +209,7 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  ContentPtr UnmaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -217,15 +217,15 @@ namespace awkward {
     return std::make_shared<UnmaskedArray>(identities, parameters_, content_.get()->getitem_range_nowrap(start, stop));
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_field(const std::string& key) const {
+  ContentPtr UnmaskedArray::getitem_field(const std::string& key) const {
     return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->getitem_field(key));
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr UnmaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->getitem_fields(keys));
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnmaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -253,7 +253,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::carry(const Index64& carry) const {
+  ContentPtr UnmaskedArray::carry(const Index64& carry) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
@@ -311,11 +311,11 @@ namespace awkward {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::shallow_simplify() const {
+  ContentPtr UnmaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::num(int64_t axis, int64_t depth) const {
+  ContentPtr UnmaskedArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -345,7 +345,7 @@ namespace awkward {
     }
   }
 
-  bool UnmaskedArray::mergeable(const std::shared_ptr<Content>& other, bool mergebool) const {
+  bool UnmaskedArray::mergeable(ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -386,13 +386,13 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::reverse_merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr UnmaskedArray::reverse_merge(ContentPtr& other) const {
     std::shared_ptr<Content> indexedoptionarray = toIndexedOptionArray64();
     IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::merge(const std::shared_ptr<Content>& other) const {
+  ContentPtr UnmaskedArray::merge(ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
@@ -400,11 +400,11 @@ namespace awkward {
     return content_.get()->asslice();
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::fillna(const std::shared_ptr<Content>& value) const {
+  ContentPtr UnmaskedArray::fillna(ContentPtr& value) const {
     return content_.get()->fillna(value);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr UnmaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -417,7 +417,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  ContentPtr UnmaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -430,11 +430,11 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  ContentPtr UnmaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     return content_.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::localindex(int64_t axis, int64_t depth) const {
+  ContentPtr UnmaskedArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -444,7 +444,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  ContentPtr UnmaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -457,36 +457,36 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnmaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(at)");
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnmaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(range)");
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnmaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(array)");
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  ContentPtr UnmaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(jagged)");
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename S>
-  const std::shared_ptr<Content> UnmaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  ContentPtr UnmaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
     UnmaskedArray out2(identities_, parameters_, content_.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail));
     return out2.simplify_optiontype();
   }

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -21,19 +21,19 @@
 #include "awkward/array/UnmaskedArray.h"
 
 namespace awkward {
-  UnmaskedArray::UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, ContentPtr& content)
+  UnmaskedArray::UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtr& content)
       : Content(identities, parameters)
       , content_(content) { }
 
-  ContentPtr UnmaskedArray::content() const {
+  const ContentPtr UnmaskedArray::content() const {
     return content_;
   }
 
-  ContentPtr UnmaskedArray::project() const {
+  const ContentPtr UnmaskedArray::project() const {
     return content_;
   }
 
-  ContentPtr UnmaskedArray::project(const Index8& mask) const {
+  const ContentPtr UnmaskedArray::project(const Index8& mask) const {
     return std::make_shared<ByteMaskedArray>(Identities::none(), util::Parameters(), mask, content_, false).get()->project();
   }
 
@@ -46,7 +46,7 @@ namespace awkward {
     return out;
   }
 
-  ContentPtr UnmaskedArray::simplify_optiontype() const {
+  const ContentPtr UnmaskedArray::simplify_optiontype() const {
     if (dynamic_cast<IndexedArray32*>(content_.get())        ||
         dynamic_cast<IndexedArrayU32*>(content_.get())       ||
         dynamic_cast<IndexedArray64*>(content_.get())        ||
@@ -62,7 +62,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnmaskedArray::toIndexedOptionArray64() const {
+  const ContentPtr UnmaskedArray::toIndexedOptionArray64() const {
     Index64 index(length());
     struct Error err = awkward_carry_arange_64(
       index.ptr().get(),
@@ -161,12 +161,12 @@ namespace awkward {
     return content_.get()->length();
   }
 
-  ContentPtr UnmaskedArray::shallow_copy() const {
+  const ContentPtr UnmaskedArray::shallow_copy() const {
     return std::make_shared<UnmaskedArray>(identities_, parameters_, content_);
   }
 
-  ContentPtr UnmaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
-    std::shared_ptr<Content> content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
+  const ContentPtr UnmaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
+    ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
     std::shared_ptr<Identities> identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
@@ -180,11 +180,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnmaskedArray::getitem_nothing() const {
+  const ContentPtr UnmaskedArray::getitem_nothing() const {
     return content_.get()->getitem_range_nowrap(0, 0);
   }
 
-  ContentPtr UnmaskedArray::getitem_at(int64_t at) const {
+  const ContentPtr UnmaskedArray::getitem_at(int64_t at) const {
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length();
@@ -195,11 +195,11 @@ namespace awkward {
     return getitem_at_nowrap(regular_at);
   }
 
-  ContentPtr UnmaskedArray::getitem_at_nowrap(int64_t at) const {
+  const ContentPtr UnmaskedArray::getitem_at_nowrap(int64_t at) const {
     return content_.get()->getitem_at_nowrap(at);
   }
 
-  ContentPtr UnmaskedArray::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr UnmaskedArray::getitem_range(int64_t start, int64_t stop) const {
     int64_t regular_start = start;
     int64_t regular_stop = stop;
     awkward_regularize_rangeslice(&regular_start, &regular_stop, true, start != Slice::none(), stop != Slice::none(), length());
@@ -209,7 +209,7 @@ namespace awkward {
     return getitem_range_nowrap(regular_start, regular_stop);
   }
 
-  ContentPtr UnmaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
+  const ContentPtr UnmaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
@@ -217,15 +217,15 @@ namespace awkward {
     return std::make_shared<UnmaskedArray>(identities, parameters_, content_.get()->getitem_range_nowrap(start, stop));
   }
 
-  ContentPtr UnmaskedArray::getitem_field(const std::string& key) const {
+  const ContentPtr UnmaskedArray::getitem_field(const std::string& key) const {
     return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->getitem_field(key));
   }
 
-  ContentPtr UnmaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr UnmaskedArray::getitem_fields(const std::vector<std::string>& keys) const {
     return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->getitem_fields(keys));
   }
 
-  ContentPtr UnmaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr UnmaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -253,7 +253,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnmaskedArray::carry(const Index64& carry) const {
+  const ContentPtr UnmaskedArray::carry(const Index64& carry) const {
     std::shared_ptr<Identities> identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
@@ -311,11 +311,11 @@ namespace awkward {
     return content_.get()->validityerror(path + std::string(".content"));
   }
 
-  ContentPtr UnmaskedArray::shallow_simplify() const {
+  const ContentPtr UnmaskedArray::shallow_simplify() const {
     return simplify_optiontype();
   }
 
-  ContentPtr UnmaskedArray::num(int64_t axis, int64_t depth) const {
+  const ContentPtr UnmaskedArray::num(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       Index64 out(1);
@@ -327,17 +327,17 @@ namespace awkward {
     }
   }
 
-  const std::pair<Index64, std::shared_ptr<Content>> UnmaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
+  const std::pair<Index64, ContentPtr> UnmaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       throw std::invalid_argument("axis=0 not allowed for flatten");
     }
     else {
-      std::pair<Index64, std::shared_ptr<Content>> offsets_flattened = content_.get()->offsets_and_flattened(axis, depth);
+      std::pair<Index64, ContentPtr> offsets_flattened = content_.get()->offsets_and_flattened(axis, depth);
       Index64 offsets = offsets_flattened.first;
-      std::shared_ptr<Content> flattened = offsets_flattened.second;
+      ContentPtr flattened = offsets_flattened.second;
       if (offsets.length() == 0) {
-        return std::pair<Index64, std::shared_ptr<Content>>(offsets, std::make_shared<UnmaskedArray>(Identities::none(), util::Parameters(), flattened));
+        return std::pair<Index64, ContentPtr>(offsets, std::make_shared<UnmaskedArray>(Identities::none(), util::Parameters(), flattened));
       }
       else {
         return offsets_flattened;
@@ -345,7 +345,7 @@ namespace awkward {
     }
   }
 
-  bool UnmaskedArray::mergeable(ContentPtr& other, bool mergebool) const {
+  bool UnmaskedArray::mergeable(const ContentPtr& other, bool mergebool) const {
     if (!parameters_equal(other.get()->parameters())) {
       return false;
     }
@@ -386,13 +386,13 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnmaskedArray::reverse_merge(ContentPtr& other) const {
-    std::shared_ptr<Content> indexedoptionarray = toIndexedOptionArray64();
+  const ContentPtr UnmaskedArray::reverse_merge(const ContentPtr& other) const {
+    ContentPtr indexedoptionarray = toIndexedOptionArray64();
     IndexedOptionArray64* raw = dynamic_cast<IndexedOptionArray64*>(indexedoptionarray.get());
     return raw->reverse_merge(other);
   }
 
-  ContentPtr UnmaskedArray::merge(ContentPtr& other) const {
+  const ContentPtr UnmaskedArray::merge(const ContentPtr& other) const {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
@@ -400,11 +400,11 @@ namespace awkward {
     return content_.get()->asslice();
   }
 
-  ContentPtr UnmaskedArray::fillna(ContentPtr& value) const {
+  const ContentPtr UnmaskedArray::fillna(const ContentPtr& value) const {
     return content_.get()->fillna(value);
   }
 
-  ContentPtr UnmaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr UnmaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -417,7 +417,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnmaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
+  const ContentPtr UnmaskedArray::rpad_and_clip(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {
       return rpad_axis0(target, false);
@@ -430,11 +430,11 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnmaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
+  const ContentPtr UnmaskedArray::reduce_next(const Reducer& reducer, int64_t negaxis, const Index64& starts, const Index64& parents, int64_t outlength, bool mask, bool keepdims) const {
     return content_.get()->reduce_next(reducer, negaxis, starts, parents, outlength, mask, keepdims);
   }
 
-  ContentPtr UnmaskedArray::localindex(int64_t axis, int64_t depth) const {
+  const ContentPtr UnmaskedArray::localindex(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (axis == depth) {
       return localindex_axis0();
@@ -444,7 +444,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnmaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr UnmaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }
@@ -457,36 +457,36 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnmaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr UnmaskedArray::getitem_next(const SliceAt& at, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(at)");
   }
 
-  ContentPtr UnmaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr UnmaskedArray::getitem_next(const SliceRange& range, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(range)");
   }
 
-  ContentPtr UnmaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr UnmaskedArray::getitem_next(const SliceArray64& array, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(array)");
   }
 
-  ContentPtr UnmaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr UnmaskedArray::getitem_next(const SliceJagged64& jagged, const Slice& tail, const Index64& advanced) const {
     throw std::runtime_error("undefined operation: UnmaskedArray::getitem_next(jagged)");
   }
 
-  ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
+  const ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceArray64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceArray64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
+  const ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceMissing64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceMissing64>(slicestarts, slicestops, slicecontent, tail);
   }
 
-  ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
+  const ContentPtr UnmaskedArray::getitem_next_jagged(const Index64& slicestarts, const Index64& slicestops, const SliceJagged64& slicecontent, const Slice& tail) const {
     return getitem_next_jagged_generic<SliceJagged64>(slicestarts, slicestops, slicecontent, tail);
   }
 
   template <typename S>
-  ContentPtr UnmaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
+  const ContentPtr UnmaskedArray::getitem_next_jagged_generic(const Index64& slicestarts, const Index64& slicestops, const S& slicecontent, const Slice& tail) const {
     UnmaskedArray out2(identities_, parameters_, content_.get()->getitem_next_jagged(slicestarts, slicestops, slicecontent, tail));
     return out2.simplify_optiontype();
   }

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -21,7 +21,7 @@
 #include "awkward/array/UnmaskedArray.h"
 
 namespace awkward {
-  UnmaskedArray::UnmaskedArray(const std::shared_ptr<Identities>& identities, const util::Parameters& parameters, const ContentPtr& content)
+  UnmaskedArray::UnmaskedArray(const IdentitiesPtr& identities, const util::Parameters& parameters, const ContentPtr& content)
       : Content(identities, parameters)
       , content_(content) { }
 
@@ -75,7 +75,7 @@ namespace awkward {
     return "UnmaskedArray";
   }
 
-  void UnmaskedArray::setidentities(const std::shared_ptr<Identities>& identities) {
+  void UnmaskedArray::setidentities(const IdentitiesPtr& identities) {
     if (identities.get() == nullptr) {
       content_.get()->setidentities(identities);
     }
@@ -116,14 +116,14 @@ namespace awkward {
 
   void UnmaskedArray::setidentities() {
     if (length() <= kMaxInt32) {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities32>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities32* rawidentities = reinterpret_cast<Identities32*>(newidentities.get());
       struct Error err = awkward_new_identities32(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
       setidentities(newidentities);
     }
     else {
-      std::shared_ptr<Identities> newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
+      IdentitiesPtr newidentities = std::make_shared<Identities64>(Identities::newref(), Identities::FieldLoc(), 1, length());
       Identities64* rawidentities = reinterpret_cast<Identities64*>(newidentities.get());
       struct Error err = awkward_new_identities64(rawidentities->ptr().get(), length());
       util::handle_error(err, classname(), identities_.get());
@@ -131,7 +131,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Type> UnmaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr UnmaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
     return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
   }
 
@@ -167,7 +167,7 @@ namespace awkward {
 
   const ContentPtr UnmaskedArray::deep_copy(bool copyarrays, bool copyindexes, bool copyidentities) const {
     ContentPtr content = content_.get()->deep_copy(copyarrays, copyindexes, copyidentities);
-    std::shared_ptr<Identities> identities = identities_;
+    IdentitiesPtr identities = identities_;
     if (copyidentities  &&  identities_.get() != nullptr) {
       identities = identities_.get()->deep_copy();
     }
@@ -210,7 +210,7 @@ namespace awkward {
   }
 
   const ContentPtr UnmaskedArray::getitem_range_nowrap(int64_t start, int64_t stop) const {
-    std::shared_ptr<Identities> identities(nullptr);
+    IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_range_nowrap(start, stop);
     }
@@ -225,7 +225,7 @@ namespace awkward {
     return std::make_shared<UnmaskedArray>(identities_, util::Parameters(), content_.get()->getitem_fields(keys));
   }
 
-  const ContentPtr UnmaskedArray::getitem_next(const std::shared_ptr<SliceItem>& head, const Slice& tail, const Index64& advanced) const {
+  const ContentPtr UnmaskedArray::getitem_next(const SliceItemPtr& head, const Slice& tail, const Index64& advanced) const {
     if (head.get() == nullptr) {
       return shallow_copy();
     }
@@ -254,7 +254,7 @@ namespace awkward {
   }
 
   const ContentPtr UnmaskedArray::carry(const Index64& carry) const {
-    std::shared_ptr<Identities> identities(nullptr);
+    IdentitiesPtr identities(nullptr);
     if (identities_.get() != nullptr) {
       identities = identities_.get()->getitem_carry_64(carry);
     }
@@ -396,7 +396,7 @@ namespace awkward {
     return toIndexedOptionArray64().get()->merge(other);
   }
 
-  const std::shared_ptr<SliceItem> UnmaskedArray::asslice() const {
+  const SliceItemPtr UnmaskedArray::asslice() const {
     return content_.get()->asslice();
   }
 
@@ -444,7 +444,7 @@ namespace awkward {
     }
   }
 
-  const ContentPtr UnmaskedArray::choose(int64_t n, bool diagonal, const std::shared_ptr<util::RecordLookup>& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
+  const ContentPtr UnmaskedArray::choose(int64_t n, bool diagonal, const util::RecordLookupPtr& recordlookup, const util::Parameters& parameters, int64_t axis, int64_t depth) const {
     if (n < 1) {
       throw std::invalid_argument("in choose, 'n' must be at least 1");
     }

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -131,7 +131,7 @@ namespace awkward {
     }
   }
 
-  const TypePtr UnmaskedArray::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr UnmaskedArray::type(const util::TypeStrs& typestrs) const {
     return std::make_shared<OptionType>(parameters_, util::gettypestr(parameters_, typestrs), content_.get()->type(typestrs));
   }
 

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -8,164 +8,204 @@ namespace awkward {
   ArrayBuilder::ArrayBuilder(const ArrayBuilderOptions& options)
       : builder_(UnknownBuilder::fromempty(options)) { }
 
-  const std::string ArrayBuilder::tostring() const {
-    std::map<std::string, std::string> typestrs;
+  const std::string
+  ArrayBuilder::tostring() const {
+    util::TypeStrs typestrs;
     typestrs["char"] = "char";
     typestrs["string"] = "string";
     std::stringstream out;
-    out << "<ArrayBuilder length=\"" << length() << "\" type=\"" << type(typestrs).get()->tostring() << "\"/>";
+    out << "<ArrayBuilder length=\"" << length() << "\" type=\""
+        << type(typestrs).get()->tostring() << "\"/>";
     return out.str();
   }
 
-  int64_t ArrayBuilder::length() const {
+  int64_t
+  ArrayBuilder::length() const {
     return builder_.get()->length();
   }
 
-  void ArrayBuilder::clear() {
+  void
+  ArrayBuilder::clear() {
     builder_.get()->clear();
   }
 
-  const TypePtr ArrayBuilder::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr
+  ArrayBuilder::type(const util::TypeStrs& typestrs) const {
     return builder_.get()->snapshot().get()->type(typestrs);
   }
 
-  const ContentPtr ArrayBuilder::snapshot() const {
+  const ContentPtr
+  ArrayBuilder::snapshot() const {
     return builder_.get()->snapshot();
   }
 
-  const ContentPtr ArrayBuilder::getitem_at(int64_t at) const {
+  const ContentPtr
+  ArrayBuilder::getitem_at(int64_t at) const {
     return snapshot().get()->getitem_at(at);
   }
 
-  const ContentPtr ArrayBuilder::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr
+  ArrayBuilder::getitem_range(int64_t start, int64_t stop) const {
     return snapshot().get()->getitem_range(start, stop);
   }
 
-  const ContentPtr ArrayBuilder::getitem_field(const std::string& key) const {
+  const ContentPtr
+  ArrayBuilder::getitem_field(const std::string& key) const {
     return snapshot().get()->getitem_field(key);
   }
 
-  const ContentPtr ArrayBuilder::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr
+  ArrayBuilder::getitem_fields(const std::vector<std::string>& keys) const {
     return snapshot().get()->getitem_fields(keys);
   }
 
-  const ContentPtr ArrayBuilder::getitem(const Slice& where) const {
+  const ContentPtr
+  ArrayBuilder::getitem(const Slice& where) const {
     return snapshot().get()->getitem(where);
   }
 
-  void ArrayBuilder::null() {
+  void
+  ArrayBuilder::null() {
     maybeupdate(builder_.get()->null());
   }
 
-  void ArrayBuilder::boolean(bool x) {
+  void
+  ArrayBuilder::boolean(bool x) {
     maybeupdate(builder_.get()->boolean(x));
   }
 
-  void ArrayBuilder::integer(int64_t x) {
+  void
+  ArrayBuilder::integer(int64_t x) {
     maybeupdate(builder_.get()->integer(x));
   }
 
-  void ArrayBuilder::real(double x) {
+  void
+  ArrayBuilder::real(double x) {
     maybeupdate(builder_.get()->real(x));
   }
 
-  void ArrayBuilder::bytestring(const char* x) {
+  void
+  ArrayBuilder::bytestring(const char* x) {
     maybeupdate(builder_.get()->string(x, -1, no_encoding));
   }
 
-  void ArrayBuilder::bytestring(const char* x, int64_t length) {
+  void
+  ArrayBuilder::bytestring(const char* x, int64_t length) {
     maybeupdate(builder_.get()->string(x, length, no_encoding));
   }
 
-  void ArrayBuilder::bytestring(const std::string& x) {
+  void
+  ArrayBuilder::bytestring(const std::string& x) {
     bytestring(x.c_str(), (int64_t)x.length());
   }
 
-  void ArrayBuilder::string(const char* x) {
+  void
+  ArrayBuilder::string(const char* x) {
     maybeupdate(builder_.get()->string(x, -1, utf8_encoding));
   }
 
-  void ArrayBuilder::string(const char* x, int64_t length) {
+  void
+  ArrayBuilder::string(const char* x, int64_t length) {
     maybeupdate(builder_.get()->string(x, length, utf8_encoding));
   }
 
-  void ArrayBuilder::string(const std::string& x) {
+  void
+  ArrayBuilder::string(const std::string& x) {
     string(x.c_str(), (int64_t)x.length());
   }
 
-  void ArrayBuilder::beginlist() {
+  void
+  ArrayBuilder::beginlist() {
     maybeupdate(builder_.get()->beginlist());
   }
 
-  void ArrayBuilder::endlist() {
+  void
+  ArrayBuilder::endlist() {
     BuilderPtr tmp = builder_.get()->endlist();
     if (tmp.get() == nullptr) {
-      throw std::invalid_argument("endlist doesn't match a corresponding beginlist");
+      throw std::invalid_argument(
+        "endlist doesn't match a corresponding beginlist");
     }
     maybeupdate(tmp);
   }
 
-  void ArrayBuilder::begintuple(int64_t numfields) {
+  void
+  ArrayBuilder::begintuple(int64_t numfields) {
     maybeupdate(builder_.get()->begintuple(numfields));
   }
 
-  void ArrayBuilder::index(int64_t index) {
+  void
+  ArrayBuilder::index(int64_t index) {
     maybeupdate(builder_.get()->index(index));
   }
 
-  void ArrayBuilder::endtuple() {
+  void
+  ArrayBuilder::endtuple() {
     maybeupdate(builder_.get()->endtuple());
   }
 
-  void ArrayBuilder::beginrecord() {
+  void
+  ArrayBuilder::beginrecord() {
     beginrecord_fast(nullptr);
   }
 
-  void ArrayBuilder::beginrecord_fast(const char* name) {
+  void
+  ArrayBuilder::beginrecord_fast(const char* name) {
     maybeupdate(builder_.get()->beginrecord(name, false));
   }
 
-  void ArrayBuilder::beginrecord_check(const char* name) {
+  void
+  ArrayBuilder::beginrecord_check(const char* name) {
     maybeupdate(builder_.get()->beginrecord(name, true));
   }
 
-  void ArrayBuilder::beginrecord_check(const std::string& name) {
+  void
+  ArrayBuilder::beginrecord_check(const std::string& name) {
     beginrecord_check(name.c_str());
   }
 
-  void ArrayBuilder::field_fast(const char* key) {
+  void
+  ArrayBuilder::field_fast(const char* key) {
     maybeupdate(builder_.get()->field(key, false));
   }
 
-  void ArrayBuilder::field_check(const char* key) {
+  void
+  ArrayBuilder::field_check(const char* key) {
     maybeupdate(builder_.get()->field(key, true));
   }
 
-  void ArrayBuilder::field_check(const std::string& key) {
+  void
+  ArrayBuilder::field_check(const std::string& key) {
     field_check(key.c_str());
   }
 
-  void ArrayBuilder::endrecord() {
+  void
+  ArrayBuilder::endrecord() {
     maybeupdate(builder_.get()->endrecord());
   }
 
-  void ArrayBuilder::append(const ContentPtr& array, int64_t at) {
+  void
+  ArrayBuilder::append(const ContentPtr& array, int64_t at) {
     int64_t length = array.get()->length();
     int64_t regular_at = at;
     if (regular_at < 0) {
       regular_at += length;
     }
     if (!(0 <= regular_at  &&  regular_at < length)) {
-      throw std::invalid_argument(std::string("'append' index (") + std::to_string(at) + std::string(") out of bounds (") + std::to_string(length) + std::string(")"));
+      throw std::invalid_argument(std::string("'append' index (")
+        + std::to_string(at) + std::string(") out of bounds (")
+        + std::to_string(length) + std::string(")"));
     }
     return append_nowrap(array, regular_at);
   }
 
-  void ArrayBuilder::append_nowrap(const ContentPtr& array, int64_t at) {
+  void
+  ArrayBuilder::append_nowrap(const ContentPtr& array, int64_t at) {
     maybeupdate(builder_.get()->append(array, at));
   }
 
-  void ArrayBuilder::extend(const ContentPtr& array) {
+  void
+  ArrayBuilder::extend(const ContentPtr& array) {
     BuilderPtr tmp = builder_;
     for (int64_t i = 0;  i < array.get()->length();  i++) {
       tmp = builder_.get()->append(array, i);
@@ -173,7 +213,8 @@ namespace awkward {
     maybeupdate(tmp);
   }
 
-  void ArrayBuilder::maybeupdate(const BuilderPtr& tmp) {
+  void
+  ArrayBuilder::maybeupdate(const BuilderPtr& tmp) {
     if (tmp.get() != builder_.get()) {
       builder_ = tmp;
     }
@@ -183,8 +224,12 @@ namespace awkward {
   const char* ArrayBuilder::utf8_encoding = "utf-8";
 }
 
-uint8_t awkward_ArrayBuilder_length(void* arraybuilder, int64_t* result) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+////////// extern C interface
+
+uint8_t awkward_ArrayBuilder_length(void* arraybuilder,
+                                    int64_t* result) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     *result = obj->length();
   }
@@ -195,7 +240,8 @@ uint8_t awkward_ArrayBuilder_length(void* arraybuilder, int64_t* result) {
 }
 
 uint8_t awkward_ArrayBuilder_clear(void* arraybuilder) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->clear();
   }
@@ -206,7 +252,8 @@ uint8_t awkward_ArrayBuilder_clear(void* arraybuilder) {
 }
 
 uint8_t awkward_ArrayBuilder_null(void* arraybuilder) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->null();
   }
@@ -216,8 +263,10 @@ uint8_t awkward_ArrayBuilder_null(void* arraybuilder) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_boolean(void* arraybuilder, bool x) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_boolean(void* arraybuilder,
+                                     bool x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->boolean(x);
   }
@@ -227,8 +276,10 @@ uint8_t awkward_ArrayBuilder_boolean(void* arraybuilder, bool x) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_integer(void* arraybuilder, int64_t x) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_integer(void* arraybuilder,
+                                     int64_t x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->integer(x);
   }
@@ -238,8 +289,10 @@ uint8_t awkward_ArrayBuilder_integer(void* arraybuilder, int64_t x) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_real(void* arraybuilder, double x) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_real(void* arraybuilder,
+                                  double x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->real(x);
   }
@@ -249,8 +302,10 @@ uint8_t awkward_ArrayBuilder_real(void* arraybuilder, double x) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_bytestring(void* arraybuilder, const char* x) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_bytestring(void* arraybuilder,
+                                        const char* x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->bytestring(x);
   }
@@ -260,8 +315,11 @@ uint8_t awkward_ArrayBuilder_bytestring(void* arraybuilder, const char* x) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_bytestring_length(void* arraybuilder, const char* x, int64_t length) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
+                                               const char* x,
+                                               int64_t length) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->bytestring(x, length);
   }
@@ -271,8 +329,10 @@ uint8_t awkward_ArrayBuilder_bytestring_length(void* arraybuilder, const char* x
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_string(void* arraybuilder, const char* x) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_string(void* arraybuilder,
+                                    const char* x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->string(x);
   }
@@ -282,8 +342,11 @@ uint8_t awkward_ArrayBuilder_string(void* arraybuilder, const char* x) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_string_length(void* arraybuilder, const char* x, int64_t length) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_string_length(void* arraybuilder,
+                                           const char* x,
+                                           int64_t length) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->string(x, length);
   }
@@ -294,7 +357,8 @@ uint8_t awkward_ArrayBuilder_string_length(void* arraybuilder, const char* x, in
 }
 
 uint8_t awkward_ArrayBuilder_beginlist(void* arraybuilder) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->beginlist();
   }
@@ -305,7 +369,8 @@ uint8_t awkward_ArrayBuilder_beginlist(void* arraybuilder) {
 }
 
 uint8_t awkward_ArrayBuilder_endlist(void* arraybuilder) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->endlist();
   }
@@ -315,8 +380,10 @@ uint8_t awkward_ArrayBuilder_endlist(void* arraybuilder) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_begintuple(void* arraybuilder, int64_t numfields) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_begintuple(void* arraybuilder,
+                                        int64_t numfields) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->begintuple(numfields);
   }
@@ -326,8 +393,10 @@ uint8_t awkward_ArrayBuilder_begintuple(void* arraybuilder, int64_t numfields) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_index(void* arraybuilder, int64_t index) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_index(void* arraybuilder,
+                                   int64_t index) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->index(index);
   }
@@ -338,7 +407,8 @@ uint8_t awkward_ArrayBuilder_index(void* arraybuilder, int64_t index) {
 }
 
 uint8_t awkward_ArrayBuilder_endtuple(void* arraybuilder) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->endtuple();
   }
@@ -349,7 +419,8 @@ uint8_t awkward_ArrayBuilder_endtuple(void* arraybuilder) {
 }
 
 uint8_t awkward_ArrayBuilder_beginrecord(void* arraybuilder) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->beginrecord();
   }
@@ -359,8 +430,10 @@ uint8_t awkward_ArrayBuilder_beginrecord(void* arraybuilder) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder, const char* name) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
+                                              const char* name) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->beginrecord_fast(name);
   }
@@ -370,8 +443,10 @@ uint8_t awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder, const char* na
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord_check(void* arraybuilder, const char* name) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
+                                               const char* name) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->beginrecord_check(name);
   }
@@ -381,8 +456,10 @@ uint8_t awkward_ArrayBuilder_beginrecord_check(void* arraybuilder, const char* n
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_field_fast(void* arraybuilder, const char* key) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_field_fast(void* arraybuilder,
+                                        const char* key) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->field_fast(key);
   }
@@ -392,8 +469,10 @@ uint8_t awkward_ArrayBuilder_field_fast(void* arraybuilder, const char* key) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_field_check(void* arraybuilder, const char* key) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_field_check(void* arraybuilder,
+                                         const char* key) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->field_check(key);
   }
@@ -404,7 +483,8 @@ uint8_t awkward_ArrayBuilder_field_check(void* arraybuilder, const char* key) {
 }
 
 uint8_t awkward_ArrayBuilder_endrecord(void* arraybuilder) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->endrecord();
   }
@@ -414,9 +494,13 @@ uint8_t awkward_ArrayBuilder_endrecord(void* arraybuilder) {
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_append_nowrap(void* arraybuilder, const void* shared_ptr_ptr, int64_t at) {
-  awkward::ArrayBuilder* obj = reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
-  const std::shared_ptr<awkward::Content>* array = reinterpret_cast<const std::shared_ptr<awkward::Content>*>(shared_ptr_ptr);
+uint8_t awkward_ArrayBuilder_append_nowrap(void* arraybuilder,
+                                           const void* shared_ptr_ptr,
+                                           int64_t at) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  const std::shared_ptr<awkward::Content>* array =
+    reinterpret_cast<const std::shared_ptr<awkward::Content>*>(shared_ptr_ptr);
   try {
     obj->append_nowrap(*array, at);
   }

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -29,27 +29,27 @@ namespace awkward {
     return builder_.get()->snapshot().get()->type(typestrs);
   }
 
-  const std::shared_ptr<Content> ArrayBuilder::snapshot() const {
+  ContentPtr ArrayBuilder::snapshot() const {
     return builder_.get()->snapshot();
   }
 
-  const std::shared_ptr<Content> ArrayBuilder::getitem_at(int64_t at) const {
+  ContentPtr ArrayBuilder::getitem_at(int64_t at) const {
     return snapshot().get()->getitem_at(at);
   }
 
-  const std::shared_ptr<Content> ArrayBuilder::getitem_range(int64_t start, int64_t stop) const {
+  ContentPtr ArrayBuilder::getitem_range(int64_t start, int64_t stop) const {
     return snapshot().get()->getitem_range(start, stop);
   }
 
-  const std::shared_ptr<Content> ArrayBuilder::getitem_field(const std::string& key) const {
+  ContentPtr ArrayBuilder::getitem_field(const std::string& key) const {
     return snapshot().get()->getitem_field(key);
   }
 
-  const std::shared_ptr<Content> ArrayBuilder::getitem_fields(const std::vector<std::string>& keys) const {
+  ContentPtr ArrayBuilder::getitem_fields(const std::vector<std::string>& keys) const {
     return snapshot().get()->getitem_fields(keys);
   }
 
-  const std::shared_ptr<Content> ArrayBuilder::getitem(const Slice& where) const {
+  ContentPtr ArrayBuilder::getitem(const Slice& where) const {
     return snapshot().get()->getitem(where);
   }
 
@@ -149,7 +149,7 @@ namespace awkward {
     maybeupdate(builder_.get()->endrecord());
   }
 
-  void ArrayBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  void ArrayBuilder::append(ContentPtr& array, int64_t at) {
     int64_t length = array.get()->length();
     int64_t regular_at = at;
     if (regular_at < 0) {
@@ -161,11 +161,11 @@ namespace awkward {
     return append_nowrap(array, regular_at);
   }
 
-  void ArrayBuilder::append_nowrap(const std::shared_ptr<Content>& array, int64_t at) {
+  void ArrayBuilder::append_nowrap(ContentPtr& array, int64_t at) {
     maybeupdate(builder_.get()->append(array, at));
   }
 
-  void ArrayBuilder::extend(const std::shared_ptr<Content>& array) {
+  void ArrayBuilder::extend(ContentPtr& array) {
     std::shared_ptr<Builder> tmp = builder_;
     for (int64_t i = 0;  i < array.get()->length();  i++) {
       tmp = builder_.get()->append(array, i);

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -29,27 +29,27 @@ namespace awkward {
     return builder_.get()->snapshot().get()->type(typestrs);
   }
 
-  ContentPtr ArrayBuilder::snapshot() const {
+  const ContentPtr ArrayBuilder::snapshot() const {
     return builder_.get()->snapshot();
   }
 
-  ContentPtr ArrayBuilder::getitem_at(int64_t at) const {
+  const ContentPtr ArrayBuilder::getitem_at(int64_t at) const {
     return snapshot().get()->getitem_at(at);
   }
 
-  ContentPtr ArrayBuilder::getitem_range(int64_t start, int64_t stop) const {
+  const ContentPtr ArrayBuilder::getitem_range(int64_t start, int64_t stop) const {
     return snapshot().get()->getitem_range(start, stop);
   }
 
-  ContentPtr ArrayBuilder::getitem_field(const std::string& key) const {
+  const ContentPtr ArrayBuilder::getitem_field(const std::string& key) const {
     return snapshot().get()->getitem_field(key);
   }
 
-  ContentPtr ArrayBuilder::getitem_fields(const std::vector<std::string>& keys) const {
+  const ContentPtr ArrayBuilder::getitem_fields(const std::vector<std::string>& keys) const {
     return snapshot().get()->getitem_fields(keys);
   }
 
-  ContentPtr ArrayBuilder::getitem(const Slice& where) const {
+  const ContentPtr ArrayBuilder::getitem(const Slice& where) const {
     return snapshot().get()->getitem(where);
   }
 
@@ -149,7 +149,7 @@ namespace awkward {
     maybeupdate(builder_.get()->endrecord());
   }
 
-  void ArrayBuilder::append(ContentPtr& array, int64_t at) {
+  void ArrayBuilder::append(const ContentPtr& array, int64_t at) {
     int64_t length = array.get()->length();
     int64_t regular_at = at;
     if (regular_at < 0) {
@@ -161,11 +161,11 @@ namespace awkward {
     return append_nowrap(array, regular_at);
   }
 
-  void ArrayBuilder::append_nowrap(ContentPtr& array, int64_t at) {
+  void ArrayBuilder::append_nowrap(const ContentPtr& array, int64_t at) {
     maybeupdate(builder_.get()->append(array, at));
   }
 
-  void ArrayBuilder::extend(ContentPtr& array) {
+  void ArrayBuilder::extend(const ContentPtr& array) {
     std::shared_ptr<Builder> tmp = builder_;
     for (int64_t i = 0;  i < array.get()->length();  i++) {
       tmp = builder_.get()->append(array, i);

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -25,7 +25,7 @@ namespace awkward {
     builder_.get()->clear();
   }
 
-  const std::shared_ptr<Type> ArrayBuilder::type(const std::map<std::string, std::string>& typestrs) const {
+  const TypePtr ArrayBuilder::type(const std::map<std::string, std::string>& typestrs) const {
     return builder_.get()->snapshot().get()->type(typestrs);
   }
 
@@ -98,7 +98,7 @@ namespace awkward {
   }
 
   void ArrayBuilder::endlist() {
-    std::shared_ptr<Builder> tmp = builder_.get()->endlist();
+    BuilderPtr tmp = builder_.get()->endlist();
     if (tmp.get() == nullptr) {
       throw std::invalid_argument("endlist doesn't match a corresponding beginlist");
     }
@@ -166,14 +166,14 @@ namespace awkward {
   }
 
   void ArrayBuilder::extend(const ContentPtr& array) {
-    std::shared_ptr<Builder> tmp = builder_;
+    BuilderPtr tmp = builder_;
     for (int64_t i = 0;  i < array.get()->length();  i++) {
       tmp = builder_.get()->append(array, i);
     }
     maybeupdate(tmp);
   }
 
-  void ArrayBuilder::maybeupdate(const std::shared_ptr<Builder>& tmp) {
+  void ArrayBuilder::maybeupdate(const BuilderPtr& tmp) {
     if (tmp.get() != builder_.get()) {
       builder_ = tmp;
     }

--- a/src/libawkward/builder/ArrayBuilderOptions.cpp
+++ b/src/libawkward/builder/ArrayBuilderOptions.cpp
@@ -7,11 +7,13 @@ namespace awkward {
       : initial_(initial)
       , resize_(resize) { }
 
-  int64_t ArrayBuilderOptions::initial() const {
+  int64_t
+  ArrayBuilderOptions::initial() const {
     return initial_;
   }
 
-  double ArrayBuilderOptions::resize() const {
+  double
+  ArrayBuilderOptions::resize() const {
     return resize_;
   }
 }

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -31,7 +31,7 @@ namespace awkward {
     buffer_.clear();
   }
 
-  ContentPtr BoolBuilder::snapshot() const {
+  const ContentPtr BoolBuilder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(bool) };
     return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), buffer_.ptr(), shape, strides, 0, sizeof(bool), "?");
@@ -108,7 +108,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> BoolBuilder::append(const ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -31,7 +31,7 @@ namespace awkward {
     buffer_.clear();
   }
 
-  const std::shared_ptr<Content> BoolBuilder::snapshot() const {
+  ContentPtr BoolBuilder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(bool) };
     return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), buffer_.ptr(), shape, strides, 0, sizeof(bool), "?");
@@ -108,7 +108,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> BoolBuilder::append(ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -9,8 +9,8 @@
 #include "awkward/builder/BoolBuilder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> BoolBuilder::fromempty(const ArrayBuilderOptions& options) {
-    std::shared_ptr<Builder> out = std::make_shared<BoolBuilder>(options, GrowableBuffer<uint8_t>::empty(options));
+  const BuilderPtr BoolBuilder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out = std::make_shared<BoolBuilder>(options, GrowableBuffer<uint8_t>::empty(options));
     out.get()->setthat(out);
     return out;
   }
@@ -41,75 +41,75 @@ namespace awkward {
     return false;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::null() {
-    std::shared_ptr<Builder> out = OptionBuilder::fromvalids(options_, that_);
+  const BuilderPtr BoolBuilder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
     out.get()->null();
     return out;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::boolean(bool x) {
+  const BuilderPtr BoolBuilder::boolean(bool x) {
     buffer_.append(x);
     return that_;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::integer(int64_t x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr BoolBuilder::integer(int64_t x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->integer(x);
     return out;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::real(double x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr BoolBuilder::real(double x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->real(x);
     return out;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->string(x, length, encoding);
     return out;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::beginlist() {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr BoolBuilder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::endlist() {
+  const BuilderPtr BoolBuilder::endlist() {
     throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::begintuple(int64_t numfields) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr BoolBuilder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::index(int64_t index) {
+  const BuilderPtr BoolBuilder::index(int64_t index) {
     throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::endtuple() {
+  const BuilderPtr BoolBuilder::endtuple() {
     throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::beginrecord(const char* name, bool check) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr BoolBuilder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::field(const char* key, bool check) {
+  const BuilderPtr BoolBuilder::field(const char* key, bool check) {
     throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::endrecord() {
+  const BuilderPtr BoolBuilder::endrecord() {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> BoolBuilder::append(const ContentPtr& array, int64_t at) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr BoolBuilder::append(const ContentPtr& array, int64_t at) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;
   }

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -9,106 +9,141 @@
 #include "awkward/builder/BoolBuilder.h"
 
 namespace awkward {
-  const BuilderPtr BoolBuilder::fromempty(const ArrayBuilderOptions& options) {
-    BuilderPtr out = std::make_shared<BoolBuilder>(options, GrowableBuffer<uint8_t>::empty(options));
+  const BuilderPtr
+  BoolBuilder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out =
+      std::make_shared<BoolBuilder>(options,
+                                    GrowableBuffer<uint8_t>::empty(options));
     out.get()->setthat(out);
     return out;
   }
 
-  BoolBuilder::BoolBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<uint8_t>& buffer)
+  BoolBuilder::BoolBuilder(const ArrayBuilderOptions& options,
+                           const GrowableBuffer<uint8_t>& buffer)
       : options_(options)
       , buffer_(buffer) { }
 
-  const std::string BoolBuilder::classname() const {
+  const std::string
+  BoolBuilder::classname() const {
     return "BoolBuilder";
   };
 
-  int64_t BoolBuilder::length() const {
+  int64_t
+  BoolBuilder::length() const {
     return buffer_.length();
   }
 
-  void BoolBuilder::clear() {
+  void
+  BoolBuilder::clear() {
     buffer_.clear();
   }
 
-  const ContentPtr BoolBuilder::snapshot() const {
+  const ContentPtr
+  BoolBuilder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(bool) };
-    return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), buffer_.ptr(), shape, strides, 0, sizeof(bool), "?");
+    return std::make_shared<NumpyArray>(Identities::none(),
+                                        util::Parameters(),
+                                        buffer_.ptr(),
+                                        shape,
+                                        strides,
+                                        0,
+                                        sizeof(bool),
+                                        "?");
   }
 
-  bool BoolBuilder::active() const {
+  bool
+  BoolBuilder::active() const {
     return false;
   }
 
-  const BuilderPtr BoolBuilder::null() {
+  const BuilderPtr
+  BoolBuilder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
     out.get()->null();
     return out;
   }
 
-  const BuilderPtr BoolBuilder::boolean(bool x) {
+  const BuilderPtr
+  BoolBuilder::boolean(bool x) {
     buffer_.append(x);
     return that_;
   }
 
-  const BuilderPtr BoolBuilder::integer(int64_t x) {
+  const BuilderPtr
+  BoolBuilder::integer(int64_t x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->integer(x);
     return out;
   }
 
-  const BuilderPtr BoolBuilder::real(double x) {
+  const BuilderPtr
+  BoolBuilder::real(double x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->real(x);
     return out;
   }
 
-  const BuilderPtr BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->string(x, length, encoding);
     return out;
   }
 
-  const BuilderPtr BoolBuilder::beginlist() {
+  const BuilderPtr
+  BoolBuilder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
-  const BuilderPtr BoolBuilder::endlist() {
-    throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+  const BuilderPtr
+  BoolBuilder::endlist() {
+    throw std::invalid_argument(
+      "called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const BuilderPtr BoolBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  BoolBuilder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
-  const BuilderPtr BoolBuilder::index(int64_t index) {
-    throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  BoolBuilder::index(int64_t index) {
+    throw std::invalid_argument(
+      "called 'index' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr BoolBuilder::endtuple() {
-    throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  BoolBuilder::endtuple() {
+    throw std::invalid_argument(
+      "called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr BoolBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  BoolBuilder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
-  const BuilderPtr BoolBuilder::field(const char* key, bool check) {
-    throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  BoolBuilder::field(const char* key, bool check) {
+    throw std::invalid_argument(
+      "called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr BoolBuilder::endrecord() {
-    throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  BoolBuilder::endrecord() {
+    throw std::invalid_argument(
+      "called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr BoolBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  BoolBuilder::append(const ContentPtr& array, int64_t at) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/Builder.cpp
+++ b/src/libawkward/builder/Builder.cpp
@@ -5,7 +5,8 @@
 namespace awkward {
   Builder::~Builder() { }
 
-  void Builder::setthat(const BuilderPtr& that) {
+  void
+  Builder::setthat(const BuilderPtr& that) {
     that_ = that;
   }
 }

--- a/src/libawkward/builder/Builder.cpp
+++ b/src/libawkward/builder/Builder.cpp
@@ -5,7 +5,7 @@
 namespace awkward {
   Builder::~Builder() { }
 
-  void Builder::setthat(const std::shared_ptr<Builder>& that) {
+  void Builder::setthat(const BuilderPtr& that) {
     that_ = that;
   }
 }

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -9,13 +9,13 @@
 #include "awkward/builder/Float64Builder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> Float64Builder::fromempty(const ArrayBuilderOptions& options) {
-    std::shared_ptr<Builder> out = std::make_shared<Float64Builder>(options, GrowableBuffer<double>::empty(options));
+  const BuilderPtr Float64Builder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out = std::make_shared<Float64Builder>(options, GrowableBuffer<double>::empty(options));
     out.get()->setthat(out);
     return out;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::fromint64(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& old) {
+  const BuilderPtr Float64Builder::fromint64(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& old) {
     GrowableBuffer<double> buffer = GrowableBuffer<double>::empty(options, old.reserved());
     int64_t* oldraw = old.ptr().get();
     double* newraw = buffer.ptr().get();
@@ -23,7 +23,7 @@ namespace awkward {
       newraw[i] = (double)oldraw[i];
     }
     buffer.set_length(old.length());
-    std::shared_ptr<Builder> out = std::make_shared<Float64Builder>(options, buffer);
+    BuilderPtr out = std::make_shared<Float64Builder>(options, buffer);
     out.get()->setthat(out);
     return out;
   }
@@ -54,74 +54,74 @@ namespace awkward {
     return false;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::null() {
-    std::shared_ptr<Builder> out = OptionBuilder::fromvalids(options_, that_);
+  const BuilderPtr Float64Builder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
     out.get()->null();
     return out;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::boolean(bool x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Float64Builder::boolean(bool x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->boolean(x);
     return out;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::integer(int64_t x) {
+  const BuilderPtr Float64Builder::integer(int64_t x) {
     buffer_.append((double)x);
     return that_;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::real(double x) {
+  const BuilderPtr Float64Builder::real(double x) {
     buffer_.append(x);
     return that_;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::string(const char* x, int64_t length, const char* encoding) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Float64Builder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->string(x, length, encoding);
     return out;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::beginlist() {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Float64Builder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::endlist() {
+  const BuilderPtr Float64Builder::endlist() {
     throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Float64Builder::begintuple(int64_t numfields) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Float64Builder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::index(int64_t index) {
+  const BuilderPtr Float64Builder::index(int64_t index) {
     throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Float64Builder::endtuple() {
+  const BuilderPtr Float64Builder::endtuple() {
     throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Float64Builder::beginrecord(const char* name, bool check) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Float64Builder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
-  const std::shared_ptr<Builder> Float64Builder::field(const char* key, bool check) {
+  const BuilderPtr Float64Builder::field(const char* key, bool check) {
     throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Float64Builder::endrecord() {
+  const BuilderPtr Float64Builder::endrecord() {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Float64Builder::append(const ContentPtr& array, int64_t at) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Float64Builder::append(const ContentPtr& array, int64_t at) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;
   }

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -44,7 +44,7 @@ namespace awkward {
     buffer_.clear();
   }
 
-  ContentPtr Float64Builder::snapshot() const {
+  const ContentPtr Float64Builder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(double) };
     return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), buffer_.ptr(), shape, strides, 0, sizeof(double), "d");
@@ -120,7 +120,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Float64Builder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> Float64Builder::append(const ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -44,7 +44,7 @@ namespace awkward {
     buffer_.clear();
   }
 
-  const std::shared_ptr<Content> Float64Builder::snapshot() const {
+  ContentPtr Float64Builder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(double) };
     return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), buffer_.ptr(), shape, strides, 0, sizeof(double), "d");
@@ -120,7 +120,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Float64Builder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> Float64Builder::append(ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -9,14 +9,20 @@
 #include "awkward/builder/Float64Builder.h"
 
 namespace awkward {
-  const BuilderPtr Float64Builder::fromempty(const ArrayBuilderOptions& options) {
-    BuilderPtr out = std::make_shared<Float64Builder>(options, GrowableBuffer<double>::empty(options));
+  const BuilderPtr
+  Float64Builder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out =
+      std::make_shared<Float64Builder>(options,
+                                       GrowableBuffer<double>::empty(options));
     out.get()->setthat(out);
     return out;
   }
 
-  const BuilderPtr Float64Builder::fromint64(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& old) {
-    GrowableBuffer<double> buffer = GrowableBuffer<double>::empty(options, old.reserved());
+  const BuilderPtr
+  Float64Builder::fromint64(const ArrayBuilderOptions& options,
+                            const GrowableBuffer<int64_t>& old) {
+    GrowableBuffer<double> buffer =
+      GrowableBuffer<double>::empty(options, old.reserved());
     int64_t* oldraw = old.ptr().get();
     double* newraw = buffer.ptr().get();
     for (int64_t i = 0;  i < old.length();  i++) {
@@ -27,100 +33,132 @@ namespace awkward {
     out.get()->setthat(out);
     return out;
   }
-
-  Float64Builder::Float64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<double>& buffer)
+ 
+  Float64Builder::Float64Builder(const ArrayBuilderOptions& options,
+                                 const GrowableBuffer<double>& buffer)
       : options_(options)
       , buffer_(buffer) { }
 
-  const std::string Float64Builder::classname() const {
+  const std::string
+  Float64Builder::classname() const {
     return "Float64Builder";
   }
 
-  int64_t Float64Builder::length() const {
+  int64_t
+  Float64Builder::length() const {
     return buffer_.length();
   }
 
-  void Float64Builder::clear() {
+  void
+  Float64Builder::clear() {
     buffer_.clear();
   }
 
-  const ContentPtr Float64Builder::snapshot() const {
+  const ContentPtr
+  Float64Builder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(double) };
-    return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), buffer_.ptr(), shape, strides, 0, sizeof(double), "d");
+    return std::make_shared<NumpyArray>(Identities::none(),
+                                        util::Parameters(),
+                                        buffer_.ptr(),
+                                        shape,
+                                        strides,
+                                        0,
+                                        sizeof(double),
+                                        "d");
   }
 
-  bool Float64Builder::active() const {
+  bool
+  Float64Builder::active() const {
     return false;
   }
 
-  const BuilderPtr Float64Builder::null() {
+  const BuilderPtr
+  Float64Builder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
     out.get()->null();
     return out;
   }
 
-  const BuilderPtr Float64Builder::boolean(bool x) {
+  const BuilderPtr
+  Float64Builder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->boolean(x);
     return out;
   }
 
-  const BuilderPtr Float64Builder::integer(int64_t x) {
+  const BuilderPtr
+  Float64Builder::integer(int64_t x) {
     buffer_.append((double)x);
     return that_;
   }
 
-  const BuilderPtr Float64Builder::real(double x) {
+  const BuilderPtr
+  Float64Builder::real(double x) {
     buffer_.append(x);
     return that_;
   }
 
-  const BuilderPtr Float64Builder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  Float64Builder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->string(x, length, encoding);
     return out;
   }
 
-  const BuilderPtr Float64Builder::beginlist() {
+  const BuilderPtr
+  Float64Builder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
-  const BuilderPtr Float64Builder::endlist() {
-    throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+  const BuilderPtr
+  Float64Builder::endlist() {
+    throw std::invalid_argument(
+      "called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const BuilderPtr Float64Builder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  Float64Builder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
-  const BuilderPtr Float64Builder::index(int64_t index) {
-    throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  Float64Builder::index(int64_t index) {
+    throw std::invalid_argument(
+      "called 'index' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr Float64Builder::endtuple() {
-    throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  Float64Builder::endtuple() {
+    throw std::invalid_argument(
+      "called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr Float64Builder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  Float64Builder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
-  const BuilderPtr Float64Builder::field(const char* key, bool check) {
-    throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  Float64Builder::field(const char* key, bool check) {
+    throw std::invalid_argument(
+      "called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr Float64Builder::endrecord() {
-    throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  Float64Builder::endrecord() {
+    throw std::invalid_argument(
+      "called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr Float64Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  Float64Builder::append(const ContentPtr& array, int64_t at) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/GrowableBuffer.cpp
+++ b/src/libawkward/builder/GrowableBuffer.cpp
@@ -4,12 +4,16 @@
 
 namespace awkward {
   template <typename T>
-  GrowableBuffer<T> GrowableBuffer<T>::empty(const ArrayBuilderOptions& options) {
-    return GrowableBuffer<T>::empty(options, 0);
+  GrowableBuffer<T>
+  GrowableBuffer<T>::empty(const ArrayBuilderOptions& options) {
+    return
+  GrowableBuffer<T>::empty(options, 0);
   }
 
   template <typename T>
-  GrowableBuffer<T> GrowableBuffer<T>::empty(const ArrayBuilderOptions& options, int64_t minreserve) {
+  GrowableBuffer<T>
+  GrowableBuffer<T>::empty(const ArrayBuilderOptions& options,
+                           int64_t minreserve) {
     size_t actual = (size_t)options.initial();
     if (actual < (size_t)minreserve) {
       actual = (size_t)minreserve;
@@ -19,7 +23,10 @@ namespace awkward {
   }
 
   template <typename T>
-  GrowableBuffer<T> GrowableBuffer<T>::full(const ArrayBuilderOptions& options, T value, int64_t length) {
+  GrowableBuffer<T>
+  GrowableBuffer<T>::full(const ArrayBuilderOptions& options,
+                          T value,
+                          int64_t length) {
     GrowableBuffer<T> out = empty(options, length);
     T* rawptr = out.ptr().get();
     for (int64_t i = 0;  i < length;  i++) {
@@ -29,7 +36,9 @@ namespace awkward {
   }
 
   template <typename T>
-  GrowableBuffer<T> GrowableBuffer<T>::arange(const ArrayBuilderOptions& options, int64_t length) {
+  GrowableBuffer<T>
+  GrowableBuffer<T>::arange(const ArrayBuilderOptions& options,
+                            int64_t length) {
     size_t actual = (size_t)options.initial();
     if (actual < (size_t)length) {
       actual = (size_t)length;
@@ -43,7 +52,10 @@ namespace awkward {
   }
 
   template <typename T>
-  GrowableBuffer<T>::GrowableBuffer(const ArrayBuilderOptions& options, std::shared_ptr<T> ptr, int64_t length, int64_t reserved)
+  GrowableBuffer<T>::GrowableBuffer(const ArrayBuilderOptions& options,
+                                    std::shared_ptr<T> ptr,
+                                    int64_t length,
+                                    int64_t reserved)
       : options_(options)
       , ptr_(ptr)
       , length_(length)
@@ -51,20 +63,27 @@ namespace awkward {
 
   template <typename T>
   GrowableBuffer<T>::GrowableBuffer(const ArrayBuilderOptions& options)
-      : GrowableBuffer(options, std::shared_ptr<T>(new T[(size_t)options.initial()], util::array_deleter<T>()), 0, options.initial()) { }
+      : GrowableBuffer(options,
+                       std::shared_ptr<T>(new T[(size_t)options.initial()],
+                                          util::array_deleter<T>()),
+                       0,
+                       options.initial()) { }
 
   template <typename T>
-  const std::shared_ptr<T> GrowableBuffer<T>::ptr() const {
+  const std::shared_ptr<T>
+  GrowableBuffer<T>::ptr() const {
     return ptr_;
   }
 
   template <typename T>
-  int64_t GrowableBuffer<T>::length() const {
+  int64_t
+  GrowableBuffer<T>::length() const {
     return length_;
   }
 
   template <typename T>
-  void GrowableBuffer<T>::set_length(int64_t newlength) {
+  void
+  GrowableBuffer<T>::set_length(int64_t newlength) {
     if (newlength > reserved_) {
       set_reserved(newlength);
     }
@@ -72,14 +91,17 @@ namespace awkward {
   }
 
   template <typename T>
-  int64_t GrowableBuffer<T>::reserved() const {
+  int64_t
+  GrowableBuffer<T>::reserved() const {
     return reserved_;
   }
 
   template <typename T>
-  void GrowableBuffer<T>::set_reserved(int64_t minreserved) {
+  void
+  GrowableBuffer<T>::set_reserved(int64_t minreserved) {
     if (minreserved > reserved_) {
-      std::shared_ptr<T> ptr(new T[(size_t)minreserved], util::array_deleter<T>());
+      std::shared_ptr<T> ptr(new T[(size_t)minreserved],
+                             util::array_deleter<T>());
       memcpy(ptr.get(), ptr_.get(), (size_t)(length_ * sizeof(T)));
       ptr_ = ptr;
       reserved_ = minreserved;
@@ -87,14 +109,17 @@ namespace awkward {
   }
 
   template <typename T>
-  void GrowableBuffer<T>::clear() {
+  void
+  GrowableBuffer<T>::clear() {
     length_ = 0;
     reserved_ = options_.initial();
-    ptr_ = std::shared_ptr<T>(new T[(size_t)options_.initial()], util::array_deleter<T>());
+    ptr_ = std::shared_ptr<T>(new T[(size_t)options_.initial()],
+                              util::array_deleter<T>());
   }
 
   template <typename T>
-  void GrowableBuffer<T>::append(T datum) {
+  void
+  GrowableBuffer<T>::append(T datum) {
     if (length_ == reserved_) {
       set_reserved((int64_t)ceil(reserved_ * options_.resize()));
     }
@@ -103,7 +128,8 @@ namespace awkward {
   }
 
   template <typename T>
-  T GrowableBuffer<T>::getitem_at_nowrap(int64_t at) const {
+  T
+  GrowableBuffer<T>::getitem_at_nowrap(int64_t at) const {
     return ptr_.get()[at];
   }
 

--- a/src/libawkward/builder/IndexedBuilder.cpp
+++ b/src/libawkward/builder/IndexedBuilder.cpp
@@ -400,8 +400,15 @@ namespace awkward {
 
   template class IndexedBuilder<IndexedOptionArray32>;
 
-  IndexedIO32Builder::IndexedIO32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray32>& array, bool hasnull)
-      : IndexedBuilder<IndexedOptionArray32>(options, index, array, hasnull) { }
+  IndexedIO32Builder::IndexedIO32Builder(
+    const ArrayBuilderOptions& options,
+    const GrowableBuffer<int64_t>& index,
+    const std::shared_ptr<IndexedOptionArray32>& array,
+    bool hasnull)
+      : IndexedBuilder<IndexedOptionArray32>(options,
+                                             index,
+                                             array,
+                                             hasnull) { }
 
   const std::string
   IndexedIO32Builder::classname() const {
@@ -435,8 +442,14 @@ namespace awkward {
 
   template class IndexedBuilder<IndexedOptionArray64>;
 
-  IndexedIO64Builder::IndexedIO64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray64>& array, bool hasnull)
-      : IndexedBuilder<IndexedOptionArray64>(options, index, array, hasnull) { }
+  IndexedIO64Builder::IndexedIO64Builder(
+    const ArrayBuilderOptions& options,
+    const GrowableBuffer<int64_t>& index,
+    const std::shared_ptr<IndexedOptionArray64>& array, bool hasnull)
+      : IndexedBuilder<IndexedOptionArray64>(options,
+                                             index,
+                                             array,
+                                             hasnull) { }
 
   const std::string
   IndexedIO64Builder::classname() const {

--- a/src/libawkward/builder/IndexedBuilder.cpp
+++ b/src/libawkward/builder/IndexedBuilder.cpp
@@ -39,92 +39,92 @@ namespace awkward {
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::null() {
+  const BuilderPtr IndexedBuilder<T>::null() {
     index_.append(-1);
     hasnull_ = true;
     return that_;
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::boolean(bool x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr IndexedBuilder<T>::boolean(bool x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->boolean(x);
     return out;
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::integer(int64_t x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr IndexedBuilder<T>::integer(int64_t x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->integer(x);
     return out;
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::real(double x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr IndexedBuilder<T>::real(double x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->real(x);
     return out;
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::string(const char* x, int64_t length, const char* encoding) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr IndexedBuilder<T>::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->string(x, length, encoding);
     return out;
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::beginlist() {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr IndexedBuilder<T>::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::endlist() {
+  const BuilderPtr IndexedBuilder<T>::endlist() {
     throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::begintuple(int64_t numfields) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr IndexedBuilder<T>::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::index(int64_t index) {
+  const BuilderPtr IndexedBuilder<T>::index(int64_t index) {
     throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::endtuple() {
+  const BuilderPtr IndexedBuilder<T>::endtuple() {
     throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::beginrecord(const char* name, bool check) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr IndexedBuilder<T>::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::field(const char* key, bool check) {
+  const BuilderPtr IndexedBuilder<T>::field(const char* key, bool check) {
     throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
   }
 
   template <typename T>
-  const std::shared_ptr<Builder> IndexedBuilder<T>::endrecord() {
+  const BuilderPtr IndexedBuilder<T>::endrecord() {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////
   template class IndexedBuilder<Content>;
 
-  const std::shared_ptr<Builder> IndexedGenericBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const ContentPtr& array) {
+  const BuilderPtr IndexedGenericBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const ContentPtr& array) {
     GrowableBuffer<int64_t> index = GrowableBuffer<int64_t>::full(options, -1, nullcount);
-    std::shared_ptr<Builder> out;
+    BuilderPtr out;
     if (std::shared_ptr<IndexedArray32> ptr = std::dynamic_pointer_cast<IndexedArray32>(array)) {
       out = std::make_shared<IndexedI32Builder>(options, index, ptr, nullcount != 0);
     }
@@ -164,12 +164,12 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedGenericBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr IndexedGenericBuilder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(at);
     }
     else {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
@@ -196,12 +196,12 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedI32Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr IndexedI32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
     else {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
@@ -228,12 +228,12 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedIU32Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr IndexedIU32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
     else {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
@@ -260,12 +260,12 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedI64Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr IndexedI64Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(array_.get()->index_at_nowrap(at));
     }
     else {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
@@ -287,12 +287,12 @@ namespace awkward {
     return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
   }
 
-  const std::shared_ptr<Builder> IndexedIO32Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr IndexedIO32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
     else {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
@@ -314,12 +314,12 @@ namespace awkward {
     return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
   }
 
-  const std::shared_ptr<Builder> IndexedIO64Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr IndexedIO64Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(array_.get()->index_at_nowrap(at));
     }
     else {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }

--- a/src/libawkward/builder/IndexedBuilder.cpp
+++ b/src/libawkward/builder/IndexedBuilder.cpp
@@ -122,7 +122,7 @@ namespace awkward {
   /////////////////////////////////////////////////////////////////////////////////////////////
   template class IndexedBuilder<Content>;
 
-  const std::shared_ptr<Builder> IndexedGenericBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, ContentPtr& array) {
+  const std::shared_ptr<Builder> IndexedGenericBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const ContentPtr& array) {
     GrowableBuffer<int64_t> index = GrowableBuffer<int64_t>::full(options, -1, nullcount);
     std::shared_ptr<Builder> out;
     if (std::shared_ptr<IndexedArray32> ptr = std::dynamic_pointer_cast<IndexedArray32>(array)) {
@@ -147,14 +147,14 @@ namespace awkward {
     return out;
   }
 
-  IndexedGenericBuilder::IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, ContentPtr& array, bool hasnull)
+  IndexedGenericBuilder::IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const ContentPtr& array, bool hasnull)
       : IndexedBuilder<Content>(options, index, array, hasnull) { }
 
   const std::string IndexedGenericBuilder::classname() const {
     return "IndexedGenericBuilder";
   };
 
-  ContentPtr IndexedGenericBuilder::snapshot() const {
+  const ContentPtr IndexedGenericBuilder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, array_);
@@ -164,7 +164,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedGenericBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedGenericBuilder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(at);
     }
@@ -186,7 +186,7 @@ namespace awkward {
     return "IndexedI32Builder";
   };
 
-  ContentPtr IndexedI32Builder::snapshot() const {
+  const ContentPtr IndexedI32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
@@ -196,7 +196,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedI32Builder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedI32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -218,7 +218,7 @@ namespace awkward {
     return "IndexedIU32Builder";
   };
 
-  ContentPtr IndexedIU32Builder::snapshot() const {
+  const ContentPtr IndexedIU32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
@@ -228,7 +228,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedIU32Builder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedIU32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -250,7 +250,7 @@ namespace awkward {
     return "IndexedI64Builder";
   };
 
-  ContentPtr IndexedI64Builder::snapshot() const {
+  const ContentPtr IndexedI64Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
@@ -260,7 +260,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedI64Builder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedI64Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(array_.get()->index_at_nowrap(at));
     }
@@ -282,12 +282,12 @@ namespace awkward {
     return "IndexedIO32Builder";
   };
 
-  ContentPtr IndexedIO32Builder::snapshot() const {
+  const ContentPtr IndexedIO32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
   }
 
-  const std::shared_ptr<Builder> IndexedIO32Builder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedIO32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -309,12 +309,12 @@ namespace awkward {
     return "IndexedIO64Builder";
   };
 
-  ContentPtr IndexedIO64Builder::snapshot() const {
+  const ContentPtr IndexedIO64Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
   }
 
-  const std::shared_ptr<Builder> IndexedIO64Builder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedIO64Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(array_.get()->index_at_nowrap(at));
     }

--- a/src/libawkward/builder/IndexedBuilder.cpp
+++ b/src/libawkward/builder/IndexedBuilder.cpp
@@ -122,7 +122,7 @@ namespace awkward {
   /////////////////////////////////////////////////////////////////////////////////////////////
   template class IndexedBuilder<Content>;
 
-  const std::shared_ptr<Builder> IndexedGenericBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const std::shared_ptr<Content>& array) {
+  const std::shared_ptr<Builder> IndexedGenericBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, ContentPtr& array) {
     GrowableBuffer<int64_t> index = GrowableBuffer<int64_t>::full(options, -1, nullcount);
     std::shared_ptr<Builder> out;
     if (std::shared_ptr<IndexedArray32> ptr = std::dynamic_pointer_cast<IndexedArray32>(array)) {
@@ -147,14 +147,14 @@ namespace awkward {
     return out;
   }
 
-  IndexedGenericBuilder::IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<Content>& array, bool hasnull)
+  IndexedGenericBuilder::IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, ContentPtr& array, bool hasnull)
       : IndexedBuilder<Content>(options, index, array, hasnull) { }
 
   const std::string IndexedGenericBuilder::classname() const {
     return "IndexedGenericBuilder";
   };
 
-  const std::shared_ptr<Content> IndexedGenericBuilder::snapshot() const {
+  ContentPtr IndexedGenericBuilder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, array_);
@@ -164,7 +164,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedGenericBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedGenericBuilder::append(ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(at);
     }
@@ -186,7 +186,7 @@ namespace awkward {
     return "IndexedI32Builder";
   };
 
-  const std::shared_ptr<Content> IndexedI32Builder::snapshot() const {
+  ContentPtr IndexedI32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
@@ -196,7 +196,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedI32Builder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedI32Builder::append(ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -218,7 +218,7 @@ namespace awkward {
     return "IndexedIU32Builder";
   };
 
-  const std::shared_ptr<Content> IndexedIU32Builder::snapshot() const {
+  ContentPtr IndexedIU32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
@@ -228,7 +228,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedIU32Builder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedIU32Builder::append(ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -250,7 +250,7 @@ namespace awkward {
     return "IndexedI64Builder";
   };
 
-  const std::shared_ptr<Content> IndexedI64Builder::snapshot() const {
+  ContentPtr IndexedI64Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
       return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
@@ -260,7 +260,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> IndexedI64Builder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedI64Builder::append(ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(array_.get()->index_at_nowrap(at));
     }
@@ -282,12 +282,12 @@ namespace awkward {
     return "IndexedIO32Builder";
   };
 
-  const std::shared_ptr<Content> IndexedIO32Builder::snapshot() const {
+  ContentPtr IndexedIO32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
   }
 
-  const std::shared_ptr<Builder> IndexedIO32Builder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedIO32Builder::append(ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -309,12 +309,12 @@ namespace awkward {
     return "IndexedIO64Builder";
   };
 
-  const std::shared_ptr<Content> IndexedIO64Builder::snapshot() const {
+  ContentPtr IndexedIO64Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
   }
 
-  const std::shared_ptr<Builder> IndexedIO64Builder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> IndexedIO64Builder::append(ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(array_.get()->index_at_nowrap(at));
     }

--- a/src/libawkward/builder/IndexedBuilder.cpp
+++ b/src/libawkward/builder/IndexedBuilder.cpp
@@ -12,159 +12,235 @@
 
 namespace awkward {
   template <typename T>
-  IndexedBuilder<T>::IndexedBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<T>& array, bool hasnull)
+  IndexedBuilder<T>::IndexedBuilder(const ArrayBuilderOptions& options,
+                                    const GrowableBuffer<int64_t>& index,
+                                    const std::shared_ptr<T>& array,
+                                    bool hasnull)
       : options_(options)
       , index_(index)
       , array_(array)
       , hasnull_(hasnull) { }
 
   template <typename T>
-  const Content* IndexedBuilder<T>::arrayptr() const {
+  const Content*
+  IndexedBuilder<T>::arrayptr() const {
     return array_.get();
   }
 
   template <typename T>
-  int64_t IndexedBuilder<T>::length() const {
+  int64_t
+  IndexedBuilder<T>::length() const {
     return index_.length();
   }
 
   template <typename T>
-  void IndexedBuilder<T>::clear() {
+  void
+  IndexedBuilder<T>::clear() {
     index_.clear();
   }
 
   template <typename T>
-  bool IndexedBuilder<T>::active() const {
+  bool
+  IndexedBuilder<T>::active() const {
     return false;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::null() {
+  const BuilderPtr
+  IndexedBuilder<T>::null() {
     index_.append(-1);
     hasnull_ = true;
     return that_;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::boolean(bool x) {
+  const BuilderPtr
+  IndexedBuilder<T>::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->boolean(x);
     return out;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::integer(int64_t x) {
+  const BuilderPtr
+  IndexedBuilder<T>::integer(int64_t x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->integer(x);
     return out;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::real(double x) {
+  const BuilderPtr
+  IndexedBuilder<T>::real(double x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->real(x);
     return out;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  IndexedBuilder<T>::string(const char* x,
+                            int64_t length,
+                            const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->string(x, length, encoding);
     return out;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::beginlist() {
+  const BuilderPtr
+  IndexedBuilder<T>::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::endlist() {
-    throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+  const BuilderPtr
+  IndexedBuilder<T>::endlist() {
+    throw std::invalid_argument(
+      "called 'endlist' without 'beginlist' at the same level before it");
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::begintuple(int64_t numfields) {
+  const BuilderPtr
+  IndexedBuilder<T>::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::index(int64_t index) {
-    throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  IndexedBuilder<T>::index(int64_t index) {
+    throw std::invalid_argument(
+      "called 'index' without 'begintuple' at the same level before it");
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::endtuple() {
-    throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  IndexedBuilder<T>::endtuple() {
+    throw std::invalid_argument(
+      "called 'endtuple' without 'begintuple' at the same level before it");
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  IndexedBuilder<T>::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::field(const char* key, bool check) {
-    throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  IndexedBuilder<T>::field(const char* key, bool check) {
+    throw std::invalid_argument(
+      "called 'field' without 'beginrecord' at the same level before it");
   }
 
   template <typename T>
-  const BuilderPtr IndexedBuilder<T>::endrecord() {
-    throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  IndexedBuilder<T>::endrecord() {
+    throw std::invalid_argument(
+      "called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  /////////////////////////////////////////////////////////////////////////////////////////////
+  ////////// IndexedGenericBuilder
+
   template class IndexedBuilder<Content>;
 
-  const BuilderPtr IndexedGenericBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const ContentPtr& array) {
-    GrowableBuffer<int64_t> index = GrowableBuffer<int64_t>::full(options, -1, nullcount);
+  const BuilderPtr
+  IndexedGenericBuilder::fromnulls(const ArrayBuilderOptions& options,
+                                   int64_t nullcount,
+                                   const ContentPtr& array) {
+    GrowableBuffer<int64_t> index =
+      GrowableBuffer<int64_t>::full(options, -1, nullcount);
     BuilderPtr out;
-    if (std::shared_ptr<IndexedArray32> ptr = std::dynamic_pointer_cast<IndexedArray32>(array)) {
-      out = std::make_shared<IndexedI32Builder>(options, index, ptr, nullcount != 0);
+    if (std::shared_ptr<IndexedArray32> ptr =
+        std::dynamic_pointer_cast<IndexedArray32>(array)) {
+      out = std::make_shared<IndexedI32Builder>(
+        options,
+        index,
+        ptr,
+        nullcount != 0);
     }
-    else if (std::shared_ptr<IndexedArrayU32> ptr = std::dynamic_pointer_cast<IndexedArrayU32>(array)) {
-      out = std::make_shared<IndexedIU32Builder>(options, index, ptr, nullcount != 0);
+    else if (std::shared_ptr<IndexedArrayU32> ptr =
+             std::dynamic_pointer_cast<IndexedArrayU32>(array)) {
+      out = std::make_shared<IndexedIU32Builder>(
+        options,
+        index,
+        ptr,
+        nullcount != 0);
     }
-    else if (std::shared_ptr<IndexedArray64> ptr = std::dynamic_pointer_cast<IndexedArray64>(array)) {
-      out = std::make_shared<IndexedI64Builder>(options, index, ptr, nullcount != 0);
+    else if (std::shared_ptr<IndexedArray64> ptr =
+             std::dynamic_pointer_cast<IndexedArray64>(array)) {
+      out = std::make_shared<IndexedI64Builder>(
+        options,
+        index,
+        ptr,
+        nullcount != 0);
     }
-    else if (std::shared_ptr<IndexedOptionArray32> ptr = std::dynamic_pointer_cast<IndexedOptionArray32>(array)) {
-      out = std::make_shared<IndexedIO32Builder>(options, index, ptr, nullcount != 0);
+    else if (std::shared_ptr<IndexedOptionArray32> ptr =
+             std::dynamic_pointer_cast<IndexedOptionArray32>(array)) {
+      out = std::make_shared<IndexedIO32Builder>(
+        options,
+        index,
+        ptr,
+        nullcount != 0);
     }
-    else if (std::shared_ptr<IndexedOptionArray64> ptr = std::dynamic_pointer_cast<IndexedOptionArray64>(array)) {
-      out = std::make_shared<IndexedIO64Builder>(options, index, ptr, nullcount != 0);
+    else if (std::shared_ptr<IndexedOptionArray64> ptr =
+             std::dynamic_pointer_cast<IndexedOptionArray64>(array)) {
+      out = std::make_shared<IndexedIO64Builder>(
+        options,
+        index,
+        ptr,
+        nullcount != 0);
     }
     else {
-      out = std::make_shared<IndexedGenericBuilder>(options, index, array, nullcount != 0);
+      out = std::make_shared<IndexedGenericBuilder>(
+        options,
+        index,
+        array,
+        nullcount != 0);
     }
     out.get()->setthat(out);
     return out;
   }
 
-  IndexedGenericBuilder::IndexedGenericBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const ContentPtr& array, bool hasnull)
+  IndexedGenericBuilder::IndexedGenericBuilder(
+    const ArrayBuilderOptions& options,
+    const GrowableBuffer<int64_t>& index,
+    const ContentPtr& array,
+    bool hasnull)
       : IndexedBuilder<Content>(options, index, array, hasnull) { }
 
-  const std::string IndexedGenericBuilder::classname() const {
+  const std::string
+  IndexedGenericBuilder::classname() const {
     return "IndexedGenericBuilder";
   };
 
-  const ContentPtr IndexedGenericBuilder::snapshot() const {
+  const ContentPtr
+  IndexedGenericBuilder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, array_);
+      return std::make_shared<IndexedOptionArray64>(
+        Identities::none(),
+        util::Parameters(),
+        index,
+        array_);
     }
     else {
-      return std::make_shared<IndexedArray64>(Identities::none(), util::Parameters(), index, array_);
+      return std::make_shared<IndexedArray64>(
+        Identities::none(),
+        util::Parameters(),
+        index,
+        array_);
     }
   }
 
-  const BuilderPtr IndexedGenericBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  IndexedGenericBuilder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(at);
     }
@@ -176,27 +252,43 @@ namespace awkward {
     return that_;
   }
 
-  /////////////////////////////////////////////////////////////////////////////////////////////
+  ////////// IndexedI32Builder (makes IndexedArray32)
+
   template class IndexedBuilder<IndexedArray32>;
 
-  IndexedI32Builder::IndexedI32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArray32>& array, bool hasnull)
+  IndexedI32Builder::IndexedI32Builder(
+    const ArrayBuilderOptions& options,
+    const GrowableBuffer<int64_t>& index,
+    const std::shared_ptr<IndexedArray32>& array,
+    bool hasnull)
       : IndexedBuilder<IndexedArray32>(options, index, array, hasnull) { }
 
-  const std::string IndexedI32Builder::classname() const {
+  const std::string
+  IndexedI32Builder::classname() const {
     return "IndexedI32Builder";
   };
 
-  const ContentPtr IndexedI32Builder::snapshot() const {
+  const ContentPtr
+  IndexedI32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
+      return std::make_shared<IndexedOptionArray64>(
+        Identities::none(),
+        array_.get()->content().get()->parameters(),
+        index,
+        array_.get()->content());
     }
     else {
-      return std::make_shared<IndexedArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
+      return std::make_shared<IndexedArray64>(
+        Identities::none(),
+        array_.get()->content().get()->parameters(),
+        index,
+        array_.get()->content());
     }
   }
 
-  const BuilderPtr IndexedI32Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  IndexedI32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -208,27 +300,43 @@ namespace awkward {
     return that_;
   }
 
-  /////////////////////////////////////////////////////////////////////////////////////////////
+  ////////// IndexedIU32Builder (makes IndexedArrayU32)
+
   template class IndexedBuilder<IndexedArrayU32>;
 
-  IndexedIU32Builder::IndexedIU32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArrayU32>& array, bool hasnull)
+  IndexedIU32Builder::IndexedIU32Builder(
+    const ArrayBuilderOptions& options,
+    const GrowableBuffer<int64_t>& index,
+    const std::shared_ptr<IndexedArrayU32>& array,
+    bool hasnull)
       : IndexedBuilder<IndexedArrayU32>(options, index, array, hasnull) { }
 
-  const std::string IndexedIU32Builder::classname() const {
+  const std::string
+  IndexedIU32Builder::classname() const {
     return "IndexedIU32Builder";
   };
 
-  const ContentPtr IndexedIU32Builder::snapshot() const {
+  const ContentPtr
+  IndexedIU32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
+      return std::make_shared<IndexedOptionArray64>(
+        Identities::none(),
+        array_.get()->content().get()->parameters(),
+        index,
+        array_.get()->content());
     }
     else {
-      return std::make_shared<IndexedArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
+      return std::make_shared<IndexedArray64>(
+        Identities::none(),
+        array_.get()->content().get()->parameters(),
+        index,
+        array_.get()->content());
     }
   }
 
-  const BuilderPtr IndexedIU32Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  IndexedIU32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -240,27 +348,43 @@ namespace awkward {
     return that_;
   }
 
-  /////////////////////////////////////////////////////////////////////////////////////////////
+  ////////// IndexedI64Builder (makes IndexedArray64)
+
   template class IndexedBuilder<IndexedArray64>;
 
-  IndexedI64Builder::IndexedI64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedArray64>& array, bool hasnull)
+  IndexedI64Builder::IndexedI64Builder(
+    const ArrayBuilderOptions& options,
+    const GrowableBuffer<int64_t>& index,
+    const std::shared_ptr<IndexedArray64>& array,
+    bool hasnull)
       : IndexedBuilder<IndexedArray64>(options, index, array, hasnull) { }
 
-  const std::string IndexedI64Builder::classname() const {
+  const std::string
+  IndexedI64Builder::classname() const {
     return "IndexedI64Builder";
   };
 
-  const ContentPtr IndexedI64Builder::snapshot() const {
+  const ContentPtr
+  IndexedI64Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
     if (hasnull_) {
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
+      return std::make_shared<IndexedOptionArray64>(
+        Identities::none(),
+        array_.get()->content().get()->parameters(),
+        index,
+        array_.get()->content());
     }
     else {
-      return std::make_shared<IndexedArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
+      return std::make_shared<IndexedArray64>(
+        Identities::none(),
+        array_.get()->content().get()->parameters(),
+        index,
+        array_.get()->content());
     }
   }
 
-  const BuilderPtr IndexedI64Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  IndexedI64Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(array_.get()->index_at_nowrap(at));
     }
@@ -272,22 +396,30 @@ namespace awkward {
     return that_;
   }
 
-  /////////////////////////////////////////////////////////////////////////////////////////////
+  ////////// IndexedIO32Builder (makes IndexedOptionArray32)
+
   template class IndexedBuilder<IndexedOptionArray32>;
 
   IndexedIO32Builder::IndexedIO32Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray32>& array, bool hasnull)
       : IndexedBuilder<IndexedOptionArray32>(options, index, array, hasnull) { }
 
-  const std::string IndexedIO32Builder::classname() const {
+  const std::string
+  IndexedIO32Builder::classname() const {
     return "IndexedIO32Builder";
   };
 
-  const ContentPtr IndexedIO32Builder::snapshot() const {
+  const ContentPtr
+  IndexedIO32Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
-    return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
+    return std::make_shared<IndexedOptionArray64>(
+      Identities::none(),
+      array_.get()->content().get()->parameters(),
+      index,
+      array_.get()->content());
   }
 
-  const BuilderPtr IndexedIO32Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  IndexedIO32Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append((int64_t)array_.get()->index_at_nowrap(at));
     }
@@ -299,22 +431,30 @@ namespace awkward {
     return that_;
   }
 
-  /////////////////////////////////////////////////////////////////////////////////////////////
+  ////////// IndexedIO64Builder (makes IndexedOptionArray64)
+
   template class IndexedBuilder<IndexedOptionArray64>;
 
   IndexedIO64Builder::IndexedIO64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& index, const std::shared_ptr<IndexedOptionArray64>& array, bool hasnull)
       : IndexedBuilder<IndexedOptionArray64>(options, index, array, hasnull) { }
 
-  const std::string IndexedIO64Builder::classname() const {
+  const std::string
+  IndexedIO64Builder::classname() const {
     return "IndexedIO64Builder";
   };
 
-  const ContentPtr IndexedIO64Builder::snapshot() const {
+  const ContentPtr
+  IndexedIO64Builder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length());
-    return std::make_shared<IndexedOptionArray64>(Identities::none(), array_.get()->content().get()->parameters(), index, array_.get()->content());
+    return std::make_shared<IndexedOptionArray64>(
+      Identities::none(),
+      array_.get()->content().get()->parameters(),
+      index,
+      array_.get()->content());
   }
 
-  const BuilderPtr IndexedIO64Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  IndexedIO64Builder::append(const ContentPtr& array, int64_t at) {
     if (array.get() == array_.get()) {
       index_.append(array_.get()->index_at_nowrap(at));
     }

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -10,8 +10,8 @@
 #include "awkward/builder/Int64Builder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> Int64Builder::fromempty(const ArrayBuilderOptions& options) {
-    std::shared_ptr<Builder> out = std::make_shared<Int64Builder>(options, GrowableBuffer<int64_t>::empty(options));
+  const BuilderPtr Int64Builder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out = std::make_shared<Int64Builder>(options, GrowableBuffer<int64_t>::empty(options));
     out.get()->setthat(out);
     return out;
   }
@@ -50,75 +50,75 @@ namespace awkward {
     return false;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::null() {
-    std::shared_ptr<Builder> out = OptionBuilder::fromvalids(options_, that_);
+  const BuilderPtr Int64Builder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
     out.get()->null();
     return out;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::boolean(bool x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Int64Builder::boolean(bool x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->boolean(x);
     return out;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::integer(int64_t x) {
+  const BuilderPtr Int64Builder::integer(int64_t x) {
     buffer_.append(x);
     return that_;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::real(double x) {
-    std::shared_ptr<Builder> out = Float64Builder::fromint64(options_, buffer_);
+  const BuilderPtr Int64Builder::real(double x) {
+    BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
     out.get()->real(x);
     return out;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::string(const char* x, int64_t length, const char* encoding) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Int64Builder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->string(x, length, encoding);
     return out;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::beginlist() {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Int64Builder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::endlist() {
+  const BuilderPtr Int64Builder::endlist() {
     throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Int64Builder::begintuple(int64_t numfields) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Int64Builder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::index(int64_t index) {
+  const BuilderPtr Int64Builder::index(int64_t index) {
     throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Int64Builder::endtuple() {
+  const BuilderPtr Int64Builder::endtuple() {
     throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Int64Builder::beginrecord(const char* name, bool check) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Int64Builder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
-  const std::shared_ptr<Builder> Int64Builder::field(const char* key, bool check) {
+  const BuilderPtr Int64Builder::field(const char* key, bool check) {
     throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Int64Builder::endrecord() {
+  const BuilderPtr Int64Builder::endrecord() {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Int64Builder::append(const ContentPtr& array, int64_t at) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr Int64Builder::append(const ContentPtr& array, int64_t at) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;
   }

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -10,114 +10,157 @@
 #include "awkward/builder/Int64Builder.h"
 
 namespace awkward {
-  const BuilderPtr Int64Builder::fromempty(const ArrayBuilderOptions& options) {
-    BuilderPtr out = std::make_shared<Int64Builder>(options, GrowableBuffer<int64_t>::empty(options));
+  const BuilderPtr
+  Int64Builder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out =
+      std::make_shared<Int64Builder>(options,
+                                     GrowableBuffer<int64_t>::empty(options));
     out.get()->setthat(out);
     return out;
   }
-
-  Int64Builder::Int64Builder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& buffer)
+ 
+  Int64Builder::Int64Builder(const ArrayBuilderOptions& options,
+                             const GrowableBuffer<int64_t>& buffer)
       : options_(options)
       , buffer_(buffer) { }
 
-  const GrowableBuffer<int64_t> Int64Builder::buffer() const {
+  const GrowableBuffer<int64_t>
+  Int64Builder::buffer() const {
     return buffer_;
   }
 
-  const std::string Int64Builder::classname() const {
+  const std::string
+  Int64Builder::classname() const {
     return "Int64Builder";
   };
 
-  int64_t Int64Builder::length() const {
+  int64_t
+  Int64Builder::length() const {
     return buffer_.length();
   }
 
-  void Int64Builder::clear() {
+  void
+  Int64Builder::clear() {
     buffer_.clear();
   }
 
-  const ContentPtr Int64Builder::snapshot() const {
+  const ContentPtr
+  Int64Builder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(int64_t) };
 #if defined _MSC_VER || defined __i386__
-    return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), buffer_.ptr(), shape, strides, 0, sizeof(int64_t), "q");
+    return std::make_shared<NumpyArray>(Identities::none(),
+                                        util::Parameters(),
+                                        buffer_.ptr(),
+                                        shape,
+                                        strides,
+                                        0,
+                                        sizeof(int64_t),
+                                        "q");
 #else
-    return std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), buffer_.ptr(), shape, strides, 0, sizeof(int64_t), "l");
+    return std::make_shared<NumpyArray>(Identities::none(),
+                                        util::Parameters(),
+                                        buffer_.ptr(),
+                                        shape,
+                                        strides,
+                                        0,
+                                        sizeof(int64_t),
+                                        "l");
 #endif
   }
 
-  bool Int64Builder::active() const {
+  bool
+  Int64Builder::active() const {
     return false;
   }
 
-  const BuilderPtr Int64Builder::null() {
+  const BuilderPtr
+  Int64Builder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
     out.get()->null();
     return out;
   }
 
-  const BuilderPtr Int64Builder::boolean(bool x) {
+  const BuilderPtr
+  Int64Builder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->boolean(x);
     return out;
   }
 
-  const BuilderPtr Int64Builder::integer(int64_t x) {
+  const BuilderPtr
+  Int64Builder::integer(int64_t x) {
     buffer_.append(x);
     return that_;
   }
 
-  const BuilderPtr Int64Builder::real(double x) {
+  const BuilderPtr
+  Int64Builder::real(double x) {
     BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
     out.get()->real(x);
     return out;
   }
 
-  const BuilderPtr Int64Builder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  Int64Builder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->string(x, length, encoding);
     return out;
   }
 
-  const BuilderPtr Int64Builder::beginlist() {
+  const BuilderPtr
+  Int64Builder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
-  const BuilderPtr Int64Builder::endlist() {
-    throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+  const BuilderPtr
+  Int64Builder::endlist() {
+    throw std::invalid_argument(
+      "called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const BuilderPtr Int64Builder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  Int64Builder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
-  const BuilderPtr Int64Builder::index(int64_t index) {
-    throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  Int64Builder::index(int64_t index) {
+    throw std::invalid_argument(
+      "called 'index' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr Int64Builder::endtuple() {
-    throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  Int64Builder::endtuple() {
+    throw std::invalid_argument(
+      "called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr Int64Builder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  Int64Builder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
-  const BuilderPtr Int64Builder::field(const char* key, bool check) {
-    throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  Int64Builder::field(const char* key, bool check) {
+    throw std::invalid_argument(
+      "called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr Int64Builder::endrecord() {
-    throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  Int64Builder::endrecord() {
+    throw std::invalid_argument(
+      "called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr Int64Builder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  Int64Builder::append(const ContentPtr& array, int64_t at) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -36,7 +36,7 @@ namespace awkward {
     buffer_.clear();
   }
 
-  const std::shared_ptr<Content> Int64Builder::snapshot() const {
+  ContentPtr Int64Builder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(int64_t) };
 #if defined _MSC_VER || defined __i386__
@@ -117,7 +117,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Int64Builder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> Int64Builder::append(ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -36,7 +36,7 @@ namespace awkward {
     buffer_.clear();
   }
 
-  ContentPtr Int64Builder::snapshot() const {
+  const ContentPtr Int64Builder::snapshot() const {
     std::vector<ssize_t> shape = { (ssize_t)buffer_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(int64_t) };
 #if defined _MSC_VER || defined __i386__
@@ -117,7 +117,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> Int64Builder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> Int64Builder::append(const ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -40,7 +40,7 @@ namespace awkward {
     content_.get()->clear();
   }
 
-  const std::shared_ptr<Content> ListBuilder::snapshot() const {
+  ContentPtr ListBuilder::snapshot() const {
     Index64 offsets(offsets_.ptr(), 0, offsets_.length());
     return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), offsets, content_.get()->snapshot());
   }
@@ -197,7 +197,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> ListBuilder::append(ContentPtr& array, int64_t at) {
     if (!begun_) {
       std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -12,44 +12,61 @@
 #include "awkward/builder/ListBuilder.h"
 
 namespace awkward {
-  const BuilderPtr ListBuilder::fromempty(const ArrayBuilderOptions& options) {
+  const BuilderPtr
+  ListBuilder::fromempty(const ArrayBuilderOptions& options) {
     GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
     offsets.append(0);
-    BuilderPtr out = std::make_shared<ListBuilder>(options, offsets, UnknownBuilder::fromempty(options), false);
+    BuilderPtr out =
+      std::make_shared<ListBuilder>(options,
+                                    offsets,
+                                    UnknownBuilder::fromempty(options),
+                                    false);
     out.get()->setthat(out);
     return out;
   }
 
-  ListBuilder::ListBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const BuilderPtr& content, bool begun)
+  ListBuilder::ListBuilder(const ArrayBuilderOptions& options,
+                           const GrowableBuffer<int64_t>& offsets,
+                           const BuilderPtr& content,
+                           bool begun)
       : options_(options)
       , offsets_(offsets)
       , content_(content)
       , begun_(begun) { }
 
-  const std::string ListBuilder::classname() const {
+  const std::string
+  ListBuilder::classname() const {
     return "ListBuilder";
   };
 
-  int64_t ListBuilder::length() const {
+  int64_t
+  ListBuilder::length() const {
     return offsets_.length() - 1;
   }
 
-  void ListBuilder::clear() {
+  void
+  ListBuilder::clear() {
     offsets_.clear();
     offsets_.append(0);
     content_.get()->clear();
   }
 
-  const ContentPtr ListBuilder::snapshot() const {
+  const ContentPtr
+  ListBuilder::snapshot() const {
     Index64 offsets(offsets_.ptr(), 0, offsets_.length());
-    return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), offsets, content_.get()->snapshot());
+    return std::make_shared<ListOffsetArray64>(Identities::none(),
+                                               util::Parameters(),
+                                               offsets,
+                                               content_.get()->snapshot());
   }
 
-  bool ListBuilder::active() const {
+  bool
+  ListBuilder::active() const {
     return begun_;
   }
 
-  const BuilderPtr ListBuilder::null() {
+  const BuilderPtr
+  ListBuilder::null() {
     if (!begun_) {
       BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
       out.get()->null();
@@ -61,7 +78,8 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::boolean(bool x) {
+  const BuilderPtr
+  ListBuilder::boolean(bool x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->boolean(x);
@@ -73,7 +91,8 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::integer(int64_t x) {
+  const BuilderPtr
+  ListBuilder::integer(int64_t x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->integer(x);
@@ -85,7 +104,8 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::real(double x) {
+  const BuilderPtr
+  ListBuilder::real(double x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->real(x);
@@ -97,7 +117,8 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  ListBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->string(x, length, encoding);
@@ -109,7 +130,8 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::beginlist() {
+  const BuilderPtr
+  ListBuilder::beginlist() {
     if (!begun_) {
       begun_ = true;
     }
@@ -119,9 +141,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr ListBuilder::endlist() {
+  const BuilderPtr
+  ListBuilder::endlist() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endlist' without 'beginlist' at the same level before it");
     }
     else if (!content_.get()->active()) {
       offsets_.append(content_.get()->length());
@@ -133,7 +157,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr ListBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  ListBuilder::begintuple(int64_t numfields) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->begintuple(numfields);
@@ -145,9 +170,11 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::index(int64_t index) {
+  const BuilderPtr
+  ListBuilder::index(int64_t index) {
     if (!begun_) {
-      throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+        "called 'index' without 'begintuple' at the same level before it");
     }
     else {
       content_.get()->index(index);
@@ -155,9 +182,11 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::endtuple() {
+  const BuilderPtr
+  ListBuilder::endtuple() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endtuple' without 'begintuple' at the same level before it");
     }
     else {
       content_.get()->endtuple();
@@ -165,7 +194,8 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  ListBuilder::beginrecord(const char* name, bool check) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginrecord(name, check);
@@ -177,9 +207,11 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::field(const char* key, bool check) {
+  const BuilderPtr
+  ListBuilder::field(const char* key, bool check) {
     if (!begun_) {
-      throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'field' without 'beginrecord' at the same level before it");
     }
     else {
       content_.get()->field(key, check);
@@ -187,9 +219,11 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::endrecord() {
+  const BuilderPtr
+  ListBuilder::endrecord() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endrecord' without 'beginrecord' at the same level before it");
     }
     else {
       content_.get()->endrecord();
@@ -197,7 +231,8 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr ListBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  ListBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
@@ -209,7 +244,8 @@ namespace awkward {
     }
   }
 
-  void ListBuilder::maybeupdate(const BuilderPtr& tmp) {
+  void
+  ListBuilder::maybeupdate(const BuilderPtr& tmp) {
     if (tmp.get() != content_.get()) {
       content_ = tmp;
     }

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -223,7 +223,8 @@ namespace awkward {
   ListBuilder::endrecord() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endrecord' without 'beginrecord' at the same level before it");
+        "called 'endrecord' without 'beginrecord' at the same level "
+        "before it");
     }
     else {
       content_.get()->endrecord();

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -12,15 +12,15 @@
 #include "awkward/builder/ListBuilder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> ListBuilder::fromempty(const ArrayBuilderOptions& options) {
+  const BuilderPtr ListBuilder::fromempty(const ArrayBuilderOptions& options) {
     GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
     offsets.append(0);
-    std::shared_ptr<Builder> out = std::make_shared<ListBuilder>(options, offsets, UnknownBuilder::fromempty(options), false);
+    BuilderPtr out = std::make_shared<ListBuilder>(options, offsets, UnknownBuilder::fromempty(options), false);
     out.get()->setthat(out);
     return out;
   }
 
-  ListBuilder::ListBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const std::shared_ptr<Builder>& content, bool begun)
+  ListBuilder::ListBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const BuilderPtr& content, bool begun)
       : options_(options)
       , offsets_(offsets)
       , content_(content)
@@ -49,9 +49,9 @@ namespace awkward {
     return begun_;
   }
 
-  const std::shared_ptr<Builder> ListBuilder::null() {
+  const BuilderPtr ListBuilder::null() {
     if (!begun_) {
-      std::shared_ptr<Builder> out = OptionBuilder::fromvalids(options_, that_);
+      BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
       out.get()->null();
       return out;
     }
@@ -61,9 +61,9 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::boolean(bool x) {
+  const BuilderPtr ListBuilder::boolean(bool x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->boolean(x);
       return out;
     }
@@ -73,9 +73,9 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::integer(int64_t x) {
+  const BuilderPtr ListBuilder::integer(int64_t x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->integer(x);
       return out;
     }
@@ -85,9 +85,9 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::real(double x) {
+  const BuilderPtr ListBuilder::real(double x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->real(x);
       return out;
     }
@@ -97,9 +97,9 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr ListBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->string(x, length, encoding);
       return out;
     }
@@ -109,7 +109,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::beginlist() {
+  const BuilderPtr ListBuilder::beginlist() {
     if (!begun_) {
       begun_ = true;
     }
@@ -119,7 +119,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> ListBuilder::endlist() {
+  const BuilderPtr ListBuilder::endlist() {
     if (!begun_) {
       throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
     }
@@ -133,9 +133,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> ListBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr ListBuilder::begintuple(int64_t numfields) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->begintuple(numfields);
       return out;
     }
@@ -145,7 +145,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::index(int64_t index) {
+  const BuilderPtr ListBuilder::index(int64_t index) {
     if (!begun_) {
       throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
     }
@@ -155,7 +155,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::endtuple() {
+  const BuilderPtr ListBuilder::endtuple() {
     if (!begun_) {
       throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
     }
@@ -165,9 +165,9 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr ListBuilder::beginrecord(const char* name, bool check) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginrecord(name, check);
       return out;
     }
@@ -177,7 +177,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::field(const char* key, bool check) {
+  const BuilderPtr ListBuilder::field(const char* key, bool check) {
     if (!begun_) {
       throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
     }
@@ -187,7 +187,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::endrecord() {
+  const BuilderPtr ListBuilder::endrecord() {
     if (!begun_) {
       throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
     }
@@ -197,9 +197,9 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr ListBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
@@ -209,7 +209,7 @@ namespace awkward {
     }
   }
 
-  void ListBuilder::maybeupdate(const std::shared_ptr<Builder>& tmp) {
+  void ListBuilder::maybeupdate(const BuilderPtr& tmp) {
     if (tmp.get() != content_.get()) {
       content_ = tmp;
     }

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -40,7 +40,7 @@ namespace awkward {
     content_.get()->clear();
   }
 
-  ContentPtr ListBuilder::snapshot() const {
+  const ContentPtr ListBuilder::snapshot() const {
     Index64 offsets(offsets_.ptr(), 0, offsets_.length());
     return std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), offsets, content_.get()->snapshot());
   }
@@ -197,7 +197,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> ListBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> ListBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
       std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -10,21 +10,21 @@
 #include "awkward/builder/OptionBuilder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> OptionBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const std::shared_ptr<Builder>& content) {
+  const BuilderPtr OptionBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const BuilderPtr& content) {
     GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::full(options, -1, nullcount);
-    std::shared_ptr<Builder> out = std::make_shared<OptionBuilder>(options, offsets, content);
+    BuilderPtr out = std::make_shared<OptionBuilder>(options, offsets, content);
     out.get()->setthat(out);
     return out;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::fromvalids(const ArrayBuilderOptions& options, const std::shared_ptr<Builder>& content) {
+  const BuilderPtr OptionBuilder::fromvalids(const ArrayBuilderOptions& options, const BuilderPtr& content) {
     GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::arange(options, content->length());
-    std::shared_ptr<Builder> out = std::make_shared<OptionBuilder>(options, offsets, content);
+    BuilderPtr out = std::make_shared<OptionBuilder>(options, offsets, content);
     out.get()->setthat(out);
     return out;
   }
 
-  OptionBuilder::OptionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const std::shared_ptr<Builder>& content)
+  OptionBuilder::OptionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const BuilderPtr& content)
       : options_(options)
       , offsets_(offsets)
       , content_(content) { }
@@ -51,7 +51,7 @@ namespace awkward {
     return content_.get()->active();
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::null() {
+  const BuilderPtr OptionBuilder::null() {
     if (!content_.get()->active()) {
       offsets_.append(-1);
     }
@@ -61,7 +61,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::boolean(bool x) {
+  const BuilderPtr OptionBuilder::boolean(bool x) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->boolean(x));
@@ -73,7 +73,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::integer(int64_t x) {
+  const BuilderPtr OptionBuilder::integer(int64_t x) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->integer(x));
@@ -85,7 +85,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::real(double x) {
+  const BuilderPtr OptionBuilder::real(double x) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->real(x));
@@ -97,7 +97,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr OptionBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!content_.get()->active()) {
       int64_t len = content_.get()->length();
       maybeupdate(content_.get()->string(x, length, encoding));
@@ -109,7 +109,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::beginlist() {
+  const BuilderPtr OptionBuilder::beginlist() {
     if (!content_.get()->active()) {
       maybeupdate(content_.get()->beginlist());
     }
@@ -119,7 +119,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::endlist() {
+  const BuilderPtr OptionBuilder::endlist() {
     if (!content_.get()->active()) {
       throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
     }
@@ -133,7 +133,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr OptionBuilder::begintuple(int64_t numfields) {
     if (!content_.get()->active()) {
       maybeupdate(content_.get()->begintuple(numfields));
     }
@@ -143,7 +143,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::index(int64_t index) {
+  const BuilderPtr OptionBuilder::index(int64_t index) {
     if (!content_.get()->active()) {
       throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
     }
@@ -153,7 +153,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::endtuple() {
+  const BuilderPtr OptionBuilder::endtuple() {
     if (!content_.get()->active()) {
       throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
     }
@@ -167,7 +167,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr OptionBuilder::beginrecord(const char* name, bool check) {
     if (!content_.get()->active()) {
       maybeupdate(content_.get()->beginrecord(name, check));
     }
@@ -177,7 +177,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::field(const char* key, bool check) {
+  const BuilderPtr OptionBuilder::field(const char* key, bool check) {
     if (!content_.get()->active()) {
       throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
     }
@@ -187,7 +187,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::endrecord() {
+  const BuilderPtr OptionBuilder::endrecord() {
     if (!content_.get()->active()) {
       throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
     }
@@ -201,7 +201,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr OptionBuilder::append(const ContentPtr& array, int64_t at) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->append(array, at));
@@ -213,7 +213,7 @@ namespace awkward {
     return that_;
   }
 
-  void OptionBuilder::maybeupdate(const std::shared_ptr<Builder>& tmp) {
+  void OptionBuilder::maybeupdate(const BuilderPtr& tmp) {
     if (tmp.get() != content_.get()) {
       content_ = tmp;
     }

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -42,7 +42,7 @@ namespace awkward {
     content_.get()->clear();
   }
 
-  ContentPtr OptionBuilder::snapshot() const {
+  const ContentPtr OptionBuilder::snapshot() const {
     Index64 index(offsets_.ptr(), 0, offsets_.length());
     return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, content_.get()->snapshot());
   }
@@ -201,7 +201,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> OptionBuilder::append(const ContentPtr& array, int64_t at) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->append(array, at));

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -229,7 +229,8 @@ namespace awkward {
   OptionBuilder::endrecord() {
     if (!content_.get()->active()) {
       throw std::invalid_argument(
-        "called 'endrecord' without 'beginrecord' at the same level before it");
+        "called 'endrecord' without 'beginrecord' at the same level "
+        "before it");
     }
     else {
       int64_t length = content_.get()->length();

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -10,48 +10,71 @@
 #include "awkward/builder/OptionBuilder.h"
 
 namespace awkward {
-  const BuilderPtr OptionBuilder::fromnulls(const ArrayBuilderOptions& options, int64_t nullcount, const BuilderPtr& content) {
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::full(options, -1, nullcount);
-    BuilderPtr out = std::make_shared<OptionBuilder>(options, offsets, content);
+  const BuilderPtr
+  OptionBuilder::fromnulls(const ArrayBuilderOptions& options,
+                           int64_t nullcount,
+                           const BuilderPtr& content) {
+    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::full(options,
+                                                                    -1,
+                                                                    nullcount);
+    BuilderPtr out = std::make_shared<OptionBuilder>(options,
+                                                     offsets,
+                                                     content);
     out.get()->setthat(out);
     return out;
   }
 
-  const BuilderPtr OptionBuilder::fromvalids(const ArrayBuilderOptions& options, const BuilderPtr& content) {
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::arange(options, content->length());
-    BuilderPtr out = std::make_shared<OptionBuilder>(options, offsets, content);
+  const BuilderPtr
+  OptionBuilder::fromvalids(const ArrayBuilderOptions& options,
+                            const BuilderPtr& content) {
+    GrowableBuffer<int64_t> offsets =
+      GrowableBuffer<int64_t>::arange(options, content->length());
+    BuilderPtr out = std::make_shared<OptionBuilder>(options,
+                                                     offsets,
+                                                     content);
     out.get()->setthat(out);
     return out;
   }
-
-  OptionBuilder::OptionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const BuilderPtr& content)
-      : options_(options)
+ 
+  OptionBuilder::OptionBuilder(const ArrayBuilderOptions& options,
+                               const GrowableBuffer<int64_t>& offsets,
+                               const BuilderPtr& content)
+    : options_(options)
       , offsets_(offsets)
       , content_(content) { }
 
-  const std::string OptionBuilder::classname() const {
+  const std::string
+  OptionBuilder::classname() const {
     return "OptionBuilder";
   };
 
-  int64_t OptionBuilder::length() const {
+  int64_t
+  OptionBuilder::length() const {
     return offsets_.length();
   }
 
-  void OptionBuilder::clear() {
+  void
+  OptionBuilder::clear() {
     offsets_.clear();
     content_.get()->clear();
   }
 
-  const ContentPtr OptionBuilder::snapshot() const {
+  const ContentPtr
+  OptionBuilder::snapshot() const {
     Index64 index(offsets_.ptr(), 0, offsets_.length());
-    return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, content_.get()->snapshot());
+    return std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                                  util::Parameters(),
+                                                  index,
+                                                  content_.get()->snapshot());
   }
 
-  bool OptionBuilder::active() const {
+  bool
+  OptionBuilder::active() const {
     return content_.get()->active();
   }
 
-  const BuilderPtr OptionBuilder::null() {
+  const BuilderPtr
+  OptionBuilder::null() {
     if (!content_.get()->active()) {
       offsets_.append(-1);
     }
@@ -61,7 +84,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::boolean(bool x) {
+  const BuilderPtr
+  OptionBuilder::boolean(bool x) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->boolean(x));
@@ -73,7 +97,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::integer(int64_t x) {
+  const BuilderPtr
+  OptionBuilder::integer(int64_t x) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->integer(x));
@@ -85,7 +110,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::real(double x) {
+  const BuilderPtr
+  OptionBuilder::real(double x) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->real(x));
@@ -97,7 +123,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  OptionBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!content_.get()->active()) {
       int64_t len = content_.get()->length();
       maybeupdate(content_.get()->string(x, length, encoding));
@@ -109,7 +136,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::beginlist() {
+  const BuilderPtr
+  OptionBuilder::beginlist() {
     if (!content_.get()->active()) {
       maybeupdate(content_.get()->beginlist());
     }
@@ -119,9 +147,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::endlist() {
+  const BuilderPtr
+  OptionBuilder::endlist() {
     if (!content_.get()->active()) {
-      throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endlist' without 'beginlist' at the same level before it");
     }
     else {
       int64_t length = content_.get()->length();
@@ -133,7 +163,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  OptionBuilder::begintuple(int64_t numfields) {
     if (!content_.get()->active()) {
       maybeupdate(content_.get()->begintuple(numfields));
     }
@@ -143,9 +174,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::index(int64_t index) {
+  const BuilderPtr
+  OptionBuilder::index(int64_t index) {
     if (!content_.get()->active()) {
-      throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+        "called 'index' without 'begintuple' at the same level before it");
     }
     else {
       content_.get()->index(index);
@@ -153,9 +186,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::endtuple() {
+  const BuilderPtr
+  OptionBuilder::endtuple() {
     if (!content_.get()->active()) {
-      throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endtuple' without 'begintuple' at the same level before it");
     }
     else {
       int64_t length = content_.get()->length();
@@ -167,7 +202,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  OptionBuilder::beginrecord(const char* name, bool check) {
     if (!content_.get()->active()) {
       maybeupdate(content_.get()->beginrecord(name, check));
     }
@@ -177,9 +213,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::field(const char* key, bool check) {
+  const BuilderPtr
+  OptionBuilder::field(const char* key, bool check) {
     if (!content_.get()->active()) {
-      throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'field' without 'beginrecord' at the same level before it");
     }
     else {
       content_.get()->field(key, check);
@@ -187,9 +225,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::endrecord() {
+  const BuilderPtr
+  OptionBuilder::endrecord() {
     if (!content_.get()->active()) {
-      throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endrecord' without 'beginrecord' at the same level before it");
     }
     else {
       int64_t length = content_.get()->length();
@@ -201,7 +241,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr OptionBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  OptionBuilder::append(const ContentPtr& array, int64_t at) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->append(array, at));
@@ -213,7 +254,8 @@ namespace awkward {
     return that_;
   }
 
-  void OptionBuilder::maybeupdate(const BuilderPtr& tmp) {
+  void
+  OptionBuilder::maybeupdate(const BuilderPtr& tmp) {
     if (tmp.get() != content_.get()) {
       content_ = tmp;
     }

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -42,7 +42,7 @@ namespace awkward {
     content_.get()->clear();
   }
 
-  const std::shared_ptr<Content> OptionBuilder::snapshot() const {
+  ContentPtr OptionBuilder::snapshot() const {
     Index64 index(offsets_.ptr(), 0, offsets_.length());
     return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, content_.get()->snapshot());
   }
@@ -201,7 +201,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> OptionBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> OptionBuilder::append(ContentPtr& array, int64_t at) {
     if (!content_.get()->active()) {
       int64_t length = content_.get()->length();
       maybeupdate(content_.get()->append(array, at));

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -65,7 +65,7 @@ namespace awkward {
     nexttotry_ = 0;
   }
 
-  const std::shared_ptr<Content> RecordBuilder::snapshot() const {
+  ContentPtr RecordBuilder::snapshot() const {
     if (length_ == -1) {
       return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
     }
@@ -394,7 +394,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> RecordBuilder::append(ContentPtr& array, int64_t at) {
     if (!begun_) {
       std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -17,13 +17,33 @@
 #include "awkward/builder/RecordBuilder.h"
 
 namespace awkward {
-  const BuilderPtr RecordBuilder::fromempty(const ArrayBuilderOptions& options) {
-    BuilderPtr out = std::make_shared<RecordBuilder>(options, std::vector<BuilderPtr>(), std::vector<std::string>(), std::vector<const char*>(), "", nullptr, -1, false, -1, -1);
+  const BuilderPtr
+  RecordBuilder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out =
+      std::make_shared<RecordBuilder>(options,
+                                      std::vector<BuilderPtr>(),
+                                      std::vector<std::string>(),
+                                      std::vector<const char*>(),
+                                      "",
+                                      nullptr,
+                                      -1,
+                                      false,
+                                      -1,
+                                      -1);
     out.get()->setthat(out);
     return out;
   }
 
-  RecordBuilder::RecordBuilder(const ArrayBuilderOptions& options, const std::vector<BuilderPtr>& contents, const std::vector<std::string>& keys, const std::vector<const char*>& pointers, const std::string& name, const char* nameptr, int64_t length, bool begun, int64_t nextindex, int64_t nexttotry)
+  RecordBuilder::RecordBuilder(const ArrayBuilderOptions& options,
+                               const std::vector<BuilderPtr>& contents,
+                               const std::vector<std::string>& keys,
+                               const std::vector<const char*>& pointers,
+                               const std::string& name,
+                               const char* nameptr,
+                               int64_t length,
+                               bool begun,
+                               int64_t nextindex,
+                               int64_t nexttotry)
       : options_(options)
       , contents_(contents)
       , keys_(keys)
@@ -35,23 +55,28 @@ namespace awkward {
       , nextindex_(nextindex)
       , nexttotry_(nexttotry) { }
 
-  const std::string RecordBuilder::name() const {
+  const std::string
+  RecordBuilder::name() const {
     return name_;
   }
 
-  const char* RecordBuilder::nameptr() const {
+  const char*
+  RecordBuilder::nameptr() const {
     return nameptr_;
   }
 
-  const std::string RecordBuilder::classname() const {
+  const std::string
+  RecordBuilder::classname() const {
     return "RecordBuilder";
   };
 
-  int64_t RecordBuilder::length() const {
+  int64_t
+  RecordBuilder::length() const {
     return length_;
   }
 
-  void RecordBuilder::clear() {
+  void
+  RecordBuilder::clear() {
     for (auto x : contents_) {
       x.get()->clear();
     }
@@ -65,9 +90,11 @@ namespace awkward {
     nexttotry_ = 0;
   }
 
-  const ContentPtr RecordBuilder::snapshot() const {
+  const ContentPtr
+  RecordBuilder::snapshot() const {
     if (length_ == -1) {
-      return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
+      return std::make_shared<EmptyArray>(Identities::none(),
+                                          util::Parameters());
     }
     util::Parameters parameters;
     if (nameptr_ != nullptr) {
@@ -79,21 +106,29 @@ namespace awkward {
       contents.push_back(contents_[i].get()->snapshot());
       recordlookup.get()->push_back(keys_[i]);
     }
-    return std::make_shared<RecordArray>(Identities::none(), parameters, contents, recordlookup, length_);
+    return std::make_shared<RecordArray>(Identities::none(),
+                                         parameters,
+                                         contents,
+                                         recordlookup,
+                                         length_);
   }
 
-  bool RecordBuilder::active() const {
+  bool
+  RecordBuilder::active() const {
     return begun_;
   }
 
-  const BuilderPtr RecordBuilder::null() {
+  const BuilderPtr
+  RecordBuilder::null() {
     if (!begun_) {
       BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
       out.get()->null();
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'null' immediately after 'beginrecord'; needs 'index' or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'null' immediately after 'beginrecord'; "
+        "needs 'index' or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
@@ -104,14 +139,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::boolean(bool x) {
+  const BuilderPtr
+  RecordBuilder::boolean(bool x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->boolean(x);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'boolean' immediately after 'beginrecord'; needs 'index' or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'boolean' immediately after 'beginrecord'; "
+        "needs 'index' or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
@@ -122,14 +160,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::integer(int64_t x) {
+  const BuilderPtr
+  RecordBuilder::integer(int64_t x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->integer(x);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'integer' immediately after 'beginrecord'; needs 'index' or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'integer' immediately after 'beginrecord'; "
+        "needs 'index' or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
@@ -140,14 +181,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::real(double x) {
+  const BuilderPtr
+  RecordBuilder::real(double x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->real(x);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'real' immediately after 'beginrecord'; needs 'index' or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'real' immediately after 'beginrecord'; "
+        "needs 'index' or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
@@ -158,17 +202,23 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  RecordBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->string(x, length, encoding);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'string' immediately after 'beginrecord'; needs 'index' or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'string' immediately after 'beginrecord'; "
+        "needs 'index' or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->string(x, length, encoding));
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->string(x,
+                                                              length,
+                                                              encoding));
     }
     else {
       contents_[(size_t)nextindex_].get()->string(x, length, encoding);
@@ -176,14 +226,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::beginlist() {
+  const BuilderPtr
+  RecordBuilder::beginlist() {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginlist();
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'beginlist' immediately after 'beginrecord'; needs 'index' or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'beginlist' immediately after 'beginrecord'; "
+        "needs 'index' or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
@@ -194,12 +247,16 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::endlist() {
+  const BuilderPtr
+  RecordBuilder::endlist() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endlist' without 'beginlist' at the same level before it");
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'endlist' immediately after 'beginrecord'; needs 'index' or 'endrecord' and then 'beginlist'");
+      throw std::invalid_argument(
+        "called 'endlist' immediately after 'beginrecord'; "
+        "needs 'index' or 'endrecord' and then 'beginlist'");
     }
     else {
       contents_[(size_t)nextindex_].get()->endlist();
@@ -207,17 +264,21 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  RecordBuilder::begintuple(int64_t numfields) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->begintuple(numfields);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'begintuple' immediately after 'beginrecord'; needs 'field_fast', 'field_check', or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'begintuple' immediately after 'beginrecord'; "
+        "needs 'field_fast', 'field_check', or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->begintuple(numfields));
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->begintuple(numfields));
     }
     else {
       contents_[(size_t)nextindex_].get()->begintuple(numfields);
@@ -225,12 +286,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::index(int64_t index) {
+  const BuilderPtr
+  RecordBuilder::index(int64_t index) {
     if (!begun_) {
-      throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+        "called 'index' without 'begintuple' at the same level before it");
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'index' immediately after 'beginrecord'; needs 'field_fast', 'field_check' or 'endrecord' and then 'begintuple'");
+      throw std::invalid_argument(
+        "called 'index' immediately after 'beginrecord'; "
+        "needs 'field_fast', 'field_check' or 'endrecord' "
+        "and then 'begintuple'");
     }
     else {
       contents_[(size_t)nextindex_].get()->index(index);
@@ -238,12 +304,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::endtuple() {
+  const BuilderPtr
+  RecordBuilder::endtuple() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endtuple' without 'begintuple' at the same level before it");
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'endtuple' immediately after 'beginrecord'; needs 'field_fast', 'field_check', or 'endrecord' and then 'begintuple'");
+      throw std::invalid_argument(
+        "called 'endtuple' immediately after 'beginrecord'; "
+        "needs 'field_fast', 'field_check', or 'endrecord' "
+        "and then 'begintuple'");
     }
     else {
       contents_[(size_t)nextindex_].get()->endtuple();
@@ -251,7 +322,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  RecordBuilder::beginrecord(const char* name, bool check) {
     if (length_ == -1) {
       if (name == nullptr) {
         name_ = std::string("");
@@ -263,7 +335,8 @@ namespace awkward {
       length_ = 0;
     }
 
-    if (!begun_  &&  ((check  &&  name_ == name)  ||  (!check  &&  nameptr_ == name))) {
+    if (!begun_  &&
+        ((check  &&  name_ == name)  ||  (!check  &&  nameptr_ == name))) {
       begun_ = true;
       nextindex_ = -1;
       nexttotry_ = 0;
@@ -274,10 +347,13 @@ namespace awkward {
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'beginrecord' immediately after 'beginrecord'; needs 'field_fast', 'field_check', or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'beginrecord' immediately after 'beginrecord'; "
+        "needs 'field_fast', 'field_check', or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginrecord(name, check));
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->beginrecord(name, check));
     }
     else {
       contents_[(size_t)nextindex_].get()->beginrecord(name, check);
@@ -285,7 +361,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::field(const char* key, bool check) {
+  const BuilderPtr
+  RecordBuilder::field(const char* key, bool check) {
     if (check) {
       return field_check(key);
     }
@@ -294,11 +371,14 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr RecordBuilder::field_fast(const char* key) {
+  const BuilderPtr
+  RecordBuilder::field_fast(const char* key) {
     if (!begun_) {
-      throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'field' without 'beginrecord' at the same level before it");
     }
-    else if (nextindex_ == -1  ||  !contents_[(size_t)nextindex_].get()->active()) {
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
       int64_t wrap_around = (int64_t)pointers_.size();
       int64_t i = nexttotry_;
       do {
@@ -321,7 +401,10 @@ namespace awkward {
         contents_.push_back(UnknownBuilder::fromempty(options_));
       }
       else {
-        contents_.push_back(OptionBuilder::fromnulls(options_, length_, UnknownBuilder::fromempty(options_)));
+        contents_.push_back(
+          OptionBuilder::fromnulls(options_,
+                                   length_,
+                                   UnknownBuilder::fromempty(options_)));
       }
       keys_.push_back(std::string(key));
       pointers_.push_back(key);
@@ -333,11 +416,14 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr RecordBuilder::field_check(const char* key) {
+  const BuilderPtr
+  RecordBuilder::field_check(const char* key) {
     if (!begun_) {
-      throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'field' without 'beginrecord' at the same level before it");
     }
-    else if (nextindex_ == -1  ||  !contents_[(size_t)nextindex_].get()->active()) {
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
       int64_t wrap_around = (int64_t)keys_.size();
       int64_t i = nexttotry_;
       do {
@@ -360,7 +446,10 @@ namespace awkward {
         contents_.push_back(UnknownBuilder::fromempty(options_));
       }
       else {
-        contents_.push_back(OptionBuilder::fromnulls(options_, length_, UnknownBuilder::fromempty(options_)));
+        contents_.push_back(
+          OptionBuilder::fromnulls(options_,
+                                   length_,
+                                   UnknownBuilder::fromempty(options_)));
       }
       keys_.push_back(std::string(key));
       pointers_.push_back(nullptr);
@@ -372,17 +461,22 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr RecordBuilder::endrecord() {
+  const BuilderPtr
+  RecordBuilder::endrecord() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endrecord' without 'beginrecord' at the same level before it");
     }
-    else if (nextindex_ == -1  ||  !contents_[(size_t)nextindex_].get()->active()) {
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
       for (size_t i = 0;  i < contents_.size();  i++) {
         if (contents_[i].get()->length() == length_) {
           maybeupdate((int64_t)i, contents_[i].get()->null());
         }
         if (contents_[i].get()->length() != length_ + 1) {
-          throw std::invalid_argument(std::string("record field ") + util::quote(keys_[i], true) + std::string(" filled more than once"));
+          throw std::invalid_argument(
+            std::string("record field ") + util::quote(keys_[i], true)
+            + std::string(" filled more than once"));
         }
       }
       length_++;
@@ -394,17 +488,21 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr RecordBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  RecordBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'append' immediately after 'beginrecord'; needs 'index' or 'endrecord'");
+      throw std::invalid_argument(
+        "called 'append' immediately after 'beginrecord'; "
+        "needs 'index' or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->append(array, at));
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->append(array, at));
     }
     else {
       contents_[(size_t)nextindex_].get()->append(array, at);
@@ -412,7 +510,8 @@ namespace awkward {
     return that_;
   }
 
-  void RecordBuilder::maybeupdate(int64_t i, const BuilderPtr& tmp) {
+  void
+  RecordBuilder::maybeupdate(int64_t i, const BuilderPtr& tmp) {
     if (tmp.get() != contents_[(size_t)i].get()) {
       contents_[(size_t)i] = tmp;
     }

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -73,7 +73,7 @@ namespace awkward {
     if (nameptr_ != nullptr) {
       parameters["__record__"] = util::quote(name_, true);
     }
-    std::vector<ContentPtr> contents;
+    ContentPtrVec contents;
     std::shared_ptr<util::RecordLookup> recordlookup = std::make_shared<util::RecordLookup>();
     for (size_t i = 0;  i < contents_.size();  i++) {
       contents.push_back(contents_[i].get()->snapshot());

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -17,13 +17,13 @@
 #include "awkward/builder/RecordBuilder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> RecordBuilder::fromempty(const ArrayBuilderOptions& options) {
-    std::shared_ptr<Builder> out = std::make_shared<RecordBuilder>(options, std::vector<std::shared_ptr<Builder>>(), std::vector<std::string>(), std::vector<const char*>(), "", nullptr, -1, false, -1, -1);
+  const BuilderPtr RecordBuilder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out = std::make_shared<RecordBuilder>(options, std::vector<BuilderPtr>(), std::vector<std::string>(), std::vector<const char*>(), "", nullptr, -1, false, -1, -1);
     out.get()->setthat(out);
     return out;
   }
 
-  RecordBuilder::RecordBuilder(const ArrayBuilderOptions& options, const std::vector<std::shared_ptr<Builder>>& contents, const std::vector<std::string>& keys, const std::vector<const char*>& pointers, const std::string& name, const char* nameptr, int64_t length, bool begun, int64_t nextindex, int64_t nexttotry)
+  RecordBuilder::RecordBuilder(const ArrayBuilderOptions& options, const std::vector<BuilderPtr>& contents, const std::vector<std::string>& keys, const std::vector<const char*>& pointers, const std::string& name, const char* nameptr, int64_t length, bool begun, int64_t nextindex, int64_t nexttotry)
       : options_(options)
       , contents_(contents)
       , keys_(keys)
@@ -74,7 +74,7 @@ namespace awkward {
       parameters["__record__"] = util::quote(name_, true);
     }
     ContentPtrVec contents;
-    std::shared_ptr<util::RecordLookup> recordlookup = std::make_shared<util::RecordLookup>();
+    util::RecordLookupPtr recordlookup = std::make_shared<util::RecordLookup>();
     for (size_t i = 0;  i < contents_.size();  i++) {
       contents.push_back(contents_[i].get()->snapshot());
       recordlookup.get()->push_back(keys_[i]);
@@ -86,9 +86,9 @@ namespace awkward {
     return begun_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::null() {
+  const BuilderPtr RecordBuilder::null() {
     if (!begun_) {
-      std::shared_ptr<Builder> out = OptionBuilder::fromvalids(options_, that_);
+      BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
       out.get()->null();
       return out;
     }
@@ -104,9 +104,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::boolean(bool x) {
+  const BuilderPtr RecordBuilder::boolean(bool x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->boolean(x);
       return out;
     }
@@ -122,9 +122,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::integer(int64_t x) {
+  const BuilderPtr RecordBuilder::integer(int64_t x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->integer(x);
       return out;
     }
@@ -140,9 +140,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::real(double x) {
+  const BuilderPtr RecordBuilder::real(double x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->real(x);
       return out;
     }
@@ -158,9 +158,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr RecordBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->string(x, length, encoding);
       return out;
     }
@@ -176,9 +176,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::beginlist() {
+  const BuilderPtr RecordBuilder::beginlist() {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginlist();
       return out;
     }
@@ -194,7 +194,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::endlist() {
+  const BuilderPtr RecordBuilder::endlist() {
     if (!begun_) {
       throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
     }
@@ -207,9 +207,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr RecordBuilder::begintuple(int64_t numfields) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->begintuple(numfields);
       return out;
     }
@@ -225,7 +225,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::index(int64_t index) {
+  const BuilderPtr RecordBuilder::index(int64_t index) {
     if (!begun_) {
       throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
     }
@@ -238,7 +238,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::endtuple() {
+  const BuilderPtr RecordBuilder::endtuple() {
     if (!begun_) {
       throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
     }
@@ -251,7 +251,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr RecordBuilder::beginrecord(const char* name, bool check) {
     if (length_ == -1) {
       if (name == nullptr) {
         name_ = std::string("");
@@ -269,7 +269,7 @@ namespace awkward {
       nexttotry_ = 0;
     }
     else if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginrecord(name, check);
       return out;
     }
@@ -285,7 +285,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::field(const char* key, bool check) {
+  const BuilderPtr RecordBuilder::field(const char* key, bool check) {
     if (check) {
       return field_check(key);
     }
@@ -294,7 +294,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::field_fast(const char* key) {
+  const BuilderPtr RecordBuilder::field_fast(const char* key) {
     if (!begun_) {
       throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
     }
@@ -333,7 +333,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::field_check(const char* key) {
+  const BuilderPtr RecordBuilder::field_check(const char* key) {
     if (!begun_) {
       throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
     }
@@ -372,7 +372,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::endrecord() {
+  const BuilderPtr RecordBuilder::endrecord() {
     if (!begun_) {
       throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
     }
@@ -394,9 +394,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr RecordBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
@@ -412,7 +412,7 @@ namespace awkward {
     return that_;
   }
 
-  void RecordBuilder::maybeupdate(int64_t i, const std::shared_ptr<Builder>& tmp) {
+  void RecordBuilder::maybeupdate(int64_t i, const BuilderPtr& tmp) {
     if (tmp.get() != contents_[(size_t)i].get()) {
       contents_[(size_t)i] = tmp;
     }

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -65,7 +65,7 @@ namespace awkward {
     nexttotry_ = 0;
   }
 
-  ContentPtr RecordBuilder::snapshot() const {
+  const ContentPtr RecordBuilder::snapshot() const {
     if (length_ == -1) {
       return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
     }
@@ -73,7 +73,7 @@ namespace awkward {
     if (nameptr_ != nullptr) {
       parameters["__record__"] = util::quote(name_, true);
     }
-    std::vector<std::shared_ptr<Content>> contents;
+    std::vector<ContentPtr> contents;
     std::shared_ptr<util::RecordLookup> recordlookup = std::make_shared<util::RecordLookup>();
     for (size_t i = 0;  i < contents_.size();  i++) {
       contents.push_back(contents_[i].get()->snapshot());
@@ -394,7 +394,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> RecordBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> RecordBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
       std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -101,7 +101,8 @@ namespace awkward {
       parameters["__record__"] = util::quote(name_, true);
     }
     ContentPtrVec contents;
-    util::RecordLookupPtr recordlookup = std::make_shared<util::RecordLookup>();
+    util::RecordLookupPtr recordlookup =
+      std::make_shared<util::RecordLookup>();
     for (size_t i = 0;  i < contents_.size();  i++) {
       contents.push_back(contents_[i].get()->snapshot());
       recordlookup.get()->push_back(keys_[i]);
@@ -239,7 +240,8 @@ namespace awkward {
         "needs 'index' or 'endrecord'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->beginlist());
     }
     else {
       contents_[(size_t)nextindex_].get()->beginlist();
@@ -353,7 +355,8 @@ namespace awkward {
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginrecord(name, check));
+                  contents_[(size_t)nextindex_].get()->beginrecord(name,
+                                                                   check));
     }
     else {
       contents_[(size_t)nextindex_].get()->beginrecord(name, check);
@@ -465,7 +468,8 @@ namespace awkward {
   RecordBuilder::endrecord() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endrecord' without 'beginrecord' at the same level before it");
+        "called 'endrecord' without 'beginrecord' at the same level "
+        "before it");
     }
     else if (nextindex_ == -1  ||
              !contents_[(size_t)nextindex_].get()->active()) {

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -11,40 +11,53 @@
 #include "awkward/builder/StringBuilder.h"
 
 namespace awkward {
-  const BuilderPtr StringBuilder::fromempty(const ArrayBuilderOptions& options, const char* encoding) {
+  const BuilderPtr
+  StringBuilder::fromempty(const ArrayBuilderOptions& options,
+                           const char* encoding) {
     GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
     offsets.append(0);
     GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
-    BuilderPtr out = std::make_shared<StringBuilder>(options, offsets, content, encoding);
+    BuilderPtr out = std::make_shared<StringBuilder>(options,
+                                                     offsets,
+                                                     content,
+                                                     encoding);
     out.get()->setthat(out);
     return out;
   }
 
-  StringBuilder::StringBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int64_t>& offsets, const GrowableBuffer<uint8_t>& content, const char* encoding)
+  StringBuilder::StringBuilder(const ArrayBuilderOptions& options,
+                               const GrowableBuffer<int64_t>& offsets,
+                               const GrowableBuffer<uint8_t>& content,
+                               const char* encoding)
       : options_(options)
       , offsets_(offsets)
       , content_(content)
       , encoding_(encoding) { }
 
-  const std::string StringBuilder::classname() const {
+  const std::string
+  StringBuilder::classname() const {
     return "StringBuilder";
   };
 
-  const char* StringBuilder::encoding() const {
+  const char*
+  StringBuilder::encoding() const {
     return encoding_;
   }
 
-  int64_t StringBuilder::length() const {
+  int64_t
+  StringBuilder::length() const {
     return offsets_.length() - 1;
   }
 
-  void StringBuilder::clear() {
+  void
+  StringBuilder::clear() {
     offsets_.clear();
     offsets_.append(0);
     content_.clear();
   }
 
-  const ContentPtr StringBuilder::snapshot() const {
+  const ContentPtr
+  StringBuilder::snapshot() const {
     util::Parameters char_parameters;
     util::Parameters string_parameters;
 
@@ -57,46 +70,63 @@ namespace awkward {
       string_parameters["__array__"] = std::string("\"string\"");
     }
     else {
-      throw std::invalid_argument(std::string("unsupported encoding: ") + util::quote(encoding_, false));
+      throw std::invalid_argument(
+        std::string("unsupported encoding: ") + util::quote(encoding_, false));
     }
 
     Index64 offsets(offsets_.ptr(), 0, offsets_.length());
     std::vector<ssize_t> shape = { (ssize_t)content_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(uint8_t) };
     ContentPtr content;
-    content = std::make_shared<NumpyArray>(Identities::none(), char_parameters, content_.ptr(), shape, strides, 0, sizeof(uint8_t), "B");
-    return std::make_shared<ListOffsetArray64>(Identities::none(), string_parameters, offsets, content);
+    content = std::make_shared<NumpyArray>(Identities::none(),
+                                           char_parameters,
+                                           content_.ptr(),
+                                           shape,
+                                           strides,
+                                           0,
+                                           sizeof(uint8_t),
+                                           "B");
+    return std::make_shared<ListOffsetArray64>(Identities::none(),
+                                               string_parameters,
+                                               offsets,
+                                               content);
   }
 
-  bool StringBuilder::active() const {
+  bool
+  StringBuilder::active() const {
     return false;
   }
 
-  const BuilderPtr StringBuilder::null() {
+  const BuilderPtr
+  StringBuilder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
     out.get()->null();
     return out;
   }
 
-  const BuilderPtr StringBuilder::boolean(bool x) {
+  const BuilderPtr
+  StringBuilder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->boolean(x);
     return out;
   }
 
-  const BuilderPtr StringBuilder::integer(int64_t x) {
+  const BuilderPtr
+  StringBuilder::integer(int64_t x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->integer(x);
     return out;
   }
 
-  const BuilderPtr StringBuilder::real(double x) {
+  const BuilderPtr
+  StringBuilder::real(double x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->real(x);
     return out;
   }
 
-  const BuilderPtr StringBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  StringBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (length < 0) {
       for (int64_t i = 0;  x[i] != 0;  i++) {
         content_.append((uint8_t)x[i]);
@@ -111,45 +141,59 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr StringBuilder::beginlist() {
+  const BuilderPtr
+  StringBuilder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
-  const BuilderPtr StringBuilder::endlist() {
-    throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+  const BuilderPtr
+  StringBuilder::endlist() {
+    throw std::invalid_argument(
+      "called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const BuilderPtr StringBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  StringBuilder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
-  const BuilderPtr StringBuilder::index(int64_t index) {
-    throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  StringBuilder::index(int64_t index) {
+    throw std::invalid_argument(
+      "called 'index' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr StringBuilder::endtuple() {
-    throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  StringBuilder::endtuple() {
+    throw std::invalid_argument(
+      "called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr StringBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  StringBuilder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
-  const BuilderPtr StringBuilder::field(const char* key, bool check) {
-    throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  StringBuilder::field(const char* key, bool check) {
+    throw std::invalid_argument(
+      "called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr StringBuilder::endrecord() {
-    throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  StringBuilder::endrecord() {
+    throw std::invalid_argument(
+      "called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr StringBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  StringBuilder::append(const ContentPtr& array, int64_t at) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -11,11 +11,11 @@
 #include "awkward/builder/StringBuilder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> StringBuilder::fromempty(const ArrayBuilderOptions& options, const char* encoding) {
+  const BuilderPtr StringBuilder::fromempty(const ArrayBuilderOptions& options, const char* encoding) {
     GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
     offsets.append(0);
     GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
-    std::shared_ptr<Builder> out = std::make_shared<StringBuilder>(options, offsets, content, encoding);
+    BuilderPtr out = std::make_shared<StringBuilder>(options, offsets, content, encoding);
     out.get()->setthat(out);
     return out;
   }
@@ -72,31 +72,31 @@ namespace awkward {
     return false;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::null() {
-    std::shared_ptr<Builder> out = OptionBuilder::fromvalids(options_, that_);
+  const BuilderPtr StringBuilder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
     out.get()->null();
     return out;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::boolean(bool x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr StringBuilder::boolean(bool x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->boolean(x);
     return out;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::integer(int64_t x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr StringBuilder::integer(int64_t x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->integer(x);
     return out;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::real(double x) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr StringBuilder::real(double x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->real(x);
     return out;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr StringBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (length < 0) {
       for (int64_t i = 0;  x[i] != 0;  i++) {
         content_.append((uint8_t)x[i]);
@@ -111,46 +111,46 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::beginlist() {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr StringBuilder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginlist();
     return out;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::endlist() {
+  const BuilderPtr StringBuilder::endlist() {
     throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> StringBuilder::begintuple(int64_t numfields) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr StringBuilder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->begintuple(numfields);
     return out;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::index(int64_t index) {
+  const BuilderPtr StringBuilder::index(int64_t index) {
     throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> StringBuilder::endtuple() {
+  const BuilderPtr StringBuilder::endtuple() {
     throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> StringBuilder::beginrecord(const char* name, bool check) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr StringBuilder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->beginrecord(name, check);
     return out;
   }
 
-  const std::shared_ptr<Builder> StringBuilder::field(const char* key, bool check) {
+  const BuilderPtr StringBuilder::field(const char* key, bool check) {
     throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> StringBuilder::endrecord() {
+  const BuilderPtr StringBuilder::endrecord() {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> StringBuilder::append(const ContentPtr& array, int64_t at) {
-    std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+  const BuilderPtr StringBuilder::append(const ContentPtr& array, int64_t at) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;
   }

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -44,7 +44,7 @@ namespace awkward {
     content_.clear();
   }
 
-  ContentPtr StringBuilder::snapshot() const {
+  const ContentPtr StringBuilder::snapshot() const {
     util::Parameters char_parameters;
     util::Parameters string_parameters;
 
@@ -63,7 +63,7 @@ namespace awkward {
     Index64 offsets(offsets_.ptr(), 0, offsets_.length());
     std::vector<ssize_t> shape = { (ssize_t)content_.length() };
     std::vector<ssize_t> strides = { (ssize_t)sizeof(uint8_t) };
-    std::shared_ptr<Content> content;
+    ContentPtr content;
     content = std::make_shared<NumpyArray>(Identities::none(), char_parameters, content_.ptr(), shape, strides, 0, sizeof(uint8_t), "B");
     return std::make_shared<ListOffsetArray64>(Identities::none(), string_parameters, offsets, content);
   }
@@ -149,7 +149,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> StringBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> StringBuilder::append(const ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -44,7 +44,7 @@ namespace awkward {
     content_.clear();
   }
 
-  const std::shared_ptr<Content> StringBuilder::snapshot() const {
+  ContentPtr StringBuilder::snapshot() const {
     util::Parameters char_parameters;
     util::Parameters string_parameters;
 
@@ -149,7 +149,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> StringBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> StringBuilder::append(ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -48,11 +48,11 @@ namespace awkward {
     nextindex_ = -1;
   }
 
-  ContentPtr TupleBuilder::snapshot() const {
+  const ContentPtr TupleBuilder::snapshot() const {
     if (length_ == -1) {
       return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
     }
-    std::vector<std::shared_ptr<Content>> contents;
+    std::vector<ContentPtr> contents;
     for (size_t i = 0;  i < contents_.size();  i++) {
       contents.push_back(contents_[i].get()->snapshot());
     }
@@ -292,7 +292,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> TupleBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
       std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -52,7 +52,7 @@ namespace awkward {
     if (length_ == -1) {
       return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
     }
-    std::vector<ContentPtr> contents;
+    ContentPtrVec contents;
     for (size_t i = 0;  i < contents_.size();  i++) {
       contents.push_back(contents_[i].get()->snapshot());
     }

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -14,32 +14,45 @@
 #include "awkward/builder/TupleBuilder.h"
 
 namespace awkward {
-  const BuilderPtr TupleBuilder::fromempty(const ArrayBuilderOptions& options) {
-    BuilderPtr out = std::make_shared<TupleBuilder>(options, std::vector<BuilderPtr>(), -1, false, -1);
+  const BuilderPtr
+  TupleBuilder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out = std::make_shared<TupleBuilder>(options,
+                                                    std::vector<BuilderPtr>(),
+                                                    -1,
+                                                    false,
+                                                    -1);
     out.get()->setthat(out);
     return out;
   }
 
-  TupleBuilder::TupleBuilder(const ArrayBuilderOptions& options, const std::vector<BuilderPtr>& contents, int64_t length, bool begun, size_t nextindex)
+  TupleBuilder::TupleBuilder(const ArrayBuilderOptions& options,
+                             const std::vector<BuilderPtr>& contents,
+                             int64_t length,
+                             bool begun,
+                             size_t nextindex)
       : options_(options)
       , contents_(contents)
       , length_(length)
       , begun_(begun)
       , nextindex_(nextindex) { }
 
-  int64_t TupleBuilder::numfields() const {
+  int64_t
+  TupleBuilder::numfields() const {
     return (int64_t)contents_.size();
   }
 
-  const std::string TupleBuilder::classname() const {
+  const std::string
+  TupleBuilder::classname() const {
     return "TupleBuilder";
   };
 
-  int64_t TupleBuilder::length() const {
+  int64_t
+  TupleBuilder::length() const {
     return length_;
   }
 
-  void TupleBuilder::clear() {
+  void
+  TupleBuilder::clear() {
     for (auto x : contents_) {
       x.get()->clear();
     }
@@ -48,29 +61,39 @@ namespace awkward {
     nextindex_ = -1;
   }
 
-  const ContentPtr TupleBuilder::snapshot() const {
+  const ContentPtr
+  TupleBuilder::snapshot() const {
     if (length_ == -1) {
-      return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
+      return std::make_shared<EmptyArray>(Identities::none(),
+                                          util::Parameters());
     }
     ContentPtrVec contents;
     for (size_t i = 0;  i < contents_.size();  i++) {
       contents.push_back(contents_[i].get()->snapshot());
     }
-    return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, util::RecordLookupPtr(nullptr), length_);
+    return std::make_shared<RecordArray>(Identities::none(),
+                                         util::Parameters(),
+                                         contents,
+                                         util::RecordLookupPtr(nullptr),
+                                         length_);
   }
 
-  bool TupleBuilder::active() const {
+  bool
+  TupleBuilder::active() const {
     return begun_;
   }
 
-  const BuilderPtr TupleBuilder::null() {
+  const BuilderPtr
+  TupleBuilder::null() {
     if (!begun_) {
       BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
       out.get()->null();
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'null' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+        "called 'null' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
@@ -81,14 +104,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::boolean(bool x) {
+  const BuilderPtr
+  TupleBuilder::boolean(bool x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->boolean(x);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'boolean' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+        "called 'boolean' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
@@ -99,14 +125,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::integer(int64_t x) {
+  const BuilderPtr
+  TupleBuilder::integer(int64_t x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->integer(x);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'integer' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+        "called 'integer' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
@@ -117,14 +146,17 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::real(double x) {
+  const BuilderPtr
+  TupleBuilder::real(double x) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->real(x);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'real' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+        "called 'real' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
@@ -135,17 +167,23 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  TupleBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->string(x, length, encoding);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'string' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+        "called 'string' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->string(x, length, encoding));
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->string(x,
+                                                              length,
+                                                              encoding));
     }
     else {
       contents_[(size_t)nextindex_].get()->string(x, length, encoding);
@@ -153,17 +191,21 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::beginlist() {
+  const BuilderPtr
+  TupleBuilder::beginlist() {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginlist();
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'beginlist' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+        "called 'beginlist' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->beginlist());
     }
     else {
       contents_[(size_t)nextindex_].get()->beginlist();
@@ -171,12 +213,16 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::endlist() {
+  const BuilderPtr
+  TupleBuilder::endlist() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endlist' without 'beginlist' at the same level before it");
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'endlist' immediately after 'begintuple'; needs 'index' or 'endtuple' and then 'beginlist'");
+      throw std::invalid_argument(
+        "called 'endlist' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple' and then 'beginlist'");
     }
     else {
       contents_[(size_t)nextindex_].get()->endlist();
@@ -184,7 +230,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  TupleBuilder::begintuple(int64_t numfields) {
     if (length_ == -1) {
       for (int64_t i = 0;  i < numfields;  i++) {
         contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
@@ -202,10 +249,13 @@ namespace awkward {
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'begintuple' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+        "called 'begintuple' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->begintuple(numfields));
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->begintuple(numfields));
     }
     else {
       contents_[(size_t)nextindex_].get()->begintuple(numfields);
@@ -213,11 +263,14 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::index(int64_t index) {
+  const BuilderPtr
+  TupleBuilder::index(int64_t index) {
     if (!begun_) {
-      throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+      "called 'index' without 'begintuple' at the same level before it");
     }
-    else if (nextindex_ == -1  ||  !contents_[(size_t)nextindex_].get()->active()) {
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
       nextindex_ = index;
     }
     else {
@@ -226,17 +279,22 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::endtuple() {
+  const BuilderPtr
+  TupleBuilder::endtuple() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+      "called 'endtuple' without 'begintuple' at the same level before it");
     }
-    else if (nextindex_ == -1  ||  !contents_[(size_t)nextindex_].get()->active()) {
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
       for (size_t i = 0;  i < contents_.size();  i++) {
         if (contents_[i].get()->length() == length_) {
           maybeupdate(i, contents_[i].get()->null());
         }
         if (contents_[i].get()->length() != length_ + 1) {
-          throw std::invalid_argument(std::string("tuple index ") + std::to_string(i) + std::string(" filled more than once"));
+          throw std::invalid_argument(
+            std::string("tuple index ") + std::to_string(i)
+            + std::string(" filled more than once"));
         }
       }
       length_++;
@@ -248,17 +306,22 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  TupleBuilder::beginrecord(const char* name, bool check) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginrecord(name, check);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'beginrecord' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+      "called 'beginrecord' immediately after 'begintuple'; "
+      "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginrecord(name, check));
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->beginrecord(name, check)
+                  );
     }
     else {
       contents_[(size_t)nextindex_].get()->beginrecord(name, check);
@@ -266,12 +329,16 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::field(const char* key, bool check) {
+  const BuilderPtr
+  TupleBuilder::field(const char* key, bool check) {
     if (!begun_) {
-      throw std::invalid_argument("called 'field_fast' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+      "called 'field_fast' without 'beginrecord' at the same level before it");
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'field_fast' immediately after 'begintuple'; needs 'index' or 'endtuple' and then 'beginrecord'");
+      throw std::invalid_argument(
+      "called 'field_fast' immediately after 'begintuple'; "
+      "needs 'index' or 'endtuple' and then 'beginrecord'");
     }
     else {
       contents_[(size_t)nextindex_].get()->field(key, check);
@@ -279,12 +346,16 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::endrecord() {
+  const BuilderPtr
+  TupleBuilder::endrecord() {
     if (!begun_) {
-      throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+      "called 'endrecord' without 'beginrecord' at the same level before it");
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'endrecord' immediately after 'begintuple'; needs 'index' or 'endtuple' and then 'beginrecord'");
+      throw std::invalid_argument(
+        "called 'endrecord' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple' and then 'beginrecord'");
     }
     else {
       contents_[(size_t)nextindex_].get()->endrecord();
@@ -292,17 +363,21 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr TupleBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  TupleBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
     else if (nextindex_ == -1) {
-      throw std::invalid_argument("called 'append' immediately after 'begintuple'; needs 'index' or 'endtuple'");
+      throw std::invalid_argument(
+        "called 'append' immediately after 'begintuple'; "
+        "needs 'index' or 'endtuple'");
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->append(array, at));
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->append(array, at));
     }
     else {
       contents_[(size_t)nextindex_].get()->append(array, at);
@@ -310,7 +385,8 @@ namespace awkward {
     return that_;
   }
 
-  void TupleBuilder::maybeupdate(int64_t i, const BuilderPtr& tmp) {
+  void
+  TupleBuilder::maybeupdate(int64_t i, const BuilderPtr& tmp) {
     if (tmp.get() != contents_[(size_t)i].get()) {
       contents_[(size_t)i] = tmp;
     }

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -48,7 +48,7 @@ namespace awkward {
     nextindex_ = -1;
   }
 
-  const std::shared_ptr<Content> TupleBuilder::snapshot() const {
+  ContentPtr TupleBuilder::snapshot() const {
     if (length_ == -1) {
       return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
     }
@@ -292,7 +292,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> TupleBuilder::append(ContentPtr& array, int64_t at) {
     if (!begun_) {
       std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -14,13 +14,13 @@
 #include "awkward/builder/TupleBuilder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> TupleBuilder::fromempty(const ArrayBuilderOptions& options) {
-    std::shared_ptr<Builder> out = std::make_shared<TupleBuilder>(options, std::vector<std::shared_ptr<Builder>>(), -1, false, -1);
+  const BuilderPtr TupleBuilder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out = std::make_shared<TupleBuilder>(options, std::vector<BuilderPtr>(), -1, false, -1);
     out.get()->setthat(out);
     return out;
   }
 
-  TupleBuilder::TupleBuilder(const ArrayBuilderOptions& options, const std::vector<std::shared_ptr<Builder>>& contents, int64_t length, bool begun, size_t nextindex)
+  TupleBuilder::TupleBuilder(const ArrayBuilderOptions& options, const std::vector<BuilderPtr>& contents, int64_t length, bool begun, size_t nextindex)
       : options_(options)
       , contents_(contents)
       , length_(length)
@@ -56,16 +56,16 @@ namespace awkward {
     for (size_t i = 0;  i < contents_.size();  i++) {
       contents.push_back(contents_[i].get()->snapshot());
     }
-    return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, std::shared_ptr<util::RecordLookup>(nullptr), length_);
+    return std::make_shared<RecordArray>(Identities::none(), util::Parameters(), contents, util::RecordLookupPtr(nullptr), length_);
   }
 
   bool TupleBuilder::active() const {
     return begun_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::null() {
+  const BuilderPtr TupleBuilder::null() {
     if (!begun_) {
-      std::shared_ptr<Builder> out = OptionBuilder::fromvalids(options_, that_);
+      BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
       out.get()->null();
       return out;
     }
@@ -81,9 +81,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::boolean(bool x) {
+  const BuilderPtr TupleBuilder::boolean(bool x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->boolean(x);
       return out;
     }
@@ -99,9 +99,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::integer(int64_t x) {
+  const BuilderPtr TupleBuilder::integer(int64_t x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->integer(x);
       return out;
     }
@@ -117,9 +117,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::real(double x) {
+  const BuilderPtr TupleBuilder::real(double x) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->real(x);
       return out;
     }
@@ -135,9 +135,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr TupleBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->string(x, length, encoding);
       return out;
     }
@@ -153,9 +153,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::beginlist() {
+  const BuilderPtr TupleBuilder::beginlist() {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginlist();
       return out;
     }
@@ -171,7 +171,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::endlist() {
+  const BuilderPtr TupleBuilder::endlist() {
     if (!begun_) {
       throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
     }
@@ -184,10 +184,10 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr TupleBuilder::begintuple(int64_t numfields) {
     if (length_ == -1) {
       for (int64_t i = 0;  i < numfields;  i++) {
-        contents_.push_back(std::shared_ptr<Builder>(UnknownBuilder::fromempty(options_)));
+        contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
       }
       length_ = 0;
     }
@@ -197,7 +197,7 @@ namespace awkward {
       nextindex_ = -1;
     }
     else if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->begintuple(numfields);
       return out;
     }
@@ -213,7 +213,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::index(int64_t index) {
+  const BuilderPtr TupleBuilder::index(int64_t index) {
     if (!begun_) {
       throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
     }
@@ -226,7 +226,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::endtuple() {
+  const BuilderPtr TupleBuilder::endtuple() {
     if (!begun_) {
       throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
     }
@@ -248,9 +248,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr TupleBuilder::beginrecord(const char* name, bool check) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->beginrecord(name, check);
       return out;
     }
@@ -266,7 +266,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::field(const char* key, bool check) {
+  const BuilderPtr TupleBuilder::field(const char* key, bool check) {
     if (!begun_) {
       throw std::invalid_argument("called 'field_fast' without 'beginrecord' at the same level before it");
     }
@@ -279,7 +279,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::endrecord() {
+  const BuilderPtr TupleBuilder::endrecord() {
     if (!begun_) {
       throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
     }
@@ -292,9 +292,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> TupleBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr TupleBuilder::append(const ContentPtr& array, int64_t at) {
     if (!begun_) {
-      std::shared_ptr<Builder> out = UnionBuilder::fromsingle(options_, that_);
+      BuilderPtr out = UnionBuilder::fromsingle(options_, that_);
       out.get()->append(array, at);
       return out;
     }
@@ -310,7 +310,7 @@ namespace awkward {
     return that_;
   }
 
-  void TupleBuilder::maybeupdate(int64_t i, const std::shared_ptr<Builder>& tmp) {
+  void TupleBuilder::maybeupdate(int64_t i, const BuilderPtr& tmp) {
     if (tmp.get() != contents_[(size_t)i].get()) {
       contents_[(size_t)i] = tmp;
     }

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -368,7 +368,8 @@ namespace awkward {
   UnionBuilder::endrecord() {
     if (current_ == -1) {
       throw std::invalid_argument(
-        "called 'endrecord' without 'beginrecord' at the same level before it");
+        "called 'endrecord' without 'beginrecord' at the same level "
+        "before it");
     }
     else {
       int64_t length = contents_[(size_t)current_].get()->length();

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -54,7 +54,7 @@ namespace awkward {
   const ContentPtr UnionBuilder::snapshot() const {
     Index8 tags(types_.ptr(), 0, types_.length());
     Index64 index(offsets_.ptr(), 0, offsets_.length());
-    std::vector<ContentPtr> contents;
+    ContentPtrVec contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->snapshot());
     }

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -19,16 +19,16 @@
 #include "awkward/builder/UnionBuilder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> UnionBuilder::fromsingle(const ArrayBuilderOptions& options, const std::shared_ptr<Builder>& firstcontent) {
+  const BuilderPtr UnionBuilder::fromsingle(const ArrayBuilderOptions& options, const BuilderPtr& firstcontent) {
     GrowableBuffer<int8_t> types = GrowableBuffer<int8_t>::full(options, 0, firstcontent->length());
     GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::arange(options, firstcontent->length());
-    std::vector<std::shared_ptr<Builder>> contents({ firstcontent });
-    std::shared_ptr<Builder> out = std::make_shared<UnionBuilder>(options, types, offsets, contents);
+    std::vector<BuilderPtr> contents({ firstcontent });
+    BuilderPtr out = std::make_shared<UnionBuilder>(options, types, offsets, contents);
     out.get()->setthat(out);
     return out;
   }
 
-  UnionBuilder::UnionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int8_t>& types, const GrowableBuffer<int64_t>& offsets, std::vector<std::shared_ptr<Builder>>& contents)
+  UnionBuilder::UnionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int8_t>& types, const GrowableBuffer<int64_t>& offsets, std::vector<BuilderPtr>& contents)
       : options_(options)
       , types_(types)
       , offsets_(offsets)
@@ -65,9 +65,9 @@ namespace awkward {
     return current_ != -1;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::null() {
+  const BuilderPtr UnionBuilder::null() {
     if (current_ == -1) {
-      std::shared_ptr<Builder> out = OptionBuilder::fromvalids(options_, that_);
+      BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
       out.get()->null();
       return out;
     }
@@ -77,9 +77,9 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::boolean(bool x) {
+  const BuilderPtr UnionBuilder::boolean(bool x) {
     if (current_ == -1) {
-      std::shared_ptr<Builder> tofill(nullptr);
+      BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (dynamic_cast<BoolBuilder*>(content.get()) != nullptr) {
@@ -103,9 +103,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::integer(int64_t x) {
+  const BuilderPtr UnionBuilder::integer(int64_t x) {
     if (current_ == -1) {
-      std::shared_ptr<Builder> tofill(nullptr);
+      BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (dynamic_cast<Int64Builder*>(content.get()) != nullptr) {
@@ -129,9 +129,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::real(double x) {
+  const BuilderPtr UnionBuilder::real(double x) {
     if (current_ == -1) {
-      std::shared_ptr<Builder> tofill(nullptr);
+      BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (dynamic_cast<Float64Builder*>(content.get()) != nullptr) {
@@ -169,9 +169,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr UnionBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (current_ == -1) {
-      std::shared_ptr<Builder> tofill(nullptr);
+      BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (StringBuilder* raw = dynamic_cast<StringBuilder*>(content.get())) {
@@ -197,9 +197,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::beginlist() {
+  const BuilderPtr UnionBuilder::beginlist() {
     if (current_ == -1) {
-      std::shared_ptr<Builder> tofill(nullptr);
+      BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (dynamic_cast<ListBuilder*>(content.get()) != nullptr) {
@@ -221,7 +221,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::endlist() {
+  const BuilderPtr UnionBuilder::endlist() {
     if (current_ == -1) {
       throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
     }
@@ -237,9 +237,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr UnionBuilder::begintuple(int64_t numfields) {
     if (current_ == -1) {
-      std::shared_ptr<Builder> tofill(nullptr);
+      BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (TupleBuilder* raw = dynamic_cast<TupleBuilder*>(content.get())) {
@@ -263,7 +263,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::index(int64_t index) {
+  const BuilderPtr UnionBuilder::index(int64_t index) {
     if (current_ == -1) {
       throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
     }
@@ -273,7 +273,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::endtuple() {
+  const BuilderPtr UnionBuilder::endtuple() {
     if (current_ == -1) {
       throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
     }
@@ -289,9 +289,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr UnionBuilder::beginrecord(const char* name, bool check) {
     if (current_ == -1) {
-      std::shared_ptr<Builder> tofill(nullptr);
+      BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (RecordBuilder* raw = dynamic_cast<RecordBuilder*>(content.get())) {
@@ -315,7 +315,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::field(const char* key, bool check) {
+  const BuilderPtr UnionBuilder::field(const char* key, bool check) {
     if (current_ == -1) {
       throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
     }
@@ -325,7 +325,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::endrecord() {
+  const BuilderPtr UnionBuilder::endrecord() {
     if (current_ == -1) {
       throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
     }
@@ -341,9 +341,9 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr UnionBuilder::append(const ContentPtr& array, int64_t at) {
     if (current_ == -1) {
-      std::shared_ptr<Builder> tofill(nullptr);
+      BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (IndexedGenericBuilder* raw = dynamic_cast<IndexedGenericBuilder*>(content.get())) {

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -19,31 +19,44 @@
 #include "awkward/builder/UnionBuilder.h"
 
 namespace awkward {
-  const BuilderPtr UnionBuilder::fromsingle(const ArrayBuilderOptions& options, const BuilderPtr& firstcontent) {
-    GrowableBuffer<int8_t> types = GrowableBuffer<int8_t>::full(options, 0, firstcontent->length());
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::arange(options, firstcontent->length());
+  const BuilderPtr
+  UnionBuilder::fromsingle(const ArrayBuilderOptions& options,
+                           const BuilderPtr& firstcontent) {
+    GrowableBuffer<int8_t> types =
+      GrowableBuffer<int8_t>::full(options, 0, firstcontent->length());
+    GrowableBuffer<int64_t> offsets =
+      GrowableBuffer<int64_t>::arange(options, firstcontent->length());
     std::vector<BuilderPtr> contents({ firstcontent });
-    BuilderPtr out = std::make_shared<UnionBuilder>(options, types, offsets, contents);
+    BuilderPtr out = std::make_shared<UnionBuilder>(options,
+                                                    types,
+                                                    offsets,
+                                                    contents);
     out.get()->setthat(out);
     return out;
   }
 
-  UnionBuilder::UnionBuilder(const ArrayBuilderOptions& options, const GrowableBuffer<int8_t>& types, const GrowableBuffer<int64_t>& offsets, std::vector<BuilderPtr>& contents)
+  UnionBuilder::UnionBuilder(const ArrayBuilderOptions& options,
+                             const GrowableBuffer<int8_t>& types,
+                             const GrowableBuffer<int64_t>& offsets,
+                             std::vector<BuilderPtr>& contents)
       : options_(options)
       , types_(types)
       , offsets_(offsets)
       , contents_(contents)
       , current_(-1) { }
 
-  const std::string UnionBuilder::classname() const {
+  const std::string
+  UnionBuilder::classname() const {
     return "UnionBuilder";
   };
 
-  int64_t UnionBuilder::length() const {
+  int64_t
+  UnionBuilder::length() const {
     return types_.length();
   }
 
-  void UnionBuilder::clear() {
+  void
+  UnionBuilder::clear() {
     types_.clear();
     offsets_.clear();
     for (auto x : contents_) {
@@ -51,21 +64,28 @@ namespace awkward {
     }
   }
 
-  const ContentPtr UnionBuilder::snapshot() const {
+  const ContentPtr
+  UnionBuilder::snapshot() const {
     Index8 tags(types_.ptr(), 0, types_.length());
     Index64 index(offsets_.ptr(), 0, offsets_.length());
     ContentPtrVec contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->snapshot());
     }
-    return std::make_shared<UnionArray8_64>(Identities::none(), util::Parameters(), tags, index, contents);
+    return std::make_shared<UnionArray8_64>(Identities::none(),
+                                            util::Parameters(),
+                                            tags,
+                                            index,
+                                            contents);
   }
 
-  bool UnionBuilder::active() const {
+  bool
+  UnionBuilder::active() const {
     return current_ != -1;
   }
 
-  const BuilderPtr UnionBuilder::null() {
+  const BuilderPtr
+  UnionBuilder::null() {
     if (current_ == -1) {
       BuilderPtr out = OptionBuilder::fromvalids(options_, that_);
       out.get()->null();
@@ -77,7 +97,8 @@ namespace awkward {
     }
   }
 
-  const BuilderPtr UnionBuilder::boolean(bool x) {
+  const BuilderPtr
+  UnionBuilder::boolean(bool x) {
     if (current_ == -1) {
       BuilderPtr tofill(nullptr);
       int8_t i = 0;
@@ -103,7 +124,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::integer(int64_t x) {
+  const BuilderPtr
+  UnionBuilder::integer(int64_t x) {
     if (current_ == -1) {
       BuilderPtr tofill(nullptr);
       int8_t i = 0;
@@ -129,7 +151,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::real(double x) {
+  const BuilderPtr
+  UnionBuilder::real(double x) {
     if (current_ == -1) {
       BuilderPtr tofill(nullptr);
       int8_t i = 0;
@@ -150,7 +173,9 @@ namespace awkward {
           i++;
         }
         if (tofill.get() != nullptr) {
-          tofill = Float64Builder::fromint64(options_, dynamic_cast<Int64Builder*>(tofill.get())->buffer());
+          tofill = Float64Builder::fromint64(
+            options_,
+            dynamic_cast<Int64Builder*>(tofill.get())->buffer());
           contents_[(size_t)i] = tofill;
         }
         else {
@@ -169,7 +194,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  UnionBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (current_ == -1) {
       BuilderPtr tofill(nullptr);
       int8_t i = 0;
@@ -197,7 +223,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::beginlist() {
+  const BuilderPtr
+  UnionBuilder::beginlist() {
     if (current_ == -1) {
       BuilderPtr tofill(nullptr);
       int8_t i = 0;
@@ -221,9 +248,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::endlist() {
+  const BuilderPtr
+  UnionBuilder::endlist() {
     if (current_ == -1) {
-      throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endlist' without 'beginlist' at the same level before it");
     }
     else {
       int64_t length = contents_[(size_t)current_].get()->length();
@@ -237,7 +266,8 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  UnionBuilder::begintuple(int64_t numfields) {
     if (current_ == -1) {
       BuilderPtr tofill(nullptr);
       int8_t i = 0;
@@ -263,9 +293,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::index(int64_t index) {
+  const BuilderPtr
+  UnionBuilder::index(int64_t index) {
     if (current_ == -1) {
-      throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+        "called 'index' without 'begintuple' at the same level before it");
     }
     else {
       contents_[(size_t)current_].get()->index(index);
@@ -273,9 +305,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::endtuple() {
+  const BuilderPtr
+  UnionBuilder::endtuple() {
     if (current_ == -1) {
-      throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endtuple' without 'begintuple' at the same level before it");
     }
     else {
       int64_t length = contents_[(size_t)current_].get()->length();
@@ -289,13 +323,16 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  UnionBuilder::beginrecord(const char* name, bool check) {
     if (current_ == -1) {
       BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
         if (RecordBuilder* raw = dynamic_cast<RecordBuilder*>(content.get())) {
-          if (raw->length() == -1  ||  ((check  &&  raw->name() == name)  ||  (!check  &&  raw->nameptr() == name))) {
+          if (raw->length() == -1  ||
+              ((check  &&  raw->name() == name)  ||
+               (!check  &&  raw->nameptr() == name))) {
             tofill = content;
             break;
           }
@@ -315,9 +352,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::field(const char* key, bool check) {
+  const BuilderPtr
+  UnionBuilder::field(const char* key, bool check) {
     if (current_ == -1) {
-      throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'field' without 'beginrecord' at the same level before it");
     }
     else {
       contents_[(size_t)current_].get()->field(key, check);
@@ -325,9 +364,11 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::endrecord() {
+  const BuilderPtr
+  UnionBuilder::endrecord() {
     if (current_ == -1) {
-      throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+      throw std::invalid_argument(
+        "called 'endrecord' without 'beginrecord' at the same level before it");
     }
     else {
       int64_t length = contents_[(size_t)current_].get()->length();
@@ -341,42 +382,49 @@ namespace awkward {
     return that_;
   }
 
-  const BuilderPtr UnionBuilder::append(const ContentPtr& array, int64_t at) {
+  const BuilderPtr
+  UnionBuilder::append(const ContentPtr& array, int64_t at) {
     if (current_ == -1) {
       BuilderPtr tofill(nullptr);
       int8_t i = 0;
       for (auto content : contents_) {
-        if (IndexedGenericBuilder* raw = dynamic_cast<IndexedGenericBuilder*>(content.get())) {
+        if (IndexedGenericBuilder* raw =
+            dynamic_cast<IndexedGenericBuilder*>(content.get())) {
           if (raw->arrayptr() == array.get()) {
             tofill = content;
             break;
           }
         }
-        else if (IndexedI32Builder* raw = dynamic_cast<IndexedI32Builder*>(content.get())) {
+        else if (IndexedI32Builder* raw =
+                 dynamic_cast<IndexedI32Builder*>(content.get())) {
           if (raw->arrayptr() == array.get()) {
             tofill = content;
             break;
           }
         }
-        else if (IndexedIU32Builder* raw = dynamic_cast<IndexedIU32Builder*>(content.get())) {
+        else if (IndexedIU32Builder* raw =
+                 dynamic_cast<IndexedIU32Builder*>(content.get())) {
           if (raw->arrayptr() == array.get()) {
             tofill = content;
             break;
           }
         }
-        else if (IndexedI64Builder* raw = dynamic_cast<IndexedI64Builder*>(content.get())) {
+        else if (IndexedI64Builder* raw =
+                 dynamic_cast<IndexedI64Builder*>(content.get())) {
           if (raw->arrayptr() == array.get()) {
             tofill = content;
             break;
           }
         }
-        else if (IndexedIO32Builder* raw = dynamic_cast<IndexedIO32Builder*>(content.get())) {
+        else if (IndexedIO32Builder* raw =
+                 dynamic_cast<IndexedIO32Builder*>(content.get())) {
           if (raw->arrayptr() == array.get()) {
             tofill = content;
             break;
           }
         }
-        else if (IndexedIO64Builder* raw = dynamic_cast<IndexedIO64Builder*>(content.get())) {
+        else if (IndexedIO64Builder* raw =
+                 dynamic_cast<IndexedIO64Builder*>(content.get())) {
           if (raw->arrayptr() == array.get()) {
             tofill = content;
             break;

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -51,10 +51,10 @@ namespace awkward {
     }
   }
 
-  ContentPtr UnionBuilder::snapshot() const {
+  const ContentPtr UnionBuilder::snapshot() const {
     Index8 tags(types_.ptr(), 0, types_.length());
     Index64 index(offsets_.ptr(), 0, offsets_.length());
-    std::vector<std::shared_ptr<Content>> contents;
+    std::vector<ContentPtr> contents;
     for (auto content : contents_) {
       contents.push_back(content.get()->snapshot());
     }
@@ -341,7 +341,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> UnionBuilder::append(const ContentPtr& array, int64_t at) {
     if (current_ == -1) {
       std::shared_ptr<Builder> tofill(nullptr);
       int8_t i = 0;

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -51,7 +51,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> UnionBuilder::snapshot() const {
+  ContentPtr UnionBuilder::snapshot() const {
     Index8 tags(types_.ptr(), 0, types_.length());
     Index64 index(offsets_.ptr(), 0, offsets_.length());
     std::vector<std::shared_ptr<Content>> contents;
@@ -341,7 +341,7 @@ namespace awkward {
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnionBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> UnionBuilder::append(ContentPtr& array, int64_t at) {
     if (current_ == -1) {
       std::shared_ptr<Builder> tofill(nullptr);
       int8_t i = 0;

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -20,7 +20,8 @@
 #include "awkward/builder/UnknownBuilder.h"
 
 namespace awkward {
-  const BuilderPtr UnknownBuilder::fromempty(const ArrayBuilderOptions& options) {
+  const BuilderPtr
+  UnknownBuilder::fromempty(const ArrayBuilderOptions& options) {
     BuilderPtr out = std::make_shared<UnknownBuilder>(options, 0);
     out.get()->setthat(out);
     return out;
@@ -30,43 +31,56 @@ namespace awkward {
       : options_(options)
       , nullcount_(nullcount) { }
 
-  const std::string UnknownBuilder::classname() const {
+  const std::string
+  UnknownBuilder::classname() const {
     return "UnknownBuilder";
   };
 
-  int64_t UnknownBuilder::length() const {
+  int64_t
+  UnknownBuilder::length() const {
     return nullcount_;
   }
 
-  void UnknownBuilder::clear() {
+  void
+  UnknownBuilder::clear() {
     nullcount_ = 0;
   }
 
-  const ContentPtr UnknownBuilder::snapshot() const {
+  const ContentPtr
+  UnknownBuilder::snapshot() const {
     if (nullcount_ == 0) {
-      return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
+      return std::make_shared<EmptyArray>(Identities::none(),
+                                          util::Parameters());
     }
     else {
-      // This is the only snapshot that is O(N), rather than O(1), but it is unusual (array of only None).
+      // This is the only snapshot that is O(N), rather than O(1),
+      // but it is a corner case (array of only Nones).
       Index64 index(nullcount_);
       int64_t* rawptr = index.ptr().get();
       for (int64_t i = 0;  i < nullcount_;  i++) {
         rawptr[i] = -1;
       }
-      return std::make_shared<IndexedOptionArray64>(Identities::none(), util::Parameters(), index, std::make_shared<EmptyArray>(Identities::none(), util::Parameters()));
+      return std::make_shared<IndexedOptionArray64>(
+        Identities::none(),
+        util::Parameters(),
+        index,
+        std::make_shared<EmptyArray>(Identities::none(), util::Parameters()));
     }
   }
 
-  bool UnknownBuilder::active() const {
+  bool
+  UnknownBuilder::active() const {
     return false;
   }
 
-  const BuilderPtr UnknownBuilder::null() {
+  const BuilderPtr
+  UnknownBuilder::null() {
     nullcount_++;
     return that_;
   }
 
-  const BuilderPtr UnknownBuilder::boolean(bool x) {
+  const BuilderPtr
+  UnknownBuilder::boolean(bool x) {
     BuilderPtr out = BoolBuilder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
@@ -75,7 +89,8 @@ namespace awkward {
     return out;
   }
 
-  const BuilderPtr UnknownBuilder::integer(int64_t x) {
+  const BuilderPtr
+  UnknownBuilder::integer(int64_t x) {
     BuilderPtr out = Int64Builder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
@@ -84,7 +99,8 @@ namespace awkward {
     return out;
   }
 
-  const BuilderPtr UnknownBuilder::real(double x) {
+  const BuilderPtr
+  UnknownBuilder::real(double x) {
     BuilderPtr out = Float64Builder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
@@ -93,7 +109,8 @@ namespace awkward {
     return out;
   }
 
-  const BuilderPtr UnknownBuilder::string(const char* x, int64_t length, const char* encoding) {
+  const BuilderPtr
+  UnknownBuilder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = StringBuilder::fromempty(options_, encoding);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
@@ -102,7 +119,8 @@ namespace awkward {
     return out;
   }
 
-  const BuilderPtr UnknownBuilder::beginlist() {
+  const BuilderPtr
+  UnknownBuilder::beginlist() {
     BuilderPtr out = ListBuilder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
@@ -111,11 +129,14 @@ namespace awkward {
     return out;
   }
 
-  const BuilderPtr UnknownBuilder::endlist() {
-    throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
+  const BuilderPtr
+  UnknownBuilder::endlist() {
+    throw std::invalid_argument(
+      "called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const BuilderPtr UnknownBuilder::begintuple(int64_t numfields) {
+  const BuilderPtr
+  UnknownBuilder::begintuple(int64_t numfields) {
     BuilderPtr out = TupleBuilder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
@@ -124,15 +145,20 @@ namespace awkward {
     return out;
   }
 
-  const BuilderPtr UnknownBuilder::index(int64_t index) {
-    throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  UnknownBuilder::index(int64_t index) {
+    throw std::invalid_argument(
+      "called 'index' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr UnknownBuilder::endtuple() {
-    throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
+  const BuilderPtr
+  UnknownBuilder::endtuple() {
+    throw std::invalid_argument(
+      "called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const BuilderPtr UnknownBuilder::beginrecord(const char* name, bool check) {
+  const BuilderPtr
+  UnknownBuilder::beginrecord(const char* name, bool check) {
     BuilderPtr out = RecordBuilder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
@@ -141,16 +167,23 @@ namespace awkward {
     return out;
   }
 
-  const BuilderPtr UnknownBuilder::field(const char* key, bool check) {
-    throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  UnknownBuilder::field(const char* key, bool check) {
+    throw std::invalid_argument(
+      "called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr UnknownBuilder::endrecord() {
-    throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
+  const BuilderPtr
+  UnknownBuilder::endrecord() {
+    throw std::invalid_argument(
+      "called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const BuilderPtr UnknownBuilder::append(const ContentPtr& array, int64_t at) {
-    BuilderPtr out = IndexedGenericBuilder::fromnulls(options_, nullcount_, array);
+  const BuilderPtr
+  UnknownBuilder::append(const ContentPtr& array, int64_t at) {
+    BuilderPtr out = IndexedGenericBuilder::fromnulls(options_,
+                                                      nullcount_,
+                                                      array);
     out.get()->append(array, at);
     return out;
   }

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -42,7 +42,7 @@ namespace awkward {
     nullcount_ = 0;
   }
 
-  ContentPtr UnknownBuilder::snapshot() const {
+  const ContentPtr UnknownBuilder::snapshot() const {
     if (nullcount_ == 0) {
       return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
     }
@@ -149,7 +149,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::append(ContentPtr& array, int64_t at) {
+  const std::shared_ptr<Builder> UnknownBuilder::append(const ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = IndexedGenericBuilder::fromnulls(options_, nullcount_, array);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -20,8 +20,8 @@
 #include "awkward/builder/UnknownBuilder.h"
 
 namespace awkward {
-  const std::shared_ptr<Builder> UnknownBuilder::fromempty(const ArrayBuilderOptions& options) {
-    std::shared_ptr<Builder> out = std::make_shared<UnknownBuilder>(options, 0);
+  const BuilderPtr UnknownBuilder::fromempty(const ArrayBuilderOptions& options) {
+    BuilderPtr out = std::make_shared<UnknownBuilder>(options, 0);
     out.get()->setthat(out);
     return out;
   }
@@ -61,13 +61,13 @@ namespace awkward {
     return false;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::null() {
+  const BuilderPtr UnknownBuilder::null() {
     nullcount_++;
     return that_;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::boolean(bool x) {
-    std::shared_ptr<Builder> out = BoolBuilder::fromempty(options_);
+  const BuilderPtr UnknownBuilder::boolean(bool x) {
+    BuilderPtr out = BoolBuilder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
@@ -75,8 +75,8 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::integer(int64_t x) {
-    std::shared_ptr<Builder> out = Int64Builder::fromempty(options_);
+  const BuilderPtr UnknownBuilder::integer(int64_t x) {
+    BuilderPtr out = Int64Builder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
@@ -84,8 +84,8 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::real(double x) {
-    std::shared_ptr<Builder> out = Float64Builder::fromempty(options_);
+  const BuilderPtr UnknownBuilder::real(double x) {
+    BuilderPtr out = Float64Builder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
@@ -93,8 +93,8 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::string(const char* x, int64_t length, const char* encoding) {
-    std::shared_ptr<Builder> out = StringBuilder::fromempty(options_, encoding);
+  const BuilderPtr UnknownBuilder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = StringBuilder::fromempty(options_, encoding);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
@@ -102,8 +102,8 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::beginlist() {
-    std::shared_ptr<Builder> out = ListBuilder::fromempty(options_);
+  const BuilderPtr UnknownBuilder::beginlist() {
+    BuilderPtr out = ListBuilder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
@@ -111,12 +111,12 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::endlist() {
+  const BuilderPtr UnknownBuilder::endlist() {
     throw std::invalid_argument("called 'endlist' without 'beginlist' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::begintuple(int64_t numfields) {
-    std::shared_ptr<Builder> out = TupleBuilder::fromempty(options_);
+  const BuilderPtr UnknownBuilder::begintuple(int64_t numfields) {
+    BuilderPtr out = TupleBuilder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
@@ -124,16 +124,16 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::index(int64_t index) {
+  const BuilderPtr UnknownBuilder::index(int64_t index) {
     throw std::invalid_argument("called 'index' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::endtuple() {
+  const BuilderPtr UnknownBuilder::endtuple() {
     throw std::invalid_argument("called 'endtuple' without 'begintuple' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::beginrecord(const char* name, bool check) {
-    std::shared_ptr<Builder> out = RecordBuilder::fromempty(options_);
+  const BuilderPtr UnknownBuilder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = RecordBuilder::fromempty(options_);
     if (nullcount_ != 0) {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
@@ -141,16 +141,16 @@ namespace awkward {
     return out;
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::field(const char* key, bool check) {
+  const BuilderPtr UnknownBuilder::field(const char* key, bool check) {
     throw std::invalid_argument("called 'field' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::endrecord() {
+  const BuilderPtr UnknownBuilder::endrecord() {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::append(const ContentPtr& array, int64_t at) {
-    std::shared_ptr<Builder> out = IndexedGenericBuilder::fromnulls(options_, nullcount_, array);
+  const BuilderPtr UnknownBuilder::append(const ContentPtr& array, int64_t at) {
+    BuilderPtr out = IndexedGenericBuilder::fromnulls(options_, nullcount_, array);
     out.get()->append(array, at);
     return out;
   }

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -27,7 +27,8 @@ namespace awkward {
     return out;
   }
 
-  UnknownBuilder::UnknownBuilder(const ArrayBuilderOptions& options, int64_t nullcount)
+  UnknownBuilder::UnknownBuilder(const ArrayBuilderOptions& options,
+                                 int64_t nullcount)
       : options_(options)
       , nullcount_(nullcount) { }
 

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -42,7 +42,7 @@ namespace awkward {
     nullcount_ = 0;
   }
 
-  const std::shared_ptr<Content> UnknownBuilder::snapshot() const {
+  ContentPtr UnknownBuilder::snapshot() const {
     if (nullcount_ == 0) {
       return std::make_shared<EmptyArray>(Identities::none(), util::Parameters());
     }
@@ -149,7 +149,7 @@ namespace awkward {
     throw std::invalid_argument("called 'endrecord' without 'beginrecord' at the same level before it");
   }
 
-  const std::shared_ptr<Builder> UnknownBuilder::append(const std::shared_ptr<Content>& array, int64_t at) {
+  const std::shared_ptr<Builder> UnknownBuilder::append(ContentPtr& array, int64_t at) {
     std::shared_ptr<Builder> out = IndexedGenericBuilder::fromnulls(options_, nullcount_, array);
     out.get()->append(array, at);
     return out;

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -199,7 +199,9 @@ namespace awkward {
   public:
     Impl(FILE* destination, int64_t maxdecimals, int64_t buffersize)
         : buffer_(new char[(size_t)buffersize], util::array_deleter<char>())
-        , stream_(destination, buffer_.get(), ((size_t)buffersize)*sizeof(char))
+        , stream_(destination,
+                  buffer_.get(),
+                  ((size_t)buffersize)*sizeof(char))
         , writer_(stream_) {
       if (maxdecimals >= 0) {
         writer_.SetMaxDecimalPlaces((int)maxdecimals);
@@ -285,7 +287,9 @@ namespace awkward {
   public:
     Impl(FILE* destination, int64_t maxdecimals, int64_t buffersize)
         : buffer_(new char[(size_t)buffersize], util::array_deleter<char>())
-        , stream_(destination, buffer_.get(), ((size_t)buffersize)*sizeof(char))
+        , stream_(destination,
+                  buffer_.get(),
+                  ((size_t)buffersize)*sizeof(char))
         , writer_(stream_) {
       if (maxdecimals >= 0) {
         writer_.SetMaxDecimalPlaces((int)maxdecimals);

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -326,7 +326,7 @@ namespace awkward {
   public:
     Handler(const ArrayBuilderOptions& options): builder_(options), depth_(0) { }
 
-    ContentPtr snapshot() const {
+    const ContentPtr snapshot() const {
       return builder_.snapshot();
     }
 
@@ -384,7 +384,7 @@ namespace awkward {
     int64_t depth_;
   };
 
-  ContentPtr FromJsonString(const char* source, const ArrayBuilderOptions& options) {
+  const ContentPtr FromJsonString(const char* source, const ArrayBuilderOptions& options) {
     Handler handler(options);
     rj::Reader reader;
     rj::StringStream stream(source);
@@ -396,7 +396,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize) {
+  const ContentPtr FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize) {
     Handler handler(options);
     rj::Reader reader;
     std::shared_ptr<char> buffer(new char[(size_t)buffersize], util::array_deleter<char>());

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -16,7 +16,7 @@
 namespace rj = rapidjson;
 
 namespace awkward {
-  /////////////////////////////////////////////////////// writing to JSON
+  ////////// writing to JSON
 
   class ToJsonString::Impl {
   public:
@@ -29,7 +29,8 @@ namespace awkward {
     void boolean(bool x) { writer_.Bool(x); }
     void integer(int64_t x) { writer_.Int64(x); }
     void real(double x) { writer_.Double(x); }
-    void string(const char* x, int64_t length) { writer_.String(x, (rj::SizeType)length); }
+    void string(const char* x, int64_t length) {
+      writer_.String(x, (rj::SizeType)length); }
     void beginlist() { writer_.StartArray(); }
     void endlist() { writer_.EndArray(); }
     void beginrecord() { writer_.StartObject(); }
@@ -41,7 +42,6 @@ namespace awkward {
   private:
     rj::StringBuffer buffer_;
     rj::Writer<rj::StringBuffer> writer_;
-    // FIXME: rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag
   };
 
   ToJsonString::ToJsonString(int64_t maxdecimals)
@@ -51,51 +51,63 @@ namespace awkward {
     delete impl_;
   }
 
-  void ToJsonString::null() {
+  void
+  ToJsonString::null() {
     impl_->null();
   }
 
-  void ToJsonString::boolean(bool x) {
+  void
+  ToJsonString::boolean(bool x) {
     impl_->boolean(x);
   }
 
-  void ToJsonString::integer(int64_t x) {
+  void
+  ToJsonString::integer(int64_t x) {
     impl_->integer(x);
   }
 
-  void ToJsonString::real(double x) {
+  void
+  ToJsonString::real(double x) {
     impl_->real(x);
   }
 
-  void ToJsonString::string(const char* x, int64_t length) {
+  void
+  ToJsonString::string(const char* x, int64_t length) {
     impl_->string(x, length);
   }
 
-  void ToJsonString::beginlist() {
+  void
+  ToJsonString::beginlist() {
     impl_->beginlist();
   }
 
-  void ToJsonString::endlist() {
+  void
+  ToJsonString::endlist() {
     impl_->endlist();
   }
 
-  void ToJsonString::beginrecord() {
+  void
+  ToJsonString::beginrecord() {
     impl_->beginrecord();
   }
 
-  void ToJsonString::field(const char* x) {
+  void
+  ToJsonString::field(const char* x) {
     impl_->field(x);
   }
 
-  void ToJsonString::endrecord() {
+  void
+  ToJsonString::endrecord() {
     impl_->endrecord();
   }
 
-  const std::string ToJsonString::tostring() {
+  const std::string
+  ToJsonString::tostring() {
     return impl_->tostring();
   }
 
-  class ToJsonPrettyString::Impl {
+  class
+  ToJsonPrettyString::Impl {
   public:
     Impl(int64_t maxdecimals): buffer_(), writer_(buffer_) {
       if (maxdecimals >= 0) {
@@ -106,7 +118,8 @@ namespace awkward {
     void boolean(bool x) { writer_.Bool(x); }
     void integer(int64_t x) { writer_.Int64(x); }
     void real(double x) { writer_.Double(x); }
-    void string(const char* x, int64_t length) { writer_.String(x, (rj::SizeType)length); }
+    void string(const char* x, int64_t length) {
+      writer_.String(x, (rj::SizeType)length); }
     void beginlist() { writer_.StartArray(); }
     void endlist() { writer_.EndArray(); }
     void beginrecord() { writer_.StartObject(); }
@@ -118,7 +131,6 @@ namespace awkward {
   private:
     rj::StringBuffer buffer_;
     rj::PrettyWriter<rj::StringBuffer> writer_;
-    // FIXME: rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag
   };
 
   ToJsonPrettyString::ToJsonPrettyString(int64_t maxdecimals)
@@ -128,47 +140,58 @@ namespace awkward {
     delete impl_;
   }
 
-  void ToJsonPrettyString::null() {
+  void
+  ToJsonPrettyString::null() {
     impl_->null();
   }
 
-  void ToJsonPrettyString::boolean(bool x) {
+  void
+  ToJsonPrettyString::boolean(bool x) {
     impl_->boolean(x);
   }
 
-  void ToJsonPrettyString::integer(int64_t x) {
+  void
+  ToJsonPrettyString::integer(int64_t x) {
     impl_->integer(x);
   }
 
-  void ToJsonPrettyString::real(double x) {
+  void
+  ToJsonPrettyString::real(double x) {
     impl_->real(x);
   }
 
-  void ToJsonPrettyString::string(const char* x, int64_t length) {
+  void
+  ToJsonPrettyString::string(const char* x, int64_t length) {
     impl_->string(x, length);
   }
 
-  void ToJsonPrettyString::beginlist() {
+  void
+  ToJsonPrettyString::beginlist() {
     impl_->beginlist();
   }
 
-  void ToJsonPrettyString::endlist() {
+  void
+  ToJsonPrettyString::endlist() {
     impl_->endlist();
   }
 
-  void ToJsonPrettyString::beginrecord() {
+  void
+  ToJsonPrettyString::beginrecord() {
     impl_->beginrecord();
   }
 
-  void ToJsonPrettyString::field(const char* x) {
+  void
+  ToJsonPrettyString::field(const char* x) {
     impl_->field(x);
   }
 
-  void ToJsonPrettyString::endrecord() {
+  void
+  ToJsonPrettyString::endrecord() {
     impl_->endrecord();
   }
 
-  const std::string ToJsonPrettyString::tostring() {
+  const std::string
+  ToJsonPrettyString::tostring() {
     return impl_->tostring();
   }
 
@@ -186,7 +209,8 @@ namespace awkward {
     void boolean(bool x) { writer_.Bool(x); }
     void integer(int64_t x) { writer_.Int64(x); }
     void real(double x) { writer_.Double(x); }
-    void string(const char* x, int64_t length) { writer_.String(x, (rj::SizeType)length); }
+    void string(const char* x, int64_t length) {
+      writer_.String(x, (rj::SizeType)length); }
     void beginlist() { writer_.StartArray(); }
     void endlist() { writer_.EndArray(); }
     void beginrecord() { writer_.StartObject(); }
@@ -196,53 +220,64 @@ namespace awkward {
     std::shared_ptr<char> buffer_;
     rj::FileWriteStream stream_;
     rj::Writer<rj::FileWriteStream> writer_ ;
-    // FIXME: rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag
   };
 
-  ToJsonFile::ToJsonFile(FILE* destination, int64_t maxdecimals, int64_t buffersize)
+  ToJsonFile::ToJsonFile(FILE* destination,
+                         int64_t maxdecimals,
+                         int64_t buffersize)
       : impl_(new ToJsonFile::Impl(destination, maxdecimals, buffersize)) { }
 
   ToJsonFile::~ToJsonFile() {
     delete impl_;
   }
 
-  void ToJsonFile::null() {
+  void
+  ToJsonFile::null() {
     impl_->null();
   }
 
-  void ToJsonFile::boolean(bool x) {
+  void
+  ToJsonFile::boolean(bool x) {
     impl_->boolean(x);
   }
 
-  void ToJsonFile::integer(int64_t x) {
+  void
+  ToJsonFile::integer(int64_t x) {
     impl_->integer(x);
   }
 
-  void ToJsonFile::real(double x) {
+  void
+  ToJsonFile::real(double x) {
     impl_->real(x);
   }
 
-  void ToJsonFile::string(const char* x, int64_t length) {
+  void
+  ToJsonFile::string(const char* x, int64_t length) {
     impl_->string(x, length);
   }
 
-  void ToJsonFile::beginlist() {
+  void
+  ToJsonFile::beginlist() {
     impl_->beginlist();
   }
 
-  void ToJsonFile::endlist() {
+  void
+  ToJsonFile::endlist() {
     impl_->endlist();
   }
 
-  void ToJsonFile::beginrecord() {
+  void
+  ToJsonFile::beginrecord() {
     impl_->beginrecord();
   }
 
-  void ToJsonFile::field(const char* x) {
+  void
+  ToJsonFile::field(const char* x) {
     impl_->field(x);
   }
 
-  void ToJsonFile::endrecord() {
+  void
+  ToJsonFile::endrecord() {
     impl_->endrecord();
   }
 
@@ -260,7 +295,8 @@ namespace awkward {
     void boolean(bool x) { writer_.Bool(x); }
     void integer(int64_t x) { writer_.Int64(x); }
     void real(double x) { writer_.Double(x); }
-    void string(const char* x, int64_t length) { writer_.String(x, (rj::SizeType)length); }
+    void string(const char* x, int64_t length) {
+      writer_.String(x, (rj::SizeType)length); }
     void beginlist() { writer_.StartArray(); }
     void endlist() { writer_.EndArray(); }
     void beginrecord() { writer_.StartObject(); }
@@ -270,61 +306,76 @@ namespace awkward {
     std::shared_ptr<char> buffer_;
     rj::FileWriteStream stream_;
     rj::PrettyWriter<rj::FileWriteStream> writer_;
-    // FIXME: rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag, rj::UTF8<>, rj::UTF8<>, rj::CrtAllocator<>, rj::kWriteNanAndInfFlag
   };
 
-  ToJsonPrettyFile::ToJsonPrettyFile(FILE* destination, int64_t maxdecimals, int64_t buffersize)
-      : impl_(new ToJsonPrettyFile::Impl(destination, maxdecimals, buffersize)) { }
+  ToJsonPrettyFile::ToJsonPrettyFile(FILE* destination,
+                                     int64_t maxdecimals,
+                                     int64_t buffersize)
+      : impl_(new ToJsonPrettyFile::Impl(destination,
+                                         maxdecimals,
+                                         buffersize)) { }
 
   ToJsonPrettyFile::~ToJsonPrettyFile() {
     delete impl_;
   }
 
-  void ToJsonPrettyFile::null() {
+  void
+  ToJsonPrettyFile::null() {
     impl_->null();
   }
 
-  void ToJsonPrettyFile::boolean(bool x) {
+  void
+  ToJsonPrettyFile::boolean(bool x) {
     impl_->boolean(x);
   }
 
-  void ToJsonPrettyFile::integer(int64_t x) {
+  void
+  ToJsonPrettyFile::integer(int64_t x) {
     impl_->integer(x);
   }
 
-  void ToJsonPrettyFile::real(double x) {
+  void
+  ToJsonPrettyFile::real(double x) {
     impl_->real(x);
   }
 
-  void ToJsonPrettyFile::string(const char* x, int64_t length) {
+  void
+  ToJsonPrettyFile::string(const char* x, int64_t length) {
     impl_->string(x, length);
   }
 
-  void ToJsonPrettyFile::beginlist() {
+  void
+  ToJsonPrettyFile::beginlist() {
     impl_->beginlist();
   }
 
-  void ToJsonPrettyFile::endlist() {
+  void
+  ToJsonPrettyFile::endlist() {
     impl_->endlist();
   }
 
-  void ToJsonPrettyFile::beginrecord() {
+  void
+  ToJsonPrettyFile::beginrecord() {
     impl_->beginrecord();
   }
 
-  void ToJsonPrettyFile::field(const char* x) {
+  void
+  ToJsonPrettyFile::field(const char* x) {
     impl_->field(x);
   }
 
-  void ToJsonPrettyFile::endrecord() {
+  void
+  ToJsonPrettyFile::endrecord() {
     impl_->endrecord();
   }
 
-  /////////////////////////////////////////////////////// reading from JSON
+  ////////// reading from JSON
 
   class Handler: public rj::BaseReaderHandler<rj::UTF8<>, Handler> {
   public:
-    Handler(const ArrayBuilderOptions& options): builder_(options), depth_(0) { }
+    Handler(const ArrayBuilderOptions& options)
+        : builder_(options)
+        , depth_(0) { }
 
     const ContentPtr snapshot() const {
       return builder_.snapshot();
@@ -338,19 +389,23 @@ namespace awkward {
     bool Uint64(uint64_t x)   { builder_.integer((int64_t)x); return true; }
     bool Double(double x)     { builder_.real(x);             return true; }
 
-    bool String(const char* str, rj::SizeType length, bool copy) {
+    bool
+    String(const char* str, rj::SizeType length, bool copy) {
       builder_.string(str, (int64_t)length);
       return true;
     }
 
-    bool StartArray() {
+    bool
+    StartArray() {
       if (depth_ != 0) {
         builder_.beginlist();
       }
       depth_++;
       return true;
     }
-    bool EndArray(rj::SizeType numfields) {
+
+    bool
+    EndArray(rj::SizeType numfields) {
       depth_--;
       if (depth_ != 0) {
         builder_.endlist();
@@ -358,7 +413,8 @@ namespace awkward {
       return true;
     }
 
-    bool StartObject() {
+    bool
+    StartObject() {
       if (depth_ == 0) {
         builder_.beginlist();
       }
@@ -366,7 +422,9 @@ namespace awkward {
       builder_.beginrecord();
       return true;
     }
-    bool EndObject(rj::SizeType numfields) {
+
+    bool
+    EndObject(rj::SizeType numfields) {
       depth_--;
       builder_.endrecord();
       if (depth_ == 0) {
@@ -374,7 +432,9 @@ namespace awkward {
       }
       return true;
     }
-    bool Key(const char* str, rj::SizeType length, bool copy) {
+
+    bool
+    Key(const char* str, rj::SizeType length, bool copy) {
       builder_.field_check(str);
       return true;
     }
@@ -384,7 +444,8 @@ namespace awkward {
     int64_t depth_;
   };
 
-  const ContentPtr FromJsonString(const char* source, const ArrayBuilderOptions& options) {
+  const ContentPtr
+  FromJsonString(const char* source, const ArrayBuilderOptions& options) {
     Handler handler(options);
     rj::Reader reader;
     rj::StringStream stream(source);
@@ -392,20 +453,32 @@ namespace awkward {
       return handler.snapshot();
     }
     else {
-      throw std::invalid_argument(std::string("JSON error at char ") + std::to_string(reader.GetErrorOffset()) + std::string(": ") + std::string(rj::GetParseError_En(reader.GetParseErrorCode())));
+      throw std::invalid_argument(
+        std::string("JSON error at char ")
+        + std::to_string(reader.GetErrorOffset()) + std::string(": ")
+        + std::string(rj::GetParseError_En(reader.GetParseErrorCode())));
     }
   }
 
-  const ContentPtr FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize) {
+  const ContentPtr
+  FromJsonFile(FILE* source,
+               const ArrayBuilderOptions& options,
+               int64_t buffersize) {
     Handler handler(options);
     rj::Reader reader;
-    std::shared_ptr<char> buffer(new char[(size_t)buffersize], util::array_deleter<char>());
-    rj::FileReadStream stream(source, buffer.get(), ((size_t)buffersize)*sizeof(char));
+    std::shared_ptr<char> buffer(new char[(size_t)buffersize],
+                                 util::array_deleter<char>());
+    rj::FileReadStream stream(source,
+                              buffer.get(),
+                              ((size_t)buffersize)*sizeof(char));
     if (reader.Parse(stream, handler)) {
       return handler.snapshot();
     }
     else {
-      throw std::invalid_argument(std::string("JSON error at char ") + std::to_string(reader.GetErrorOffset()) + std::string(": ") + std::string(rj::GetParseError_En(reader.GetParseErrorCode())));
+      throw std::invalid_argument(
+        std::string("JSON error at char ")
+        + std::to_string(reader.GetErrorOffset()) + std::string(": ")
+        + std::string(rj::GetParseError_En(reader.GetParseErrorCode())));
     }
     return handler.snapshot();
   }

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -326,7 +326,7 @@ namespace awkward {
   public:
     Handler(const ArrayBuilderOptions& options): builder_(options), depth_(0) { }
 
-    const std::shared_ptr<Content> snapshot() const {
+    ContentPtr snapshot() const {
       return builder_.snapshot();
     }
 
@@ -384,7 +384,7 @@ namespace awkward {
     int64_t depth_;
   };
 
-  const std::shared_ptr<Content> FromJsonString(const char* source, const ArrayBuilderOptions& options) {
+  ContentPtr FromJsonString(const char* source, const ArrayBuilderOptions& options) {
     Handler handler(options);
     rj::Reader reader;
     rj::StringStream stream(source);
@@ -396,7 +396,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize) {
+  ContentPtr FromJsonFile(FILE* source, const ArrayBuilderOptions& options, int64_t buffersize) {
     Handler handler(options);
     rj::Reader reader;
     std::shared_ptr<char> buffer(new char[(size_t)buffersize], util::array_deleter<char>());

--- a/src/libawkward/io/root.cpp
+++ b/src/libawkward/io/root.cpp
@@ -34,7 +34,7 @@ namespace awkward {
     }
   }
 
-  ContentPtr FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options) {
+  const ContentPtr FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options) {
     if (depth <= 0) {
       throw std::runtime_error("FromROOT_nestedvector: depth <= 0");
     }
@@ -70,7 +70,7 @@ namespace awkward {
 
     std::vector<ssize_t> shape = { (ssize_t)bytepos_tocopy.length() };
     std::vector<ssize_t> strides = { (ssize_t)itemsize };
-    std::shared_ptr<Content> out = std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), ptr, shape, strides, 0, (ssize_t)itemsize, format);
+    ContentPtr out = std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), ptr, shape, strides, 0, (ssize_t)itemsize, format);
 
     for (int64_t i = depth - 1;  i >= 0;  i--) {
       Index64 index(levels[(size_t)i].ptr(), 0, levels[(size_t)i].length());

--- a/src/libawkward/io/root.cpp
+++ b/src/libawkward/io/root.cpp
@@ -34,7 +34,7 @@ namespace awkward {
     }
   }
 
-  const std::shared_ptr<Content> FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options) {
+  ContentPtr FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options) {
     if (depth <= 0) {
       throw std::runtime_error("FromROOT_nestedvector: depth <= 0");
     }

--- a/src/libawkward/io/root.cpp
+++ b/src/libawkward/io/root.cpp
@@ -10,31 +10,51 @@
 #include "awkward/io/root.h"
 
 namespace awkward {
-  void FromROOT_nestedvector_fill(std::vector<GrowableBuffer<int64_t>>& levels, GrowableBuffer<int64_t>& bytepos_tocopy, int64_t& bytepos, const NumpyArray& rawdata, int64_t whichlevel, int64_t itemsize) {
+  void
+  FromROOT_nestedvector_fill(std::vector<GrowableBuffer<int64_t>>& levels,
+                             GrowableBuffer<int64_t>& bytepos_tocopy,
+                             int64_t& bytepos,
+                             const NumpyArray& rawdata,
+                             int64_t whichlevel,
+                             int64_t itemsize) {
     if (whichlevel == levels.size()) {
       bytepos_tocopy.append(bytepos);
       bytepos += itemsize;
     }
 
     else {
-      uint32_t bigendian = *reinterpret_cast<uint32_t*>(rawdata.byteptr((ssize_t)bytepos));
+      uint32_t bigendian =
+        *reinterpret_cast<uint32_t*>(rawdata.byteptr((ssize_t)bytepos));
 
       // FIXME: check native endianness
-      uint32_t length = ((bigendian >> 24) & 0xff)     |  // move byte 3 to byte 0
-                        ((bigendian <<  8) & 0xff0000) |  // move byte 1 to byte 2
-                        ((bigendian >>  8) & 0xff00)   |  // move byte 2 to byte 1
-                        ((bigendian << 24) & 0xff000000); // byte 0 to byte 3
+      uint32_t length =
+        ((bigendian >> 24) & 0xff)     |  // move byte 3 to byte 0
+        ((bigendian <<  8) & 0xff0000) |  // move byte 1 to byte 2
+        ((bigendian >>  8) & 0xff00)   |  // move byte 2 to byte 1
+        ((bigendian << 24) & 0xff000000); // byte 0 to byte 3
 
       bytepos += sizeof(int32_t);
       for (uint32_t i = 0;  i < length;  i++) {
-        FromROOT_nestedvector_fill(levels, bytepos_tocopy, bytepos, rawdata, whichlevel + 1, itemsize);
+        FromROOT_nestedvector_fill(levels,
+                                   bytepos_tocopy,
+                                   bytepos,
+                                   rawdata,
+                                   whichlevel + 1,
+                                   itemsize);
       }
-      int64_t previous = levels[(unsigned int)whichlevel].getitem_at_nowrap(levels[(unsigned int)whichlevel].length() - 1);
+      int64_t previous = levels[(unsigned int)whichlevel].getitem_at_nowrap(
+        levels[(unsigned int)whichlevel].length() - 1);
       levels[(unsigned int)whichlevel].append(previous + length);
     }
   }
 
-  const ContentPtr FromROOT_nestedvector(const Index64& byteoffsets, const NumpyArray& rawdata, int64_t depth, int64_t itemsize, std::string format, const ArrayBuilderOptions& options) {
+  const ContentPtr
+  FromROOT_nestedvector(const Index64& byteoffsets,
+                        const NumpyArray& rawdata,
+                        int64_t depth,
+                        int64_t itemsize,
+                        std::string format,
+                        const ArrayBuilderOptions& options) {
     if (depth <= 0) {
       throw std::runtime_error("FromROOT_nestedvector: depth <= 0");
     }
@@ -55,26 +75,45 @@ namespace awkward {
 
     for (int64_t i = 0;  i < byteoffsets.length() - 1;  i++) {
       int64_t bytepos = byteoffsets.getitem_at_nowrap(i);
-      FromROOT_nestedvector_fill(levels, bytepos_tocopy, bytepos, rawdata, 0, itemsize);
+      FromROOT_nestedvector_fill(levels,
+                                 bytepos_tocopy,
+                                 bytepos,
+                                 rawdata,
+                                 0,
+                                 itemsize);
       level0.setitem_at_nowrap(i + 1, levels[0].length());
     }
 
-    std::shared_ptr<void> ptr(new uint8_t[(size_t)(bytepos_tocopy.length()*itemsize)], util::array_deleter<uint8_t>());
+    std::shared_ptr<void> ptr(
+      new uint8_t[(size_t)(bytepos_tocopy.length()*itemsize)],
+      util::array_deleter<uint8_t>());
     ssize_t offset = rawdata.byteoffset();
     uint8_t* toptr = reinterpret_cast<uint8_t*>(ptr.get());
     uint8_t* fromptr = reinterpret_cast<uint8_t*>(rawdata.ptr().get());
     for (int64_t i = 0;  i < bytepos_tocopy.length();  i++) {
       ssize_t bytepos = (ssize_t)bytepos_tocopy.getitem_at_nowrap(i);
-      std::memcpy(&toptr[(ssize_t)(i*itemsize)], &fromptr[offset + bytepos], (size_t)itemsize);
+      std::memcpy(&toptr[(ssize_t)(i*itemsize)],
+                  &fromptr[offset + bytepos],
+                  (size_t)itemsize);
     }
 
     std::vector<ssize_t> shape = { (ssize_t)bytepos_tocopy.length() };
     std::vector<ssize_t> strides = { (ssize_t)itemsize };
-    ContentPtr out = std::make_shared<NumpyArray>(Identities::none(), util::Parameters(), ptr, shape, strides, 0, (ssize_t)itemsize, format);
+    ContentPtr out = std::make_shared<NumpyArray>(Identities::none(),
+                                                  util::Parameters(),
+                                                  ptr,
+                                                  shape,
+                                                  strides,
+                                                  0,
+                                                  (ssize_t)itemsize,
+                                                  format);
 
     for (int64_t i = depth - 1;  i >= 0;  i--) {
       Index64 index(levels[(size_t)i].ptr(), 0, levels[(size_t)i].length());
-      out = std::make_shared<ListOffsetArray64>(Identities::none(), util::Parameters(), index, out);
+      out = std::make_shared<ListOffsetArray64>(Identities::none(),
+                                                util::Parameters(),
+                                                index,
+                                                out);
     }
     return out;
   }

--- a/src/libawkward/type/ArrayType.cpp
+++ b/src/libawkward/type/ArrayType.cpp
@@ -55,7 +55,7 @@ namespace awkward {
     return type_.get()->keys();
   }
 
-  ContentPtr ArrayType::empty() const {
+  const ContentPtr ArrayType::empty() const {
     if (length_ != 0) {
       throw std::invalid_argument(std::string("ArrayType with length ") + std::to_string(length_) + std::string(" does not describe an empty array"));
     }

--- a/src/libawkward/type/ArrayType.cpp
+++ b/src/libawkward/type/ArrayType.cpp
@@ -5,68 +5,87 @@
 #include "awkward/type/ArrayType.h"
 
 namespace awkward {
-  ArrayType::ArrayType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type, int64_t length)
+  ArrayType::ArrayType(const util::Parameters& parameters,
+                       const std::string& typestr,
+                       const TypePtr& type,
+                       int64_t length)
       : Type(parameters, typestr)
       , type_(type)
       , length_(length) { }
 
-  std::string ArrayType::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  std::string
+  ArrayType::tostring_part(const std::string& indent,
+                           const std::string& pre,
+                           const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
       return typestr;
     }
-
-    return indent + pre + std::to_string(length_) + " * " + type_.get()->tostring_part(indent, "", "") + post;
+    return (indent + pre + std::to_string(length_) + " * "
+            + type_.get()->tostring_part(indent, "", "") + post);
   }
 
-  const TypePtr ArrayType::shallow_copy() const {
+  const TypePtr
+  ArrayType::shallow_copy() const {
     return std::make_shared<ArrayType>(parameters_, typestr_, type_, length_);
   }
 
-  bool ArrayType::equal(const TypePtr& other, bool check_parameters) const {
+  bool
+  ArrayType::equal(const TypePtr& other, bool check_parameters) const {
     if (ArrayType* t = dynamic_cast<ArrayType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
       }
-      return length_ == t->length_  &&  type_.get()->equal(t->type_, check_parameters);
+      return (length_ == t->length_  &&
+              type_.get()->equal(t->type_, check_parameters));
     }
     else {
       return false;
     }
   }
 
-  int64_t ArrayType::numfields() const {
+  int64_t
+  ArrayType::numfields() const {
     return type_.get()->numfields();
   }
 
-  int64_t ArrayType::fieldindex(const std::string& key) const {
+  int64_t
+  ArrayType::fieldindex(const std::string& key) const {
     return type_.get()->fieldindex(key);
   }
 
-  const std::string ArrayType::key(int64_t fieldindex) const {
+  const std::string
+  ArrayType::key(int64_t fieldindex) const {
     return type_.get()->key(fieldindex);
   }
 
-  bool ArrayType::haskey(const std::string& key) const {
+  bool
+  ArrayType::haskey(const std::string& key) const {
     return type_.get()->haskey(key);
   }
 
-  const std::vector<std::string> ArrayType::keys() const {
+  const std::vector<std::string>
+  ArrayType::keys() const {
     return type_.get()->keys();
   }
 
-  const ContentPtr ArrayType::empty() const {
+  const ContentPtr
+  ArrayType::empty() const {
     if (length_ != 0) {
-      throw std::invalid_argument(std::string("ArrayType with length ") + std::to_string(length_) + std::string(" does not describe an empty array"));
+      throw std::invalid_argument(
+        std::string("ArrayType with length ") + std::to_string(length_)
+        + std::string(" does not describe an empty array"));
     }
     return type_.get()->empty();
   }
 
-  int64_t ArrayType::length() const {
+  int64_t
+  ArrayType::length() const {
     return length_;
   }
 
-  const TypePtr ArrayType::type() const {
+  const TypePtr
+  ArrayType::type() const {
     return type_;
   }
 }

--- a/src/libawkward/type/ArrayType.cpp
+++ b/src/libawkward/type/ArrayType.cpp
@@ -5,7 +5,7 @@
 #include "awkward/type/ArrayType.h"
 
 namespace awkward {
-  ArrayType::ArrayType(const util::Parameters& parameters, const std::string& typestr, const std::shared_ptr<Type>& type, int64_t length)
+  ArrayType::ArrayType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type, int64_t length)
       : Type(parameters, typestr)
       , type_(type)
       , length_(length) { }
@@ -19,11 +19,11 @@ namespace awkward {
     return indent + pre + std::to_string(length_) + " * " + type_.get()->tostring_part(indent, "", "") + post;
   }
 
-  const std::shared_ptr<Type> ArrayType::shallow_copy() const {
+  const TypePtr ArrayType::shallow_copy() const {
     return std::make_shared<ArrayType>(parameters_, typestr_, type_, length_);
   }
 
-  bool ArrayType::equal(const std::shared_ptr<Type>& other, bool check_parameters) const {
+  bool ArrayType::equal(const TypePtr& other, bool check_parameters) const {
     if (ArrayType* t = dynamic_cast<ArrayType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -66,7 +66,7 @@ namespace awkward {
     return length_;
   }
 
-  const std::shared_ptr<Type> ArrayType::type() const {
+  const TypePtr ArrayType::type() const {
     return type_;
   }
 }

--- a/src/libawkward/type/ArrayType.cpp
+++ b/src/libawkward/type/ArrayType.cpp
@@ -55,7 +55,7 @@ namespace awkward {
     return type_.get()->keys();
   }
 
-  const std::shared_ptr<Content> ArrayType::empty() const {
+  ContentPtr ArrayType::empty() const {
     if (length_ != 0) {
       throw std::invalid_argument(std::string("ArrayType with length ") + std::to_string(length_) + std::string(" does not describe an empty array"));
     }

--- a/src/libawkward/type/ListType.cpp
+++ b/src/libawkward/type/ListType.cpp
@@ -10,7 +10,7 @@
 #include "awkward/type/ListType.h"
 
 namespace awkward {
-  ListType::ListType(const util::Parameters& parameters, const std::string& typestr, const std::shared_ptr<Type>& type)
+  ListType::ListType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type)
       : Type(parameters, typestr)
       , type_(type) { }
 
@@ -30,11 +30,11 @@ namespace awkward {
     return out.str();
   }
 
-  const std::shared_ptr<Type> ListType::shallow_copy() const {
+  const TypePtr ListType::shallow_copy() const {
     return std::make_shared<ListType>(parameters_, typestr_, type_);
   }
 
-  bool ListType::equal(const std::shared_ptr<Type>& other, bool check_parameters) const {
+  bool ListType::equal(const TypePtr& other, bool check_parameters) const {
     if (ListType* t = dynamic_cast<ListType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -73,7 +73,7 @@ namespace awkward {
     return std::make_shared<ListOffsetArray64>(Identities::none(), parameters_, offsets, content);
   }
 
-  const std::shared_ptr<Type> ListType::type() const {
+  const TypePtr ListType::type() const {
     return type_;
   }
 }

--- a/src/libawkward/type/ListType.cpp
+++ b/src/libawkward/type/ListType.cpp
@@ -66,7 +66,7 @@ namespace awkward {
     return type_.get()->keys();
   }
 
-  const std::shared_ptr<Content> ListType::empty() const {
+  ContentPtr ListType::empty() const {
     Index64 offsets(1);
     offsets.setitem_at_nowrap(0, 0);
     std::shared_ptr<Content> content = type_.get()->empty();

--- a/src/libawkward/type/ListType.cpp
+++ b/src/libawkward/type/ListType.cpp
@@ -10,11 +10,16 @@
 #include "awkward/type/ListType.h"
 
 namespace awkward {
-  ListType::ListType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type)
+  ListType::ListType(const util::Parameters& parameters,
+                     const std::string& typestr,
+                     const TypePtr& type)
       : Type(parameters, typestr)
       , type_(type) { }
 
-  std::string ListType::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  std::string
+  ListType::tostring_part(const std::string& indent,
+                          const std::string& pre,
+                          const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
       return typestr;
@@ -22,19 +27,24 @@ namespace awkward {
 
     std::stringstream out;
     if (parameters_.empty()) {
-      out << indent << pre << "var * " << type_.get()->tostring_part(indent, "", "") << post;
+      out << indent << pre << "var * "
+          << type_.get()->tostring_part(indent, "", "") << post;
     }
     else {
-      out << indent << pre << "[var * " << type_.get()->tostring_part(indent, "", "") << ", " << string_parameters() << "]" << post;
+      out << indent << pre << "[var * "
+          << type_.get()->tostring_part(indent, "", "") << ", "
+          << string_parameters() << "]" << post;
     }
     return out.str();
   }
 
-  const TypePtr ListType::shallow_copy() const {
+  const TypePtr
+  ListType::shallow_copy() const {
     return std::make_shared<ListType>(parameters_, typestr_, type_);
   }
 
-  bool ListType::equal(const TypePtr& other, bool check_parameters) const {
+  bool
+  ListType::equal(const TypePtr& other, bool check_parameters) const {
     if (ListType* t = dynamic_cast<ListType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -46,34 +56,44 @@ namespace awkward {
     }
   }
 
-  int64_t ListType::numfields() const {
+  int64_t
+  ListType::numfields() const {
     return type_.get()->numfields();
   }
 
-  int64_t ListType::fieldindex(const std::string& key) const {
+  int64_t
+  ListType::fieldindex(const std::string& key) const {
     return type_.get()->fieldindex(key);
   }
 
-  const std::string ListType::key(int64_t fieldindex) const {
+  const std::string
+  ListType::key(int64_t fieldindex) const {
     return type_.get()->key(fieldindex);
   }
 
-  bool ListType::haskey(const std::string& key) const {
+  bool
+  ListType::haskey(const std::string& key) const {
     return type_.get()->haskey(key);
   }
 
-  const std::vector<std::string> ListType::keys() const {
+  const std::vector<std::string>
+  ListType::keys() const {
     return type_.get()->keys();
   }
 
-  const ContentPtr ListType::empty() const {
+  const ContentPtr
+  ListType::empty() const {
     Index64 offsets(1);
     offsets.setitem_at_nowrap(0, 0);
     ContentPtr content = type_.get()->empty();
-    return std::make_shared<ListOffsetArray64>(Identities::none(), parameters_, offsets, content);
+    return std::make_shared<ListOffsetArray64>(Identities::none(),
+                                               parameters_,
+                                               offsets,
+                                               content);
   }
 
-  const TypePtr ListType::type() const {
+  const TypePtr
+  ListType::type() const {
     return type_;
   }
 }

--- a/src/libawkward/type/ListType.cpp
+++ b/src/libawkward/type/ListType.cpp
@@ -66,10 +66,10 @@ namespace awkward {
     return type_.get()->keys();
   }
 
-  ContentPtr ListType::empty() const {
+  const ContentPtr ListType::empty() const {
     Index64 offsets(1);
     offsets.setitem_at_nowrap(0, 0);
-    std::shared_ptr<Content> content = type_.get()->empty();
+    ContentPtr content = type_.get()->empty();
     return std::make_shared<ListOffsetArray64>(Identities::none(), parameters_, offsets, content);
   }
 

--- a/src/libawkward/type/OptionType.cpp
+++ b/src/libawkward/type/OptionType.cpp
@@ -74,7 +74,7 @@ namespace awkward {
     return type_.get()->keys();
   }
 
-  const std::shared_ptr<Content> OptionType::empty() const {
+  ContentPtr OptionType::empty() const {
     std::shared_ptr<Content> content = type_.get()->empty();
     Index64 index(0);
     return std::make_shared<IndexedOptionArray64>(Identities::none(), parameters_, index, content);

--- a/src/libawkward/type/OptionType.cpp
+++ b/src/libawkward/type/OptionType.cpp
@@ -12,7 +12,7 @@
 #include "awkward/type/OptionType.h"
 
 namespace awkward {
-  OptionType::OptionType(const util::Parameters& parameters, const std::string& typestr, const std::shared_ptr<Type>& type)
+  OptionType::OptionType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type)
       : Type(parameters, typestr)
       , type_(type) { }
 
@@ -38,11 +38,11 @@ namespace awkward {
     return out.str();
   }
 
-  const std::shared_ptr<Type> OptionType::shallow_copy() const {
+  const TypePtr OptionType::shallow_copy() const {
     return std::make_shared<OptionType>(parameters_, typestr_, type_);
   }
 
-  bool OptionType::equal(const std::shared_ptr<Type>& other, bool check_parameters) const {
+  bool OptionType::equal(const TypePtr& other, bool check_parameters) const {
     if (OptionType* t = dynamic_cast<OptionType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -80,8 +80,8 @@ namespace awkward {
     return std::make_shared<IndexedOptionArray64>(Identities::none(), parameters_, index, content);
   }
 
-  const std::shared_ptr<Type> OptionType::type() const {
-    std::shared_ptr<Type> out = type_;
+  const TypePtr OptionType::type() const {
+    TypePtr out = type_;
     while (OptionType* t = dynamic_cast<OptionType*>(out.get())) {
       out = t->type_;
     }

--- a/src/libawkward/type/OptionType.cpp
+++ b/src/libawkward/type/OptionType.cpp
@@ -16,7 +16,10 @@ namespace awkward {
       : Type(parameters, typestr)
       , type_(type) { }
 
-  std::string OptionType::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  std::string
+  OptionType::tostring_part(const std::string& indent,
+                            const std::string& pre,
+                            const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
       return typestr;
@@ -26,23 +29,29 @@ namespace awkward {
     if (parameters_.empty()) {
       if (dynamic_cast<ListType*>(type_.get()) != nullptr  ||
           dynamic_cast<RegularType*>(type_.get()) != nullptr) {
-        out << indent << pre << "option[" << type_.get()->tostring_part(indent, "", "") << "]" << post;
+        out << indent << pre << "option["
+            << type_.get()->tostring_part(indent, "", "") << "]" << post;
       }
       else {
-        out << indent << pre << "?" << type_.get()->tostring_part("", "", "") << post;
+        out << indent << pre << "?"
+            << type_.get()->tostring_part("", "", "") << post;
       }
     }
     else {
-      out << indent << pre << "option[" << type_.get()->tostring_part(indent, "", "") << ", " << string_parameters() << "]" << post;
+      out << indent << pre << "option["
+          << type_.get()->tostring_part(indent, "", "") << ", "
+          << string_parameters() << "]" << post;
     }
     return out.str();
   }
 
-  const TypePtr OptionType::shallow_copy() const {
+  const TypePtr
+  OptionType::shallow_copy() const {
     return std::make_shared<OptionType>(parameters_, typestr_, type_);
   }
 
-  bool OptionType::equal(const TypePtr& other, bool check_parameters) const {
+  bool
+  OptionType::equal(const TypePtr& other, bool check_parameters) const {
     if (OptionType* t = dynamic_cast<OptionType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -54,33 +63,43 @@ namespace awkward {
     }
   }
 
-  int64_t OptionType::numfields() const {
+  int64_t
+  OptionType::numfields() const {
     return type_.get()->numfields();
   }
 
-  int64_t OptionType::fieldindex(const std::string& key) const {
+  int64_t
+  OptionType::fieldindex(const std::string& key) const {
     return type_.get()->fieldindex(key);
   }
 
-  const std::string OptionType::key(int64_t fieldindex) const {
+  const std::string
+  OptionType::key(int64_t fieldindex) const {
     return type_.get()->key(fieldindex);
   }
 
-  bool OptionType::haskey(const std::string& key) const {
+  bool
+  OptionType::haskey(const std::string& key) const {
     return type_.get()->haskey(key);
   }
 
-  const std::vector<std::string> OptionType::keys() const {
+  const std::vector<std::string>
+  OptionType::keys() const {
     return type_.get()->keys();
   }
 
-  const ContentPtr OptionType::empty() const {
+  const ContentPtr
+  OptionType::empty() const {
     ContentPtr content = type_.get()->empty();
     Index64 index(0);
-    return std::make_shared<IndexedOptionArray64>(Identities::none(), parameters_, index, content);
+    return std::make_shared<IndexedOptionArray64>(Identities::none(),
+                                                  parameters_,
+                                                  index,
+                                                  content);
   }
 
-  const TypePtr OptionType::type() const {
+  const TypePtr
+  OptionType::type() const {
     TypePtr out = type_;
     while (OptionType* t = dynamic_cast<OptionType*>(out.get())) {
       out = t->type_;

--- a/src/libawkward/type/OptionType.cpp
+++ b/src/libawkward/type/OptionType.cpp
@@ -12,7 +12,9 @@
 #include "awkward/type/OptionType.h"
 
 namespace awkward {
-  OptionType::OptionType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type)
+  OptionType::OptionType(const util::Parameters& parameters,
+                         const std::string& typestr,
+                         const TypePtr& type)
       : Type(parameters, typestr)
       , type_(type) { }
 

--- a/src/libawkward/type/OptionType.cpp
+++ b/src/libawkward/type/OptionType.cpp
@@ -74,8 +74,8 @@ namespace awkward {
     return type_.get()->keys();
   }
 
-  ContentPtr OptionType::empty() const {
-    std::shared_ptr<Content> content = type_.get()->empty();
+  const ContentPtr OptionType::empty() const {
+    ContentPtr content = type_.get()->empty();
     Index64 index(0);
     return std::make_shared<IndexedOptionArray64>(Identities::none(), parameters_, index, content);
   }

--- a/src/libawkward/type/PrimitiveType.cpp
+++ b/src/libawkward/type/PrimitiveType.cpp
@@ -80,7 +80,7 @@ namespace awkward {
     throw std::invalid_argument("type contains no Records");
   }
 
-  ContentPtr PrimitiveType::empty() const {
+  const ContentPtr PrimitiveType::empty() const {
     std::shared_ptr<void> ptr(new uint8_t[0], util::array_deleter<uint8_t>());
     std::vector<ssize_t> shape({ 0 });
     std::vector<ssize_t> strides({ 0 });

--- a/src/libawkward/type/PrimitiveType.cpp
+++ b/src/libawkward/type/PrimitiveType.cpp
@@ -9,11 +9,16 @@
 #include "awkward/type/PrimitiveType.h"
 
 namespace awkward {
-  PrimitiveType::PrimitiveType(const util::Parameters& parameters, const std::string& typestr, DType dtype)
+  PrimitiveType::PrimitiveType(const util::Parameters& parameters,
+                               const std::string& typestr,
+                               PrimitiveType::DType dtype)
       : Type(parameters, typestr)
       , dtype_(dtype) { }
 
-  std::string PrimitiveType::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  std::string
+  PrimitiveType::tostring_part(const std::string& indent,
+                               const std::string& pre,
+                               const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
       return typestr;
@@ -44,11 +49,13 @@ namespace awkward {
     return out.str();
   }
 
-  const TypePtr PrimitiveType::shallow_copy() const {
+  const TypePtr
+  PrimitiveType::shallow_copy() const {
     return std::make_shared<PrimitiveType>(parameters_, typestr_, dtype_);
   }
 
-  bool PrimitiveType::equal(const TypePtr& other, bool check_parameters) const {
+  bool
+  PrimitiveType::equal(const TypePtr& other, bool check_parameters) const {
     if (PrimitiveType* t = dynamic_cast<PrimitiveType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -60,27 +67,33 @@ namespace awkward {
     }
   }
 
-  int64_t PrimitiveType::numfields() const {
+  int64_t
+  PrimitiveType::numfields() const {
     return -1;
   }
 
-  int64_t PrimitiveType::fieldindex(const std::string& key) const {
+  int64_t
+  PrimitiveType::fieldindex(const std::string& key) const {
     throw std::invalid_argument("type contains no Records");
   }
 
-  const std::string PrimitiveType::key(int64_t fieldindex) const {
+  const std::string
+  PrimitiveType::key(int64_t fieldindex) const {
     throw std::invalid_argument("type contains no Records");
   }
 
-  bool PrimitiveType::haskey(const std::string& key) const {
+  bool
+  PrimitiveType::haskey(const std::string& key) const {
     throw std::invalid_argument("type contains no Records");
   }
 
-  const std::vector<std::string> PrimitiveType::keys() const {
+  const std::vector<std::string>
+  PrimitiveType::keys() const {
     throw std::invalid_argument("type contains no Records");
   }
 
-  const ContentPtr PrimitiveType::empty() const {
+  const ContentPtr
+  PrimitiveType::empty() const {
     std::shared_ptr<void> ptr(new uint8_t[0], util::array_deleter<uint8_t>());
     std::vector<ssize_t> shape({ 0 });
     std::vector<ssize_t> strides({ 0 });
@@ -105,12 +118,21 @@ namespace awkward {
 #endif
       case float32: itemsize = 4; format = "f"; break;
       case float64: itemsize = 8; format = "d"; break;
-      default: throw std::runtime_error(std::string("unexpected dtype: ") + std::to_string(dtype_));
+      default: throw std::runtime_error(
+                 std::string("unexpected dtype: ") + std::to_string(dtype_));
     }
-    return std::make_shared<NumpyArray>(Identities::none(), parameters_, ptr, shape, strides, 0, itemsize, format);
+    return std::make_shared<NumpyArray>(Identities::none(),
+                                        parameters_,
+                                        ptr,
+                                        shape,
+                                        strides,
+                                        0,
+                                        itemsize,
+                                        format);
   }
 
-  const PrimitiveType::DType PrimitiveType::dtype() const {
+  const PrimitiveType::DType
+  PrimitiveType::dtype() const {
     return dtype_;
   }
 }

--- a/src/libawkward/type/PrimitiveType.cpp
+++ b/src/libawkward/type/PrimitiveType.cpp
@@ -80,7 +80,7 @@ namespace awkward {
     throw std::invalid_argument("type contains no Records");
   }
 
-  const std::shared_ptr<Content> PrimitiveType::empty() const {
+  ContentPtr PrimitiveType::empty() const {
     std::shared_ptr<void> ptr(new uint8_t[0], util::array_deleter<uint8_t>());
     std::vector<ssize_t> shape({ 0 });
     std::vector<ssize_t> strides({ 0 });

--- a/src/libawkward/type/PrimitiveType.cpp
+++ b/src/libawkward/type/PrimitiveType.cpp
@@ -44,11 +44,11 @@ namespace awkward {
     return out.str();
   }
 
-  const std::shared_ptr<Type> PrimitiveType::shallow_copy() const {
+  const TypePtr PrimitiveType::shallow_copy() const {
     return std::make_shared<PrimitiveType>(parameters_, typestr_, dtype_);
   }
 
-  bool PrimitiveType::equal(const std::shared_ptr<Type>& other, bool check_parameters) const {
+  bool PrimitiveType::equal(const TypePtr& other, bool check_parameters) const {
     if (PrimitiveType* t = dynamic_cast<PrimitiveType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -11,33 +11,46 @@
 #include "awkward/type/RecordType.h"
 
 namespace awkward {
-  RecordType::RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types, const util::RecordLookupPtr& recordlookup)
+  RecordType::RecordType(const util::Parameters& parameters,
+                         const std::string& typestr,
+                         const std::vector<TypePtr>& types,
+                         const util::RecordLookupPtr& recordlookup)
       : Type(parameters, typestr)
       , types_(types)
       , recordlookup_(recordlookup) {
-    if (recordlookup_.get() != nullptr  &&  recordlookup_.get()->size() != types_.size()) {
-      throw std::runtime_error("recordlookup and types must have the same length");
+    if (recordlookup_.get() != nullptr  &&
+        recordlookup_.get()->size() != types_.size()) {
+      throw std::runtime_error(
+        "recordlookup and types must have the same length");
     }
   }
 
-  RecordType::RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types)
+  RecordType::RecordType(const util::Parameters& parameters,
+                         const std::string& typestr,
+                         const std::vector<TypePtr>& types)
       : Type(parameters, typestr)
       , types_(types)
       , recordlookup_(nullptr) { }
 
-  const std::vector<TypePtr> RecordType::types() const {
+  const std::vector<TypePtr>
+  RecordType::types() const {
     return types_;
   };
 
-  const util::RecordLookupPtr RecordType::recordlookup() const {
+  const util::RecordLookupPtr
+  RecordType::recordlookup() const {
     return recordlookup_;
   }
 
-  bool RecordType::istuple() const {
+  bool
+  RecordType::istuple() const {
     return recordlookup_.get() == nullptr;
   }
 
-  std::string RecordType::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  std::string
+  RecordType::tostring_part(const std::string& indent,
+                            const std::string& pre,
+                            const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
       return typestr;
@@ -98,11 +111,16 @@ namespace awkward {
     return out.str();
   }
 
-  const TypePtr RecordType::shallow_copy() const {
-    return std::make_shared<RecordType>(parameters_, typestr_, types_, recordlookup_);
+  const TypePtr
+  RecordType::shallow_copy() const {
+    return std::make_shared<RecordType>(parameters_,
+                                        typestr_,
+                                        types_,
+                                        recordlookup_);
   }
 
-  bool RecordType::equal(const TypePtr& other, bool check_parameters) const {
+  bool
+  RecordType::equal(const TypePtr& other, bool check_parameters) const {
     if (RecordType* t = dynamic_cast<RecordType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -141,68 +159,92 @@ namespace awkward {
     }
   }
 
-  int64_t RecordType::numfields() const {
+  int64_t
+  RecordType::numfields() const {
     return (int64_t)types_.size();
   }
 
-  int64_t RecordType::fieldindex(const std::string& key) const {
+  int64_t
+  RecordType::fieldindex(const std::string& key) const {
     return util::fieldindex(recordlookup_, key, numfields());
   }
 
-  const std::string RecordType::key(int64_t fieldindex) const {
+  const std::string
+  RecordType::key(int64_t fieldindex) const {
     return util::key(recordlookup_, fieldindex, numfields());
   }
 
-  bool RecordType::haskey(const std::string& key) const {
+  bool
+  RecordType::haskey(const std::string& key) const {
     return util::haskey(recordlookup_, key, numfields());
   }
 
-  const std::vector<std::string> RecordType::keys() const {
+  const std::vector<std::string>
+  RecordType::keys() const {
     return util::keys(recordlookup_, numfields());
   }
 
-  const ContentPtr RecordType::empty() const {
+  const ContentPtr
+  RecordType::empty() const {
     ContentPtrVec contents;
     for (auto type : types_) {
       contents.push_back(type.get()->empty());
     }
-    return std::make_shared<RecordArray>(Identities::none(), parameters_, contents, recordlookup_);
+    return std::make_shared<RecordArray>(Identities::none(),
+                                         parameters_,
+                                         contents,
+                                         recordlookup_);
   }
 
-  const TypePtr RecordType::field(int64_t fieldindex) const {
+  const TypePtr
+  RecordType::field(int64_t fieldindex) const {
     if (fieldindex >= numfields()) {
-      throw std::invalid_argument(std::string("fieldindex ") + std::to_string(fieldindex) + std::string(" for record with only " + std::to_string(numfields()) + std::string(" fields")));
+      throw std::invalid_argument(
+        std::string("fieldindex ") + std::to_string(fieldindex)
+        + std::string(" for record with only ") + std::to_string(numfields())
+        + std::string(" fields"));
     }
     return types_[(size_t)fieldindex];
   }
 
-  const TypePtr RecordType::field(const std::string& key) const {
+  const TypePtr
+  RecordType::field(const std::string& key) const {
     return types_[(size_t)fieldindex(key)];
   }
 
-  const std::vector<TypePtr> RecordType::fields() const {
+  const std::vector<TypePtr>
+  RecordType::fields() const {
     return std::vector<TypePtr>(types_);
   }
 
-  const std::vector<std::pair<std::string, TypePtr>> RecordType::fielditems() const {
+  const std::vector<std::pair<std::string, TypePtr>>
+  RecordType::fielditems() const {
     std::vector<std::pair<std::string, TypePtr>> out;
     if (recordlookup_.get() != nullptr) {
       size_t cols = types_.size();
       for (size_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, TypePtr>(recordlookup_.get()->at(j), types_[j]));
+        out.push_back(
+          std::pair<std::string, TypePtr>(recordlookup_.get()->at(j),
+                                          types_[j]));
       }
     }
     else {
       size_t cols = types_.size();
       for (size_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, TypePtr>(std::to_string(j), types_[j]));
+        out.push_back(
+          std::pair<std::string, TypePtr>(std::to_string(j),
+                                          types_[j]));
       }
     }
     return out;
   }
 
-  const TypePtr RecordType::astuple() const {
-    return std::make_shared<RecordType>(parameters_, typestr_, types_, util::RecordLookupPtr(nullptr));
+  const TypePtr
+  RecordType::astuple() const {
+    return std::make_shared<RecordType>(parameters_,
+                                        typestr_,
+                                        types_,
+                                        util::RecordLookupPtr(nullptr));
   }
 
 }

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -161,8 +161,8 @@ namespace awkward {
     return util::keys(recordlookup_, numfields());
   }
 
-  ContentPtr RecordType::empty() const {
-    std::vector<std::shared_ptr<Content>> contents;
+  const ContentPtr RecordType::empty() const {
+    std::vector<ContentPtr> contents;
     for (auto type : types_) {
       contents.push_back(type.get()->empty());
     }

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -11,7 +11,7 @@
 #include "awkward/type/RecordType.h"
 
 namespace awkward {
-  RecordType::RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<std::shared_ptr<Type>>& types, const std::shared_ptr<util::RecordLookup>& recordlookup)
+  RecordType::RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types, const util::RecordLookupPtr& recordlookup)
       : Type(parameters, typestr)
       , types_(types)
       , recordlookup_(recordlookup) {
@@ -20,16 +20,16 @@ namespace awkward {
     }
   }
 
-  RecordType::RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<std::shared_ptr<Type>>& types)
+  RecordType::RecordType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types)
       : Type(parameters, typestr)
       , types_(types)
       , recordlookup_(nullptr) { }
 
-  const std::vector<std::shared_ptr<Type>> RecordType::types() const {
+  const std::vector<TypePtr> RecordType::types() const {
     return types_;
   };
 
-  const std::shared_ptr<util::RecordLookup> RecordType::recordlookup() const {
+  const util::RecordLookupPtr RecordType::recordlookup() const {
     return recordlookup_;
   }
 
@@ -98,11 +98,11 @@ namespace awkward {
     return out.str();
   }
 
-  const std::shared_ptr<Type> RecordType::shallow_copy() const {
+  const TypePtr RecordType::shallow_copy() const {
     return std::make_shared<RecordType>(parameters_, typestr_, types_, recordlookup_);
   }
 
-  bool RecordType::equal(const std::shared_ptr<Type>& other, bool check_parameters) const {
+  bool RecordType::equal(const TypePtr& other, bool check_parameters) const {
     if (RecordType* t = dynamic_cast<RecordType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -169,40 +169,40 @@ namespace awkward {
     return std::make_shared<RecordArray>(Identities::none(), parameters_, contents, recordlookup_);
   }
 
-  const std::shared_ptr<Type> RecordType::field(int64_t fieldindex) const {
+  const TypePtr RecordType::field(int64_t fieldindex) const {
     if (fieldindex >= numfields()) {
       throw std::invalid_argument(std::string("fieldindex ") + std::to_string(fieldindex) + std::string(" for record with only " + std::to_string(numfields()) + std::string(" fields")));
     }
     return types_[(size_t)fieldindex];
   }
 
-  const std::shared_ptr<Type> RecordType::field(const std::string& key) const {
+  const TypePtr RecordType::field(const std::string& key) const {
     return types_[(size_t)fieldindex(key)];
   }
 
-  const std::vector<std::shared_ptr<Type>> RecordType::fields() const {
-    return std::vector<std::shared_ptr<Type>>(types_);
+  const std::vector<TypePtr> RecordType::fields() const {
+    return std::vector<TypePtr>(types_);
   }
 
-  const std::vector<std::pair<std::string, std::shared_ptr<Type>>> RecordType::fielditems() const {
-    std::vector<std::pair<std::string, std::shared_ptr<Type>>> out;
+  const std::vector<std::pair<std::string, TypePtr>> RecordType::fielditems() const {
+    std::vector<std::pair<std::string, TypePtr>> out;
     if (recordlookup_.get() != nullptr) {
       size_t cols = types_.size();
       for (size_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, std::shared_ptr<Type>>(recordlookup_.get()->at(j), types_[j]));
+        out.push_back(std::pair<std::string, TypePtr>(recordlookup_.get()->at(j), types_[j]));
       }
     }
     else {
       size_t cols = types_.size();
       for (size_t j = 0;  j < cols;  j++) {
-        out.push_back(std::pair<std::string, std::shared_ptr<Type>>(std::to_string(j), types_[j]));
+        out.push_back(std::pair<std::string, TypePtr>(std::to_string(j), types_[j]));
       }
     }
     return out;
   }
 
-  const std::shared_ptr<Type> RecordType::astuple() const {
-    return std::make_shared<RecordType>(parameters_, typestr_, types_, std::shared_ptr<util::RecordLookup>(nullptr));
+  const TypePtr RecordType::astuple() const {
+    return std::make_shared<RecordType>(parameters_, typestr_, types_, util::RecordLookupPtr(nullptr));
   }
 
 }

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -162,7 +162,7 @@ namespace awkward {
   }
 
   const ContentPtr RecordType::empty() const {
-    std::vector<ContentPtr> contents;
+    ContentPtrVec contents;
     for (auto type : types_) {
       contents.push_back(type.get()->empty());
     }

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -161,7 +161,7 @@ namespace awkward {
     return util::keys(recordlookup_, numfields());
   }
 
-  const std::shared_ptr<Content> RecordType::empty() const {
+  ContentPtr RecordType::empty() const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto type : types_) {
       contents.push_back(type.get()->empty());

--- a/src/libawkward/type/RegularType.cpp
+++ b/src/libawkward/type/RegularType.cpp
@@ -10,7 +10,7 @@
 #include "awkward/type/RegularType.h"
 
 namespace awkward {
-  RegularType::RegularType(const util::Parameters& parameters, const std::string& typestr, const std::shared_ptr<Type>& type, int64_t size)
+  RegularType::RegularType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type, int64_t size)
       : Type(parameters, typestr)
       , type_(type)
       , size_(size) { }
@@ -31,11 +31,11 @@ namespace awkward {
     return out.str();
   }
 
-  const std::shared_ptr<Type> RegularType::shallow_copy() const {
+  const TypePtr RegularType::shallow_copy() const {
     return std::make_shared<RegularType>(parameters_, typestr_, type_, size_);
   }
 
-  bool RegularType::equal(const std::shared_ptr<Type>& other, bool check_parameters) const {
+  bool RegularType::equal(const TypePtr& other, bool check_parameters) const {
     if (RegularType* t = dynamic_cast<RegularType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -72,7 +72,7 @@ namespace awkward {
     return std::make_shared<RegularArray>(Identities::none(), parameters_, content, size_);
   }
 
-  const std::shared_ptr<Type> RegularType::type() const {
+  const TypePtr RegularType::type() const {
     return type_;
   }
 

--- a/src/libawkward/type/RegularType.cpp
+++ b/src/libawkward/type/RegularType.cpp
@@ -67,7 +67,7 @@ namespace awkward {
     return type_.get()->keys();
   }
 
-  const std::shared_ptr<Content> RegularType::empty() const {
+  ContentPtr RegularType::empty() const {
     std::shared_ptr<Content> content = type_.get()->empty();
     return std::make_shared<RegularArray>(Identities::none(), parameters_, content, size_);
   }

--- a/src/libawkward/type/RegularType.cpp
+++ b/src/libawkward/type/RegularType.cpp
@@ -67,8 +67,8 @@ namespace awkward {
     return type_.get()->keys();
   }
 
-  ContentPtr RegularType::empty() const {
-    std::shared_ptr<Content> content = type_.get()->empty();
+  const ContentPtr RegularType::empty() const {
+    ContentPtr content = type_.get()->empty();
     return std::make_shared<RegularArray>(Identities::none(), parameters_, content, size_);
   }
 

--- a/src/libawkward/type/RegularType.cpp
+++ b/src/libawkward/type/RegularType.cpp
@@ -10,12 +10,18 @@
 #include "awkward/type/RegularType.h"
 
 namespace awkward {
-  RegularType::RegularType(const util::Parameters& parameters, const std::string& typestr, const TypePtr& type, int64_t size)
+  RegularType::RegularType(const util::Parameters& parameters,
+                           const std::string& typestr,
+                           const TypePtr& type,
+                           int64_t size)
       : Type(parameters, typestr)
       , type_(type)
       , size_(size) { }
 
-  std::string RegularType::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  std::string
+  RegularType::tostring_part(const std::string& indent,
+                             const std::string& pre,
+                             const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
       return typestr;
@@ -23,60 +29,77 @@ namespace awkward {
 
     std::stringstream out;
     if (parameters_.empty()) {
-      out << indent << pre << size_ << " * " << type_.get()->tostring_part(indent, "", "") << post;
+      out << indent << pre << size_ << " * "
+          << type_.get()->tostring_part(indent, "", "") << post;
     }
     else {
-      out << indent << pre << "[" << size_ << " * " << type_.get()->tostring_part(indent, "", "") << ", " << string_parameters() << "]" << post;
+      out << indent << pre << "[" << size_ << " * "
+          << type_.get()->tostring_part(indent, "", "") << ", "
+          << string_parameters() << "]" << post;
     }
     return out.str();
   }
 
-  const TypePtr RegularType::shallow_copy() const {
+  const TypePtr
+  RegularType::shallow_copy() const {
     return std::make_shared<RegularType>(parameters_, typestr_, type_, size_);
   }
 
-  bool RegularType::equal(const TypePtr& other, bool check_parameters) const {
+  bool
+  RegularType::equal(const TypePtr& other, bool check_parameters) const {
     if (RegularType* t = dynamic_cast<RegularType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
       }
-      return size() == t->size()  &&  type().get()->equal(t->type(), check_parameters);
+      return (size() == t->size()  &&
+              type().get()->equal(t->type(), check_parameters));
     }
     else {
       return false;
     }
   }
 
-  int64_t RegularType::numfields() const {
+  int64_t
+  RegularType::numfields() const {
     return type_.get()->numfields();
   }
 
-  int64_t RegularType::fieldindex(const std::string& key) const {
+  int64_t
+  RegularType::fieldindex(const std::string& key) const {
     return type_.get()->fieldindex(key);
   }
 
-  const std::string RegularType::key(int64_t fieldindex) const {
+  const std::string
+  RegularType::key(int64_t fieldindex) const {
     return type_.get()->key(fieldindex);
   }
 
-  bool RegularType::haskey(const std::string& key) const {
+  bool
+  RegularType::haskey(const std::string& key) const {
     return type_.get()->haskey(key);
   }
 
-  const std::vector<std::string> RegularType::keys() const {
+  const std::vector<std::string>
+  RegularType::keys() const {
     return type_.get()->keys();
   }
 
-  const ContentPtr RegularType::empty() const {
+  const ContentPtr
+  RegularType::empty() const {
     ContentPtr content = type_.get()->empty();
-    return std::make_shared<RegularArray>(Identities::none(), parameters_, content, size_);
+    return std::make_shared<RegularArray>(Identities::none(),
+                                          parameters_,
+                                          content,
+                                          size_);
   }
 
-  const TypePtr RegularType::type() const {
+  const TypePtr
+  RegularType::type() const {
     return type_;
   }
 
-  int64_t RegularType::size() const {
+  int64_t
+  RegularType::size() const {
     return size_;
   }
 }

--- a/src/libawkward/type/Type.cpp
+++ b/src/libawkward/type/Type.cpp
@@ -12,8 +12,8 @@
 namespace rj = rapidjson;
 
 namespace awkward {
-  std::shared_ptr<Type> Type::none() {
-    return std::shared_ptr<Type>(nullptr);
+  TypePtr Type::none() {
+    return TypePtr(nullptr);
   }
 
   Type::Type(const util::Parameters& parameters, const std::string& typestr)
@@ -58,7 +58,7 @@ namespace awkward {
     return tostring_part("", "", "");
   };
 
-  const std::string Type::compare(std::shared_ptr<Type> supertype) {
+  const std::string Type::compare(TypePtr supertype) {
     // FIXME: better side-by-side comparison
     return tostring() + std::string(" versus ") + supertype.get()->tostring();
   }

--- a/src/libawkward/type/Type.cpp
+++ b/src/libawkward/type/Type.cpp
@@ -12,7 +12,8 @@
 namespace rj = rapidjson;
 
 namespace awkward {
-  TypePtr Type::none() {
+  TypePtr
+  Type::none() {
     return TypePtr(nullptr);
   }
 
@@ -22,19 +23,23 @@ namespace awkward {
 
   Type::~Type() { }
 
-  const util::Parameters Type::parameters() const {
+  const util::Parameters
+  Type::parameters() const {
     return parameters_;
   }
 
-  const std::string Type::typestr() const {
+  const std::string
+  Type::typestr() const {
     return typestr_;
   }
 
-  void Type::setparameters(const util::Parameters& parameters) {
+  void
+  Type::setparameters(const util::Parameters& parameters) {
     parameters_ = parameters;
   }
 
-  const std::string Type::parameter(const std::string& key) const {
+  const std::string
+  Type::parameter(const std::string& key) const {
     auto item = parameters_.find(key);
     if (item == parameters_.end()) {
       return "null";
@@ -42,28 +47,35 @@ namespace awkward {
     return item->second;
   }
 
-  void Type::setparameter(const std::string& key, const std::string& value) {
+  void
+  Type::setparameter(const std::string& key, const std::string& value) {
     parameters_[key] = value;
   }
 
-  bool Type::parameter_equals(const std::string& key, const std::string& value) const {
+  bool
+  Type::parameter_equals(const std::string& key,
+                         const std::string& value) const {
     return util::parameter_equals(parameters_, key, value);
   }
 
-  bool Type::parameters_equal(const util::Parameters& other) const {
+  bool
+  Type::parameters_equal(const util::Parameters& other) const {
     return util::parameters_equal(parameters_, other);
   }
 
-  const std::string Type::tostring() const {
+  const std::string
+  Type::tostring() const {
     return tostring_part("", "", "");
   };
 
-  const std::string Type::compare(TypePtr supertype) {
+  const std::string
+  Type::compare(TypePtr supertype) {
     // FIXME: better side-by-side comparison
     return tostring() + std::string(" versus ") + supertype.get()->tostring();
   }
 
-  bool Type::get_typestr(std::string& output) const {
+  bool
+  Type::get_typestr(std::string& output) const {
     if (typestr_.empty()) {
       return false;
     }
@@ -73,7 +85,8 @@ namespace awkward {
     }
   }
 
-  const std::string Type::string_parameters() const {
+  const std::string
+  Type::string_parameters() const {
     std::stringstream out;
     out << "parameters={";
     bool first = true;

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -10,11 +10,16 @@
 #include "awkward/type/UnionType.h"
 
 namespace awkward {
-  UnionType::UnionType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types)
+  UnionType::UnionType(const util::Parameters& parameters,
+                       const std::string& typestr,
+                       const std::vector<TypePtr>& types)
       : Type(parameters, typestr)
       , types_(types) { }
 
-  std::string UnionType::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  std::string
+  UnionType::tostring_part(const std::string& indent,
+                           const std::string& pre,
+                           const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
       return typestr;
@@ -35,11 +40,13 @@ namespace awkward {
     return out.str();
   }
 
-  const TypePtr UnionType::shallow_copy() const {
+  const TypePtr
+  UnionType::shallow_copy() const {
     return std::make_shared<UnionType>(parameters_, typestr_, types_);
   }
 
-  bool UnionType::equal(const TypePtr& other, bool check_parameters) const {
+  bool
+  UnionType::equal(const TypePtr& other, bool check_parameters) const {
     if (UnionType* t = dynamic_cast<UnionType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -59,35 +66,43 @@ namespace awkward {
     }
   }
 
-  int64_t UnionType::numtypes() const {
+  int64_t
+  UnionType::numtypes() const {
     return (int64_t)types_.size();
   }
 
-  int64_t UnionType::numfields() const {
+  int64_t
+  UnionType::numfields() const {
     throw std::runtime_error("FIXME: UnionType::numfields");
   }
 
-  int64_t UnionType::fieldindex(const std::string& key) const {
+  int64_t
+  UnionType::fieldindex(const std::string& key) const {
     throw std::runtime_error("FIXME: UnionType::fieldindex(key)");
   }
 
-  const std::string UnionType::key(int64_t fieldindex) const {
+  const std::string
+  UnionType::key(int64_t fieldindex) const {
     throw std::runtime_error("FIXME: UnionType::key(fieldindex)");
   }
 
-  bool UnionType::haskey(const std::string& key) const {
+  bool
+  UnionType::haskey(const std::string& key) const {
     throw std::runtime_error("FIXME: UnionType::haskey(key)");
   }
 
-  const std::vector<std::string> UnionType::keys() const {
+  const std::vector<std::string>
+  UnionType::keys() const {
     throw std::runtime_error("FIXME: UnionType::keys");
   }
 
-  const std::vector<TypePtr> UnionType::types() const {
+  const std::vector<TypePtr>
+  UnionType::types() const {
     return types_;
   }
 
-  const ContentPtr UnionType::empty() const {
+  const ContentPtr
+  UnionType::empty() const {
     ContentPtrVec contents;
     for (auto type : types_) {
       contents.push_back(type.get()->empty());
@@ -97,7 +112,8 @@ namespace awkward {
     return std::make_shared<UnionArray8_64>(Identities::none(), parameters_, tags, index, contents);
   }
 
-  const TypePtr UnionType::type(int64_t index) const {
+  const TypePtr
+  UnionType::type(int64_t index) const {
     return types_[(size_t)index];
   }
 }

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -88,7 +88,7 @@ namespace awkward {
   }
 
   const ContentPtr UnionType::empty() const {
-    std::vector<ContentPtr> contents;
+    ContentPtrVec contents;
     for (auto type : types_) {
       contents.push_back(type.get()->empty());
     }

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -109,7 +109,11 @@ namespace awkward {
     }
     Index8 tags(0);
     Index64 index(0);
-    return std::make_shared<UnionArray8_64>(Identities::none(), parameters_, tags, index, contents);
+    return std::make_shared<UnionArray8_64>(Identities::none(),
+                                            parameters_,
+                                            tags,
+                                            index,
+                                            contents);
   }
 
   const TypePtr

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -87,7 +87,7 @@ namespace awkward {
     return types_;
   }
 
-  const std::shared_ptr<Content> UnionType::empty() const {
+  ContentPtr UnionType::empty() const {
     std::vector<std::shared_ptr<Content>> contents;
     for (auto type : types_) {
       contents.push_back(type.get()->empty());

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -10,7 +10,7 @@
 #include "awkward/type/UnionType.h"
 
 namespace awkward {
-  UnionType::UnionType(const util::Parameters& parameters, const std::string& typestr, const std::vector<std::shared_ptr<Type>>& types)
+  UnionType::UnionType(const util::Parameters& parameters, const std::string& typestr, const std::vector<TypePtr>& types)
       : Type(parameters, typestr)
       , types_(types) { }
 
@@ -35,11 +35,11 @@ namespace awkward {
     return out.str();
   }
 
-  const std::shared_ptr<Type> UnionType::shallow_copy() const {
+  const TypePtr UnionType::shallow_copy() const {
     return std::make_shared<UnionType>(parameters_, typestr_, types_);
   }
 
-  bool UnionType::equal(const std::shared_ptr<Type>& other, bool check_parameters) const {
+  bool UnionType::equal(const TypePtr& other, bool check_parameters) const {
     if (UnionType* t = dynamic_cast<UnionType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -83,7 +83,7 @@ namespace awkward {
     throw std::runtime_error("FIXME: UnionType::keys");
   }
 
-  const std::vector<std::shared_ptr<Type>> UnionType::types() const {
+  const std::vector<TypePtr> UnionType::types() const {
     return types_;
   }
 
@@ -97,7 +97,7 @@ namespace awkward {
     return std::make_shared<UnionArray8_64>(Identities::none(), parameters_, tags, index, contents);
   }
 
-  const std::shared_ptr<Type> UnionType::type(int64_t index) const {
+  const TypePtr UnionType::type(int64_t index) const {
     return types_[(size_t)index];
   }
 }

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -87,8 +87,8 @@ namespace awkward {
     return types_;
   }
 
-  ContentPtr UnionType::empty() const {
-    std::vector<std::shared_ptr<Content>> contents;
+  const ContentPtr UnionType::empty() const {
+    std::vector<ContentPtr> contents;
     for (auto type : types_) {
       contents.push_back(type.get()->empty());
     }

--- a/src/libawkward/type/UnknownType.cpp
+++ b/src/libawkward/type/UnknownType.cpp
@@ -26,11 +26,11 @@ namespace awkward {
     return out.str();
   }
 
-  const std::shared_ptr<Type> UnknownType::shallow_copy() const {
+  const TypePtr UnknownType::shallow_copy() const {
     return std::make_shared<UnknownType>(parameters_, typestr_);
   }
 
-  bool UnknownType::equal(const std::shared_ptr<Type>& other, bool check_parameters) const {
+  bool UnknownType::equal(const TypePtr& other, bool check_parameters) const {
     if (UnknownType* t = dynamic_cast<UnknownType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;

--- a/src/libawkward/type/UnknownType.cpp
+++ b/src/libawkward/type/UnknownType.cpp
@@ -7,10 +7,14 @@
 #include "awkward/type/UnknownType.h"
 
 namespace awkward {
-  UnknownType::UnknownType(const util::Parameters& parameters, const std::string& typestr)
+  UnknownType::UnknownType(const util::Parameters& parameters,
+                           const std::string& typestr)
       : Type(parameters, typestr) { }
 
-  std::string UnknownType::tostring_part(const std::string& indent, const std::string& pre, const std::string& post) const {
+  std::string
+  UnknownType::tostring_part(const std::string& indent,
+                             const std::string& pre,
+                             const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
       return typestr;
@@ -26,11 +30,13 @@ namespace awkward {
     return out.str();
   }
 
-  const TypePtr UnknownType::shallow_copy() const {
+  const TypePtr
+  UnknownType::shallow_copy() const {
     return std::make_shared<UnknownType>(parameters_, typestr_);
   }
 
-  bool UnknownType::equal(const TypePtr& other, bool check_parameters) const {
+  bool
+  UnknownType::equal(const TypePtr& other, bool check_parameters) const {
     if (UnknownType* t = dynamic_cast<UnknownType*>(other.get())) {
       if (check_parameters  &&  !parameters_equal(other.get()->parameters())) {
         return false;
@@ -42,27 +48,33 @@ namespace awkward {
     }
   }
 
-  int64_t UnknownType::numfields() const {
+  int64_t
+  UnknownType::numfields() const {
     return -1;
   }
 
-  int64_t UnknownType::fieldindex(const std::string& key) const {
+  int64_t
+  UnknownType::fieldindex(const std::string& key) const {
     throw std::invalid_argument("type contains no Records");
   }
 
-  const std::string UnknownType::key(int64_t fieldindex) const {
+  const std::string
+  UnknownType::key(int64_t fieldindex) const {
     throw std::invalid_argument("type contains no Records");
   }
 
-  bool UnknownType::haskey(const std::string& key) const {
+  bool
+  UnknownType::haskey(const std::string& key) const {
     throw std::invalid_argument("type contains no Records");
   }
 
-  const std::vector<std::string> UnknownType::keys() const {
+  const std::vector<std::string>
+  UnknownType::keys() const {
     throw std::invalid_argument("type contains no Records");
   }
 
-  const ContentPtr UnknownType::empty() const {
+  const ContentPtr
+  UnknownType::empty() const {
     return std::make_shared<EmptyArray>(Identities::none(), parameters_);
   }
 }

--- a/src/libawkward/type/UnknownType.cpp
+++ b/src/libawkward/type/UnknownType.cpp
@@ -62,7 +62,7 @@ namespace awkward {
     throw std::invalid_argument("type contains no Records");
   }
 
-  const std::shared_ptr<Content> UnknownType::empty() const {
+  const ContentPtr UnknownType::empty() const {
     return std::make_shared<EmptyArray>(Identities::none(), parameters_);
   }
 }

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -17,13 +17,17 @@ namespace rj = rapidjson;
 
 namespace awkward {
   namespace util {
-    void handle_error(const struct Error& err, const std::string& classname, const Identities* identities) {
+    void
+    handle_error(const struct Error& err,
+                 const std::string& classname,
+                 const Identities* identities) {
       if (err.str != nullptr) {
         std::stringstream out;
         out << "in " << classname;
         if (err.identity != kSliceNone  &&  identities != nullptr) {
           if (0 <= err.identity  &&  err.identity < identities->length()) {
-            out << " with identity [" << identities->identity_at(err.identity) << "]";
+            out << " with identity ["
+                << identities->identity_at(err.identity) << "]";
           }
           else {
             out << " with invalid identity";
@@ -39,22 +43,27 @@ namespace awkward {
 
     template <typename T>
     IndexOf<T> make_starts(const IndexOf<T>& offsets) {
-      return IndexOf<T>(offsets.ptr(), offsets.offset(), offsets.length() - 1);
+      return IndexOf<T>(offsets.ptr(),
+                        offsets.offset(),
+                        offsets.length() - 1);
     }
 
     template <typename T>
     IndexOf<T> make_stops(const IndexOf<T>& offsets) {
-      return IndexOf<T>(offsets.ptr(), offsets.offset() + 1, offsets.length() - 1);
+      return IndexOf<T>(offsets.ptr(),
+                        offsets.offset() + 1,
+                        offsets.length() - 1);
     }
 
-    template IndexOf<int32_t> make_starts(const IndexOf<int32_t>& offsets);
+    template IndexOf<int32_t>  make_starts(const IndexOf<int32_t>& offsets);
     template IndexOf<uint32_t> make_starts(const IndexOf<uint32_t>& offsets);
-    template IndexOf<int64_t> make_starts(const IndexOf<int64_t>& offsets);
-    template IndexOf<int32_t> make_stops(const IndexOf<int32_t>& offsets);
+    template IndexOf<int64_t>  make_starts(const IndexOf<int64_t>& offsets);
+    template IndexOf<int32_t>  make_stops(const IndexOf<int32_t>& offsets);
     template IndexOf<uint32_t> make_stops(const IndexOf<uint32_t>& offsets);
-    template IndexOf<int64_t> make_stops(const IndexOf<int64_t>& offsets);
+    template IndexOf<int64_t>  make_stops(const IndexOf<int64_t>& offsets);
 
-    std::string quote(const std::string& x, bool doublequote) {
+    std::string
+    quote(const std::string& x, bool doublequote) {
       // TODO: escape characters, possibly using RapidJSON.
       if (doublequote) {
         return std::string("\"") + x + std::string("\"");
@@ -64,7 +73,8 @@ namespace awkward {
       }
     }
 
-    RecordLookupPtr init_recordlookup(int64_t numfields) {
+    RecordLookupPtr
+    init_recordlookup(int64_t numfields) {
       RecordLookupPtr out = std::make_shared<RecordLookup>();
       for (int64_t i = 0;  i < numfields;  i++) {
         out.get()->push_back(std::to_string(i));
@@ -72,7 +82,10 @@ namespace awkward {
       return out;
     }
 
-    int64_t fieldindex(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields) {
+    int64_t
+    fieldindex(const RecordLookupPtr& recordlookup,
+               const std::string& key,
+               int64_t numfields) {
       int64_t out = -1;
       if (recordlookup.get() != nullptr) {
         for (size_t i = 0;  i < recordlookup.get()->size();  i++) {
@@ -87,18 +100,29 @@ namespace awkward {
           out = (int64_t)std::stoi(key);
         }
         catch (std::invalid_argument err) {
-          throw std::invalid_argument(std::string("key ") + quote(key, true) + std::string(" does not exist (not in record)"));
+          throw std::invalid_argument(
+            std::string("key ") + quote(key, true)
+            + std::string(" does not exist (not in record)"));
         }
         if (!(0 <= out  &&  out < numfields)) {
-          throw std::invalid_argument(std::string("key interpreted as fieldindex ") + key + std::string(" for records with only " + std::to_string(numfields) + std::string(" fields")));
+          throw std::invalid_argument(
+            std::string("key interpreted as fieldindex ") + key
+            + std::string(" for records with only " + std::to_string(numfields)
+            + std::string(" fields")));
         }
       }
       return out;
     }
 
-    const std::string key(const RecordLookupPtr& recordlookup, int64_t fieldindex, int64_t numfields) {
+    const std::string
+    key(const RecordLookupPtr& recordlookup,
+        int64_t fieldindex,
+        int64_t numfields) {
       if (fieldindex >= numfields) {
-        throw std::invalid_argument(std::string("fieldindex ") + std::to_string(fieldindex) + std::string(" for records with only " + std::to_string(numfields) + std::string(" fields")));
+        throw std::invalid_argument(
+          std::string("fieldindex ") + std::to_string(fieldindex)
+          + std::string(" for records with only " + std::to_string(numfields)
+          + std::string(" fields")));
       }
       if (recordlookup.get() != nullptr) {
         return recordlookup.get()->at((size_t)fieldindex);
@@ -108,7 +132,10 @@ namespace awkward {
       }
     }
 
-    bool haskey(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields) {
+    bool
+    haskey(const RecordLookupPtr& recordlookup,
+           const std::string& key,
+           int64_t numfields) {
       try {
         fieldindex(recordlookup, key, numfields);
       }
@@ -118,10 +145,13 @@ namespace awkward {
       return true;
     }
 
-    const std::vector<std::string> keys(const RecordLookupPtr& recordlookup, int64_t numfields) {
+    const std::vector<std::string>
+    keys(const RecordLookupPtr& recordlookup, int64_t numfields) {
       std::vector<std::string> out;
       if (recordlookup.get() != nullptr) {
-        out.insert(out.end(), recordlookup.get()->begin(), recordlookup.get()->end());
+        out.insert(out.end(),
+                   recordlookup.get()->begin(),
+                   recordlookup.get()->end());
       }
       else {
         int64_t cols = numfields;
@@ -132,7 +162,10 @@ namespace awkward {
       return out;
     }
 
-    bool parameter_equals(const Parameters& parameters, const std::string& key, const std::string& value) {
+    bool
+    parameter_equals(const Parameters& parameters,
+                     const std::string& key,
+                     const std::string& value) {
       auto item = parameters.find(key);
       std::string myvalue;
       if (item == parameters.end()) {
@@ -148,7 +181,8 @@ namespace awkward {
       return mine == yours;
     }
 
-    bool parameters_equal(const Parameters& self, const Parameters& other) {
+    bool
+    parameters_equal(const Parameters& self, const Parameters& other) {
       std::set<std::string> checked;
       for (auto pair : self) {
         if (!parameter_equals(other, pair.first, pair.second)) {
@@ -166,7 +200,8 @@ namespace awkward {
       return true;
     }
 
-    std::string gettypestr(const Parameters& parameters, const std::map<std::string, std::string>& typestrs) {
+    std::string
+    gettypestr(const Parameters& parameters, const TypeStrs& typestrs) {
       auto item = parameters.find("__record__");
       if (item != parameters.end()) {
         std::string source = item->second;
@@ -199,852 +234,3813 @@ namespace awkward {
     }
 
     template <>
-    Error awkward_identities32_from_listoffsetarray<int32_t>(int32_t* toptr, const int32_t* fromptr, const int32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_listoffsetarray32(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+    Error awkward_identities32_from_listoffsetarray<int32_t>(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int32_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_listoffsetarray32(
+        toptr,
+        fromptr,
+        fromoffsets,
+        fromptroffset,
+        offsetsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_identities32_from_listoffsetarray<uint32_t>(int32_t* toptr, const int32_t* fromptr, const uint32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_listoffsetarrayU32(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+    Error awkward_identities32_from_listoffsetarray<uint32_t>(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const uint32_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_listoffsetarrayU32(
+        toptr,
+        fromptr,
+        fromoffsets,
+        fromptroffset,
+        offsetsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_identities32_from_listoffsetarray<int64_t>(int32_t* toptr, const int32_t* fromptr, const int64_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_listoffsetarray64(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+    Error awkward_identities32_from_listoffsetarray<int64_t>(
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int64_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_listoffsetarray64(
+        toptr,
+        fromptr,
+        fromoffsets,
+        fromptroffset,
+        offsetsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_identities64_from_listoffsetarray<int32_t>(int64_t* toptr, const int64_t* fromptr, const int32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_listoffsetarray32(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+    Error awkward_identities64_from_listoffsetarray<int32_t>(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int32_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_listoffsetarray32(
+        toptr,
+        fromptr,
+        fromoffsets,
+        fromptroffset,
+        offsetsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_identities64_from_listoffsetarray<uint32_t>(int64_t* toptr, const int64_t* fromptr, const uint32_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_listoffsetarrayU32(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
+    Error awkward_identities64_from_listoffsetarray<uint32_t>(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const uint32_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_listoffsetarrayU32(
+        toptr,
+        fromptr,
+        fromoffsets,
+        fromptroffset,
+        offsetsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_identities64_from_listoffsetarray<int64_t>(int64_t* toptr, const int64_t* fromptr, const int64_t* fromoffsets, int64_t fromptroffset, int64_t offsetsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_listoffsetarray64(toptr, fromptr, fromoffsets, fromptroffset, offsetsoffset, tolength, fromlength, fromwidth);
-    }
-
-    template <>
-    Error awkward_identities32_from_listarray<int32_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int32_t* fromstarts, const int32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_listarray32(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities32_from_listarray<uint32_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_listarrayU32(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities32_from_listarray<int64_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int64_t* fromstarts, const int64_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_listarray64(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities64_from_listarray<int32_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int32_t* fromstarts, const int32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_listarray32(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities64_from_listarray<uint32_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_listarrayU32(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities64_from_listarray<int64_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int64_t* fromstarts, const int64_t* fromstops, int64_t fromptroffset, int64_t startsoffset, int64_t stopsoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_listarray64(uniquecontents, toptr, fromptr, fromstarts, fromstops, fromptroffset, startsoffset, stopsoffset, tolength, fromlength, fromwidth);
-    }
-
-    template <>
-    Error awkward_identities32_from_indexedarray<int32_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_indexedarray32(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities32_from_indexedarray<uint32_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const uint32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_indexedarrayU32(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities32_from_indexedarray<int64_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int64_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities32_from_indexedarray64(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities64_from_indexedarray<int32_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_indexedarray32(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities64_from_indexedarray<uint32_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const uint32_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_indexedarrayU32(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
-    }
-    template <>
-    Error awkward_identities64_from_indexedarray<int64_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int64_t* fromindex, int64_t fromptroffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth) {
-      return awkward_identities64_from_indexedarray64(uniquecontents, toptr, fromptr, fromindex, fromptroffset, indexoffset, tolength, fromlength, fromwidth);
-    }
-
-    template <>
-    Error awkward_identities32_from_unionarray<int8_t, int32_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const int32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-      return awkward_identities32_from_unionarray8_32(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
-    }
-    template <>
-    Error awkward_identities32_from_unionarray<int8_t, uint32_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const uint32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-      return awkward_identities32_from_unionarray8_U32(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
-    }
-    template <>
-    Error awkward_identities32_from_unionarray<int8_t, int64_t>(bool* uniquecontents, int32_t* toptr, const int32_t* fromptr, const int8_t* fromtags, const int64_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-      return awkward_identities32_from_unionarray8_64(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
-    }
-    template <>
-    Error awkward_identities64_from_unionarray<int8_t, int32_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const int32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-      return awkward_identities64_from_unionarray8_32(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
-    }
-    template <>
-    Error awkward_identities64_from_unionarray<int8_t, uint32_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const uint32_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-      return awkward_identities64_from_unionarray8_U32(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
-    }
-    template <>
-    Error awkward_identities64_from_unionarray<int8_t, int64_t>(bool* uniquecontents, int64_t* toptr, const int64_t* fromptr, const int8_t* fromtags, const int64_t* fromindex, int64_t fromptroffset, int64_t tagsoffset, int64_t indexoffset, int64_t tolength, int64_t fromlength, int64_t fromwidth, int64_t which) {
-      return awkward_identities64_from_unionarray8_64(uniquecontents, toptr, fromptr, fromtags, fromindex, fromptroffset, tagsoffset, indexoffset, tolength, fromlength, fromwidth, which);
-    }
-
-    template <>
-    Error awkward_index_carry_64<int8_t>(int8_t* toindex, const int8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-      return awkward_index8_carry_64(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
-    }
-    template <>
-    Error awkward_index_carry_64<uint8_t>(uint8_t* toindex, const uint8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-      return awkward_indexU8_carry_64(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
-    }
-    template <>
-    Error awkward_index_carry_64<int32_t>(int32_t* toindex, const int32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-      return awkward_index32_carry_64(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
-    }
-    template <>
-    Error awkward_index_carry_64<uint32_t>(uint32_t* toindex, const uint32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-      return awkward_indexU32_carry_64(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
-    }
-    template <>
-    Error awkward_index_carry_64<int64_t>(int64_t* toindex, const int64_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t lenfromindex, int64_t length) {
-      return awkward_index64_carry_64(toindex, fromindex, carry, fromindexoffset, lenfromindex, length);
-    }
-
-    template <>
-    Error awkward_index_carry_nocheck_64<int8_t>(int8_t* toindex, const int8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-      return awkward_index8_carry_nocheck_64(toindex, fromindex, carry, fromindexoffset, length);
-    }
-    template <>
-    Error awkward_index_carry_nocheck_64<uint8_t>(uint8_t* toindex, const uint8_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-      return awkward_indexU8_carry_nocheck_64(toindex, fromindex, carry, fromindexoffset, length);
-    }
-    template <>
-    Error awkward_index_carry_nocheck_64<int32_t>(int32_t* toindex, const int32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-      return awkward_index32_carry_nocheck_64(toindex, fromindex, carry, fromindexoffset, length);
-    }
-    template <>
-    Error awkward_index_carry_nocheck_64<uint32_t>(uint32_t* toindex, const uint32_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-      return awkward_indexU32_carry_nocheck_64(toindex, fromindex, carry, fromindexoffset, length);
-    }
-    template <>
-    Error awkward_index_carry_nocheck_64<int64_t>(int64_t* toindex, const int64_t* fromindex, const int64_t* carry, int64_t fromindexoffset, int64_t length) {
-      return awkward_index64_carry_nocheck_64(toindex, fromindex, carry, fromindexoffset, length);
+    Error awkward_identities64_from_listoffsetarray<int64_t>(
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int64_t* fromoffsets,
+      int64_t fromptroffset,
+      int64_t offsetsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_listoffsetarray64(
+        toptr,
+        fromptr,
+        fromoffsets,
+        fromptroffset,
+        offsetsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
 
     template <>
-    Error awkward_listarray_getitem_next_at_64<int32_t>(int64_t* tocarry, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at) {
-      return awkward_listarray32_getitem_next_at_64(tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, at);
+    Error awkward_identities32_from_listarray<int32_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_listarray32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromstarts,
+        fromstops,
+        fromptroffset,
+        startsoffset,
+        stopsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_listarray_getitem_next_at_64<uint32_t>(int64_t* tocarry, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at) {
-      return awkward_listarrayU32_getitem_next_at_64(tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, at);
+    Error awkward_identities32_from_listarray<uint32_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_listarrayU32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromstarts,
+        fromstops,
+        fromptroffset,
+        startsoffset,
+        stopsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_listarray_getitem_next_at_64<int64_t>(int64_t* tocarry, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t at) {
-      return awkward_listarray64_getitem_next_at_64(tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, at);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_next_range_carrylength<int32_t>(int64_t* carrylength, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-      return awkward_listarray32_getitem_next_range_carrylength(carrylength, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_range_carrylength<uint32_t>(int64_t* carrylength, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-      return awkward_listarrayU32_getitem_next_range_carrylength(carrylength, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_range_carrylength<int64_t>(int64_t* carrylength, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-      return awkward_listarray64_getitem_next_range_carrylength(carrylength, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_next_range_64<int32_t>(int32_t* tooffsets, int64_t* tocarry, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-      return awkward_listarray32_getitem_next_range_64(tooffsets, tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_range_64<uint32_t>(uint32_t* tooffsets, int64_t* tocarry, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-      return awkward_listarrayU32_getitem_next_range_64(tooffsets, tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_range_64<int64_t>(int64_t* tooffsets, int64_t* tocarry, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset, int64_t start, int64_t stop, int64_t step) {
-      return awkward_listarray64_getitem_next_range_64(tooffsets, tocarry, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset, start, stop, step);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_next_range_counts_64<int32_t>(int64_t* total, const int32_t* fromoffsets, int64_t lenstarts) {
-      return awkward_listarray32_getitem_next_range_counts_64(total, fromoffsets, lenstarts);
+    Error awkward_identities32_from_listarray<int64_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_listarray64(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromstarts,
+        fromstops,
+        fromptroffset,
+        startsoffset,
+        stopsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_listarray_getitem_next_range_counts_64<uint32_t>(int64_t* total, const uint32_t* fromoffsets, int64_t lenstarts) {
-      return awkward_listarrayU32_getitem_next_range_counts_64(total, fromoffsets, lenstarts);
+    Error awkward_identities64_from_listarray<int32_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_listarray32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromstarts,
+        fromstops,
+        fromptroffset,
+        startsoffset,
+        stopsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_listarray_getitem_next_range_counts_64<int64_t>(int64_t* total, const int64_t* fromoffsets, int64_t lenstarts) {
-      return awkward_listarray64_getitem_next_range_counts_64(total, fromoffsets, lenstarts);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_next_range_spreadadvanced_64<int32_t>(int64_t* toadvanced, const int64_t* fromadvanced, const int32_t* fromoffsets, int64_t lenstarts) {
-      return awkward_listarray32_getitem_next_range_spreadadvanced_64(toadvanced, fromadvanced, fromoffsets, lenstarts);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_range_spreadadvanced_64<uint32_t>(int64_t* toadvanced, const int64_t* fromadvanced, const uint32_t* fromoffsets, int64_t lenstarts) {
-      return awkward_listarrayU32_getitem_next_range_spreadadvanced_64(toadvanced, fromadvanced, fromoffsets, lenstarts);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_range_spreadadvanced_64<int64_t>(int64_t* toadvanced, const int64_t* fromadvanced, const int64_t* fromoffsets, int64_t lenstarts) {
-      return awkward_listarray64_getitem_next_range_spreadadvanced_64(toadvanced, fromadvanced, fromoffsets, lenstarts);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_next_array_64<int32_t>(int64_t* tocarry, int64_t* toadvanced, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-      return awkward_listarray32_getitem_next_array_64(tocarry, toadvanced, fromstarts, fromstops, fromarray, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_array_64<uint32_t>(int64_t* tocarry, int64_t* toadvanced, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-      return awkward_listarrayU32_getitem_next_array_64(tocarry, toadvanced, fromstarts, fromstops, fromarray, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_array_64<int64_t>(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromarray, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-      return awkward_listarray64_getitem_next_array_64(tocarry, toadvanced, fromstarts, fromstops, fromarray, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_next_array_advanced_64<int32_t>(int64_t* tocarry, int64_t* toadvanced, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-      return awkward_listarray32_getitem_next_array_advanced_64(tocarry, toadvanced, fromstarts, fromstops, fromarray, fromadvanced, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
+    Error awkward_identities64_from_listarray<uint32_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_listarrayU32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromstarts,
+        fromstops,
+        fromptroffset,
+        startsoffset,
+        stopsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_listarray_getitem_next_array_advanced_64<uint32_t>(int64_t* tocarry, int64_t* toadvanced, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-      return awkward_listarrayU32_getitem_next_array_advanced_64(tocarry, toadvanced, fromstarts, fromstops, fromarray, fromadvanced, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
-    }
-    template <>
-    Error awkward_listarray_getitem_next_array_advanced_64<int64_t>(int64_t* tocarry, int64_t* toadvanced, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromarray, const int64_t* fromadvanced, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lenarray, int64_t lencontent) {
-      return awkward_listarray64_getitem_next_array_advanced_64(tocarry, toadvanced, fromstarts, fromstops, fromarray, fromadvanced, startsoffset, stopsoffset, lenstarts, lenarray, lencontent);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_carry_64<int32_t>(int32_t* tostarts, int32_t* tostops, const int32_t* fromstarts, const int32_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry) {
-      return awkward_listarray32_getitem_carry_64(tostarts, tostops, fromstarts, fromstops, fromcarry, startsoffset, stopsoffset, lenstarts, lencarry);
-    }
-    template <>
-    Error awkward_listarray_getitem_carry_64<uint32_t>(uint32_t* tostarts, uint32_t* tostops, const uint32_t* fromstarts, const uint32_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry) {
-      return awkward_listarrayU32_getitem_carry_64(tostarts, tostops, fromstarts, fromstops, fromcarry, startsoffset, stopsoffset, lenstarts, lencarry);
-    }
-    template <>
-    Error awkward_listarray_getitem_carry_64<int64_t>(int64_t* tostarts, int64_t* tostops, const int64_t* fromstarts, const int64_t* fromstops, const int64_t* fromcarry, int64_t startsoffset, int64_t stopsoffset, int64_t lenstarts, int64_t lencarry) {
-      return awkward_listarray64_getitem_carry_64(tostarts, tostops, fromstarts, fromstops, fromcarry, startsoffset, stopsoffset, lenstarts, lencarry);
-    }
-
-    template <>
-    Error awkward_listarray_num_64<int32_t>(int64_t* tonum, const int32_t* fromstarts, int64_t startsoffset, const int32_t* fromstops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarray32_num_64(tonum, fromstarts, startsoffset, fromstops, stopsoffset, length);
-    }
-    template <>
-    Error awkward_listarray_num_64<uint32_t>(int64_t* tonum, const uint32_t* fromstarts, int64_t startsoffset, const uint32_t* fromstops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarrayU32_num_64(tonum, fromstarts, startsoffset, fromstops, stopsoffset, length);
-    }
-    template <>
-    Error awkward_listarray_num_64<int64_t>(int64_t* tonum, const int64_t* fromstarts, int64_t startsoffset, const int64_t* fromstops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarray64_num_64(tonum, fromstarts, startsoffset, fromstops, stopsoffset, length);
-    }
-
-    template <>
-    Error awkward_listoffsetarray_flatten_offsets_64<int32_t>(int64_t* tooffsets, const int32_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen) {
-      return awkward_listoffsetarray32_flatten_offsets_64(tooffsets, outeroffsets, outeroffsetsoffset, outeroffsetslen, inneroffsets, inneroffsetsoffset, inneroffsetslen);
-    }
-    template <>
-    Error awkward_listoffsetarray_flatten_offsets_64<uint32_t>(int64_t* tooffsets, const uint32_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen) {
-      return awkward_listoffsetarrayU32_flatten_offsets_64(tooffsets, outeroffsets, outeroffsetsoffset, outeroffsetslen, inneroffsets, inneroffsetsoffset, inneroffsetslen);
-    }
-    template <>
-    Error awkward_listoffsetarray_flatten_offsets_64<int64_t>(int64_t* tooffsets, const int64_t* outeroffsets, int64_t outeroffsetsoffset, int64_t outeroffsetslen, const int64_t* inneroffsets, int64_t inneroffsetsoffset, int64_t inneroffsetslen) {
-      return awkward_listoffsetarray64_flatten_offsets_64(tooffsets, outeroffsets, outeroffsetsoffset, outeroffsetslen, inneroffsets, inneroffsetsoffset, inneroffsetslen);
-    }
-
-    template <>
-    Error awkward_indexedarray_flatten_none2empty_64<int32_t>(int64_t* outoffsets, const int32_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength) {
-      return awkward_indexedarray32_flatten_none2empty_64(outoffsets, outindex, outindexoffset, outindexlength, offsets, offsetsoffset, offsetslength);
-    }
-    template <>
-    Error awkward_indexedarray_flatten_none2empty_64<uint32_t>(int64_t* outoffsets, const uint32_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength) {
-      return awkward_indexedarrayU32_flatten_none2empty_64(outoffsets, outindex, outindexoffset, outindexlength, offsets, offsetsoffset, offsetslength);
-    }
-    template <>
-    Error awkward_indexedarray_flatten_none2empty_64<int64_t>(int64_t* outoffsets, const int64_t* outindex, int64_t outindexoffset, int64_t outindexlength, const int64_t* offsets, int64_t offsetsoffset, int64_t offsetslength) {
-      return awkward_indexedarray64_flatten_none2empty_64(outoffsets, outindex, outindexoffset, outindexlength, offsets, offsetsoffset, offsetslength);
-    }
-
-    template <>
-    Error awkward_unionarray_flatten_length_64<int8_t, int32_t>(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-      return awkward_unionarray32_flatten_length_64(total_length, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
-    }
-    template <>
-    Error awkward_unionarray_flatten_length_64<int8_t, uint32_t>(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-      return awkward_unionarrayU32_flatten_length_64(total_length, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
-    }
-    template <>
-    Error awkward_unionarray_flatten_length_64<int8_t, int64_t>(int64_t* total_length, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-      return awkward_unionarray64_flatten_length_64(total_length, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
-    }
-
-    template <>
-    Error awkward_unionarray_flatten_combine_64<int8_t, int32_t>(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-      return awkward_unionarray32_flatten_combine_64(totags, toindex, tooffsets, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
-    }
-    template <>
-    Error awkward_unionarray_flatten_combine_64<int8_t, uint32_t>(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-      return awkward_unionarrayU32_flatten_combine_64(totags, toindex, tooffsets, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
-    }
-    template <>
-    Error awkward_unionarray_flatten_combine_64<int8_t, int64_t>(int8_t* totags, int64_t* toindex, int64_t* tooffsets, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t length, int64_t** offsetsraws, int64_t* offsetsoffsets) {
-      return awkward_unionarray64_flatten_combine_64(totags, toindex, tooffsets, fromtags, fromtagsoffset, fromindex, fromindexoffset, length, offsetsraws, offsetsoffsets);
+    Error awkward_identities64_from_listarray<int64_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t fromptroffset,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_listarray64(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromstarts,
+        fromstops,
+        fromptroffset,
+        startsoffset,
+        stopsoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
 
     template <>
-    Error awkward_indexedarray_flatten_nextcarry_64<int32_t>(int64_t* tocarry, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarray32_flatten_nextcarry_64(tocarry, fromindex, indexoffset, lenindex, lencontent);
+    Error awkward_identities32_from_indexedarray<int32_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_indexedarray32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromindex,
+        fromptroffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_indexedarray_flatten_nextcarry_64<uint32_t>(int64_t* tocarry, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarrayU32_flatten_nextcarry_64(tocarry, fromindex, indexoffset, lenindex, lencontent);
+    Error awkward_identities32_from_indexedarray<uint32_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const uint32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_indexedarrayU32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromindex,
+        fromptroffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_indexedarray_flatten_nextcarry_64<int64_t>(int64_t* tocarry, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarray64_flatten_nextcarry_64(tocarry, fromindex, indexoffset, lenindex, lencontent);
-    }
-
-    template <>
-    Error awkward_indexedarray_numnull<int32_t>(int64_t* numnull, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex) {
-      return awkward_indexedarray32_numnull(numnull, fromindex, indexoffset, lenindex);
-    }
-    template <>
-    Error awkward_indexedarray_numnull<uint32_t>(int64_t* numnull, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex) {
-      return awkward_indexedarrayU32_numnull(numnull, fromindex, indexoffset, lenindex);
-    }
-    template <>
-    Error awkward_indexedarray_numnull<int64_t>(int64_t* numnull, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex) {
-      return awkward_indexedarray64_numnull(numnull, fromindex, indexoffset, lenindex);
-    }
-
-    template <>
-    Error awkward_indexedarray_getitem_nextcarry_outindex_64<int32_t>(int64_t* tocarry, int32_t* toindex, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarray32_getitem_nextcarry_outindex_64(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
-    }
-    template <>
-    Error awkward_indexedarray_getitem_nextcarry_outindex_64<uint32_t>(int64_t* tocarry, uint32_t* toindex, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarrayU32_getitem_nextcarry_outindex_64(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
+    Error awkward_identities32_from_indexedarray<int64_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int64_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities32_from_indexedarray64(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromindex,
+        fromptroffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_indexedarray_getitem_nextcarry_outindex_64<int64_t>(int64_t* tocarry, int64_t* toindex, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarray64_getitem_nextcarry_outindex_64(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
-    }
-
-    template <>
-    Error awkward_indexedarray_getitem_nextcarry_outindex_mask_64<int32_t>(int64_t* tocarry, int64_t* toindex, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarray32_getitem_nextcarry_outindex_mask_64(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
-    }
-    template <>
-    Error awkward_indexedarray_getitem_nextcarry_outindex_mask_64<uint32_t>(int64_t* tocarry, int64_t* toindex, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarrayU32_getitem_nextcarry_outindex_mask_64(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
-    }
-    template <>
-    Error awkward_indexedarray_getitem_nextcarry_outindex_mask_64<int64_t>(int64_t* tocarry, int64_t* toindex, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarray64_getitem_nextcarry_outindex_mask_64(tocarry, toindex, fromindex, indexoffset, lenindex, lencontent);
-    }
-
-    template <>
-    Error awkward_indexedarray_getitem_nextcarry_64<int32_t>(int64_t* tocarry, const int32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarray32_getitem_nextcarry_64(tocarry, fromindex, indexoffset, lenindex, lencontent);
-    }
-    template <>
-    Error awkward_indexedarray_getitem_nextcarry_64<uint32_t>(int64_t* tocarry, const uint32_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarrayU32_getitem_nextcarry_64(tocarry, fromindex, indexoffset, lenindex, lencontent);
+    Error awkward_identities64_from_indexedarray<int32_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_indexedarray32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromindex,
+        fromptroffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_indexedarray_getitem_nextcarry_64<int64_t>(int64_t* tocarry, const int64_t* fromindex, int64_t indexoffset, int64_t lenindex, int64_t lencontent) {
-      return awkward_indexedarray64_getitem_nextcarry_64(tocarry, fromindex, indexoffset, lenindex, lencontent);
-    }
-
-    template <>
-    Error awkward_indexedarray_getitem_carry_64<int32_t>(int32_t* toindex, const int32_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry) {
-      return awkward_indexedarray32_getitem_carry_64(toindex, fromindex, fromcarry, indexoffset, lenindex, lencarry);
-    }
-    template <>
-    Error awkward_indexedarray_getitem_carry_64<uint32_t>(uint32_t* toindex, const uint32_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry) {
-      return awkward_indexedarrayU32_getitem_carry_64(toindex, fromindex, fromcarry, indexoffset, lenindex, lencarry);
-    }
-    template <>
-    Error awkward_indexedarray_getitem_carry_64<int64_t>(int64_t* toindex, const int64_t* fromindex, const int64_t* fromcarry, int64_t indexoffset, int64_t lenindex, int64_t lencarry) {
-      return awkward_indexedarray64_getitem_carry_64(toindex, fromindex, fromcarry, indexoffset, lenindex, lencarry);
-    }
-
-    template <>
-    Error awkward_indexedarray_overlay_mask8_to64<int32_t>(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const int32_t* fromindex, int64_t indexoffset, int64_t length) {
-      return awkward_indexedarray32_overlay_mask8_to64(toindex, mask, maskoffset, fromindex, indexoffset, length);
-    }
-    template <>
-    Error awkward_indexedarray_overlay_mask8_to64<uint32_t>(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const uint32_t* fromindex, int64_t indexoffset, int64_t length) {
-      return awkward_indexedarrayU32_overlay_mask8_to64(toindex, mask, maskoffset, fromindex, indexoffset, length);
+    Error awkward_identities64_from_indexedarray<uint32_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const uint32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_indexedarrayU32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromindex,
+        fromptroffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
     template <>
-    Error awkward_indexedarray_overlay_mask8_to64<int64_t>(int64_t* toindex, const int8_t* mask, int64_t maskoffset, const int64_t* fromindex, int64_t indexoffset, int64_t length) {
-      return awkward_indexedarray64_overlay_mask8_to64(toindex, mask, maskoffset, fromindex, indexoffset, length);
-    }
-
-    template <>
-    Error awkward_indexedarray_mask8<int32_t>(int8_t* tomask, const int32_t* fromindex, int64_t indexoffset, int64_t length) {
-      return awkward_indexedarray32_mask8(tomask, fromindex, indexoffset, length);
-    }
-    template <>
-    Error awkward_indexedarray_mask8<uint32_t>(int8_t* tomask, const uint32_t* fromindex, int64_t indexoffset, int64_t length) {
-      return awkward_indexedarrayU32_mask8(tomask, fromindex, indexoffset, length);
-    }
-    template <>
-    Error awkward_indexedarray_mask8<int64_t>(int8_t* tomask, const int64_t* fromindex, int64_t indexoffset, int64_t length) {
-      return awkward_indexedarray64_mask8(tomask, fromindex, indexoffset, length);
-    }
-
-    template <>
-    Error awkward_indexedarray_simplify32_to64<int32_t>(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarray32_simplify32_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
-    }
-    template <>
-    Error awkward_indexedarray_simplify32_to64<uint32_t>(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarrayU32_simplify32_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
-    }
-    template <>
-    Error awkward_indexedarray_simplify32_to64<int64_t>(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const int32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarray64_simplify32_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
-    }
-
-    template <>
-    Error awkward_indexedarray_simplifyU32_to64<int32_t>(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarray32_simplifyU32_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
-    }
-    template <>
-    Error awkward_indexedarray_simplifyU32_to64<uint32_t>(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarrayU32_simplifyU32_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
-    }
-    template <>
-    Error awkward_indexedarray_simplifyU32_to64<int64_t>(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const uint32_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarray64_simplifyU32_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
-    }
-
-    template <>
-    Error awkward_indexedarray_simplify64_to64<int32_t>(int64_t* toindex, const int32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarray32_simplify64_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
-    }
-    template <>
-    Error awkward_indexedarray_simplify64_to64<uint32_t>(int64_t* toindex, const uint32_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarrayU32_simplify64_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
-    }
-    template <>
-    Error awkward_indexedarray_simplify64_to64<int64_t>(int64_t* toindex, const int64_t* outerindex, int64_t outeroffset, int64_t outerlength, const int64_t* innerindex, int64_t inneroffset, int64_t innerlength) {
-      return awkward_indexedarray64_simplify64_to64(toindex, outerindex, outeroffset, outerlength, innerindex, inneroffset, innerlength);
+    Error awkward_identities64_from_indexedarray<int64_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int64_t* fromindex,
+      int64_t fromptroffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth) {
+      return awkward_identities64_from_indexedarray64(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromindex,
+        fromptroffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth);
     }
 
     template <>
-    Error awkward_unionarray_regular_index<int8_t, int32_t>(int32_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length) {
-      return awkward_unionarray8_32_regular_index(toindex, fromtags, tagsoffset, length);
+    Error awkward_identities32_from_unionarray<int8_t,
+                                               int32_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int8_t* fromtags,
+      const int32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which) {
+      return awkward_identities32_from_unionarray8_32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromtags,
+        fromindex,
+        fromptroffset,
+        tagsoffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth,
+        which);
     }
     template <>
-    Error awkward_unionarray_regular_index<int8_t, uint32_t>(uint32_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length) {
-      return awkward_unionarray8_U32_regular_index(toindex, fromtags, tagsoffset, length);
+    Error awkward_identities32_from_unionarray<int8_t,
+                                               uint32_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int8_t* fromtags,
+      const uint32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which) {
+      return awkward_identities32_from_unionarray8_U32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromtags,
+        fromindex,
+        fromptroffset,
+        tagsoffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth,
+        which);
     }
     template <>
-    Error awkward_unionarray_regular_index<int8_t, int64_t>(int64_t* toindex, const int8_t* fromtags, int64_t tagsoffset, int64_t length) {
-      return awkward_unionarray8_64_regular_index(toindex, fromtags, tagsoffset, length);
-    }
-
-    template <>
-    Error awkward_unionarray_project_64<int8_t, int32_t>(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const int32_t* fromindex, int64_t indexoffset, int64_t length, int64_t which) {
-      return awkward_unionarray8_32_project_64(lenout, tocarry, fromtags, tagsoffset, fromindex, indexoffset, length, which);
-    }
-    template <>
-    Error awkward_unionarray_project_64<int8_t, uint32_t>(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const uint32_t* fromindex, int64_t indexoffset, int64_t length, int64_t which) {
-      return awkward_unionarray8_U32_project_64(lenout, tocarry, fromtags, tagsoffset, fromindex, indexoffset, length, which);
-    }
-    template <>
-    Error awkward_unionarray_project_64<int8_t, int64_t>(int64_t* lenout, int64_t* tocarry, const int8_t* fromtags, int64_t tagsoffset, const int64_t* fromindex, int64_t indexoffset, int64_t length, int64_t which) {
-      return awkward_unionarray8_64_project_64(lenout, tocarry, fromtags, tagsoffset, fromindex, indexoffset, length, which);
-    }
-
-    template <>
-    Error awkward_listarray_compact_offsets64(int64_t* tooffsets, const int32_t* fromstarts, const int32_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length) {
-      return awkward_listarray32_compact_offsets64(tooffsets, fromstarts, fromstops, startsoffset, stopsoffset, length);
-    }
-    template <>
-    Error awkward_listarray_compact_offsets64(int64_t* tooffsets, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length) {
-      return awkward_listarrayU32_compact_offsets64(tooffsets, fromstarts, fromstops, startsoffset, stopsoffset, length);
-    }
-    template <>
-    Error awkward_listarray_compact_offsets64(int64_t* tooffsets, const int64_t* fromstarts, const int64_t* fromstops, int64_t startsoffset, int64_t stopsoffset, int64_t length) {
-      return awkward_listarray64_compact_offsets64(tooffsets, fromstarts, fromstops, startsoffset, stopsoffset, length);
-    }
-
-    template <>
-    Error awkward_listoffsetarray_compact_offsets64(int64_t* tooffsets, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t length) {
-      return awkward_listoffsetarray32_compact_offsets64(tooffsets, fromoffsets, offsetsoffset, length);
+    Error awkward_identities32_from_unionarray<int8_t,
+                                               int64_t>(
+      bool* uniquecontents,
+      int32_t* toptr,
+      const int32_t* fromptr,
+      const int8_t* fromtags,
+      const int64_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which) {
+      return awkward_identities32_from_unionarray8_64(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromtags,
+        fromindex,
+        fromptroffset,
+        tagsoffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth,
+        which);
     }
     template <>
-    Error awkward_listoffsetarray_compact_offsets64(int64_t* tooffsets, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t length) {
-      return awkward_listoffsetarrayU32_compact_offsets64(tooffsets, fromoffsets, offsetsoffset, length);
+    Error awkward_identities64_from_unionarray<int8_t,
+                                               int32_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int8_t* fromtags,
+      const int32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which) {
+      return awkward_identities64_from_unionarray8_32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromtags,
+        fromindex,
+        fromptroffset,
+        tagsoffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth,
+        which);
     }
     template <>
-    Error awkward_listoffsetarray_compact_offsets64(int64_t* tooffsets, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length) {
-      return awkward_listoffsetarray64_compact_offsets64(tooffsets, fromoffsets, offsetsoffset, length);
-    }
-
-    template <>
-    Error awkward_listarray_broadcast_tooffsets64<int32_t>(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const int32_t* fromstarts, int64_t startsoffset, const int32_t* fromstops, int64_t stopsoffset, int64_t lencontent) {
-      return awkward_listarray32_broadcast_tooffsets64(tocarry, fromoffsets, offsetsoffset, offsetslength, fromstarts, startsoffset, fromstops, stopsoffset, lencontent);
-    }
-    template <>
-    Error awkward_listarray_broadcast_tooffsets64<uint32_t>(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const uint32_t* fromstarts, int64_t startsoffset, const uint32_t* fromstops, int64_t stopsoffset, int64_t lencontent) {
-      return awkward_listarrayU32_broadcast_tooffsets64(tocarry, fromoffsets, offsetsoffset, offsetslength, fromstarts, startsoffset, fromstops, stopsoffset, lencontent);
-    }
-    template <>
-    Error awkward_listarray_broadcast_tooffsets64<int64_t>(int64_t* tocarry, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength, const int64_t* fromstarts, int64_t startsoffset, const int64_t* fromstops, int64_t stopsoffset, int64_t lencontent) {
-      return awkward_listarray64_broadcast_tooffsets64(tocarry, fromoffsets, offsetsoffset, offsetslength, fromstarts, startsoffset, fromstops, stopsoffset, lencontent);
-    }
-
-    template <>
-    Error awkward_listoffsetarray_toRegularArray<int32_t>(int64_t* size, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
-      return awkward_listoffsetarray32_toRegularArray(size, fromoffsets, offsetsoffset, offsetslength);
-    }
-    template <>
-    Error awkward_listoffsetarray_toRegularArray<uint32_t>(int64_t* size, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
-      return awkward_listoffsetarrayU32_toRegularArray(size, fromoffsets, offsetsoffset, offsetslength);
-    }
-    template <>
-    Error awkward_listoffsetarray_toRegularArray(int64_t* size, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t offsetslength) {
-      return awkward_listoffsetarray64_toRegularArray(size, fromoffsets, offsetsoffset, offsetslength);
-    }
-
-    template <>
-    Error awkward_unionarray_simplify8_32_to8_64<int8_t, int32_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_32_simplify8_32_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
+    Error awkward_identities64_from_unionarray<int8_t,
+                                               uint32_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int8_t* fromtags,
+      const uint32_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which) {
+      return awkward_identities64_from_unionarray8_U32(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromtags,
+        fromindex,
+        fromptroffset,
+        tagsoffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth,
+        which);
     }
     template <>
-    Error awkward_unionarray_simplify8_32_to8_64<int8_t, uint32_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_U32_simplify8_32_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
-    }
-    template <>
-    Error awkward_unionarray_simplify8_32_to8_64<int8_t, int64_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_64_simplify8_32_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
-    }
-
-    template <>
-    Error awkward_unionarray_simplify8_U32_to8_64<int8_t, int32_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_32_simplify8_U32_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
-    }
-    template <>
-    Error awkward_unionarray_simplify8_U32_to8_64<int8_t, uint32_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_U32_simplify8_U32_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
-    }
-    template <>
-    Error awkward_unionarray_simplify8_U32_to8_64<int8_t, int64_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const uint32_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_64_simplify8_U32_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
-    }
-
-    template <>
-    Error awkward_unionarray_simplify8_64_to8_64<int8_t, int32_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_32_simplify8_64_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
-    }
-    template <>
-    Error awkward_unionarray_simplify8_64_to8_64<int8_t, uint32_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const uint32_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_U32_simplify8_64_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
-    }
-    template <>
-    Error awkward_unionarray_simplify8_64_to8_64<int8_t, int64_t>(int8_t* totags, int64_t* toindex, const int8_t* outertags, int64_t outertagsoffset, const int64_t* outerindex, int64_t outerindexoffset, const int8_t* innertags, int64_t innertagsoffset, const int64_t* innerindex, int64_t innerindexoffset, int64_t towhich, int64_t innerwhich, int64_t outerwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_64_simplify8_64_to8_64(totags, toindex, outertags, outertagsoffset, outerindex, outerindexoffset, innertags, innertagsoffset, innerindex, innerindexoffset, towhich, innerwhich, outerwhich, length, base);
-    }
-
-    template <>
-    Error awkward_unionarray_simplify_one_to8_64<int8_t, int32_t>(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const int32_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_32_simplify_one_to8_64(totags, toindex, fromtags, fromtagsoffset, fromindex, fromindexoffset, towhich, fromwhich, length, base);
-    }
-    template <>
-    Error awkward_unionarray_simplify_one_to8_64<int8_t, uint32_t>(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const uint32_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_U32_simplify_one_to8_64(totags, toindex, fromtags, fromtagsoffset, fromindex, fromindexoffset, towhich, fromwhich, length, base);
-    }
-    template <>
-    Error awkward_unionarray_simplify_one_to8_64<int8_t, int64_t>(int8_t* totags, int64_t* toindex, const int8_t* fromtags, int64_t fromtagsoffset, const int64_t* fromindex, int64_t fromindexoffset, int64_t towhich, int64_t fromwhich, int64_t length, int64_t base) {
-      return awkward_unionarray8_64_simplify_one_to8_64(totags, toindex, fromtags, fromtagsoffset, fromindex, fromindexoffset, towhich, fromwhich, length, base);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_jagged_expand_64<int32_t>(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length) {
-      return awkward_listarray32_getitem_jagged_expand_64(multistarts, multistops, singleoffsets, tocarry, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, jaggedsize, length);
-    }
-    template <>
-    Error awkward_listarray_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length) {
-      return awkward_listarrayU32_getitem_jagged_expand_64(multistarts, multistops, singleoffsets, tocarry, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, jaggedsize, length);
-    }
-    template <>
-    Error awkward_listarray_getitem_jagged_expand_64(int64_t* multistarts, int64_t* multistops, const int64_t* singleoffsets, int64_t* tocarry, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset, int64_t jaggedsize, int64_t length) {
-      return awkward_listarray64_getitem_jagged_expand_64(multistarts, multistops, singleoffsets, tocarry, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, jaggedsize, length);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_jagged_apply_64<int32_t>(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset, int64_t contentlen) {
-      return awkward_listarray32_getitem_jagged_apply_64(tooffsets, tocarry, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, sliceindex, sliceindexoffset, sliceinnerlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, contentlen);
-    }
-    template <>
-    Error awkward_listarray_getitem_jagged_apply_64<uint32_t>(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset, int64_t contentlen) {
-      return awkward_listarrayU32_getitem_jagged_apply_64(tooffsets, tocarry, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, sliceindex, sliceindexoffset, sliceinnerlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, contentlen);
-    }
-    template <>
-    Error awkward_listarray_getitem_jagged_apply_64<int64_t>(int64_t* tooffsets, int64_t* tocarry, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* sliceindex, int64_t sliceindexoffset, int64_t sliceinnerlen, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset, int64_t contentlen) {
-      return awkward_listarray64_getitem_jagged_apply_64(tooffsets, tocarry, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, sliceindex, sliceindexoffset, sliceinnerlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset, contentlen);
-    }
-
-    template <>
-    Error awkward_listarray_getitem_jagged_descend_64<int32_t>(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int32_t* fromstarts, int64_t fromstartsoffset, const int32_t* fromstops, int64_t fromstopsoffset) {
-      return awkward_listarray32_getitem_jagged_descend_64(tooffsets, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset);
-    }
-    template <>
-    Error awkward_listarray_getitem_jagged_descend_64<uint32_t>(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const uint32_t* fromstarts, int64_t fromstartsoffset, const uint32_t* fromstops, int64_t fromstopsoffset) {
-      return awkward_listarrayU32_getitem_jagged_descend_64(tooffsets, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset);
-    }
-    template <>
-    Error awkward_listarray_getitem_jagged_descend_64<int64_t>(int64_t* tooffsets, const int64_t* slicestarts, int64_t slicestartsoffset, const int64_t* slicestops, int64_t slicestopsoffset, int64_t sliceouterlen, const int64_t* fromstarts, int64_t fromstartsoffset, const int64_t* fromstops, int64_t fromstopsoffset) {
-      return awkward_listarray64_getitem_jagged_descend_64(tooffsets, slicestarts, slicestartsoffset, slicestops, slicestopsoffset, sliceouterlen, fromstarts, fromstartsoffset, fromstops, fromstopsoffset);
-    }
-
-    template <>
-    Error awkward_indexedarray_reduce_next_64<int32_t>(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-      return awkward_indexedarray32_reduce_next_64(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
-    }
-
-    template <>
-    Error awkward_indexedarray_reduce_next_64<uint32_t>(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const uint32_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-      return awkward_indexedarrayU32_reduce_next_64(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
+    Error awkward_identities64_from_unionarray<int8_t,
+                                               int64_t>(
+      bool* uniquecontents,
+      int64_t* toptr,
+      const int64_t* fromptr,
+      const int8_t* fromtags,
+      const int64_t* fromindex,
+      int64_t fromptroffset,
+      int64_t tagsoffset,
+      int64_t indexoffset,
+      int64_t tolength,
+      int64_t fromlength,
+      int64_t fromwidth,
+      int64_t which) {
+      return awkward_identities64_from_unionarray8_64(
+        uniquecontents,
+        toptr,
+        fromptr,
+        fromtags,
+        fromindex,
+        fromptroffset,
+        tagsoffset,
+        indexoffset,
+        tolength,
+        fromlength,
+        fromwidth,
+        which);
     }
 
     template <>
-    Error awkward_indexedarray_reduce_next_64<int64_t>(int64_t* nextcarry, int64_t* nextparents, int64_t* outindex, const int64_t* index, int64_t indexoffset, int64_t* parents, int64_t parentsoffset, int64_t length) {
-      return awkward_indexedarray64_reduce_next_64(nextcarry, nextparents, outindex, index, indexoffset, parents, parentsoffset, length);
+    Error awkward_index_carry_64<int8_t>(
+      int8_t* toindex,
+      const int8_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length) {
+      return awkward_index8_carry_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        lenfromindex,
+        length);
+    }
+    template <>
+    Error awkward_index_carry_64<uint8_t>(
+      uint8_t* toindex,
+      const uint8_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length) {
+      return awkward_indexU8_carry_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        lenfromindex,
+        length);
+    }
+    template <>
+    Error awkward_index_carry_64<int32_t>(
+      int32_t* toindex,
+      const int32_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length) {
+      return awkward_index32_carry_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        lenfromindex,
+        length);
+    }
+    template <>
+    Error awkward_index_carry_64<uint32_t>(
+      uint32_t* toindex,
+      const uint32_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length) {
+      return awkward_indexU32_carry_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        lenfromindex,
+        length);
+    }
+    template <>
+    Error awkward_index_carry_64<int64_t>(
+      int64_t* toindex,
+      const int64_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t lenfromindex,
+      int64_t length) {
+      return awkward_index64_carry_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        lenfromindex,
+        length);
     }
 
     template <>
-    Error awkward_UnionArray_fillna_64<int32_t>(int64_t* toindex, const int32_t* fromindex, int64_t offset, int64_t length) {
-      return awkward_UnionArray_fillna_from32_to64(toindex, fromindex, offset, length);
+    Error awkward_index_carry_nocheck_64<int8_t>(
+      int8_t* toindex,
+      const int8_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length) {
+      return awkward_index8_carry_nocheck_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        length);
     }
     template <>
-    Error awkward_UnionArray_fillna_64<uint32_t>(int64_t* toindex, const uint32_t* fromindex, int64_t offset, int64_t length) {
-      return awkward_UnionArray_fillna_fromU32_to64(toindex, fromindex, offset, length);
+    Error awkward_index_carry_nocheck_64<uint8_t>(
+      uint8_t* toindex,
+      const uint8_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length) {
+      return awkward_indexU8_carry_nocheck_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        length);
     }
     template <>
-    Error awkward_UnionArray_fillna_64<int64_t>(int64_t* toindex, const int64_t* fromindex, int64_t offset, int64_t length) {
-      return awkward_UnionArray_fillna_from64_to64(toindex, fromindex, offset, length);
-    }
-
-    template <>
-    Error awkward_ListArray_min_range<int32_t>(int64_t* tomin, const int32_t* fromstarts, const int32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArray32_min_range(tomin, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset);
-    }
-    template <>
-    Error awkward_ListArray_min_range<uint32_t>(int64_t* tomin, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArrayU32_min_range(tomin, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset);
-    }
-    template <>
-    Error awkward_ListArray_min_range<int64_t>(int64_t* tomin, const int64_t* fromstarts, const int64_t* fromstops, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArray64_min_range(tomin, fromstarts, fromstops, lenstarts, startsoffset, stopsoffset);
+    Error awkward_index_carry_nocheck_64<int32_t>(
+      int32_t* toindex,
+      const int32_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length) {
+      return awkward_index32_carry_nocheck_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        length);
     }
     template <>
-    Error awkward_ListOffsetArray_rpad_length_axis1<int32_t>(int32_t* tooffsets, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t length, int64_t* tocount) {
-      return awkward_ListOffsetArray32_rpad_length_axis1(tooffsets, fromoffsets, offsetsoffset, fromlength, length, tocount);
-    }
-
-    template <>
-    Error awkward_ListOffsetArray_rpad_length_axis1<uint32_t>(uint32_t* tooffsets, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t length, int64_t* tocount) {
-      return awkward_ListOffsetArrayU32_rpad_length_axis1(tooffsets, fromoffsets, offsetsoffset, fromlength, length, tocount);
-    }
-    template <>
-    Error awkward_ListOffsetArray_rpad_length_axis1<int64_t>(int64_t* tooffsets, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t length, int64_t* tocount) {
-      return awkward_ListOffsetArray64_rpad_length_axis1(tooffsets, fromoffsets, offsetsoffset, fromlength, length, tocount);
-    }
-
-    template <>
-    Error awkward_ListOffsetArray_rpad_axis1_64<int32_t>(int64_t* toindex, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target) {
-      return awkward_ListOffsetArray32_rpad_axis1_64(toindex, fromoffsets, offsetsoffset, fromlength, target);
+    Error awkward_index_carry_nocheck_64<uint32_t>(
+      uint32_t* toindex,
+      const uint32_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length) {
+      return awkward_indexU32_carry_nocheck_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        length);
     }
     template <>
-    Error awkward_ListOffsetArray_rpad_axis1_64<uint32_t>(int64_t* toindex, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target) {
-      return awkward_ListOffsetArrayU32_rpad_axis1_64(toindex, fromoffsets, offsetsoffset, fromlength, target);
-    }
-    template <>
-    Error awkward_ListOffsetArray_rpad_axis1_64<int64_t>(int64_t* toindex, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t fromlength, int64_t target) {
-      return awkward_ListOffsetArray64_rpad_axis1_64(toindex, fromoffsets, offsetsoffset, fromlength, target);
-    }
-
-    template <>
-    Error awkward_ListArray_rpad_axis1_64<int32_t>(int64_t* toindex, const int32_t* fromstarts, const int32_t* fromstops, int32_t* tostarts, int32_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArray32_rpad_axis1_64(toindex, fromstarts, fromstops, tostarts, tostops, target, length, startsoffset, stopsoffset);
-    }
-    template <>
-    Error awkward_ListArray_rpad_axis1_64<uint32_t>(int64_t* toindex, const uint32_t* fromstarts, const uint32_t* fromstops, uint32_t* tostarts, uint32_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArrayU32_rpad_axis1_64(toindex, fromstarts, fromstops, tostarts, tostops, target, length, startsoffset, stopsoffset);
-    }
-    template <>
-    Error awkward_ListArray_rpad_axis1_64<int64_t>(int64_t* toindex, const int64_t* fromstarts, const int64_t* fromstops, int64_t* tostarts, int64_t* tostops, int64_t target, int64_t length, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArray64_rpad_axis1_64(toindex, fromstarts, fromstops, tostarts, tostops, target, length, startsoffset, stopsoffset);
-    }
-
-    template <>
-    Error awkward_ListArray_rpad_and_clip_length_axis1<int32_t>(int64_t* tolength, const int32_t* fromstarts, const int32_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArray32_rpad_and_clip_length_axis1(tolength, fromstarts, fromstops, target, lenstarts, startsoffset, stopsoffset);
-    }
-    template <>
-    Error awkward_ListArray_rpad_and_clip_length_axis1<uint32_t>(int64_t* tolength, const uint32_t* fromstarts, const uint32_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArrayU32_rpad_and_clip_length_axis1(tolength, fromstarts, fromstops, target, lenstarts, startsoffset, stopsoffset);
-    }
-    template <>
-    Error awkward_ListArray_rpad_and_clip_length_axis1<int64_t>(int64_t* tolength, const int64_t* fromstarts, const int64_t* fromstops, int64_t target, int64_t lenstarts, int64_t startsoffset, int64_t stopsoffset) {
-      return awkward_ListArray64_rpad_and_clip_length_axis1(tolength, fromstarts, fromstops, target, lenstarts, startsoffset, stopsoffset);
+    Error awkward_index_carry_nocheck_64<int64_t>(
+      int64_t* toindex,
+      const int64_t* fromindex,
+      const int64_t* carry,
+      int64_t fromindexoffset,
+      int64_t length) {
+      return awkward_index64_carry_nocheck_64(
+        toindex,
+        fromindex,
+        carry,
+        fromindexoffset,
+        length);
     }
 
     template <>
-    Error awkward_ListOffsetArray_rpad_and_clip_axis1_64<int32_t>(int64_t* toindex, const int32_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target) {
-      return awkward_ListOffsetArray32_rpad_and_clip_axis1_64(toindex, fromoffsets, offsetsoffset, length, target);
+    Error awkward_listarray_getitem_next_at_64<int32_t>(
+      int64_t* tocarry,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t at) {
+      return awkward_listarray32_getitem_next_at_64(
+        tocarry,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        at);
     }
     template <>
-    Error awkward_ListOffsetArray_rpad_and_clip_axis1_64<uint32_t>(int64_t* toindex, const uint32_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target) {
-      return awkward_ListOffsetArrayU32_rpad_and_clip_axis1_64(toindex, fromoffsets, offsetsoffset, length, target);
+    Error awkward_listarray_getitem_next_at_64<uint32_t>(
+      int64_t* tocarry,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t at) {
+      return awkward_listarrayU32_getitem_next_at_64(
+        tocarry,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        at);
     }
     template <>
-    Error awkward_ListOffsetArray_rpad_and_clip_axis1_64<int64_t>(int64_t* toindex, const int64_t* fromoffsets, int64_t offsetsoffset, int64_t length, int64_t target) {
-      return awkward_ListOffsetArray64_rpad_and_clip_axis1_64(toindex, fromoffsets, offsetsoffset, length, target);
-    }
-
-    template <>
-    Error awkward_listarray_validity<int32_t>(const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent) {
-      return awkward_listarray32_validity(starts, startsoffset, stops, stopsoffset, length, lencontent);
-    }
-    template <>
-    Error awkward_listarray_validity<uint32_t>(const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent) {
-      return awkward_listarrayU32_validity(starts, startsoffset, stops, stopsoffset, length, lencontent);
-    }
-    template <>
-    Error awkward_listarray_validity<int64_t>(const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length, int64_t lencontent) {
-      return awkward_listarray64_validity(starts, startsoffset, stops, stopsoffset, length, lencontent);
-    }
-
-    template <>
-    Error awkward_indexedarray_validity<int32_t>(const int32_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption) {
-      return awkward_indexedarray32_validity(index, indexoffset, length, lencontent, isoption);
-    }
-    template <>
-    Error awkward_indexedarray_validity<uint32_t>(const uint32_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption) {
-      return awkward_indexedarrayU32_validity(index, indexoffset, length, lencontent, isoption);
-    }
-    template <>
-    Error awkward_indexedarray_validity<int64_t>(const int64_t* index, int64_t indexoffset, int64_t length, int64_t lencontent, bool isoption) {
-      return awkward_indexedarray64_validity(index, indexoffset, length, lencontent, isoption);
-    }
-
-    template <>
-    Error awkward_unionarray_validity<int8_t, int32_t>(const int8_t* tags, int64_t tagsoffset, const int32_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents) {
-      return awkward_unionarray8_32_validity(tags, tagsoffset, index, indexoffset, length, numcontents, lencontents);
-    }
-    template <>
-    Error awkward_unionarray_validity<int8_t, uint32_t>(const int8_t* tags, int64_t tagsoffset, const uint32_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents) {
-      return awkward_unionarray8_U32_validity(tags, tagsoffset, index, indexoffset, length, numcontents, lencontents);
-    }
-    template <>
-    Error awkward_unionarray_validity<int8_t, int64_t>(const int8_t* tags, int64_t tagsoffset, const int64_t* index, int64_t indexoffset, int64_t length, int64_t numcontents, const int64_t* lencontents) {
-      return awkward_unionarray8_64_validity(tags, tagsoffset, index, indexoffset, length, numcontents, lencontents);
-    }
-
-    template <>
-    Error awkward_listarray_localindex_64<int32_t>(int64_t* toindex, const int32_t* offsets, int64_t offsetsoffset, int64_t length) {
-      return awkward_listarray32_localindex_64(toindex, offsets, offsetsoffset, length);
-    }
-    template <>
-    Error awkward_listarray_localindex_64<uint32_t>(int64_t* toindex, const uint32_t* offsets, int64_t offsetsoffset, int64_t length) {
-      return awkward_listarrayU32_localindex_64(toindex, offsets, offsetsoffset, length);
-    }
-    template <>
-    Error awkward_listarray_localindex_64<int64_t>(int64_t* toindex, const int64_t* offsets, int64_t offsetsoffset, int64_t length) {
-      return awkward_listarray64_localindex_64(toindex, offsets, offsetsoffset, length);
+    Error awkward_listarray_getitem_next_at_64<int64_t>(
+      int64_t* tocarry,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t at) {
+      return awkward_listarray64_getitem_next_at_64(
+        tocarry,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        at);
     }
 
     template <>
-    Error awkward_listarray_choose_length_64<int32_t>(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarray32_choose_length_64(totallen, tooffsets, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+    Error awkward_listarray_getitem_next_range_carrylength<int32_t>(
+      int64_t* carrylength,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step) {
+      return awkward_listarray32_getitem_next_range_carrylength(
+        carrylength,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        start,
+        stop,
+        step);
     }
     template <>
-    Error awkward_listarray_choose_length_64<uint32_t>(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarrayU32_choose_length_64(totallen, tooffsets, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+    Error awkward_listarray_getitem_next_range_carrylength<uint32_t>(
+      int64_t* carrylength,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step) {
+      return awkward_listarrayU32_getitem_next_range_carrylength(
+        carrylength,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        start,
+        stop,
+        step);
     }
     template <>
-    Error awkward_listarray_choose_length_64<int64_t>(int64_t* totallen, int64_t* tooffsets, int64_t n, bool diagonal, const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarray64_choose_length_64(totallen, tooffsets, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+    Error awkward_listarray_getitem_next_range_carrylength<int64_t>(
+      int64_t* carrylength,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step) {
+      return awkward_listarray64_getitem_next_range_carrylength(
+        carrylength,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        start,
+        stop,
+        step);
     }
 
     template <>
-    Error awkward_listarray_choose_64<int32_t>(int64_t** tocarry, int64_t n, bool diagonal, const int32_t* starts, int64_t startsoffset, const int32_t* stops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarray32_choose_64(tocarry, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+    Error awkward_listarray_getitem_next_range_64<int32_t>(
+      int32_t* tooffsets,
+      int64_t* tocarry,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step) {
+      return awkward_listarray32_getitem_next_range_64(
+        tooffsets,
+        tocarry,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        start,
+        stop,
+        step);
     }
     template <>
-    Error awkward_listarray_choose_64<uint32_t>(int64_t** tocarry, int64_t n, bool diagonal, const uint32_t* starts, int64_t startsoffset, const uint32_t* stops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarrayU32_choose_64(tocarry, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+    Error awkward_listarray_getitem_next_range_64<uint32_t>(
+      uint32_t* tooffsets,
+      int64_t* tocarry,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step) {
+      return awkward_listarrayU32_getitem_next_range_64(
+        tooffsets,
+        tocarry,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        start,
+        stop,
+        step);
     }
     template <>
-    Error awkward_listarray_choose_64<int64_t>(int64_t** tocarry, int64_t n, bool diagonal, const int64_t* starts, int64_t startsoffset, const int64_t* stops, int64_t stopsoffset, int64_t length) {
-      return awkward_listarray64_choose_64(tocarry, n, diagonal, starts, startsoffset, stops, stopsoffset, length);
+    Error awkward_listarray_getitem_next_range_64<int64_t>(
+      int64_t* tooffsets,
+      int64_t* tocarry,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t start,
+      int64_t stop,
+      int64_t step) {
+      return awkward_listarray64_getitem_next_range_64(
+        tooffsets,
+        tocarry,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset,
+        start,
+        stop,
+        step);
+    }
+
+    template <>
+    Error awkward_listarray_getitem_next_range_counts_64<int32_t>(
+      int64_t* total,
+      const int32_t* fromoffsets,
+      int64_t lenstarts) {
+      return awkward_listarray32_getitem_next_range_counts_64(
+        total,
+        fromoffsets,
+        lenstarts);
+    }
+    template <>
+    Error awkward_listarray_getitem_next_range_counts_64<uint32_t>(
+      int64_t* total,
+      const uint32_t* fromoffsets,
+      int64_t lenstarts) {
+      return awkward_listarrayU32_getitem_next_range_counts_64(
+        total,
+        fromoffsets,
+        lenstarts);
+    }
+    template <>
+    Error awkward_listarray_getitem_next_range_counts_64<int64_t>(
+      int64_t* total,
+      const int64_t* fromoffsets,
+      int64_t lenstarts) {
+      return awkward_listarray64_getitem_next_range_counts_64(
+        total,
+        fromoffsets,
+        lenstarts);
+    }
+
+    template <>
+    Error awkward_listarray_getitem_next_range_spreadadvanced_64<int32_t>(
+      int64_t* toadvanced,
+      const int64_t* fromadvanced,
+      const int32_t* fromoffsets,
+      int64_t lenstarts) {
+      return awkward_listarray32_getitem_next_range_spreadadvanced_64(
+        toadvanced,
+        fromadvanced,
+        fromoffsets,
+        lenstarts);
+    }
+    template <>
+    Error awkward_listarray_getitem_next_range_spreadadvanced_64<uint32_t>(
+      int64_t* toadvanced,
+      const int64_t* fromadvanced,
+      const uint32_t* fromoffsets,
+      int64_t lenstarts) {
+      return awkward_listarrayU32_getitem_next_range_spreadadvanced_64(
+        toadvanced,
+        fromadvanced,
+        fromoffsets,
+        lenstarts);
+    }
+    template <>
+    Error awkward_listarray_getitem_next_range_spreadadvanced_64<int64_t>(
+      int64_t* toadvanced,
+      const int64_t* fromadvanced,
+      const int64_t* fromoffsets,
+      int64_t lenstarts) {
+      return awkward_listarray64_getitem_next_range_spreadadvanced_64(
+        toadvanced,
+        fromadvanced,
+        fromoffsets,
+        lenstarts);
+    }
+
+    template <>
+    Error awkward_listarray_getitem_next_array_64<int32_t>(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      const int64_t* fromarray,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent) {
+      return awkward_listarray32_getitem_next_array_64(
+        tocarry,
+        toadvanced,
+        fromstarts,
+        fromstops,
+        fromarray,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lenarray,
+        lencontent);
+    }
+    template <>
+    Error awkward_listarray_getitem_next_array_64<uint32_t>(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      const int64_t* fromarray,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent) {
+      return awkward_listarrayU32_getitem_next_array_64(
+        tocarry,
+        toadvanced,
+        fromstarts,
+        fromstops,
+        fromarray,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lenarray,
+        lencontent);
+    }
+    template <>
+    Error awkward_listarray_getitem_next_array_64<int64_t>(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      const int64_t* fromarray,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent) {
+      return awkward_listarray64_getitem_next_array_64(
+        tocarry,
+        toadvanced,
+        fromstarts,
+        fromstops,
+        fromarray,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lenarray,
+        lencontent);
+    }
+
+    template <>
+    Error awkward_listarray_getitem_next_array_advanced_64<int32_t>(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      const int64_t* fromarray,
+      const int64_t* fromadvanced,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent) {
+      return awkward_listarray32_getitem_next_array_advanced_64(
+        tocarry,
+        toadvanced,
+        fromstarts,
+        fromstops,
+        fromarray,
+        fromadvanced,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lenarray,
+        lencontent);
+    }
+    template <>
+    Error awkward_listarray_getitem_next_array_advanced_64<uint32_t>(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      const int64_t* fromarray,
+      const int64_t* fromadvanced,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent) {
+      return awkward_listarrayU32_getitem_next_array_advanced_64(
+        tocarry,
+        toadvanced,
+        fromstarts,
+        fromstops,
+        fromarray,
+        fromadvanced,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lenarray,
+        lencontent);
+    }
+    template <>
+    Error awkward_listarray_getitem_next_array_advanced_64<int64_t>(
+      int64_t* tocarry,
+      int64_t* toadvanced,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      const int64_t* fromarray,
+      const int64_t* fromadvanced,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lenarray,
+      int64_t lencontent) {
+      return awkward_listarray64_getitem_next_array_advanced_64(
+        tocarry,
+        toadvanced,
+        fromstarts,
+        fromstops,
+        fromarray,
+        fromadvanced,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lenarray,
+        lencontent);
+    }
+
+    template <>
+    Error awkward_listarray_getitem_carry_64<int32_t>(
+      int32_t* tostarts,
+      int32_t* tostops,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      const int64_t* fromcarry,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lencarry) {
+      return awkward_listarray32_getitem_carry_64(
+        tostarts,
+        tostops,
+        fromstarts,
+        fromstops,
+        fromcarry,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lencarry);
+    }
+    template <>
+    Error awkward_listarray_getitem_carry_64<uint32_t>(
+      uint32_t* tostarts,
+      uint32_t* tostops,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      const int64_t* fromcarry,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lencarry) {
+      return awkward_listarrayU32_getitem_carry_64(
+        tostarts,
+        tostops,
+        fromstarts,
+        fromstops,
+        fromcarry,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lencarry);
+    }
+    template <>
+    Error awkward_listarray_getitem_carry_64<int64_t>(
+      int64_t* tostarts,
+      int64_t* tostops,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      const int64_t* fromcarry,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t lenstarts,
+      int64_t lencarry) {
+      return awkward_listarray64_getitem_carry_64(
+        tostarts,
+        tostops,
+        fromstarts,
+        fromstops,
+        fromcarry,
+        startsoffset,
+        stopsoffset,
+        lenstarts,
+        lencarry);
+    }
+
+    template <>
+    Error awkward_listarray_num_64<int32_t>(
+      int64_t* tonum,
+      const int32_t* fromstarts,
+      int64_t startsoffset,
+      const int32_t* fromstops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarray32_num_64(
+        tonum,
+        fromstarts,
+        startsoffset,
+        fromstops,
+        stopsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_num_64<uint32_t>(
+      int64_t* tonum,
+      const uint32_t* fromstarts,
+      int64_t startsoffset,
+      const uint32_t* fromstops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarrayU32_num_64(
+        tonum,
+        fromstarts,
+        startsoffset,
+        fromstops,
+        stopsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_num_64<int64_t>(
+      int64_t* tonum,
+      const int64_t* fromstarts,
+      int64_t startsoffset,
+      const int64_t* fromstops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarray64_num_64(
+        tonum,
+        fromstarts,
+        startsoffset,
+        fromstops,
+        stopsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_listoffsetarray_flatten_offsets_64<int32_t>(
+      int64_t* tooffsets,
+      const int32_t* outeroffsets,
+      int64_t outeroffsetsoffset,
+      int64_t outeroffsetslen,
+      const int64_t* inneroffsets,
+      int64_t inneroffsetsoffset,
+      int64_t inneroffsetslen) {
+      return awkward_listoffsetarray32_flatten_offsets_64(
+        tooffsets,
+        outeroffsets,
+        outeroffsetsoffset,
+        outeroffsetslen,
+        inneroffsets,
+        inneroffsetsoffset,
+        inneroffsetslen);
+    }
+    template <>
+    Error awkward_listoffsetarray_flatten_offsets_64<uint32_t>(
+      int64_t* tooffsets,
+      const uint32_t* outeroffsets,
+      int64_t outeroffsetsoffset,
+      int64_t outeroffsetslen,
+      const int64_t* inneroffsets,
+      int64_t inneroffsetsoffset,
+      int64_t inneroffsetslen) {
+      return awkward_listoffsetarrayU32_flatten_offsets_64(
+        tooffsets,
+        outeroffsets,
+        outeroffsetsoffset,
+        outeroffsetslen,
+        inneroffsets,
+        inneroffsetsoffset,
+        inneroffsetslen);
+    }
+    template <>
+    Error awkward_listoffsetarray_flatten_offsets_64<int64_t>(
+      int64_t* tooffsets,
+      const int64_t* outeroffsets,
+      int64_t outeroffsetsoffset,
+      int64_t outeroffsetslen,
+      const int64_t* inneroffsets,
+      int64_t inneroffsetsoffset,
+      int64_t inneroffsetslen) {
+      return awkward_listoffsetarray64_flatten_offsets_64(
+        tooffsets,
+        outeroffsets,
+        outeroffsetsoffset,
+        outeroffsetslen,
+        inneroffsets,
+        inneroffsetsoffset,
+        inneroffsetslen);
+    }
+
+    template <>
+    Error awkward_indexedarray_flatten_none2empty_64<int32_t>(
+      int64_t* outoffsets,
+      const int32_t* outindex,
+      int64_t outindexoffset,
+      int64_t outindexlength,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength) {
+      return awkward_indexedarray32_flatten_none2empty_64(
+        outoffsets,
+        outindex,
+        outindexoffset,
+        outindexlength,
+        offsets,
+        offsetsoffset,
+        offsetslength);
+    }
+    template <>
+    Error awkward_indexedarray_flatten_none2empty_64<uint32_t>(
+      int64_t* outoffsets,
+      const uint32_t* outindex,
+      int64_t outindexoffset,
+      int64_t outindexlength,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength) {
+      return awkward_indexedarrayU32_flatten_none2empty_64(
+        outoffsets,
+        outindex,
+        outindexoffset,
+        outindexlength,
+        offsets,
+        offsetsoffset,
+        offsetslength);
+    }
+    template <>
+    Error awkward_indexedarray_flatten_none2empty_64<int64_t>(
+      int64_t* outoffsets,
+      const int64_t* outindex,
+      int64_t outindexoffset,
+      int64_t outindexlength,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength) {
+      return awkward_indexedarray64_flatten_none2empty_64(
+        outoffsets,
+        outindex,
+        outindexoffset,
+        outindexlength,
+        offsets,
+        offsetsoffset,
+        offsetslength);
+    }
+
+    template <>
+    Error awkward_unionarray_flatten_length_64<int8_t,
+                                               int32_t>(
+      int64_t* total_length,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets) {
+      return awkward_unionarray32_flatten_length_64(
+        total_length,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        length,
+        offsetsraws,
+        offsetsoffsets);
+    }
+    template <>
+    Error awkward_unionarray_flatten_length_64<int8_t,
+                                               uint32_t>(
+      int64_t* total_length,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const uint32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets) {
+      return awkward_unionarrayU32_flatten_length_64(
+        total_length,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        length,
+        offsetsraws,
+        offsetsoffsets);
+    }
+    template <>
+    Error awkward_unionarray_flatten_length_64<int8_t,
+                                               int64_t>(
+      int64_t* total_length,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets) {
+      return awkward_unionarray64_flatten_length_64(
+        total_length,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        length,
+        offsetsraws,
+        offsetsoffsets);
+    }
+
+    template <>
+    Error awkward_unionarray_flatten_combine_64<int8_t,
+                                                int32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      int64_t* tooffsets,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets) {
+      return awkward_unionarray32_flatten_combine_64(
+        totags,
+        toindex,
+        tooffsets,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        length,
+        offsetsraws,
+        offsetsoffsets);
+    }
+    template <>
+    Error awkward_unionarray_flatten_combine_64<int8_t,
+                                                uint32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      int64_t* tooffsets,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const uint32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets) {
+      return awkward_unionarrayU32_flatten_combine_64(
+        totags,
+        toindex,
+        tooffsets,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        length,
+        offsetsraws,
+        offsetsoffsets);
+    }
+    template <>
+    Error awkward_unionarray_flatten_combine_64<int8_t,
+                                                int64_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      int64_t* tooffsets,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t length,
+      int64_t** offsetsraws,
+      int64_t* offsetsoffsets) {
+      return awkward_unionarray64_flatten_combine_64(
+        totags,
+        toindex,
+        tooffsets,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        length,
+        offsetsraws,
+        offsetsoffsets);
+    }
+
+    template <>
+    Error awkward_indexedarray_flatten_nextcarry_64<int32_t>(
+      int64_t* tocarry,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarray32_flatten_nextcarry_64(
+        tocarry,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+    template <>
+    Error awkward_indexedarray_flatten_nextcarry_64<uint32_t>(
+      int64_t* tocarry,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarrayU32_flatten_nextcarry_64(
+        tocarry,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+    template <>
+    Error awkward_indexedarray_flatten_nextcarry_64<int64_t>(
+      int64_t* tocarry,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarray64_flatten_nextcarry_64(
+        tocarry,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+
+    template <>
+    Error awkward_indexedarray_numnull<int32_t>(
+      int64_t* numnull,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex) {
+      return awkward_indexedarray32_numnull(
+        numnull,
+        fromindex,
+        indexoffset,
+        lenindex);
+    }
+    template <>
+    Error awkward_indexedarray_numnull<uint32_t>(
+      int64_t* numnull,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex) {
+      return awkward_indexedarrayU32_numnull(
+        numnull,
+        fromindex,
+        indexoffset,
+        lenindex);
+    }
+    template <>
+    Error awkward_indexedarray_numnull<int64_t>(
+      int64_t* numnull,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex) {
+      return awkward_indexedarray64_numnull(
+        numnull,
+        fromindex,
+        indexoffset,
+        lenindex);
+    }
+
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_outindex_64<int32_t>(
+      int64_t* tocarry,
+      int32_t* toindex,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarray32_getitem_nextcarry_outindex_64(
+        tocarry,
+        toindex,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_outindex_64<uint32_t>(
+      int64_t* tocarry,
+      uint32_t* toindex,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarrayU32_getitem_nextcarry_outindex_64(
+        tocarry,
+        toindex,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_outindex_64<int64_t>(
+      int64_t* tocarry,
+      int64_t* toindex,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarray64_getitem_nextcarry_outindex_64(
+        tocarry,
+        toindex,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_outindex_mask_64<int32_t>(
+      int64_t* tocarry,
+      int64_t* toindex,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarray32_getitem_nextcarry_outindex_mask_64(
+        tocarry,
+        toindex,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_outindex_mask_64<uint32_t>(
+      int64_t* tocarry,
+      int64_t* toindex,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarrayU32_getitem_nextcarry_outindex_mask_64(
+        tocarry,
+        toindex,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_outindex_mask_64<int64_t>(
+      int64_t* tocarry,
+      int64_t* toindex,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarray64_getitem_nextcarry_outindex_mask_64(
+        tocarry,
+        toindex,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_64<int32_t>(
+      int64_t* tocarry,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarray32_getitem_nextcarry_64(
+        tocarry,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_64<uint32_t>(
+      int64_t* tocarry,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarrayU32_getitem_nextcarry_64(
+        tocarry,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+    template <>
+    Error awkward_indexedarray_getitem_nextcarry_64<int64_t>(
+      int64_t* tocarry,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencontent) {
+      return awkward_indexedarray64_getitem_nextcarry_64(
+        tocarry,
+        fromindex,
+        indexoffset,
+        lenindex,
+        lencontent);
+    }
+
+    template <>
+    Error awkward_indexedarray_getitem_carry_64<int32_t>(
+      int32_t* toindex,
+      const int32_t* fromindex,
+      const int64_t* fromcarry,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencarry) {
+      return awkward_indexedarray32_getitem_carry_64(
+        toindex,
+        fromindex,
+        fromcarry,
+        indexoffset,
+        lenindex,
+        lencarry);
+    }
+    template <>
+    Error awkward_indexedarray_getitem_carry_64<uint32_t>(
+      uint32_t* toindex,
+      const uint32_t* fromindex,
+      const int64_t* fromcarry,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencarry) {
+      return awkward_indexedarrayU32_getitem_carry_64(
+        toindex,
+        fromindex,
+        fromcarry,
+        indexoffset,
+        lenindex,
+        lencarry);
+    }
+    template <>
+    Error awkward_indexedarray_getitem_carry_64<int64_t>(
+      int64_t* toindex,
+      const int64_t* fromindex,
+      const int64_t* fromcarry,
+      int64_t indexoffset,
+      int64_t lenindex,
+      int64_t lencarry) {
+      return awkward_indexedarray64_getitem_carry_64(
+        toindex,
+        fromindex,
+        fromcarry,
+        indexoffset,
+        lenindex,
+        lencarry);
+    }
+
+    template <>
+    Error awkward_indexedarray_overlay_mask8_to64<int32_t>(
+      int64_t* toindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length) {
+      return awkward_indexedarray32_overlay_mask8_to64(
+        toindex,
+        mask,
+        maskoffset,
+        fromindex,
+        indexoffset,
+        length);
+    }
+    template <>
+    Error awkward_indexedarray_overlay_mask8_to64<uint32_t>(
+      int64_t* toindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length) {
+      return awkward_indexedarrayU32_overlay_mask8_to64(
+        toindex,
+        mask,
+        maskoffset,
+        fromindex,
+        indexoffset,
+        length);
+    }
+    template <>
+    Error awkward_indexedarray_overlay_mask8_to64<int64_t>(
+      int64_t* toindex,
+      const int8_t* mask,
+      int64_t maskoffset,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t length) {
+      return awkward_indexedarray64_overlay_mask8_to64(
+        toindex,
+        mask,
+        maskoffset,
+        fromindex,
+        indexoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_indexedarray_mask8<int32_t>(
+      int8_t* tomask,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length) {
+      return awkward_indexedarray32_mask8(
+        tomask,
+        fromindex,
+        indexoffset,
+        length);
+    }
+    template <>
+    Error awkward_indexedarray_mask8<uint32_t>(
+      int8_t* tomask,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length) {
+      return awkward_indexedarrayU32_mask8(
+        tomask,
+        fromindex,
+        indexoffset,
+        length);
+    }
+    template <>
+    Error awkward_indexedarray_mask8<int64_t>(
+      int8_t* tomask,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t length) {
+      return awkward_indexedarray64_mask8(
+        tomask,
+        fromindex,
+        indexoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_indexedarray_simplify32_to64<int32_t>(
+      int64_t* toindex,
+      const int32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarray32_simplify32_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+    template <>
+    Error awkward_indexedarray_simplify32_to64<uint32_t>(
+      int64_t* toindex,
+      const uint32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarrayU32_simplify32_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+    template <>
+    Error awkward_indexedarray_simplify32_to64<int64_t>(
+      int64_t* toindex,
+      const int64_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarray64_simplify32_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+
+    template <>
+    Error awkward_indexedarray_simplifyU32_to64<int32_t>(
+      int64_t* toindex,
+      const int32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const uint32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarray32_simplifyU32_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+    template <>
+    Error awkward_indexedarray_simplifyU32_to64<uint32_t>(
+      int64_t* toindex,
+      const uint32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const uint32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarrayU32_simplifyU32_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+    template <>
+    Error awkward_indexedarray_simplifyU32_to64<int64_t>(
+      int64_t* toindex,
+      const int64_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const uint32_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarray64_simplifyU32_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+
+    template <>
+    Error awkward_indexedarray_simplify64_to64<int32_t>(
+      int64_t* toindex,
+      const int32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int64_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarray32_simplify64_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+    template <>
+    Error awkward_indexedarray_simplify64_to64<uint32_t>(
+      int64_t* toindex,
+      const uint32_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int64_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarrayU32_simplify64_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+    template <>
+    Error awkward_indexedarray_simplify64_to64<int64_t>(
+      int64_t* toindex,
+      const int64_t* outerindex,
+      int64_t outeroffset,
+      int64_t outerlength,
+      const int64_t* innerindex,
+      int64_t inneroffset,
+      int64_t innerlength) {
+      return awkward_indexedarray64_simplify64_to64(
+        toindex,
+        outerindex,
+        outeroffset,
+        outerlength,
+        innerindex,
+        inneroffset,
+        innerlength);
+    }
+
+    template <>
+    Error awkward_unionarray_regular_index<int8_t,
+                                           int32_t>(
+      int32_t* toindex,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      int64_t length) {
+      return awkward_unionarray8_32_regular_index(
+        toindex,
+        fromtags,
+        tagsoffset,
+        length);
+    }
+    template <>
+    Error awkward_unionarray_regular_index<int8_t,
+                                           uint32_t>(
+      uint32_t* toindex,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      int64_t length) {
+      return awkward_unionarray8_U32_regular_index(
+        toindex,
+        fromtags,
+        tagsoffset,
+        length);
+    }
+    template <>
+    Error awkward_unionarray_regular_index<int8_t,
+                                           int64_t>(
+      int64_t* toindex,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      int64_t length) {
+      return awkward_unionarray8_64_regular_index(
+        toindex,
+        fromtags,
+        tagsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_unionarray_project_64<int8_t,
+                                        int32_t>(
+      int64_t* lenout,
+      int64_t* tocarry,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      const int32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t which) {
+      return awkward_unionarray8_32_project_64(
+        lenout,
+        tocarry,
+        fromtags,
+        tagsoffset,
+        fromindex,
+        indexoffset,
+        length,
+        which);
+    }
+    template <>
+    Error awkward_unionarray_project_64<int8_t,
+                                        uint32_t>(
+      int64_t* lenout,
+      int64_t* tocarry,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      const uint32_t* fromindex,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t which) {
+      return awkward_unionarray8_U32_project_64(
+        lenout,
+        tocarry,
+        fromtags,
+        tagsoffset,
+        fromindex,
+        indexoffset,
+        length,
+        which);
+    }
+    template <>
+    Error awkward_unionarray_project_64<int8_t,
+                                        int64_t>(
+      int64_t* lenout,
+      int64_t* tocarry,
+      const int8_t* fromtags,
+      int64_t tagsoffset,
+      const int64_t* fromindex,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t which) {
+      return awkward_unionarray8_64_project_64(
+        lenout,
+        tocarry,
+        fromtags,
+        tagsoffset,
+        fromindex,
+        indexoffset,
+        length,
+        which);
+    }
+
+    template <>
+    Error awkward_listarray_compact_offsets64(
+      int64_t* tooffsets,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarray32_compact_offsets64(
+        tooffsets,
+        fromstarts,
+        fromstops,
+        startsoffset,
+        stopsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_compact_offsets64(
+      int64_t* tooffsets,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarrayU32_compact_offsets64(
+        tooffsets,
+        fromstarts,
+        fromstops,
+        startsoffset,
+        stopsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_compact_offsets64(
+      int64_t* tooffsets,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t startsoffset,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarray64_compact_offsets64(
+        tooffsets,
+        fromstarts,
+        fromstops,
+        startsoffset,
+        stopsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_listoffsetarray_compact_offsets64(
+      int64_t* tooffsets,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length) {
+      return awkward_listoffsetarray32_compact_offsets64(
+        tooffsets,
+        fromoffsets,
+        offsetsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listoffsetarray_compact_offsets64(
+      int64_t* tooffsets,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length) {
+      return awkward_listoffsetarrayU32_compact_offsets64(
+        tooffsets,
+        fromoffsets,
+        offsetsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listoffsetarray_compact_offsets64(
+      int64_t* tooffsets,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length) {
+      return awkward_listoffsetarray64_compact_offsets64(
+        tooffsets,
+        fromoffsets,
+        offsetsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_listarray_broadcast_tooffsets64<int32_t>(
+      int64_t* tocarry,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength,
+      const int32_t* fromstarts,
+      int64_t startsoffset,
+      const int32_t* fromstops,
+      int64_t stopsoffset,
+      int64_t lencontent) {
+      return awkward_listarray32_broadcast_tooffsets64(
+        tocarry,
+        fromoffsets,
+        offsetsoffset,
+        offsetslength,
+        fromstarts,
+        startsoffset,
+        fromstops,
+        stopsoffset,
+        lencontent);
+    }
+    template <>
+    Error awkward_listarray_broadcast_tooffsets64<uint32_t>(
+      int64_t* tocarry,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength,
+      const uint32_t* fromstarts,
+      int64_t startsoffset,
+      const uint32_t* fromstops,
+      int64_t stopsoffset,
+      int64_t lencontent) {
+      return awkward_listarrayU32_broadcast_tooffsets64(
+        tocarry,
+        fromoffsets,
+        offsetsoffset,
+        offsetslength,
+        fromstarts,
+        startsoffset,
+        fromstops,
+        stopsoffset,
+        lencontent);
+    }
+    template <>
+    Error awkward_listarray_broadcast_tooffsets64<int64_t>(
+      int64_t* tocarry,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength,
+      const int64_t* fromstarts,
+      int64_t startsoffset,
+      const int64_t* fromstops,
+      int64_t stopsoffset,
+      int64_t lencontent) {
+      return awkward_listarray64_broadcast_tooffsets64(
+        tocarry,
+        fromoffsets,
+        offsetsoffset,
+        offsetslength,
+        fromstarts,
+        startsoffset,
+        fromstops,
+        stopsoffset,
+        lencontent);
+    }
+
+    template <>
+    Error awkward_listoffsetarray_toRegularArray<int32_t>(
+      int64_t* size,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength) {
+      return awkward_listoffsetarray32_toRegularArray(
+        size,
+        fromoffsets,
+        offsetsoffset,
+        offsetslength);
+    }
+    template <>
+    Error awkward_listoffsetarray_toRegularArray<uint32_t>(
+      int64_t* size,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength) {
+      return awkward_listoffsetarrayU32_toRegularArray(
+        size,
+        fromoffsets,
+        offsetsoffset,
+        offsetslength);
+    }
+    template <>
+    Error awkward_listoffsetarray_toRegularArray(
+      int64_t* size,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t offsetslength) {
+      return awkward_listoffsetarray64_toRegularArray(
+        size,
+        fromoffsets,
+        offsetsoffset,
+        offsetslength);
+    }
+
+    template <>
+    Error awkward_unionarray_simplify8_32_to8_64<int8_t,
+                                                 int32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_32_simplify8_32_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+    template <>
+    Error awkward_unionarray_simplify8_32_to8_64<int8_t,
+                                                 uint32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const uint32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_U32_simplify8_32_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+    template <>
+    Error awkward_unionarray_simplify8_32_to8_64<int8_t,
+                                                 int64_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int64_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_64_simplify8_32_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+
+    template <>
+    Error awkward_unionarray_simplify8_U32_to8_64<int8_t,
+                                                  int32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const uint32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_32_simplify8_U32_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+    template <>
+    Error awkward_unionarray_simplify8_U32_to8_64<int8_t,
+                                                  uint32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const uint32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const uint32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_U32_simplify8_U32_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+    template <>
+    Error awkward_unionarray_simplify8_U32_to8_64<int8_t,
+                                                  int64_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int64_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const uint32_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_64_simplify8_U32_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+
+    template <>
+    Error awkward_unionarray_simplify8_64_to8_64<int8_t,
+                                                 int32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int64_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_32_simplify8_64_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+    template <>
+    Error awkward_unionarray_simplify8_64_to8_64<int8_t,
+                                                 uint32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const uint32_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int64_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_U32_simplify8_64_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+    template <>
+    Error awkward_unionarray_simplify8_64_to8_64<int8_t,
+                                                 int64_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* outertags,
+      int64_t outertagsoffset,
+      const int64_t* outerindex,
+      int64_t outerindexoffset,
+      const int8_t* innertags,
+      int64_t innertagsoffset,
+      const int64_t* innerindex,
+      int64_t innerindexoffset,
+      int64_t towhich,
+      int64_t innerwhich,
+      int64_t outerwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_64_simplify8_64_to8_64(
+        totags,
+        toindex,
+        outertags,
+        outertagsoffset,
+        outerindex,
+        outerindexoffset,
+        innertags,
+        innertagsoffset,
+        innerindex,
+        innerindexoffset,
+        towhich,
+        innerwhich,
+        outerwhich,
+        length,
+        base);
+    }
+
+    template <>
+    Error awkward_unionarray_simplify_one_to8_64<int8_t,
+                                                 int32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t towhich,
+      int64_t fromwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_32_simplify_one_to8_64(
+        totags,
+        toindex,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        towhich,
+        fromwhich,
+        length,
+        base);
+    }
+    template <>
+    Error awkward_unionarray_simplify_one_to8_64<int8_t,
+                                                 uint32_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const uint32_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t towhich,
+      int64_t fromwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_U32_simplify_one_to8_64(
+        totags,
+        toindex,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        towhich,
+        fromwhich,
+        length,
+        base);
+    }
+    template <>
+    Error awkward_unionarray_simplify_one_to8_64<int8_t,
+                                                 int64_t>(
+      int8_t* totags,
+      int64_t* toindex,
+      const int8_t* fromtags,
+      int64_t fromtagsoffset,
+      const int64_t* fromindex,
+      int64_t fromindexoffset,
+      int64_t towhich,
+      int64_t fromwhich,
+      int64_t length,
+      int64_t base) {
+      return awkward_unionarray8_64_simplify_one_to8_64(
+        totags,
+        toindex,
+        fromtags,
+        fromtagsoffset,
+        fromindex,
+        fromindexoffset,
+        towhich,
+        fromwhich,
+        length,
+        base);
+    }
+
+    template <>
+    Error awkward_listarray_getitem_jagged_expand_64<int32_t>(
+      int64_t* multistarts,
+      int64_t* multistops,
+      const int64_t* singleoffsets,
+      int64_t* tocarry,
+      const int32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t jaggedsize,
+      int64_t length) {
+      return awkward_listarray32_getitem_jagged_expand_64(
+        multistarts,
+        multistops,
+        singleoffsets,
+        tocarry,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset,
+        jaggedsize,
+        length);
+    }
+    template <>
+    Error awkward_listarray_getitem_jagged_expand_64(
+      int64_t* multistarts,
+      int64_t* multistops,
+      const int64_t* singleoffsets,
+      int64_t* tocarry,
+      const uint32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const uint32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t jaggedsize,
+      int64_t length) {
+      return awkward_listarrayU32_getitem_jagged_expand_64(
+        multistarts,
+        multistops,
+        singleoffsets,
+        tocarry,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset,
+        jaggedsize,
+        length);
+    }
+    template <>
+    Error awkward_listarray_getitem_jagged_expand_64(
+      int64_t* multistarts,
+      int64_t* multistops,
+      const int64_t* singleoffsets,
+      int64_t* tocarry,
+      const int64_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int64_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t jaggedsize,
+      int64_t length) {
+      return awkward_listarray64_getitem_jagged_expand_64(
+        multistarts,
+        multistops,
+        singleoffsets,
+        tocarry,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset,
+        jaggedsize,
+        length);
+    }
+
+    template <>
+    Error awkward_listarray_getitem_jagged_apply_64<int32_t>(
+      int64_t* tooffsets,
+      int64_t* tocarry,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int64_t* sliceindex,
+      int64_t sliceindexoffset,
+      int64_t sliceinnerlen,
+      const int32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t contentlen) {
+      return awkward_listarray32_getitem_jagged_apply_64(
+        tooffsets,
+        tocarry,
+        slicestarts,
+        slicestartsoffset,
+        slicestops,
+        slicestopsoffset,
+        sliceouterlen,
+        sliceindex,
+        sliceindexoffset,
+        sliceinnerlen,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset,
+        contentlen);
+    }
+    template <>
+    Error awkward_listarray_getitem_jagged_apply_64<uint32_t>(
+      int64_t* tooffsets,
+      int64_t* tocarry,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int64_t* sliceindex,
+      int64_t sliceindexoffset,
+      int64_t sliceinnerlen,
+      const uint32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const uint32_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t contentlen) {
+      return awkward_listarrayU32_getitem_jagged_apply_64(
+        tooffsets,
+        tocarry,
+        slicestarts,
+        slicestartsoffset,
+        slicestops,
+        slicestopsoffset,
+        sliceouterlen,
+        sliceindex,
+        sliceindexoffset,
+        sliceinnerlen,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset,
+        contentlen);
+    }
+    template <>
+    Error awkward_listarray_getitem_jagged_apply_64<int64_t>(
+      int64_t* tooffsets,
+      int64_t* tocarry,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int64_t* sliceindex,
+      int64_t sliceindexoffset,
+      int64_t sliceinnerlen,
+      const int64_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int64_t* fromstops,
+      int64_t fromstopsoffset,
+      int64_t contentlen) {
+      return awkward_listarray64_getitem_jagged_apply_64(
+        tooffsets,
+        tocarry,
+        slicestarts,
+        slicestartsoffset,
+        slicestops,
+        slicestopsoffset,
+        sliceouterlen,
+        sliceindex,
+        sliceindexoffset,
+        sliceinnerlen,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset,
+        contentlen);
+    }
+
+    template <>
+    Error awkward_listarray_getitem_jagged_descend_64<int32_t>(
+      int64_t* tooffsets,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int32_t* fromstops,
+      int64_t fromstopsoffset) {
+      return awkward_listarray32_getitem_jagged_descend_64(
+        tooffsets,
+        slicestarts,
+        slicestartsoffset,
+        slicestops,
+        slicestopsoffset,
+        sliceouterlen,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset);
+    }
+    template <>
+    Error awkward_listarray_getitem_jagged_descend_64<uint32_t>(
+      int64_t* tooffsets,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const uint32_t* fromstarts,
+      int64_t fromstartsoffset,
+      const uint32_t* fromstops,
+      int64_t fromstopsoffset) {
+      return awkward_listarrayU32_getitem_jagged_descend_64(
+        tooffsets,
+        slicestarts,
+        slicestartsoffset,
+        slicestops,
+        slicestopsoffset,
+        sliceouterlen,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset);
+    }
+    template <>
+    Error awkward_listarray_getitem_jagged_descend_64<int64_t>(
+      int64_t* tooffsets,
+      const int64_t* slicestarts,
+      int64_t slicestartsoffset,
+      const int64_t* slicestops,
+      int64_t slicestopsoffset,
+      int64_t sliceouterlen,
+      const int64_t* fromstarts,
+      int64_t fromstartsoffset,
+      const int64_t* fromstops,
+      int64_t fromstopsoffset) {
+      return awkward_listarray64_getitem_jagged_descend_64(
+        tooffsets,
+        slicestarts,
+        slicestartsoffset,
+        slicestops,
+        slicestopsoffset,
+        sliceouterlen,
+        fromstarts,
+        fromstartsoffset,
+        fromstops,
+        fromstopsoffset);
+    }
+
+    template <>
+    Error awkward_indexedarray_reduce_next_64<int32_t>(
+      int64_t* nextcarry,
+      int64_t* nextparents,
+      int64_t* outindex,
+      const int32_t* index,
+      int64_t indexoffset,
+      int64_t* parents,
+      int64_t parentsoffset,
+      int64_t length) {
+      return awkward_indexedarray32_reduce_next_64(
+        nextcarry,
+        nextparents,
+        outindex,
+        index,
+        indexoffset,
+        parents,
+        parentsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_indexedarray_reduce_next_64<uint32_t>(
+      int64_t* nextcarry,
+      int64_t* nextparents,
+      int64_t* outindex,
+      const uint32_t* index,
+      int64_t indexoffset,
+      int64_t* parents,
+      int64_t parentsoffset,
+      int64_t length) {
+      return awkward_indexedarrayU32_reduce_next_64(
+        nextcarry,
+        nextparents,
+        outindex,
+        index,
+        indexoffset,
+        parents,
+        parentsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_indexedarray_reduce_next_64<int64_t>(
+      int64_t* nextcarry,
+      int64_t* nextparents,
+      int64_t* outindex,
+      const int64_t* index,
+      int64_t indexoffset,
+      int64_t* parents,
+      int64_t parentsoffset,
+      int64_t length) {
+      return awkward_indexedarray64_reduce_next_64(
+        nextcarry,
+        nextparents,
+        outindex,
+        index,
+        indexoffset,
+        parents,
+        parentsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_UnionArray_fillna_64<int32_t>(
+      int64_t* toindex,
+      const int32_t* fromindex,
+      int64_t offset,
+      int64_t length) {
+      return awkward_UnionArray_fillna_from32_to64(
+        toindex,
+        fromindex,
+        offset,
+        length);
+    }
+    template <>
+    Error awkward_UnionArray_fillna_64<uint32_t>(
+      int64_t* toindex,
+      const uint32_t* fromindex,
+      int64_t offset,
+      int64_t length) {
+      return awkward_UnionArray_fillna_fromU32_to64(
+        toindex,
+        fromindex,
+        offset,
+        length);
+    }
+    template <>
+    Error awkward_UnionArray_fillna_64<int64_t>(
+      int64_t* toindex,
+      const int64_t* fromindex,
+      int64_t offset,
+      int64_t length) {
+      return awkward_UnionArray_fillna_from64_to64(
+        toindex,
+        fromindex,
+        offset,
+        length);
+    }
+
+    template <>
+    Error awkward_ListArray_min_range<int32_t>(
+      int64_t* tomin,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArray32_min_range(
+        tomin,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset);
+    }
+    template <>
+    Error awkward_ListArray_min_range<uint32_t>(
+      int64_t* tomin,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArrayU32_min_range(
+        tomin,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset);
+    }
+    template <>
+    Error awkward_ListArray_min_range<int64_t>(
+      int64_t* tomin,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArray64_min_range(
+        tomin,
+        fromstarts,
+        fromstops,
+        lenstarts,
+        startsoffset,
+        stopsoffset);
+    }
+    template <>
+    Error awkward_ListOffsetArray_rpad_length_axis1<int32_t>(
+      int32_t* tooffsets,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t length,
+      int64_t* tocount) {
+      return awkward_ListOffsetArray32_rpad_length_axis1(
+        tooffsets,
+        fromoffsets,
+        offsetsoffset,
+        fromlength,
+        length,
+        tocount);
+    }
+
+    template <>
+    Error awkward_ListOffsetArray_rpad_length_axis1<uint32_t>(
+      uint32_t* tooffsets,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t length,
+      int64_t* tocount) {
+      return awkward_ListOffsetArrayU32_rpad_length_axis1(
+        tooffsets,
+        fromoffsets,
+        offsetsoffset,
+        fromlength,
+        length,
+        tocount);
+    }
+    template <>
+    Error awkward_ListOffsetArray_rpad_length_axis1<int64_t>(
+      int64_t* tooffsets,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t length,
+      int64_t* tocount) {
+      return awkward_ListOffsetArray64_rpad_length_axis1(
+        tooffsets,
+        fromoffsets,
+        offsetsoffset,
+        fromlength,
+        length,
+        tocount);
+    }
+
+    template <>
+    Error awkward_ListOffsetArray_rpad_axis1_64<int32_t>(
+      int64_t* toindex,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target) {
+      return awkward_ListOffsetArray32_rpad_axis1_64(
+        toindex,
+        fromoffsets,
+        offsetsoffset,
+        fromlength,
+        target);
+    }
+    template <>
+    Error awkward_ListOffsetArray_rpad_axis1_64<uint32_t>(
+      int64_t* toindex,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target) {
+      return awkward_ListOffsetArrayU32_rpad_axis1_64(
+        toindex,
+        fromoffsets,
+        offsetsoffset,
+        fromlength,
+        target);
+    }
+    template <>
+    Error awkward_ListOffsetArray_rpad_axis1_64<int64_t>(
+      int64_t* toindex,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t fromlength,
+      int64_t target) {
+      return awkward_ListOffsetArray64_rpad_axis1_64(
+        toindex,
+        fromoffsets,
+        offsetsoffset,
+        fromlength,
+        target);
+    }
+
+    template <>
+    Error awkward_ListArray_rpad_axis1_64<int32_t>(
+      int64_t* toindex,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int32_t* tostarts,
+      int32_t* tostops,
+      int64_t target,
+      int64_t length,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArray32_rpad_axis1_64(
+        toindex,
+        fromstarts,
+        fromstops,
+        tostarts,
+        tostops,
+        target,
+        length,
+        startsoffset,
+        stopsoffset);
+    }
+    template <>
+    Error awkward_ListArray_rpad_axis1_64<uint32_t>(
+      int64_t* toindex,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      uint32_t* tostarts,
+      uint32_t* tostops,
+      int64_t target,
+      int64_t length,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArrayU32_rpad_axis1_64(
+        toindex,
+        fromstarts,
+        fromstops,
+        tostarts,
+        tostops,
+        target,
+        length,
+        startsoffset,
+        stopsoffset);
+    }
+    template <>
+    Error awkward_ListArray_rpad_axis1_64<int64_t>(
+      int64_t* toindex,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t* tostarts,
+      int64_t* tostops,
+      int64_t target,
+      int64_t length,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArray64_rpad_axis1_64(
+        toindex,
+        fromstarts,
+        fromstops,
+        tostarts,
+        tostops,
+        target,
+        length,
+        startsoffset,
+        stopsoffset);
+    }
+
+    template <>
+    Error awkward_ListArray_rpad_and_clip_length_axis1<int32_t>(
+      int64_t* tolength,
+      const int32_t* fromstarts,
+      const int32_t* fromstops,
+      int64_t target,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArray32_rpad_and_clip_length_axis1(
+        tolength,
+        fromstarts,
+        fromstops,
+        target,
+        lenstarts,
+        startsoffset,
+        stopsoffset);
+    }
+    template <>
+    Error awkward_ListArray_rpad_and_clip_length_axis1<uint32_t>(
+      int64_t* tolength,
+      const uint32_t* fromstarts,
+      const uint32_t* fromstops,
+      int64_t target,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArrayU32_rpad_and_clip_length_axis1(
+        tolength,
+        fromstarts,
+        fromstops,
+        target,
+        lenstarts,
+        startsoffset,
+        stopsoffset);
+    }
+    template <>
+    Error awkward_ListArray_rpad_and_clip_length_axis1<int64_t>(
+      int64_t* tolength,
+      const int64_t* fromstarts,
+      const int64_t* fromstops,
+      int64_t target,
+      int64_t lenstarts,
+      int64_t startsoffset,
+      int64_t stopsoffset) {
+      return awkward_ListArray64_rpad_and_clip_length_axis1(
+        tolength,
+        fromstarts,
+        fromstops,
+        target,
+        lenstarts,
+        startsoffset,
+        stopsoffset);
+    }
+
+    template <>
+    Error awkward_ListOffsetArray_rpad_and_clip_axis1_64<int32_t>(
+      int64_t* toindex,
+      const int32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      int64_t target) {
+      return awkward_ListOffsetArray32_rpad_and_clip_axis1_64(
+        toindex,
+        fromoffsets,
+        offsetsoffset,
+        length,
+        target);
+    }
+    template <>
+    Error awkward_ListOffsetArray_rpad_and_clip_axis1_64<uint32_t>(
+      int64_t* toindex,
+      const uint32_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      int64_t target) {
+      return awkward_ListOffsetArrayU32_rpad_and_clip_axis1_64(
+        toindex,
+        fromoffsets,
+        offsetsoffset,
+        length,
+        target);
+    }
+    template <>
+    Error awkward_ListOffsetArray_rpad_and_clip_axis1_64<int64_t>(
+      int64_t* toindex,
+      const int64_t* fromoffsets,
+      int64_t offsetsoffset,
+      int64_t length,
+      int64_t target) {
+      return awkward_ListOffsetArray64_rpad_and_clip_axis1_64(
+        toindex,
+        fromoffsets,
+        offsetsoffset,
+        length,
+        target);
+    }
+
+    template <>
+    Error awkward_listarray_validity<int32_t>(
+      const int32_t* starts,
+      int64_t startsoffset,
+      const int32_t* stops,
+      int64_t stopsoffset,
+      int64_t length,
+      int64_t lencontent) {
+      return awkward_listarray32_validity(
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length,
+        lencontent);
+    }
+    template <>
+    Error awkward_listarray_validity<uint32_t>(
+      const uint32_t* starts,
+      int64_t startsoffset,
+      const uint32_t* stops,
+      int64_t stopsoffset,
+      int64_t length,
+      int64_t lencontent) {
+      return awkward_listarrayU32_validity(
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length,
+        lencontent);
+    }
+    template <>
+    Error awkward_listarray_validity<int64_t>(
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* stops,
+      int64_t stopsoffset,
+      int64_t length,
+      int64_t lencontent) {
+      return awkward_listarray64_validity(
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length,
+        lencontent);
+    }
+
+    template <>
+    Error awkward_indexedarray_validity<int32_t>(
+      const int32_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t lencontent,
+      bool isoption) {
+      return awkward_indexedarray32_validity(
+        index,
+        indexoffset,
+        length,
+        lencontent,
+        isoption);
+    }
+    template <>
+    Error awkward_indexedarray_validity<uint32_t>(
+      const uint32_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t lencontent,
+      bool isoption) {
+      return awkward_indexedarrayU32_validity(
+        index,
+        indexoffset,
+        length,
+        lencontent,
+        isoption);
+    }
+    template <>
+    Error awkward_indexedarray_validity<int64_t>(
+      const int64_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t lencontent,
+      bool isoption) {
+      return awkward_indexedarray64_validity(
+        index,
+        indexoffset,
+        length,
+        lencontent,
+        isoption);
+    }
+
+    template <>
+    Error awkward_unionarray_validity<int8_t,
+                                      int32_t>(
+      const int8_t* tags,
+      int64_t tagsoffset,
+      const int32_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t numcontents,
+      const int64_t* lencontents) {
+      return awkward_unionarray8_32_validity(
+        tags,
+        tagsoffset,
+        index,
+        indexoffset,
+        length,
+        numcontents,
+        lencontents);
+    }
+    template <>
+    Error awkward_unionarray_validity<int8_t,
+                                      uint32_t>(
+      const int8_t* tags,
+      int64_t tagsoffset,
+      const uint32_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t numcontents,
+      const int64_t* lencontents) {
+      return awkward_unionarray8_U32_validity(
+        tags,
+        tagsoffset,
+        index,
+        indexoffset,
+        length,
+        numcontents,
+        lencontents);
+    }
+    template <>
+    Error awkward_unionarray_validity<int8_t,
+                                      int64_t>(
+      const int8_t* tags,
+      int64_t tagsoffset,
+      const int64_t* index,
+      int64_t indexoffset,
+      int64_t length,
+      int64_t numcontents,
+      const int64_t* lencontents) {
+      return awkward_unionarray8_64_validity(
+        tags,
+        tagsoffset,
+        index,
+        indexoffset,
+        length,
+        numcontents,
+        lencontents);
+    }
+
+    template <>
+    Error awkward_listarray_localindex_64<int32_t>(
+      int64_t* toindex,
+      const int32_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length) {
+      return awkward_listarray32_localindex_64(
+        toindex,
+        offsets,
+        offsetsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_localindex_64<uint32_t>(
+      int64_t* toindex,
+      const uint32_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length) {
+      return awkward_listarrayU32_localindex_64(
+        toindex,
+        offsets,
+        offsetsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_localindex_64<int64_t>(
+      int64_t* toindex,
+      const int64_t* offsets,
+      int64_t offsetsoffset,
+      int64_t length) {
+      return awkward_listarray64_localindex_64(
+        toindex,
+        offsets,
+        offsetsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_listarray_choose_length_64<int32_t>(
+      int64_t* totallen,
+      int64_t* tooffsets,
+      int64_t n,
+      bool diagonal,
+      const int32_t* starts,
+      int64_t startsoffset,
+      const int32_t* stops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarray32_choose_length_64(
+        totallen,
+        tooffsets,
+        n,
+        diagonal,
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_choose_length_64<uint32_t>(
+      int64_t* totallen,
+      int64_t* tooffsets,
+      int64_t n,
+      bool diagonal,
+      const uint32_t* starts,
+      int64_t startsoffset,
+      const uint32_t* stops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarrayU32_choose_length_64(
+        totallen,
+        tooffsets,
+        n,
+        diagonal,
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_choose_length_64<int64_t>(
+      int64_t* totallen,
+      int64_t* tooffsets,
+      int64_t n,
+      bool diagonal,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* stops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarray64_choose_length_64(
+        totallen,
+        tooffsets,
+        n,
+        diagonal,
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length);
+    }
+
+    template <>
+    Error awkward_listarray_choose_64<int32_t>(
+      int64_t** tocarry,
+      int64_t n,
+      bool diagonal,
+      const int32_t* starts,
+      int64_t startsoffset,
+      const int32_t* stops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarray32_choose_64(
+        tocarry,
+        n,
+        diagonal,
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_choose_64<uint32_t>(
+      int64_t** tocarry,
+      int64_t n,
+      bool diagonal,
+      const uint32_t* starts,
+      int64_t startsoffset,
+      const uint32_t* stops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarrayU32_choose_64(
+        tocarry,
+        n,
+        diagonal,
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length);
+    }
+    template <>
+    Error awkward_listarray_choose_64<int64_t>(
+      int64_t** tocarry,
+      int64_t n,
+      bool diagonal,
+      const int64_t* starts,
+      int64_t startsoffset,
+      const int64_t* stops,
+      int64_t stopsoffset,
+      int64_t length) {
+      return awkward_listarray64_choose_64(
+        tocarry,
+        n,
+        diagonal,
+        starts,
+        startsoffset,
+        stops,
+        stopsoffset,
+        length);
     }
 
     template<>
-    int8_t awkward_index_getitem_at_nowrap<int8_t>(const int8_t* ptr, int64_t offset, int64_t at) {
-      return awkward_index8_getitem_at_nowrap(ptr, offset, at);
+    int8_t awkward_index_getitem_at_nowrap<int8_t>(
+      const int8_t* ptr,
+      int64_t offset,
+      int64_t at) {
+      return awkward_index8_getitem_at_nowrap(
+        ptr,
+        offset,
+        at);
     }
     template<>
-    uint8_t awkward_index_getitem_at_nowrap<uint8_t>(const uint8_t* ptr, int64_t offset, int64_t at) {
-      return awkward_indexU8_getitem_at_nowrap(ptr, offset, at);
+    uint8_t awkward_index_getitem_at_nowrap<uint8_t>(
+      const uint8_t* ptr,
+      int64_t offset,
+      int64_t at) {
+      return awkward_indexU8_getitem_at_nowrap(
+        ptr,
+        offset,
+        at);
     }
     template<>
-    int32_t awkward_index_getitem_at_nowrap<int32_t>(const int32_t* ptr, int64_t offset, int64_t at) {
-      return awkward_index32_getitem_at_nowrap(ptr, offset, at);
+    int32_t awkward_index_getitem_at_nowrap<int32_t>(
+      const int32_t* ptr,
+      int64_t offset,
+      int64_t at) {
+      return awkward_index32_getitem_at_nowrap(
+        ptr,
+        offset,
+        at);
     }
     template<>
-    uint32_t awkward_index_getitem_at_nowrap<uint32_t>(const uint32_t* ptr, int64_t offset, int64_t at) {
-      return awkward_indexU32_getitem_at_nowrap(ptr, offset, at);
+    uint32_t awkward_index_getitem_at_nowrap<uint32_t>(
+      const uint32_t* ptr,
+      int64_t offset,
+      int64_t at) {
+      return awkward_indexU32_getitem_at_nowrap(
+        ptr,
+        offset,
+        at);
     }
     template<>
-    int64_t awkward_index_getitem_at_nowrap<int64_t>(const int64_t* ptr, int64_t offset, int64_t at) {
-      return awkward_index64_getitem_at_nowrap(ptr, offset, at);
+    int64_t awkward_index_getitem_at_nowrap<int64_t>(
+      const int64_t* ptr,
+      int64_t offset,
+      int64_t at) {
+      return awkward_index64_getitem_at_nowrap(
+        ptr,
+        offset,
+        at);
     }
 
     template<>
-    void awkward_index_setitem_at_nowrap<int8_t>(int8_t* ptr, int64_t offset, int64_t at, int8_t value) {
-      awkward_index8_setitem_at_nowrap(ptr, offset, at, value);
+    void awkward_index_setitem_at_nowrap<int8_t>(
+      int8_t* ptr,
+      int64_t offset,
+      int64_t at,
+      int8_t value) {
+      awkward_index8_setitem_at_nowrap(
+        ptr,
+        offset,
+        at,
+        value);
     }
     template<>
-    void awkward_index_setitem_at_nowrap<uint8_t>(uint8_t* ptr, int64_t offset, int64_t at, uint8_t value) {
-      awkward_indexU8_setitem_at_nowrap(ptr, offset, at, value);
+    void awkward_index_setitem_at_nowrap<uint8_t>(
+      uint8_t* ptr,
+      int64_t offset,
+      int64_t at,
+      uint8_t value) {
+      awkward_indexU8_setitem_at_nowrap(
+        ptr,
+        offset,
+        at,
+        value);
     }
     template<>
-    void awkward_index_setitem_at_nowrap<int32_t>(int32_t* ptr, int64_t offset, int64_t at, int32_t value) {
-      awkward_index32_setitem_at_nowrap(ptr, offset, at, value);
+    void awkward_index_setitem_at_nowrap<int32_t>(
+      int32_t* ptr,
+      int64_t offset,
+      int64_t at,
+      int32_t value) {
+      awkward_index32_setitem_at_nowrap(
+        ptr,
+        offset,
+        at,
+        value);
     }
     template<>
-    void awkward_index_setitem_at_nowrap<uint32_t>(uint32_t* ptr, int64_t offset, int64_t at, uint32_t value) {
-      awkward_indexU32_setitem_at_nowrap(ptr, offset, at, value);
+    void awkward_index_setitem_at_nowrap<uint32_t>(
+      uint32_t* ptr,
+      int64_t offset,
+      int64_t at,
+      uint32_t value) {
+      awkward_indexU32_setitem_at_nowrap(
+        ptr,
+        offset,
+        at,
+        value);
     }
     template<>
-    void awkward_index_setitem_at_nowrap<int64_t>(int64_t* ptr, int64_t offset, int64_t at, int64_t value) {
-      awkward_index64_setitem_at_nowrap(ptr, offset, at, value);
+    void awkward_index_setitem_at_nowrap<int64_t>(
+      int64_t* ptr,
+      int64_t offset,
+      int64_t at,
+      int64_t value) {
+      awkward_index64_setitem_at_nowrap(
+        ptr,
+        offset,
+        at,
+        value);
     }
 
   }

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -64,15 +64,15 @@ namespace awkward {
       }
     }
 
-    std::shared_ptr<RecordLookup> init_recordlookup(int64_t numfields) {
-      std::shared_ptr<RecordLookup> out = std::make_shared<RecordLookup>();
+    RecordLookupPtr init_recordlookup(int64_t numfields) {
+      RecordLookupPtr out = std::make_shared<RecordLookup>();
       for (int64_t i = 0;  i < numfields;  i++) {
         out.get()->push_back(std::to_string(i));
       }
       return out;
     }
 
-    int64_t fieldindex(const std::shared_ptr<RecordLookup>& recordlookup, const std::string& key, int64_t numfields) {
+    int64_t fieldindex(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields) {
       int64_t out = -1;
       if (recordlookup.get() != nullptr) {
         for (size_t i = 0;  i < recordlookup.get()->size();  i++) {
@@ -96,7 +96,7 @@ namespace awkward {
       return out;
     }
 
-    const std::string key(const std::shared_ptr<RecordLookup>& recordlookup, int64_t fieldindex, int64_t numfields) {
+    const std::string key(const RecordLookupPtr& recordlookup, int64_t fieldindex, int64_t numfields) {
       if (fieldindex >= numfields) {
         throw std::invalid_argument(std::string("fieldindex ") + std::to_string(fieldindex) + std::string(" for records with only " + std::to_string(numfields) + std::string(" fields")));
       }
@@ -108,7 +108,7 @@ namespace awkward {
       }
     }
 
-    bool haskey(const std::shared_ptr<RecordLookup>& recordlookup, const std::string& key, int64_t numfields) {
+    bool haskey(const RecordLookupPtr& recordlookup, const std::string& key, int64_t numfields) {
       try {
         fieldindex(recordlookup, key, numfields);
       }
@@ -118,7 +118,7 @@ namespace awkward {
       return true;
     }
 
-    const std::vector<std::string> keys(const std::shared_ptr<RecordLookup>& recordlookup, int64_t numfields) {
+    const std::vector<std::string> keys(const RecordLookupPtr& recordlookup, int64_t numfields) {
       std::vector<std::string> out;
       if (recordlookup.get() != nullptr) {
         out.insert(out.end(), recordlookup.get()->begin(), recordlookup.get()->end());

--- a/src/python/_io.cpp
+++ b/src/python/_io.cpp
@@ -14,10 +14,15 @@
 namespace py = pybind11;
 namespace ak = awkward;
 
-/////////////////////////////////////////////////////////////// fromjson
+////////// fromjson
 
-void make_fromjson(py::module& m, const std::string& name) {
-  m.def(name.c_str(), [](const std::string& source, int64_t initial, double resize, int64_t buffersize) -> std::shared_ptr<ak::Content> {
+void
+make_fromjson(py::module& m, const std::string& name) {
+  m.def(name.c_str(),
+        [](const std::string& source,
+           int64_t initial,
+           double resize,
+           int64_t buffersize) -> std::shared_ptr<ak::Content> {
     bool isarray = false;
     for (char const &x: source) {
       if (x != 9  &&  x != 10  &&  x != 13  &&  x != 32) {  // whitespace
@@ -28,7 +33,8 @@ void make_fromjson(py::module& m, const std::string& name) {
       }
     }
     if (isarray) {
-      return ak::FromJsonString(source.c_str(), ak::ArrayBuilderOptions(initial, resize));
+      return ak::FromJsonString(
+        source.c_str(), ak::ArrayBuilderOptions(initial, resize));
     }
     else {
 #ifdef _MSC_VER
@@ -38,11 +44,15 @@ void make_fromjson(py::module& m, const std::string& name) {
       FILE* file = fopen(source.c_str(), "rb");
       if (file == nullptr) {
 #endif
-        throw std::invalid_argument(std::string("file \"") + source + std::string("\" could not be opened for reading"));
+        throw std::invalid_argument(
+          std::string("file \"") + source
+          + std::string("\" could not be opened for reading"));
       }
       std::shared_ptr<ak::Content> out(nullptr);
       try {
-        out = FromJsonFile(file, ak::ArrayBuilderOptions(initial, resize), buffersize);
+        out = FromJsonFile(file,
+                           ak::ArrayBuilderOptions(initial, resize),
+                           buffersize);
       }
       catch (...) {
         fclose(file);
@@ -51,18 +61,40 @@ void make_fromjson(py::module& m, const std::string& name) {
       fclose(file);
       return out;
     }
-  }, py::arg("source"), py::arg("initial") = 1024, py::arg("resize") = 2.0, py::arg("buffersize") = 65536);
+  }, py::arg("source"),
+      py::arg("initial") = 1024,
+      py::arg("resize") = 2.0,
+      py::arg("buffersize") = 65536);
 }
 
-/////////////////////////////////////////////////////////////// fromroot
+////////// fromroot
 
-void make_fromroot_nestedvector(py::module& m, const std::string& name) {
-  m.def(name.c_str(), [](const ak::Index64& byteoffsets, const ak::NumpyArray& rawdata, int64_t depth, int64_t itemsize, const std::string& format, int64_t initial, double resize) -> std::shared_ptr<ak::Content> {
-      return FromROOT_nestedvector(byteoffsets, rawdata, depth, itemsize, format, ak::ArrayBuilderOptions(initial, resize));
-  }, py::arg("byteoffsets"), py::arg("rawdata"), py::arg("depth"), py::arg("itemsize"), py::arg("format"), py::arg("initial") = 1024, py::arg("resize") = 2.0);
+void
+make_fromroot_nestedvector(py::module& m, const std::string& name) {
+  m.def(name.c_str(),
+        [](const ak::Index64& byteoffsets,
+           const ak::NumpyArray& rawdata,
+           int64_t depth,
+           int64_t itemsize,
+           const std::string& format,
+           int64_t initial,
+           double resize) -> std::shared_ptr<ak::Content> {
+      return FromROOT_nestedvector(byteoffsets,
+                                   rawdata,
+                                   depth,
+                                   itemsize,
+                                   format,
+                                   ak::ArrayBuilderOptions(initial, resize));
+  }, py::arg("byteoffsets"),
+     py::arg("rawdata"),
+     py::arg("depth"),
+     py::arg("itemsize"),
+     py::arg("format"),
+     py::arg("initial") = 1024,
+     py::arg("resize") = 2.0);
 }
 
-/////////////////////////////////////////////////////////////// module
+////////// module
 
 namespace py = pybind11;
 PYBIND11_MODULE(_io, m) {

--- a/src/python/layout.cpp
+++ b/src/python/layout.cpp
@@ -14,7 +14,7 @@ PYBIND11_MODULE(layout, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  /////////////////////////////////////////////////////////////// index.h
+  ////////// index.h
 
   make_IndexOf<int8_t>(m,   "Index8");
   make_IndexOf<uint8_t>(m,  "IndexU8");
@@ -22,12 +22,12 @@ PYBIND11_MODULE(layout, m) {
   make_IndexOf<uint32_t>(m, "IndexU32");
   make_IndexOf<int64_t>(m,  "Index64");
 
-  /////////////////////////////////////////////////////////////// identities.h
+  ////////// identities.h
 
   make_IdentitiesOf<int32_t>(m, "Identities32");
   make_IdentitiesOf<int64_t>(m, "Identities64");
 
-  /////////////////////////////////////////////////////////////// content.h
+  ////////// content.h
 
   make_Iterator(m, "Iterator");
   make_ArrayBuilder(m, "ArrayBuilder");

--- a/src/python/layout/content.cpp
+++ b/src/python/layout/content.cpp
@@ -7,18 +7,22 @@
 
 #include "awkward/python/content.h"
 
-/////////////////////////////////////////////////////////////// boxing
+////////// boxing
 
-py::object box(const std::shared_ptr<ak::Content>& content) {
+py::object
+box(const std::shared_ptr<ak::Content>& content) {
   // scalars
-  if (ak::None* raw = dynamic_cast<ak::None*>(content.get())) {
+  if (ak::None* raw =
+      dynamic_cast<ak::None*>(content.get())) {
     return py::none();
   }
-  else if (ak::Record* raw = dynamic_cast<ak::Record*>(content.get())) {
+  else if (ak::Record* raw =
+           dynamic_cast<ak::Record*>(content.get())) {
     return py::cast(*raw);
   }
   // scalar or array
-  else if (ak::NumpyArray* raw = dynamic_cast<ak::NumpyArray*>(content.get())) {
+  else if (ak::NumpyArray* raw =
+           dynamic_cast<ak::NumpyArray*>(content.get())) {
     if (raw->isscalar()) {
       return py::array(py::buffer_info(
         raw->byteptr(),
@@ -34,64 +38,84 @@ py::object box(const std::shared_ptr<ak::Content>& content) {
     }
   }
   // arrays
-  else if (ak::EmptyArray* raw = dynamic_cast<ak::EmptyArray*>(content.get())) {
+  else if (ak::EmptyArray* raw =
+           dynamic_cast<ak::EmptyArray*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::IndexedArray32* raw = dynamic_cast<ak::IndexedArray32*>(content.get())) {
+  else if (ak::IndexedArray32* raw =
+           dynamic_cast<ak::IndexedArray32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::IndexedArrayU32* raw = dynamic_cast<ak::IndexedArrayU32*>(content.get())) {
+  else if (ak::IndexedArrayU32* raw =
+           dynamic_cast<ak::IndexedArrayU32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::IndexedArray64* raw = dynamic_cast<ak::IndexedArray64*>(content.get())) {
+  else if (ak::IndexedArray64* raw =
+           dynamic_cast<ak::IndexedArray64*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::IndexedOptionArray32* raw = dynamic_cast<ak::IndexedOptionArray32*>(content.get())) {
+  else if (ak::IndexedOptionArray32* raw =
+           dynamic_cast<ak::IndexedOptionArray32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::IndexedOptionArray64* raw = dynamic_cast<ak::IndexedOptionArray64*>(content.get())) {
+  else if (ak::IndexedOptionArray64* raw =
+           dynamic_cast<ak::IndexedOptionArray64*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::ByteMaskedArray* raw = dynamic_cast<ak::ByteMaskedArray*>(content.get())) {
+  else if (ak::ByteMaskedArray* raw =
+           dynamic_cast<ak::ByteMaskedArray*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::BitMaskedArray* raw = dynamic_cast<ak::BitMaskedArray*>(content.get())) {
+  else if (ak::BitMaskedArray* raw =
+           dynamic_cast<ak::BitMaskedArray*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::UnmaskedArray* raw = dynamic_cast<ak::UnmaskedArray*>(content.get())) {
+  else if (ak::UnmaskedArray* raw =
+           dynamic_cast<ak::UnmaskedArray*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::ListArray32* raw = dynamic_cast<ak::ListArray32*>(content.get())) {
+  else if (ak::ListArray32* raw =
+           dynamic_cast<ak::ListArray32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::ListArrayU32* raw = dynamic_cast<ak::ListArrayU32*>(content.get())) {
+  else if (ak::ListArrayU32* raw =
+           dynamic_cast<ak::ListArrayU32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::ListArray64* raw = dynamic_cast<ak::ListArray64*>(content.get())) {
+  else if (ak::ListArray64* raw =
+           dynamic_cast<ak::ListArray64*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::ListOffsetArray32* raw = dynamic_cast<ak::ListOffsetArray32*>(content.get())) {
+  else if (ak::ListOffsetArray32* raw =
+           dynamic_cast<ak::ListOffsetArray32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::ListOffsetArrayU32* raw = dynamic_cast<ak::ListOffsetArrayU32*>(content.get())) {
+  else if (ak::ListOffsetArrayU32* raw =
+           dynamic_cast<ak::ListOffsetArrayU32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::ListOffsetArray64* raw = dynamic_cast<ak::ListOffsetArray64*>(content.get())) {
+  else if (ak::ListOffsetArray64* raw =
+           dynamic_cast<ak::ListOffsetArray64*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::RecordArray* raw = dynamic_cast<ak::RecordArray*>(content.get())) {
+  else if (ak::RecordArray* raw =
+           dynamic_cast<ak::RecordArray*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::RegularArray* raw = dynamic_cast<ak::RegularArray*>(content.get())) {
+  else if (ak::RegularArray* raw =
+           dynamic_cast<ak::RegularArray*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::UnionArray8_32* raw = dynamic_cast<ak::UnionArray8_32*>(content.get())) {
+  else if (ak::UnionArray8_32* raw =
+           dynamic_cast<ak::UnionArray8_32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::UnionArray8_U32* raw = dynamic_cast<ak::UnionArray8_U32*>(content.get())) {
+  else if (ak::UnionArray8_U32* raw =
+           dynamic_cast<ak::UnionArray8_U32*>(content.get())) {
     return py::cast(*raw);
   }
-  else if (ak::UnionArray8_64* raw = dynamic_cast<ak::UnionArray8_64*>(content.get())) {
+  else if (ak::UnionArray8_64* raw =
+           dynamic_cast<ak::UnionArray8_64*>(content.get())) {
     return py::cast(*raw);
   }
   else {
@@ -99,14 +123,17 @@ py::object box(const std::shared_ptr<ak::Content>& content) {
   }
 }
 
-py::object box(const std::shared_ptr<ak::Identities>& identities) {
+py::object
+box(const std::shared_ptr<ak::Identities>& identities) {
   if (identities.get() == nullptr) {
     return py::none();
   }
-  else if (ak::Identities32* raw = dynamic_cast<ak::Identities32*>(identities.get())) {
+  else if (ak::Identities32* raw =
+           dynamic_cast<ak::Identities32*>(identities.get())) {
     return py::cast(*raw);
   }
-  else if (ak::Identities64* raw = dynamic_cast<ak::Identities64*>(identities.get())) {
+  else if (ak::Identities64* raw =
+           dynamic_cast<ak::Identities64*>(identities.get())) {
     return py::cast(*raw);
   }
   else {
@@ -114,10 +141,12 @@ py::object box(const std::shared_ptr<ak::Identities>& identities) {
   }
 }
 
-std::shared_ptr<ak::Content> unbox_content(const py::handle& obj) {
+std::shared_ptr<ak::Content>
+unbox_content(const py::handle& obj) {
   try {
     obj.cast<ak::Record*>();
-    throw std::invalid_argument("content argument must be a Content subtype (excluding Record)");
+    throw std::invalid_argument(
+      "content argument must be a Content subtype (excluding Record)");
   }
   catch (py::cast_error err) { }
   try {
@@ -207,7 +236,8 @@ std::shared_ptr<ak::Content> unbox_content(const py::handle& obj) {
   throw std::invalid_argument("content argument must be a Content subtype");
 }
 
-std::shared_ptr<ak::Identities> unbox_identities(const py::handle& obj) {
+std::shared_ptr<ak::Identities>
+unbox_identities(const py::handle& obj) {
   try {
     return obj.cast<ak::Identities32*>()->shallow_copy();
   }
@@ -219,7 +249,8 @@ std::shared_ptr<ak::Identities> unbox_identities(const py::handle& obj) {
   throw std::invalid_argument("id argument must be an Identities subtype");
 }
 
-std::shared_ptr<ak::Identities> unbox_identities_none(const py::handle& obj) {
+std::shared_ptr<ak::Identities>
+unbox_identities_none(const py::handle& obj) {
   if (obj.is(py::none())) {
     return ak::Identities::none();
   }
@@ -228,31 +259,39 @@ std::shared_ptr<ak::Identities> unbox_identities_none(const py::handle& obj) {
   }
 }
 
-/////////////////////////////////////////////////////////////// slicing
+////////// slicing
 
 bool handle_as_numpy(const std::shared_ptr<ak::Content>& content) {
-  // if (content.get()->parameter_equals("__array__", "\"string\"")  ||  content.get()->parameter_equals("__array__", "\"bytestring\"")) {
+  // if (content.get()->parameter_equals("__array__", "\"string\"")  ||
+  //     content.get()->parameter_equals("__array__", "\"bytestring\"")) {
   //   return true;
   // }
-  if (ak::NumpyArray* raw = dynamic_cast<ak::NumpyArray*>(content.get())) {
+  if (ak::NumpyArray* raw =
+      dynamic_cast<ak::NumpyArray*>(content.get())) {
     return true;
   }
-  else if (ak::EmptyArray* raw = dynamic_cast<ak::EmptyArray*>(content.get())) {
+  else if (ak::EmptyArray* raw =
+           dynamic_cast<ak::EmptyArray*>(content.get())) {
     return true;
   }
-  else if (ak::RegularArray* raw = dynamic_cast<ak::RegularArray*>(content.get())) {
+  else if (ak::RegularArray* raw =
+           dynamic_cast<ak::RegularArray*>(content.get())) {
     return handle_as_numpy(raw->content());
   }
-  else if (ak::IndexedArray32* raw = dynamic_cast<ak::IndexedArray32*>(content.get())) {
+  else if (ak::IndexedArray32* raw =
+           dynamic_cast<ak::IndexedArray32*>(content.get())) {
     return handle_as_numpy(raw->content());
   }
-  else if (ak::IndexedArrayU32* raw = dynamic_cast<ak::IndexedArrayU32*>(content.get())) {
+  else if (ak::IndexedArrayU32* raw =
+           dynamic_cast<ak::IndexedArrayU32*>(content.get())) {
     return handle_as_numpy(raw->content());
   }
-  else if (ak::IndexedArray64* raw = dynamic_cast<ak::IndexedArray64*>(content.get())) {
+  else if (ak::IndexedArray64* raw =
+           dynamic_cast<ak::IndexedArray64*>(content.get())) {
     return handle_as_numpy(raw->content());
   }
-  else if (ak::UnionArray8_32* raw = dynamic_cast<ak::UnionArray8_32*>(content.get())) {
+  else if (ak::UnionArray8_32* raw =
+           dynamic_cast<ak::UnionArray8_32*>(content.get())) {
     std::shared_ptr<ak::Content> first = raw->content(0);
     for (int64_t i = 1;  i < raw->numcontents();  i++) {
       if (!first.get()->mergeable(raw->content(i), false)) {
@@ -261,7 +300,8 @@ bool handle_as_numpy(const std::shared_ptr<ak::Content>& content) {
     }
     return handle_as_numpy(first);
   }
-  else if (ak::UnionArray8_U32* raw = dynamic_cast<ak::UnionArray8_U32*>(content.get())) {
+  else if (ak::UnionArray8_U32* raw =
+           dynamic_cast<ak::UnionArray8_U32*>(content.get())) {
     std::shared_ptr<ak::Content> first = raw->content(0);
     for (int64_t i = 1;  i < raw->numcontents();  i++) {
       if (!first.get()->mergeable(raw->content(i), false)) {
@@ -270,7 +310,8 @@ bool handle_as_numpy(const std::shared_ptr<ak::Content>& content) {
     }
     return handle_as_numpy(first);
   }
-  else if (ak::UnionArray8_64* raw = dynamic_cast<ak::UnionArray8_64*>(content.get())) {
+  else if (ak::UnionArray8_64* raw =
+           dynamic_cast<ak::UnionArray8_64*>(content.get())) {
     std::shared_ptr<ak::Content> first = raw->content(0);
     for (int64_t i = 1;  i < raw->numcontents();  i++) {
       if (!first.get()->mergeable(raw->content(i), false)) {
@@ -284,11 +325,13 @@ bool handle_as_numpy(const std::shared_ptr<ak::Content>& content) {
   }
 }
 
-void toslice_part(ak::Slice& slice, py::object obj) {
+void
+toslice_part(ak::Slice& slice, py::object obj) {
   int64_t length_before = slice.length();
 
   if (py::isinstance<py::int_>(obj)) {
-    // FIXME: what happens if you give this a Numpy integer? a Numpy 0-dimensional array?
+    // FIXME: what should happen if you give this a Numpy integer?
+    //        what about a Numpy 0-dimensional array?
     slice.append(std::make_shared<ak::SliceAt>(obj.cast<int64_t>()));
   }
 
@@ -347,10 +390,16 @@ void toslice_part(ak::Slice& slice, py::object obj) {
     else {
       std::shared_ptr<ak::Content> content(nullptr);
 
-      if (py::isinstance(obj, py::module::import("numpy").attr("ma").attr("MaskedArray"))) {
-        content = unbox_content(py::module::import("awkward1").attr("fromnumpy")(obj, false, false));
+      if (py::isinstance(
+            obj,
+            py::module::import("numpy").attr("ma").attr("MaskedArray"))) {
+        content = unbox_content(
+            py::module::import("awkward1").attr("fromnumpy")(obj,
+                                                             false,
+                                                             false));
       }
-      else if (py::isinstance(obj, py::module::import("numpy").attr("ndarray"))) {
+      else if (py::isinstance(
+            obj, py::module::import("numpy").attr("ndarray"))) {
         // content = nullptr!
       }
       else if (py::isinstance<ak::Content>(obj)) {
@@ -359,10 +408,12 @@ void toslice_part(ak::Slice& slice, py::object obj) {
       else if (py::isinstance<ak::ArrayBuilder>(obj)) {
         content = unbox_content(obj.attr("snapshot")());
       }
-      else if (py::isinstance(obj, py::module::import("awkward1").attr("Array"))) {
+      else if (py::isinstance(
+                 obj, py::module::import("awkward1").attr("Array"))) {
         content = unbox_content(obj.attr("layout"));
       }
-      else if (py::isinstance(obj, py::module::import("awkward1").attr("ArrayBuilder"))) {
+      else if (py::isinstance(
+                 obj, py::module::import("awkward1").attr("ArrayBuilder"))) {
         content = unbox_content(obj.attr("snapshot")().attr("layout"));
       }
       else {
@@ -383,12 +434,14 @@ void toslice_part(ak::Slice& slice, py::object obj) {
           }
         }
         if (bad) {
-          content = unbox_content(py::module::import("awkward1").attr("fromiter")(obj, false));
+          content = unbox_content(py::module::import("awkward1")
+                    .attr("fromiter")(obj, false));
         }
       }
 
       if (content.get() != nullptr  &&  !handle_as_numpy(content)) {
-        if (content.get()->parameter_equals("__array__", "\"string\"")  ||  content.get()->parameter_equals("__array__", "\"bytestring\"")) {
+        if (content.get()->parameter_equals("__array__", "\"string\"")  ||
+            content.get()->parameter_equals("__array__", "\"bytestring\"")) {
           obj = box(content);
           obj = py::module::import("awkward1").attr("tolist")(obj);
           std::vector<std::string> strings;
@@ -404,14 +457,19 @@ void toslice_part(ak::Slice& slice, py::object obj) {
       else {
         py::array array = obj.cast<py::array>();
         if (array.ndim() == 0) {
-          throw std::invalid_argument("arrays used as an index must have at least one dimension");
+          throw std::invalid_argument(
+            "arrays used as an index must have at least one dimension");
         }
 
         py::buffer_info info = array.request();
         if (info.format.compare("?") == 0) {
-          py::object nonzero_tuple = py::module::import("numpy").attr("nonzero")(array);
+          py::object nonzero_tuple =
+            py::module::import("numpy").attr("nonzero")(array);
           for (auto x : nonzero_tuple.cast<py::tuple>()) {
-            py::object intarray_object = py::module::import("numpy").attr("asarray")(x.cast<py::object>(), py::module::import("numpy").attr("int64"));
+            py::object intarray_object =
+              py::module::import("numpy").attr("asarray")(
+                x.cast<py::object>(),
+                py::module::import("numpy").attr("int64"));
             py::array intarray = intarray_object.cast<py::array>();
             py::buffer_info intinfo = intarray.request();
             std::vector<int64_t> shape;
@@ -420,8 +478,16 @@ void toslice_part(ak::Slice& slice, py::object obj) {
               shape.push_back((int64_t)intinfo.shape[i]);
               strides.push_back((int64_t)intinfo.strides[i] / sizeof(int64_t));
             }
-            ak::Index64 index(std::shared_ptr<int64_t>(reinterpret_cast<int64_t*>(intinfo.ptr), pyobject_deleter<int64_t>(intarray.ptr())), 0, shape[0]);
-            slice.append(std::make_shared<ak::SliceArray64>(index, shape, strides, true));
+            ak::Index64 index(
+              std::shared_ptr<int64_t>(
+                reinterpret_cast<int64_t*>(intinfo.ptr),
+                pyobject_deleter<int64_t>(intarray.ptr())),
+              0,
+              shape[0]);
+            slice.append(std::make_shared<ak::SliceArray64>(index,
+                                                            shape,
+                                                            strides,
+                                                            true));
           }
         }
 
@@ -445,31 +511,46 @@ void toslice_part(ak::Slice& slice, py::object obj) {
               format.compare("q") != 0       &&
               format.compare("Q") != 0       &&
               flatlen != 0) {
-            throw std::invalid_argument("arrays used as an index must be integer or boolean");
+            throw std::invalid_argument(
+              "arrays used as an index must be integer or boolean");
           }
 
-          py::object intarray_object = py::module::import("numpy").attr("asarray")(array, py::module::import("numpy").attr("int64"));
+          py::object intarray_object =
+            py::module::import("numpy").attr("asarray")(
+              array, py::module::import("numpy").attr("int64"));
           py::array intarray = intarray_object.cast<py::array>();
           py::buffer_info intinfo = intarray.request();
           std::vector<int64_t> shape;
           std::vector<int64_t> strides;
           for (ssize_t i = 0;  i < intinfo.ndim;  i++) {
             shape.push_back((int64_t)intinfo.shape[i]);
-            strides.push_back((int64_t)intinfo.strides[i] / (int64_t)sizeof(int64_t));
+            strides.push_back(
+              (int64_t)intinfo.strides[i] / (int64_t)sizeof(int64_t));
           }
-          ak::Index64 index(std::shared_ptr<int64_t>(reinterpret_cast<int64_t*>(intinfo.ptr), pyobject_deleter<int64_t>(intarray.ptr())), 0, shape[0]);
-          slice.append(std::make_shared<ak::SliceArray64>(index, shape, strides, false));
+          ak::Index64 index(
+            std::shared_ptr<int64_t>(
+              reinterpret_cast<int64_t*>(intinfo.ptr),
+              pyobject_deleter<int64_t>(intarray.ptr())),
+            0,
+            shape[0]);
+          slice.append(std::make_shared<ak::SliceArray64>(index,
+                                                          shape,
+                                                          strides,
+                                                          false));
         }
       }
     }
   }
 
   else {
-    throw std::invalid_argument("only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`), and integer or boolean arrays (possibly jagged) are valid indices");
+    throw std::invalid_argument(
+      "only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`), "
+      "and integer or boolean arrays (possibly jagged) are valid indices");
   }
 }
 
-ak::Slice toslice(py::object obj) {
+ak::Slice
+toslice(py::object obj) {
   ak::Slice out;
   if (py::isinstance<py::tuple>(obj)) {
     for (auto x : obj.cast<py::tuple>()) {
@@ -484,13 +565,15 @@ ak::Slice toslice(py::object obj) {
 }
 
 template <typename T>
-py::object getitem(const T& self, const py::object& obj) {
+py::object
+getitem(const T& self, const py::object& obj) {
   if (py::isinstance<py::int_>(obj)) {
     return box(self.getitem_at(obj.cast<int64_t>()));
   }
   if (py::isinstance<py::slice>(obj)) {
     py::object pystep = obj.attr("step");
-    if ((py::isinstance<py::int_>(pystep)  &&  pystep.cast<int64_t>() == 1)  ||  pystep.is(py::none())) {
+    if ((py::isinstance<py::int_>(pystep)  &&  pystep.cast<int64_t>() == 1)  ||
+        pystep.is(py::none())) {
       int64_t start = ak::Slice::none();
       int64_t stop = ak::Slice::none();
       py::object pystart = obj.attr("start");
@@ -503,7 +586,7 @@ py::object getitem(const T& self, const py::object& obj) {
       }
       return box(self.getitem_range(start, stop));
     }
-    // NOTE: control flow can pass through here; don't make the last line an 'else'!
+    // control flow can pass through here; don't make the last line an 'else'!
   }
   if (py::isinstance<py::str>(obj)) {
     return box(self.getitem_field(obj.cast<std::string>()));
@@ -523,14 +606,15 @@ py::object getitem(const T& self, const py::object& obj) {
     if (all_strings  &&  !strings.empty()) {
       return box(self.getitem_fields(strings));
     }
-    // NOTE: control flow can pass through here; don't make the last line an 'else'!
+    // control flow can pass through here; don't make the last line an 'else'!
   }
   return box(self.getitem(toslice(obj)));
 }
 
-/////////////////////////////////////////////////////////////// ArrayBuilder
+////////// ArrayBuilder
 
-void builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
+void
+builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
   if (obj.is(py::none())) {
     self.null();
   }
@@ -563,7 +647,8 @@ void builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
     self.beginrecord();
     for (auto pair : dict) {
       if (!py::isinstance<py::str>(pair.first)) {
-        throw std::invalid_argument("keys of dicts in 'fromiter' must all be strings");
+        throw std::invalid_argument(
+          "keys of dicts in 'fromiter' must all be strings");
       }
       std::string key = pair.first.cast<std::string>();
       self.field_check(key.c_str());
@@ -597,16 +682,24 @@ void builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
     self.real(obj.cast<double>());
   }
   else {
-    throw std::invalid_argument(std::string("cannot convert ") + obj.attr("__repr__")().cast<std::string>() + std::string(" (type ") + obj.attr("__class__").attr("__name__").cast<std::string>() + std::string(") to an array element"));
+    throw std::invalid_argument(
+      std::string("cannot convert ")
+      + obj.attr("__repr__")().cast<std::string>() + std::string(" (type ")
+      + obj.attr("__class__").attr("__name__").cast<std::string>()
+      + std::string(") to an array element"));
   }
 }
 
-py::class_<ak::ArrayBuilder> make_ArrayBuilder(const py::handle& m, const std::string& name) {
+py::class_<ak::ArrayBuilder>
+make_ArrayBuilder(const py::handle& m, const std::string& name) {
   return (py::class_<ak::ArrayBuilder>(m, name.c_str())
       .def(py::init([](int64_t initial, double resize) -> ak::ArrayBuilder {
         return ak::ArrayBuilder(ak::ArrayBuilderOptions(initial, resize));
       }), py::arg("initial") = 1024, py::arg("resize") = 2.0)
-      .def_property_readonly("_ptr", [](const ak::ArrayBuilder* self) -> size_t { return reinterpret_cast<size_t>(self); })
+      .def_property_readonly("_ptr",
+                             [](const ak::ArrayBuilder* self) -> size_t {
+        return reinterpret_cast<size_t>(self);
+      })
       .def("__repr__", &ak::ArrayBuilder::tostring)
       .def("__len__", &ak::ArrayBuilder::length)
       .def("clear", &ak::ArrayBuilder::clear)
@@ -622,7 +715,8 @@ py::class_<ak::ArrayBuilder> make_ArrayBuilder(const py::handle& m, const std::s
       .def("boolean", &ak::ArrayBuilder::boolean)
       .def("integer", &ak::ArrayBuilder::integer)
       .def("real", &ak::ArrayBuilder::real)
-      .def("bytestring", [](ak::ArrayBuilder& self, const py::bytes& x) -> void {
+      .def("bytestring",
+           [](ak::ArrayBuilder& self, const py::bytes& x) -> void {
         self.bytestring(x.cast<std::string>());
       })
       .def("string", [](ak::ArrayBuilder& self, const py::str& x) -> void {
@@ -633,7 +727,8 @@ py::class_<ak::ArrayBuilder> make_ArrayBuilder(const py::handle& m, const std::s
       .def("begintuple", &ak::ArrayBuilder::begintuple)
       .def("index", &ak::ArrayBuilder::index)
       .def("endtuple", &ak::ArrayBuilder::endtuple)
-      .def("beginrecord", [](ak::ArrayBuilder& self, const py::object& name) -> void {
+      .def("beginrecord",
+           [](ak::ArrayBuilder& self, const py::object& name) -> void {
         if (name.is(py::none())) {
           self.beginrecord();
         }
@@ -646,19 +741,25 @@ py::class_<ak::ArrayBuilder> make_ArrayBuilder(const py::handle& m, const std::s
         self.field_check(x);
       })
       .def("endrecord", &ak::ArrayBuilder::endrecord)
-      .def("append", [](ak::ArrayBuilder& self, const std::shared_ptr<ak::Content>& array, int64_t at) {
+      .def("append",
+           [](ak::ArrayBuilder& self,
+              const std::shared_ptr<ak::Content>& array,
+              int64_t at) {
         self.append(array, at);
       })
-      .def("extend", [](ak::ArrayBuilder& self, const std::shared_ptr<ak::Content>& array) {
+      .def("extend",
+           [](ak::ArrayBuilder& self,
+              const std::shared_ptr<ak::Content>& array) {
         self.extend(array);
       })
       .def("fromiter", &builder_fromiter)
   );
 }
 
-/////////////////////////////////////////////////////////////// Iterator
+////////// Iterator
 
-py::class_<ak::Iterator, std::shared_ptr<ak::Iterator>> make_Iterator(const py::handle& m, const std::string& name) {
+py::class_<ak::Iterator, std::shared_ptr<ak::Iterator>>
+make_Iterator(const py::handle& m, const std::string& name) {
   auto next = [](ak::Iterator& iterator) -> py::object {
     if (iterator.isdone()) {
       throw py::stop_iteration();
@@ -666,48 +767,61 @@ py::class_<ak::Iterator, std::shared_ptr<ak::Iterator>> make_Iterator(const py::
     return box(iterator.next());
   };
 
-  return (py::class_<ak::Iterator, std::shared_ptr<ak::Iterator>>(m, name.c_str())
+  return (py::class_<ak::Iterator, std::shared_ptr<ak::Iterator>>(m,
+                                                                  name.c_str())
       .def(py::init([](const py::object& content) -> ak::Iterator {
         return ak::Iterator(unbox_content(content));
       }))
       .def("__repr__", &ak::Iterator::tostring)
       .def("__next__", next)
       .def("next", next)
-      .def("__iter__", [](const py::object& self) -> py::object { return self; })
+      .def("__iter__",
+           [](const py::object& self) -> py::object { return self; })
   );
 }
 
-/////////////////////////////////////////////////////////////// Content
+////////// Content
 
-PersistentSharedPtr::PersistentSharedPtr(const std::shared_ptr<ak::Content>& ptr)
+PersistentSharedPtr::PersistentSharedPtr(
+  const std::shared_ptr<ak::Content>& ptr)
     : ptr_(ptr) { }
 
-py::object PersistentSharedPtr::layout() const {
+py::object
+PersistentSharedPtr::layout() const {
   return box(ptr_);
 }
 
-size_t PersistentSharedPtr::ptr() const {
+size_t
+PersistentSharedPtr::ptr() const {
   return reinterpret_cast<size_t>(&ptr_);
 }
 
-py::class_<PersistentSharedPtr> make_PersistentSharedPtr(const py::handle& m, const std::string& name) {
+py::class_<PersistentSharedPtr>
+make_PersistentSharedPtr(const py::handle& m, const std::string& name) {
   return py::class_<PersistentSharedPtr>(m, name.c_str())
              .def("layout", &PersistentSharedPtr::layout)
              .def("ptr", &PersistentSharedPtr::ptr);
 }
 
-py::class_<ak::Content, std::shared_ptr<ak::Content>> make_Content(const py::handle& m, const std::string& name) {
-  return py::class_<ak::Content, std::shared_ptr<ak::Content>>(m, name.c_str());
+py::class_<ak::Content, std::shared_ptr<ak::Content>>
+make_Content(const py::handle& m, const std::string& name) {
+  return py::class_<ak::Content, std::shared_ptr<ak::Content>>(m,
+                                                               name.c_str());
 }
 
 template <typename T>
-py::tuple identity(const T& self) {
+py::tuple
+identity(const T& self) {
   if (self.identities().get() == nullptr) {
-    throw std::invalid_argument(self.classname() + std::string(" instance has no associated identities (use 'setidentities' to assign one to the array it is in)"));
+    throw std::invalid_argument(
+      self.classname()
+      + std::string(" instance has no associated identities (use "
+                    "'setidentities' to assign one to the array it is in)"));
   }
   ak::Identities::FieldLoc fieldloc = self.identities().get()->fieldloc();
   if (self.isscalar()) {
-    py::tuple out((size_t)(self.identities().get()->width()) + fieldloc.size());
+    py::tuple out((size_t)(self.identities().get()->width())
+                  + fieldloc.size());
     size_t j = 0;
     for (int64_t i = 0;  i < self.identities().get()->width();  i++) {
       out[j] = py::cast(self.identities().get()->value(0, i));
@@ -722,7 +836,8 @@ py::tuple identity(const T& self) {
     return out;
   }
   else {
-    py::tuple out((size_t)(self.identities().get()->width() - 1) + fieldloc.size());
+    py::tuple out((size_t)(self.identities().get()->width() - 1)
+                  + fieldloc.size());
     size_t j = 0;
     for (int64_t i = 0;  i < self.identities().get()->width();  i++) {
       if (i < self.identities().get()->width() - 1) {
@@ -741,21 +856,25 @@ py::tuple identity(const T& self) {
 }
 
 template <typename T>
-std::string repr(const T& self) {
+std::string
+repr(const T& self) {
   return self.tostring();
 }
 
 template <typename T>
-int64_t len(const T& self) {
+int64_t
+len(const T& self) {
   return self.length();
 }
 
 template <typename T>
-ak::Iterator iter(const T& self) {
+ak::Iterator
+iter(const T& self) {
   return ak::Iterator(self.shallow_copy());
 }
 
-ak::util::Parameters dict2parameters(const py::object& in) {
+ak::util::Parameters
+dict2parameters(const py::object& in) {
   ak::util::Parameters out;
   if (in.is(py::none())) {
     // None is equivalent to an empty dict
@@ -773,49 +892,64 @@ ak::util::Parameters dict2parameters(const py::object& in) {
   return out;
 }
 
-py::dict parameters2dict(const ak::util::Parameters& in) {
+py::dict
+parameters2dict(const ak::util::Parameters& in) {
   py::dict out;
   for (auto pair : in) {
     std::string cppkey = pair.first;
     std::string cppvalue = pair.second;
-    py::str pykey(PyUnicode_DecodeUTF8(cppkey.data(), cppkey.length(), "surrogateescape"));
-    py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(), cppvalue.length(), "surrogateescape"));
+    py::str pykey(PyUnicode_DecodeUTF8(cppkey.data(),
+                                       cppkey.length(),
+                                       "surrogateescape"));
+    py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(),
+                                         cppvalue.length(),
+                                         "surrogateescape"));
     out[pykey] = py::module::import("json").attr("loads")(pyvalue);
   }
   return out;
 }
 
 template <typename T>
-py::dict getparameters(const T& self) {
+py::dict
+getparameters(const T& self) {
   return parameters2dict(self.parameters());
 }
 
 template <typename T>
-py::object parameter(const T& self, const std::string& key) {
+py::object
+parameter(const T& self, const std::string& key) {
   std::string cppvalue = self.parameter(key);
-  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(), cppvalue.length(), "surrogateescape"));
+  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(),
+                                       cppvalue.length(),
+                                       "surrogateescape"));
   return py::module::import("json").attr("loads")(pyvalue);
 }
 
 template <typename T>
-py::object purelist_parameter(const T& self, const std::string& key) {
+py::object
+purelist_parameter(const T& self, const std::string& key) {
   std::string cppvalue = self.purelist_parameter(key);
-  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(), cppvalue.length(), "surrogateescape"));
+  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(),
+                                       cppvalue.length(),
+                                       "surrogateescape"));
   return py::module::import("json").attr("loads")(pyvalue);
 }
 
 template <typename T>
-void setparameters(T& self, const py::object& parameters) {
+void
+setparameters(T& self, const py::object& parameters) {
   self.setparameters(dict2parameters(parameters));
 }
 
 template <typename T>
-void setparameter(T& self, const std::string& key, const py::object& value) {
+void
+setparameter(T& self, const std::string& key, const py::object& value) {
   py::object valuestr = py::module::import("json").attr("dumps")(value);
   self.setparameter(key, valuestr.cast<std::string>());
 }
 
-int64_t check_maxdecimals(const py::object& maxdecimals) {
+int64_t
+check_maxdecimals(const py::object& maxdecimals) {
   if (maxdecimals.is(py::none())) {
     return -1;
   }
@@ -828,12 +962,18 @@ int64_t check_maxdecimals(const py::object& maxdecimals) {
 }
 
 template <typename T>
-std::string tojson_string(const T& self, bool pretty, const py::object& maxdecimals) {
+std::string
+tojson_string(const T& self, bool pretty, const py::object& maxdecimals) {
   return self.tojson(pretty, check_maxdecimals(maxdecimals));
 }
 
 template <typename T>
-void tojson_file(const T& self, const std::string& destination, bool pretty, py::object maxdecimals, int64_t buffersize) {
+void
+tojson_file(const T& self,
+            const std::string& destination,
+            bool pretty,
+            py::object maxdecimals,
+            int64_t buffersize) {
 #ifdef _MSC_VER
   FILE* file;
   if (fopen_s(&file, destination.c_str(), "wb") != 0) {
@@ -841,7 +981,9 @@ void tojson_file(const T& self, const std::string& destination, bool pretty, py:
   FILE* file = fopen(destination.c_str(), "wb");
   if (file == nullptr) {
 #endif
-    throw std::invalid_argument(std::string("file \"") + destination + std::string("\" could not be opened for writing"));
+    throw std::invalid_argument(
+      std::string("file \"") + destination
+      + std::string("\" could not be opened for writing"));
   }
   try {
     self.tojson(file, pretty, check_maxdecimals(maxdecimals), buffersize);
@@ -854,10 +996,19 @@ void tojson_file(const T& self, const std::string& destination, bool pretty, py:
 }
 
 template <typename T>
-py::class_<T, std::shared_ptr<T>, ak::Content> content_methods(py::class_<T, std::shared_ptr<T>, ak::Content>& x) {
+py::class_<T, std::shared_ptr<T>, ak::Content>
+content_methods(py::class_<T, std::shared_ptr<T>, ak::Content>& x) {
   return x.def("__repr__", &repr<T>)
-          .def_property("identities", [](const T& self) -> py::object { return box(self.identities()); }, [](T& self, const py::object& identities) -> void { self.setidentities(unbox_identities_none(identities)); })
-          .def("setidentities", [](T& self, const py::object& identities) -> void {
+          .def_property(
+            "identities",
+            [](const T& self) -> py::object {
+            return box(self.identities());
+          },
+            [](T& self, const py::object& identities) -> void {
+            self.setidentities(unbox_identities_none(identities));
+          })
+          .def("setidentities",
+               [](T& self, const py::object& identities) -> void {
            self.setidentities(unbox_identities_none(identities));
           })
           .def("setidentities", [](T& self) -> void {
@@ -867,16 +1018,31 @@ py::class_<T, std::shared_ptr<T>, ak::Content> content_methods(py::class_<T, std
           .def("setparameter", &setparameter<T>)
           .def("parameter", &parameter<T>)
           .def("purelist_parameter", &purelist_parameter<T>)
-          .def("type", [](const T& self, const std::map<std::string, std::string>& typestrs) -> std::shared_ptr<ak::Type> {
+          .def("type",
+               [](const T& self,
+                  const std::map<std::string,
+                  std::string>& typestrs) -> std::shared_ptr<ak::Type> {
             return self.type(typestrs);
           })
           .def("__len__", &len<T>)
           .def("__getitem__", &getitem<T>)
           .def("__iter__", &iter<T>)
-          .def("tojson", &tojson_string<T>, py::arg("pretty") = false, py::arg("maxdecimals") = py::none())
-          .def("tojson", &tojson_file<T>, py::arg("destination"), py::arg("pretty") = false, py::arg("maxdecimals") = py::none(), py::arg("buffersize") = 65536)
+          .def("tojson",
+               &tojson_string<T>,
+               py::arg("pretty") = false,
+               py::arg("maxdecimals") = py::none())
+          .def("tojson",
+               &tojson_file<T>,
+               py::arg("destination"),
+               py::arg("pretty") = false,
+               py::arg("maxdecimals") = py::none(),
+               py::arg("buffersize") = 65536)
           .def_property_readonly("nbytes", &T::nbytes)
-          .def("deep_copy", &T::deep_copy, py::arg("copyarrays") = true, py::arg("copyindexes") = true, py::arg("copyidentities") = true)
+          .def("deep_copy",
+               &T::deep_copy,
+               py::arg("copyarrays") = true,
+               py::arg("copyindexes") = true,
+               py::arg("copyidentities") = true)
           .def_property_readonly("identity", &identity<T>)
           .def_property_readonly("numfields", &T::numfields)
           .def("fieldindex", &T::fieldindex)
@@ -886,7 +1052,9 @@ py::class_<T, std::shared_ptr<T>, ak::Content> content_methods(py::class_<T, std
           .def_property_readonly("purelist_isregular", &T::purelist_isregular)
           .def_property_readonly("purelist_depth", &T::purelist_depth)
           .def("getitem_nothing", &T::getitem_nothing)
-          .def_property_readonly("_persistent_shared_ptr", [](std::shared_ptr<ak::Content>& self) -> PersistentSharedPtr {
+          .def_property_readonly(
+            "_persistent_shared_ptr",
+            [](std::shared_ptr<ak::Content>& self) -> PersistentSharedPtr {
             return PersistentSharedPtr(self);
           })
 
@@ -897,83 +1065,141 @@ py::class_<T, std::shared_ptr<T>, ak::Content> content_methods(py::class_<T, std
               return py::none();
             }
             else {
-              py::str pyvalue(PyUnicode_DecodeUTF8(out.data(), out.length(), "surrogateescape"));
+              py::str pyvalue(PyUnicode_DecodeUTF8(out.data(),
+                                                   out.length(),
+                                                   "surrogateescape"));
               return pyvalue;
             }
           })
-          .def("fillna", [](const T&self, const py::object&  value) -> py::object {
+          .def("fillna",
+               [](const T&self, const py::object&  value) -> py::object {
             return box(self.fillna(unbox_content(value)));
           })
           .def("num", [](const T& self, int64_t axis) -> py::object {
             return box(self.num(axis, 0));
           }, py::arg("axis") = 1)
           .def("flatten", [](const T& self, int64_t axis) -> py::object {
-            std::pair<ak::Index64, std::shared_ptr<ak::Content>> pair = self.offsets_and_flattened(axis, 0);
+            std::pair<ak::Index64, std::shared_ptr<ak::Content>> pair =
+              self.offsets_and_flattened(axis, 0);
             return box(pair.second);
           }, py::arg("axis") = 1)
-          .def("offsets_and_flatten", [](const T& self, int64_t axis) -> py::object {
-            std::pair<ak::Index64, std::shared_ptr<ak::Content>> pair = self.offsets_and_flattened(axis, 0);
+          .def("offsets_and_flatten",
+               [](const T& self, int64_t axis) -> py::object {
+            std::pair<ak::Index64, std::shared_ptr<ak::Content>> pair =
+              self.offsets_and_flattened(axis, 0);
             return py::make_tuple(py::cast(pair.first), box(pair.second));
           }, py::arg("axis") = 1)
-          .def("rpad", [](const T&self, int64_t length, int64_t axis) -> py::object {
+          .def("rpad",
+               [](const T&self, int64_t length, int64_t axis) -> py::object {
             return box(self.rpad(length, axis, 0));
           })
-          .def("rpad_and_clip", [](const T&self, int64_t length, int64_t axis) -> py::object {
+          .def("rpad_and_clip",
+               [](const T&self, int64_t length, int64_t axis) -> py::object {
             return box(self.rpad_and_clip(length, axis, 0));
           })
-          .def("mergeable", [](const T& self, const py::object& other, bool mergebool) -> bool {
+          .def("mergeable",
+               [](const T& self, const py::object& other, bool mergebool)
+               -> bool {
             return self.mergeable(unbox_content(other), mergebool);
           }, py::arg("other"), py::arg("mergebool") = false)
-          .def("merge", [](const T& self, const py::object& other) -> py::object {
+          .def("merge",
+               [](const T& self, const py::object& other) -> py::object {
             return box(self.merge(unbox_content(other)));
           })
-          .def("merge_as_union", [](const T& self, const py::object& other) -> py::object {
+          .def("merge_as_union",
+               [](const T& self, const py::object& other) -> py::object {
             return box(self.merge_as_union(unbox_content(other)));
           })
-          .def("count", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          .def("count",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerCount reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = false, py::arg("keepdims") = false)
-          .def("count_nonzero", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = false,
+             py::arg("keepdims") = false)
+          .def("count_nonzero",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerCountNonzero reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = false, py::arg("keepdims") = false)
-          .def("sum", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = false,
+             py::arg("keepdims") = false)
+          .def("sum",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerSum reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = false, py::arg("keepdims") = false)
-          .def("prod", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = false,
+               py::arg("keepdims") = false)
+          .def("prod",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerProd reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = false, py::arg("keepdims") = false)
-          .def("any", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = false,
+             py::arg("keepdims") = false)
+          .def("any",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerAny reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = false, py::arg("keepdims") = false)
-          .def("all", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = false,
+             py::arg("keepdims") = false)
+          .def("all",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerAll reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = false, py::arg("keepdims") = false)
-          .def("min", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = false,
+             py::arg("keepdims") = false)
+          .def("min",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerMin reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = true, py::arg("keepdims") = false)
-          .def("max", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = true,
+             py::arg("keepdims") = false)
+          .def("max",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerMax reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = true, py::arg("keepdims") = false)
-          .def("argmin", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = true,
+             py::arg("keepdims") = false)
+          .def("argmin",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerArgmin reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = true, py::arg("keepdims") = false)
-          .def("argmax", [](const T& self, int64_t axis, bool mask, bool keepdims) -> py::object {
+          }, py::arg("axis") = -1,
+             py::arg("mask") = true,
+             py::arg("keepdims") = false)
+          .def("argmax",
+               [](const T& self, int64_t axis, bool mask, bool keepdims)
+               -> py::object {
             ak::ReducerArgmax reducer;
             return box(self.reduce(reducer, axis, mask, keepdims));
-          }, py::arg("axis") = -1, py::arg("mask") = true, py::arg("keepdims") = false)
+          }, py::arg("axis") = -1,
+             py::arg("mask") = true,
+             py::arg("keepdims") = false)
           .def("localindex", [](const T& self, int64_t axis) -> py::object {
             return box(self.localindex(axis, 0));
           }, py::arg("axis") = 1)
-          .def("choose", [](const T& self, int64_t n, bool diagonal, py::object keys, py::object parameters, int64_t axis) -> py::object {
+          .def("choose",
+               [](const T& self,
+                  int64_t n,
+                  bool diagonal,
+                  py::object keys,
+                  py::object parameters,
+                  int64_t axis) -> py::object {
             std::shared_ptr<ak::util::RecordLookup> recordlookup(nullptr);
             if (!keys.is(py::none())) {
               recordlookup = std::make_shared<ak::util::RecordLookup>();
@@ -981,22 +1207,38 @@ py::class_<T, std::shared_ptr<T>, ak::Content> content_methods(py::class_<T, std
                 recordlookup.get()->push_back(x.cast<std::string>());
               }
               if (n != recordlookup.get()->size()) {
-                throw std::invalid_argument("if provided, the length of 'keys' must be 'n'");
+                throw std::invalid_argument(
+                  "if provided, the length of 'keys' must be 'n'");
               }
             }
-            return box(self.choose(n, diagonal, recordlookup, dict2parameters(parameters), axis, 0));
-          }, py::arg("n"), py::arg("diagonal") = false, py::arg("keys") = py::none(), py::arg("parameters") = py::none(), py::arg("axis") = 1)
+            return box(self.choose(n,
+                                   diagonal,
+                                   recordlookup,
+                                   dict2parameters(parameters),
+                                   axis,
+                                   0));
+          }, py::arg("n"),
+             py::arg("diagonal") = false,
+             py::arg("keys") = py::none(),
+             py::arg("parameters") = py::none(),
+             py::arg("axis") = 1)
 
   ;
 }
 
-/////////////////////////////////////////////////////////////// EmptyArray
+////////// EmptyArray
 
-py::class_<ak::EmptyArray, std::shared_ptr<ak::EmptyArray>, ak::Content> make_EmptyArray(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::EmptyArray, std::shared_ptr<ak::EmptyArray>, ak::Content>(m, name.c_str())
-      .def(py::init([](const py::object& identities, const py::object& parameters) -> ak::EmptyArray {
-        return ak::EmptyArray(unbox_identities_none(identities), dict2parameters(parameters));
-      }), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+py::class_<ak::EmptyArray, std::shared_ptr<ak::EmptyArray>, ak::Content>
+make_EmptyArray(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::EmptyArray,
+                         std::shared_ptr<ak::EmptyArray>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const py::object& identities,
+                       const py::object& parameters) -> ak::EmptyArray {
+        return ak::EmptyArray(unbox_identities_none(identities),
+                              dict2parameters(parameters));
+      }), py::arg("identities") = py::none(),
+         py::arg("parameters") = py::none())
       .def("toNumpyArray", [](const ak::EmptyArray& self) -> py::object {
         return box(self.toNumpyArray("d", sizeof(double)));
       })
@@ -1006,19 +1248,40 @@ py::class_<ak::EmptyArray, std::shared_ptr<ak::EmptyArray>, ak::Content> make_Em
   );
 }
 
-/////////////////////////////////////////////////////////////// IndexedArray
+////////// IndexedArray
 
 template <typename T, bool ISOPTION>
-py::class_<ak::IndexedArrayOf<T, ISOPTION>, std::shared_ptr<ak::IndexedArrayOf<T, ISOPTION>>, ak::Content> make_IndexedArrayOf(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::IndexedArrayOf<T, ISOPTION>, std::shared_ptr<ak::IndexedArrayOf<T, ISOPTION>>, ak::Content>(m, name.c_str())
-      .def(py::init([](const ak::IndexOf<T>& index, const py::object& content, const py::object& identities, const py::object& parameters) -> ak::IndexedArrayOf<T, ISOPTION> {
-        return ak::IndexedArrayOf<T, ISOPTION>(unbox_identities_none(identities), dict2parameters(parameters), index, std::shared_ptr<ak::Content>(unbox_content(content)));
-      }), py::arg("index"), py::arg("content"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+py::class_<ak::IndexedArrayOf<T, ISOPTION>,
+           std::shared_ptr<ak::IndexedArrayOf<T, ISOPTION>>,
+           ak::Content>
+make_IndexedArrayOf(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::IndexedArrayOf<T, ISOPTION>,
+                         std::shared_ptr<ak::IndexedArrayOf<T, ISOPTION>>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const ak::IndexOf<T>& index,
+                       const py::object& content,
+                       const py::object& identities,
+                       const py::object& parameters)
+                    -> ak::IndexedArrayOf<T, ISOPTION> {
+        return ak::IndexedArrayOf<T, ISOPTION>(
+          unbox_identities_none(identities),
+          dict2parameters(parameters),
+          index,
+          std::shared_ptr<ak::Content>(unbox_content(content)));
+      }), py::arg("index"),
+          py::arg("content"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
-      .def_property_readonly("index", &ak::IndexedArrayOf<T, ISOPTION>::index)
-      .def_property_readonly("content", &ak::IndexedArrayOf<T, ISOPTION>::content)
-      .def_property_readonly("isoption", &ak::IndexedArrayOf<T, ISOPTION>::isoption)
-      .def("project", [](const ak::IndexedArrayOf<T, ISOPTION>& self, const py::object& mask) {
+      .def_property_readonly("index",
+                             &ak::IndexedArrayOf<T, ISOPTION>::index)
+      .def_property_readonly("content",
+                             &ak::IndexedArrayOf<T, ISOPTION>::content)
+      .def_property_readonly("isoption",
+                             &ak::IndexedArrayOf<T, ISOPTION>::isoption)
+      .def("project",
+           [](const ak::IndexedArrayOf<T, ISOPTION>& self,
+              const py::object& mask) {
         if (mask.is(py::none())) {
           return box(self.project());
         }
@@ -1033,24 +1296,61 @@ py::class_<ak::IndexedArrayOf<T, ISOPTION>, std::shared_ptr<ak::IndexedArrayOf<T
   );
 }
 
-template py::class_<ak::IndexedArray32, std::shared_ptr<ak::IndexedArray32>, ak::Content> make_IndexedArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::IndexedArrayU32, std::shared_ptr<ak::IndexedArrayU32>, ak::Content> make_IndexedArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::IndexedArray64, std::shared_ptr<ak::IndexedArray64>, ak::Content> make_IndexedArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::IndexedOptionArray32, std::shared_ptr<ak::IndexedOptionArray32>, ak::Content> make_IndexedArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::IndexedOptionArray64, std::shared_ptr<ak::IndexedOptionArray64>, ak::Content> make_IndexedArrayOf(const py::handle& m, const std::string& name);
+template py::class_<ak::IndexedArray32,
+                    std::shared_ptr<ak::IndexedArray32>,
+                    ak::Content>
+make_IndexedArrayOf(const py::handle& m, const std::string& name);
 
-/////////////////////////////////////////////////////////////// ByteMaskedArray
+template py::class_<ak::IndexedArrayU32,
+                    std::shared_ptr<ak::IndexedArrayU32>,
+                    ak::Content>
+make_IndexedArrayOf(const py::handle& m, const std::string& name);
 
-py::class_<ak::ByteMaskedArray, std::shared_ptr<ak::ByteMaskedArray>, ak::Content> make_ByteMaskedArray(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::ByteMaskedArray, std::shared_ptr<ak::ByteMaskedArray>, ak::Content>(m, name.c_str())
-      .def(py::init([](const ak::Index8& mask, const py::object& content, bool validwhen, const py::object& identities, const py::object& parameters) -> ak::ByteMaskedArray {
-        return ak::ByteMaskedArray(unbox_identities_none(identities), dict2parameters(parameters), mask, std::shared_ptr<ak::Content>(unbox_content(content)), validwhen);
-      }), py::arg("mask"), py::arg("content"), py::arg("validwhen"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+template py::class_<ak::IndexedArray64,
+                    std::shared_ptr<ak::IndexedArray64>,
+                    ak::Content>
+make_IndexedArrayOf(const py::handle& m, const std::string& name);
+
+template py::class_<ak::IndexedOptionArray32,
+                    std::shared_ptr<ak::IndexedOptionArray32>,
+                    ak::Content>
+make_IndexedArrayOf(const py::handle& m, const std::string& name);
+
+template py::class_<ak::IndexedOptionArray64,
+                    std::shared_ptr<ak::IndexedOptionArray64>,
+                    ak::Content>
+make_IndexedArrayOf(const py::handle& m, const std::string& name);
+
+////////// ByteMaskedArray
+
+py::class_<ak::ByteMaskedArray,
+           std::shared_ptr<ak::ByteMaskedArray>,
+           ak::Content>
+make_ByteMaskedArray(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::ByteMaskedArray,
+                         std::shared_ptr<ak::ByteMaskedArray>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const ak::Index8& mask,
+                       const py::object& content,
+                       bool validwhen,
+                       const py::object& identities,
+                       const py::object& parameters) -> ak::ByteMaskedArray {
+        return ak::ByteMaskedArray(
+          unbox_identities_none(identities),
+          dict2parameters(parameters),
+          mask,
+          std::shared_ptr<ak::Content>(unbox_content(content)), validwhen);
+      }), py::arg("mask"),
+          py::arg("content"),
+          py::arg("validwhen"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
       .def_property_readonly("mask", &ak::ByteMaskedArray::mask)
       .def_property_readonly("content", &ak::ByteMaskedArray::content)
       .def_property_readonly("validwhen", &ak::ByteMaskedArray::validwhen)
-      .def("project", [](const ak::ByteMaskedArray& self, const py::object& mask) {
+      .def("project",
+           [](const ak::ByteMaskedArray& self, const py::object& mask) {
         if (mask.is(py::none())) {
           return box(self.project());
         }
@@ -1065,19 +1365,44 @@ py::class_<ak::ByteMaskedArray, std::shared_ptr<ak::ByteMaskedArray>, ak::Conten
   );
 }
 
-/////////////////////////////////////////////////////////////// BitMaskedArray
+////////// BitMaskedArray
 
-py::class_<ak::BitMaskedArray, std::shared_ptr<ak::BitMaskedArray>, ak::Content> make_BitMaskedArray(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::BitMaskedArray, std::shared_ptr<ak::BitMaskedArray>, ak::Content>(m, name.c_str())
-      .def(py::init([](const ak::IndexU8& mask, const py::object& content, bool validwhen, int64_t length, bool lsb_order, const py::object& identities, const py::object& parameters) -> ak::BitMaskedArray {
-        return ak::BitMaskedArray(unbox_identities_none(identities), dict2parameters(parameters), mask, std::shared_ptr<ak::Content>(unbox_content(content)), validwhen, length, lsb_order);
-      }), py::arg("mask"), py::arg("content"), py::arg("validwhen"), py::arg("length"), py::arg("lsb_order"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+py::class_<ak::BitMaskedArray,
+           std::shared_ptr<ak::BitMaskedArray>,
+           ak::Content>
+make_BitMaskedArray(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::BitMaskedArray,
+                         std::shared_ptr<ak::BitMaskedArray>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const ak::IndexU8& mask,
+                       const py::object& content,
+                       bool validwhen,
+                       int64_t length,
+                       bool lsb_order,
+                       const py::object& identities,
+                       const py::object& parameters) -> ak::BitMaskedArray {
+        return ak::BitMaskedArray(
+          unbox_identities_none(identities),
+          dict2parameters(parameters),
+          mask,
+          std::shared_ptr<ak::Content>(unbox_content(content)),
+          validwhen,
+          length,
+          lsb_order);
+      }), py::arg("mask"),
+          py::arg("content"),
+          py::arg("validwhen"),
+          py::arg("length"),
+          py::arg("lsb_order"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
       .def_property_readonly("mask", &ak::BitMaskedArray::mask)
       .def_property_readonly("content", &ak::BitMaskedArray::content)
       .def_property_readonly("validwhen", &ak::BitMaskedArray::validwhen)
       .def_property_readonly("lsb_order", &ak::BitMaskedArray::lsb_order)
-      .def("project", [](const ak::BitMaskedArray& self, const py::object& mask) {
+      .def("project",
+           [](const ak::BitMaskedArray& self, const py::object& mask) {
         if (mask.is(py::none())) {
           return box(self.project());
         }
@@ -1089,21 +1414,34 @@ py::class_<ak::BitMaskedArray, std::shared_ptr<ak::BitMaskedArray>, ak::Content>
       .def("simplify", [](const ak::BitMaskedArray& self) {
         return box(self.simplify_optiontype());
       })
-      .def("toByteMaskedArray", &ak::BitMaskedArray::toByteMaskedArray)
-      .def("toIndexedOptionArray64", &ak::BitMaskedArray::toIndexedOptionArray64)
+      .def("toByteMaskedArray",
+           &ak::BitMaskedArray::toByteMaskedArray)
+      .def("toIndexedOptionArray64",
+           &ak::BitMaskedArray::toIndexedOptionArray64)
   );
 }
 
-/////////////////////////////////////////////////////////////// UnmaskedArray
+////////// UnmaskedArray
 
-py::class_<ak::UnmaskedArray, std::shared_ptr<ak::UnmaskedArray>, ak::Content> make_UnmaskedArray(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::UnmaskedArray, std::shared_ptr<ak::UnmaskedArray>, ak::Content>(m, name.c_str())
-      .def(py::init([](const py::object& content, const py::object& identities, const py::object& parameters) -> ak::UnmaskedArray {
-        return ak::UnmaskedArray(unbox_identities_none(identities), dict2parameters(parameters), std::shared_ptr<ak::Content>(unbox_content(content)));
-      }), py::arg("content"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+py::class_<ak::UnmaskedArray, std::shared_ptr<ak::UnmaskedArray>, ak::Content>
+make_UnmaskedArray(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::UnmaskedArray,
+                         std::shared_ptr<ak::UnmaskedArray>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const py::object& content,
+                       const py::object& identities,
+                       const py::object& parameters) -> ak::UnmaskedArray {
+        return ak::UnmaskedArray(
+          unbox_identities_none(identities),
+          dict2parameters(parameters),
+          std::shared_ptr<ak::Content>(unbox_content(content)));
+      }), py::arg("content"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
       .def_property_readonly("content", &ak::UnmaskedArray::content)
-      .def("project", [](const ak::UnmaskedArray& self, const py::object& mask) {
+      .def("project",
+           [](const ak::UnmaskedArray& self, const py::object& mask) {
         if (mask.is(py::none())) {
           return box(self.project());
         }
@@ -1118,19 +1456,38 @@ py::class_<ak::UnmaskedArray, std::shared_ptr<ak::UnmaskedArray>, ak::Content> m
   );
 }
 
-/////////////////////////////////////////////////////////////// ListArray
+////////// ListArray
 
 template <typename T>
-py::class_<ak::ListArrayOf<T>, std::shared_ptr<ak::ListArrayOf<T>>, ak::Content> make_ListArrayOf(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::ListArrayOf<T>, std::shared_ptr<ak::ListArrayOf<T>>, ak::Content>(m, name.c_str())
-      .def(py::init([](const ak::IndexOf<T>& starts, const ak::IndexOf<T>& stops, const py::object& content, const py::object& identities, const py::object& parameters) -> ak::ListArrayOf<T> {
-        return ak::ListArrayOf<T>(unbox_identities_none(identities), dict2parameters(parameters), starts, stops, unbox_content(content));
-      }), py::arg("starts"), py::arg("stops"), py::arg("content"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+py::class_<ak::ListArrayOf<T>,
+           std::shared_ptr<ak::ListArrayOf<T>>,
+           ak::Content>
+make_ListArrayOf(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::ListArrayOf<T>,
+                         std::shared_ptr<ak::ListArrayOf<T>>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const ak::IndexOf<T>& starts,
+                       const ak::IndexOf<T>& stops,
+                       const py::object& content,
+                       const py::object& identities,
+                       const py::object& parameters) -> ak::ListArrayOf<T> {
+        return ak::ListArrayOf<T>(unbox_identities_none(identities),
+                                  dict2parameters(parameters),
+                                  starts,
+                                  stops,
+                                  unbox_content(content));
+      }), py::arg("starts"),
+          py::arg("stops"),
+          py::arg("content"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
       .def_property_readonly("starts", &ak::ListArrayOf<T>::starts)
       .def_property_readonly("stops", &ak::ListArrayOf<T>::stops)
       .def_property_readonly("content", &ak::ListArrayOf<T>::content)
-      .def("compact_offsets64", &ak::ListArrayOf<T>::compact_offsets64, py::arg("start_at_zero") = true)
+      .def("compact_offsets64",
+           &ak::ListArrayOf<T>::compact_offsets64,
+           py::arg("start_at_zero") = true)
       .def("broadcast_tooffsets64", &ak::ListArrayOf<T>::broadcast_tooffsets64)
       .def("toRegularArray", &ak::ListArrayOf<T>::toRegularArray)
       .def("simplify", [](const ak::ListArrayOf<T>& self) {
@@ -1139,25 +1496,55 @@ py::class_<ak::ListArrayOf<T>, std::shared_ptr<ak::ListArrayOf<T>>, ak::Content>
   );
 }
 
-template py::class_<ak::ListArray32, std::shared_ptr<ak::ListArray32>, ak::Content> make_ListArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::ListArrayU32, std::shared_ptr<ak::ListArrayU32>, ak::Content> make_ListArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::ListArray64, std::shared_ptr<ak::ListArray64>, ak::Content> make_ListArrayOf(const py::handle& m, const std::string& name);
+template py::class_<ak::ListArray32,
+                    std::shared_ptr<ak::ListArray32>,
+                    ak::Content>
+make_ListArrayOf(const py::handle& m, const std::string& name);
 
-/////////////////////////////////////////////////////////////// ListOffsetArray
+template py::class_<ak::ListArrayU32,
+                    std::shared_ptr<ak::ListArrayU32>,
+                    ak::Content>
+make_ListArrayOf(const py::handle& m, const std::string& name);
+
+template py::class_<ak::ListArray64,
+                    std::shared_ptr<ak::ListArray64>,
+                    ak::Content>
+make_ListArrayOf(const py::handle& m, const std::string& name);
+
+////////// ListOffsetArray
 
 template <typename T>
-py::class_<ak::ListOffsetArrayOf<T>, std::shared_ptr<ak::ListOffsetArrayOf<T>>, ak::Content> make_ListOffsetArrayOf(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::ListOffsetArrayOf<T>, std::shared_ptr<ak::ListOffsetArrayOf<T>>, ak::Content>(m, name.c_str())
-      .def(py::init([](const ak::IndexOf<T>& offsets, const py::object& content, const py::object& identities, const py::object& parameters) -> ak::ListOffsetArrayOf<T> {
-        return ak::ListOffsetArrayOf<T>(unbox_identities_none(identities), dict2parameters(parameters), offsets, std::shared_ptr<ak::Content>(unbox_content(content)));
-      }), py::arg("offsets"), py::arg("content"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+py::class_<ak::ListOffsetArrayOf<T>,
+           std::shared_ptr<ak::ListOffsetArrayOf<T>>,
+           ak::Content>
+make_ListOffsetArrayOf(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::ListOffsetArrayOf<T>,
+                         std::shared_ptr<ak::ListOffsetArrayOf<T>>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const ak::IndexOf<T>& offsets,
+                       const py::object& content,
+                       const py::object& identities,
+                       const py::object& parameters)
+                    -> ak::ListOffsetArrayOf<T> {
+        return ak::ListOffsetArrayOf<T>(
+          unbox_identities_none(identities),
+          dict2parameters(parameters),
+          offsets,
+          std::shared_ptr<ak::Content>(unbox_content(content)));
+      }), py::arg("offsets"),
+          py::arg("content"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
       .def_property_readonly("starts", &ak::ListOffsetArrayOf<T>::starts)
       .def_property_readonly("stops", &ak::ListOffsetArrayOf<T>::stops)
       .def_property_readonly("offsets", &ak::ListOffsetArrayOf<T>::offsets)
       .def_property_readonly("content", &ak::ListOffsetArrayOf<T>::content)
-      .def("compact_offsets64", &ak::ListOffsetArrayOf<T>::compact_offsets64, py::arg("start_at_zero") = true)
-      .def("broadcast_tooffsets64", &ak::ListOffsetArrayOf<T>::broadcast_tooffsets64)
+      .def("compact_offsets64",
+           &ak::ListOffsetArrayOf<T>::compact_offsets64,
+           py::arg("start_at_zero") = true)
+      .def("broadcast_tooffsets64",
+           &ak::ListOffsetArrayOf<T>::broadcast_tooffsets64)
       .def("toRegularArray", &ak::ListOffsetArrayOf<T>::toRegularArray)
       .def("simplify", [](const ak::ListOffsetArrayOf<T>& self) {
         return box(self.shallow_simplify());
@@ -1165,14 +1552,28 @@ py::class_<ak::ListOffsetArrayOf<T>, std::shared_ptr<ak::ListOffsetArrayOf<T>>, 
   );
 }
 
-template py::class_<ak::ListOffsetArray32, std::shared_ptr<ak::ListOffsetArray32>, ak::Content> make_ListOffsetArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::ListOffsetArrayU32, std::shared_ptr<ak::ListOffsetArrayU32>, ak::Content> make_ListOffsetArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::ListOffsetArray64, std::shared_ptr<ak::ListOffsetArray64>, ak::Content> make_ListOffsetArrayOf(const py::handle& m, const std::string& name);
+template py::class_<ak::ListOffsetArray32,
+                    std::shared_ptr<ak::ListOffsetArray32>,
+                    ak::Content>
+make_ListOffsetArrayOf(const py::handle& m, const std::string& name);
 
-/////////////////////////////////////////////////////////////// NumpyArray
+template py::class_<ak::ListOffsetArrayU32,
+                    std::shared_ptr<ak::ListOffsetArrayU32>,
+                    ak::Content>
+make_ListOffsetArrayOf(const py::handle& m, const std::string& name);
 
-py::class_<ak::NumpyArray, std::shared_ptr<ak::NumpyArray>, ak::Content> make_NumpyArray(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::NumpyArray, std::shared_ptr<ak::NumpyArray>, ak::Content>(m, name.c_str(), py::buffer_protocol())
+template py::class_<ak::ListOffsetArray64,
+                    std::shared_ptr<ak::ListOffsetArray64>,
+                    ak::Content>
+make_ListOffsetArrayOf(const py::handle& m, const std::string& name);
+
+////////// NumpyArray
+
+py::class_<ak::NumpyArray, std::shared_ptr<ak::NumpyArray>, ak::Content>
+make_NumpyArray(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::NumpyArray,
+                         std::shared_ptr<ak::NumpyArray>,
+                         ak::Content>(m, name.c_str(), py::buffer_protocol())
       .def_buffer([](const ak::NumpyArray& self) -> py::buffer_info {
         return py::buffer_info(
           self.byteptr(),
@@ -1183,22 +1584,32 @@ py::class_<ak::NumpyArray, std::shared_ptr<ak::NumpyArray>, ak::Content> make_Nu
           self.strides());
       })
 
-      .def(py::init([](py::array& array, const py::object& identities, const py::object& parameters) -> ak::NumpyArray {
+      .def(py::init([](py::array& array,
+                       const py::object& identities,
+                       const py::object& parameters) -> ak::NumpyArray {
         py::buffer_info info = array.request();
         if (info.ndim == 0) {
-          throw std::invalid_argument("NumpyArray must not be scalar; try array.reshape(1)");
+          throw std::invalid_argument(
+            "NumpyArray must not be scalar; try array.reshape(1)");
         }
-        if (info.shape.size() != info.ndim  ||  info.strides.size() != info.ndim) {
-          throw std::invalid_argument("NumpyArray len(shape) != ndim or len(strides) != ndim");
+        if (info.shape.size() != info.ndim  ||
+            info.strides.size() != info.ndim) {
+          throw std::invalid_argument(
+            "NumpyArray len(shape) != ndim or len(strides) != ndim");
         }
-        return ak::NumpyArray(unbox_identities_none(identities), dict2parameters(parameters), std::shared_ptr<void>(
-          reinterpret_cast<void*>(info.ptr), pyobject_deleter<void>(array.ptr())),
+        return ak::NumpyArray(
+          unbox_identities_none(identities),
+          dict2parameters(parameters),
+          std::shared_ptr<void>(reinterpret_cast<void*>(info.ptr),
+                                pyobject_deleter<void>(array.ptr())),
           info.shape,
           info.strides,
           0,
           info.itemsize,
           info.format);
-      }), py::arg("array"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+      }), py::arg("array"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
       .def_property_readonly("shape", &ak::NumpyArray::shape)
       .def_property_readonly("strides", &ak::NumpyArray::strides)
@@ -1217,27 +1628,47 @@ py::class_<ak::NumpyArray, std::shared_ptr<ak::NumpyArray>, ak::Content> make_Nu
   );
 }
 
-/////////////////////////////////////////////////////////////// RecordArray
+////////// RecordArray
 
-py::class_<ak::Record, std::shared_ptr<ak::Record>> make_Record(const py::handle& m, const std::string& name) {
+py::class_<ak::Record, std::shared_ptr<ak::Record>>
+make_Record(const py::handle& m, const std::string& name) {
   return py::class_<ak::Record, std::shared_ptr<ak::Record>>(m, name.c_str())
-      .def(py::init([](const std::shared_ptr<ak::RecordArray>& array, int64_t at) -> ak::Record {
+      .def(py::init([](const std::shared_ptr<ak::RecordArray>& array,
+                       int64_t at) -> ak::Record {
         return ak::Record(array, at);
       }), py::arg("array"), py::arg("at"))
       .def("__repr__", &repr<ak::Record>)
-      .def_property_readonly("identities", [](const ak::Record& self) -> py::object { return box(self.identities()); })
+      .def_property_readonly("identities",
+                             [](const ak::Record& self) -> py::object {
+        return box(self.identities());
+      })
       .def("__getitem__", &getitem<ak::Record>)
-      .def("type", [](const ak::Record& self, const std::map<std::string, std::string>& typestrs) -> std::shared_ptr<ak::Type> {
+      .def("type", [](const ak::Record& self,
+                      const std::map<std::string,
+                      std::string>& typestrs) -> std::shared_ptr<ak::Type> {
         return self.type(typestrs);
       })
-      .def_property("parameters", &getparameters<ak::Record>, &setparameters<ak::Record>)
+      .def_property("parameters",
+                    &getparameters<ak::Record>, &setparameters<ak::Record>)
       .def("setparameter", &setparameter<ak::Record>)
       .def("parameter", &parameter<ak::Record>)
       .def("purelist_parameter", &purelist_parameter<ak::Record>)
-      .def("tojson", &tojson_string<ak::Record>, py::arg("pretty") = false, py::arg("maxdecimals") = py::none())
-      .def("tojson", &tojson_file<ak::Record>, py::arg("destination"), py::arg("pretty") = false, py::arg("maxdecimals") = py::none(), py::arg("buffersize") = 65536)
+      .def("tojson",
+           &tojson_string<ak::Record>,
+           py::arg("pretty") = false,
+           py::arg("maxdecimals") = py::none())
+      .def("tojson",
+           &tojson_file<ak::Record>,
+           py::arg("destination"),
+           py::arg("pretty") = false,
+           py::arg("maxdecimals") = py::none(),
+           py::arg("buffersize") = 65536)
 
-      .def_property_readonly("array", [](const ak::Record& self) -> std::shared_ptr<const ak::RecordArray> { return self.array(); })
+      .def_property_readonly("array",
+                             [](const ak::Record& self)
+                             -> std::shared_ptr<const ak::RecordArray> {
+        return self.array();
+      })
       .def_property_readonly("at", &ak::Record::at)
       .def_property_readonly("istuple", &ak::Record::istuple)
       .def_property_readonly("numfields", &ak::Record::numfields)
@@ -1245,10 +1676,12 @@ py::class_<ak::Record, std::shared_ptr<ak::Record>> make_Record(const py::handle
       .def("key", &ak::Record::key)
       .def("haskey", &ak::Record::haskey)
       .def("keys", &ak::Record::keys)
-      .def("field", [](const ak::Record& self, int64_t fieldindex) -> py::object {
+      .def("field",
+           [](const ak::Record& self, int64_t fieldindex) -> py::object {
         return box(self.field(fieldindex));
       })
-      .def("field", [](const ak::Record& self, const std::string& key) -> py::object {
+      .def("field",
+           [](const ak::Record& self, const std::string& key) -> py::object {
         return box(self.field(key));
       })
       .def("fields", [](const ak::Record& self) -> py::object {
@@ -1270,7 +1703,8 @@ py::class_<ak::Record, std::shared_ptr<ak::Record>> make_Record(const py::handle
         }
         return out;
       })
-      .def_property_readonly("astuple", [](const ak::Record& self) -> py::object {
+      .def_property_readonly("astuple",
+                             [](const ak::Record& self) -> py::object {
         return box(self.astuple());
       })
      .def_property_readonly("identity", &identity<ak::Record>)
@@ -1281,7 +1715,12 @@ py::class_<ak::Record, std::shared_ptr<ak::Record>> make_Record(const py::handle
   ;
 }
 
-ak::RecordArray iterable_to_RecordArray(const py::iterable& contents, const py::object& keys, const py::object& length, const py::object& identities, const py::object& parameters) {
+ak::RecordArray
+iterable_to_RecordArray(const py::iterable& contents,
+                        const py::object& keys,
+                        const py::object& length,
+                        const py::object& identities,
+                        const py::object& parameters) {
   std::vector<std::shared_ptr<ak::Content>> out;
   for (auto x : contents) {
     out.push_back(unbox_content(x));
@@ -1293,22 +1732,37 @@ ak::RecordArray iterable_to_RecordArray(const py::iterable& contents, const py::
       recordlookup.get()->push_back(x.cast<std::string>());
     }
     if (out.size() != recordlookup.get()->size()) {
-      throw std::invalid_argument("if provided, 'keys' must have the same length as 'types'");
+      throw std::invalid_argument(
+        "if provided, 'keys' must have the same length as 'types'");
     }
   }
   if (length.is(py::none())) {
-    return ak::RecordArray(unbox_identities_none(identities), dict2parameters(parameters), out, recordlookup);
+    return ak::RecordArray(unbox_identities_none(identities),
+                           dict2parameters(parameters),
+                           out,
+                           recordlookup);
   }
   else {
     int64_t intlength = length.cast<int64_t>();
-    return ak::RecordArray(unbox_identities_none(identities), dict2parameters(parameters), out, recordlookup, intlength);
+    return ak::RecordArray(unbox_identities_none(identities),
+                           dict2parameters(parameters),
+                           out,
+                           recordlookup,
+                           intlength);
   }
 }
 
-py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content> make_RecordArray(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content>(m, name.c_str())
-      .def(py::init([](const py::dict& contents, const py::object& length, const py::object& identities, const py::object& parameters) -> ak::RecordArray {
-        std::shared_ptr<ak::util::RecordLookup> recordlookup = std::make_shared<ak::util::RecordLookup>();
+py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content>
+make_RecordArray(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::RecordArray,
+                         std::shared_ptr<ak::RecordArray>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const py::dict& contents,
+                       const py::object& length,
+                       const py::object& identities,
+                       const py::object& parameters) -> ak::RecordArray {
+        std::shared_ptr<ak::util::RecordLookup> recordlookup =
+          std::make_shared<ak::util::RecordLookup>();
         std::vector<std::shared_ptr<ak::Content>> out;
         for (auto x : contents) {
           std::string key = x.first.cast<std::string>();
@@ -1316,24 +1770,43 @@ py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content> make_
           out.push_back(unbox_content(x.second));
         }
         if (length.is(py::none())) {
-          return ak::RecordArray(unbox_identities_none(identities), dict2parameters(parameters), out, recordlookup);
+          return ak::RecordArray(unbox_identities_none(identities),
+                                 dict2parameters(parameters),
+                                 out,
+                                 recordlookup);
         }
         else {
           int64_t intlength = length.cast<int64_t>();
-          return ak::RecordArray(unbox_identities_none(identities), dict2parameters(parameters), out, recordlookup, intlength);
+          return ak::RecordArray(unbox_identities_none(identities),
+                                 dict2parameters(parameters),
+                                 out,
+                                 recordlookup,
+                                 intlength);
         }
-      }), py::arg("contents"), py::arg("length") = py::none(), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
-      .def(py::init(&iterable_to_RecordArray), py::arg("contents"), py::arg("keys") = py::none(), py::arg("length") = py::none(), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+      }), py::arg("contents"),
+          py::arg("length") = py::none(),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
+      .def(py::init(&iterable_to_RecordArray),
+           py::arg("contents"),
+           py::arg("keys") = py::none(),
+           py::arg("length") = py::none(),
+           py::arg("identities") = py::none(),
+           py::arg("parameters") = py::none())
 
-      .def_property_readonly("recordlookup", [](const ak::RecordArray& self) -> py::object {
-        std::shared_ptr<ak::util::RecordLookup> recordlookup = self.recordlookup();
+      .def_property_readonly("recordlookup",
+                             [](const ak::RecordArray& self) -> py::object {
+        std::shared_ptr<ak::util::RecordLookup> recordlookup =
+          self.recordlookup();
         if (recordlookup.get() == nullptr) {
           return py::none();
         }
         else {
           py::list out;
           for (auto x : *recordlookup.get()) {
-            py::str pyvalue(PyUnicode_DecodeUTF8(x.data(), x.length(), "surrogateescape"));
+            py::str pyvalue(PyUnicode_DecodeUTF8(x.data(),
+                                                 x.length(),
+                                                 "surrogateescape"));
             out.append(pyvalue);
           }
           return out;
@@ -1341,7 +1814,10 @@ py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content> make_
       })
       .def_property_readonly("istuple", &ak::RecordArray::istuple)
       .def_property_readonly("contents", &ak::RecordArray::contents)
-      .def("setitem_field", [](const ak::RecordArray& self, const py::object& where, const py::object& what) -> py::object {
+      .def("setitem_field",
+           [](const ak::RecordArray& self,
+              const py::object& where,
+              const py::object& what) -> py::object {
         std::shared_ptr<ak::Content> mywhat = unbox_content(what);
         if (where.is(py::none())) {
           return box(self.setitem_field(self.numfields(), mywhat));
@@ -1363,10 +1839,14 @@ py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content> make_
         }
       }, py::arg("where"), py::arg("what"))
 
-      .def("field", [](const ak::RecordArray& self, int64_t fieldindex) -> std::shared_ptr<ak::Content> {
+      .def("field",
+           [](const ak::RecordArray& self, int64_t fieldindex)
+           -> std::shared_ptr<ak::Content> {
         return self.field(fieldindex);
       })
-      .def("field", [](const ak::RecordArray& self, const std::string& key) -> std::shared_ptr<ak::Content> {
+      .def("field",
+           [](const ak::RecordArray& self, const std::string& key)
+           -> std::shared_ptr<ak::Content> {
         return self.field(key);
       })
       .def("fields", [](const ak::RecordArray& self) -> py::object {
@@ -1388,7 +1868,8 @@ py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content> make_
         }
         return out;
       })
-      .def_property_readonly("astuple", [](const ak::RecordArray& self) -> py::object {
+      .def_property_readonly("astuple",
+                             [](const ak::RecordArray& self) -> py::object {
         return box(self.astuple());
       })
       .def("simplify", [](const ak::RecordArray& self) {
@@ -1398,17 +1879,32 @@ py::class_<ak::RecordArray, std::shared_ptr<ak::RecordArray>, ak::Content> make_
   );
 }
 
-/////////////////////////////////////////////////////////////// RegularArray
+////////// RegularArray
 
-py::class_<ak::RegularArray, std::shared_ptr<ak::RegularArray>, ak::Content> make_RegularArray(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::RegularArray, std::shared_ptr<ak::RegularArray>, ak::Content>(m, name.c_str())
-      .def(py::init([](const py::object& content, int64_t size, const py::object& identities, const py::object& parameters) -> ak::RegularArray {
-        return ak::RegularArray(unbox_identities_none(identities), dict2parameters(parameters), std::shared_ptr<ak::Content>(unbox_content(content)), size);
-      }), py::arg("content"), py::arg("size"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+py::class_<ak::RegularArray, std::shared_ptr<ak::RegularArray>, ak::Content>
+make_RegularArray(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::RegularArray,
+                         std::shared_ptr<ak::RegularArray>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const py::object& content,
+                       int64_t size,
+                       const py::object& identities,
+                       const py::object& parameters) -> ak::RegularArray {
+        return ak::RegularArray(
+          unbox_identities_none(identities),
+          dict2parameters(parameters),
+          std::shared_ptr<ak::Content>(unbox_content(content)),
+          size);
+      }), py::arg("content"),
+          py::arg("size"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
       .def_property_readonly("size", &ak::RegularArray::size)
       .def_property_readonly("content", &ak::RegularArray::content)
-      .def("compact_offsets64", &ak::RegularArray::compact_offsets64, py::arg("start_at_zero") = true)
+      .def("compact_offsets64",
+           &ak::RegularArray::compact_offsets64,
+           py::arg("start_at_zero") = true)
       .def("broadcast_tooffsets64", &ak::RegularArray::broadcast_tooffsets64)
       .def("simplify", [](const ak::RegularArray& self) {
         return box(self.shallow_simplify());
@@ -1416,33 +1912,65 @@ py::class_<ak::RegularArray, std::shared_ptr<ak::RegularArray>, ak::Content> mak
   );
 }
 
-/////////////////////////////////////////////////////////////// UnionArray
+////////// UnionArray
 
 template <typename T, typename I>
-py::class_<ak::UnionArrayOf<T, I>, std::shared_ptr<ak::UnionArrayOf<T, I>>, ak::Content> make_UnionArrayOf(const py::handle& m, const std::string& name) {
-  return content_methods(py::class_<ak::UnionArrayOf<T, I>, std::shared_ptr<ak::UnionArrayOf<T, I>>, ak::Content>(m, name.c_str())
-      .def(py::init([](const ak::IndexOf<T>& tags, ak::IndexOf<I>& index, const py::iterable& contents, const py::object& identities, const py::object& parameters) -> ak::UnionArrayOf<T, I> {
+py::class_<ak::UnionArrayOf<T, I>,
+           std::shared_ptr<ak::UnionArrayOf<T, I>>,
+           ak::Content>
+make_UnionArrayOf(const py::handle& m, const std::string& name) {
+  return content_methods(py::class_<ak::UnionArrayOf<T, I>,
+                         std::shared_ptr<ak::UnionArrayOf<T, I>>,
+                         ak::Content>(m, name.c_str())
+      .def(py::init([](const ak::IndexOf<T>& tags,
+                       ak::IndexOf<I>& index,
+                       const py::iterable& contents,
+                       const py::object& identities,
+                       const py::object& parameters)
+                    -> ak::UnionArrayOf<T, I> {
         std::vector<std::shared_ptr<ak::Content>> out;
         for (auto content : contents) {
           out.push_back(std::shared_ptr<ak::Content>(unbox_content(content)));
         }
-        return ak::UnionArrayOf<T, I>(unbox_identities_none(identities), dict2parameters(parameters), tags, index, out);
-      }), py::arg("tags"), py::arg("index"), py::arg("contents"), py::arg("identities") = py::none(), py::arg("parameters") = py::none())
+        return ak::UnionArrayOf<T, I>(unbox_identities_none(identities),
+                                      dict2parameters(parameters),
+                                      tags,
+                                      index,
+                                      out);
+      }), py::arg("tags"),
+          py::arg("index"),
+          py::arg("contents"),
+          py::arg("identities") = py::none(),
+          py::arg("parameters") = py::none())
 
       .def_static("regular_index", &ak::UnionArrayOf<T, I>::regular_index)
       .def_property_readonly("tags", &ak::UnionArrayOf<T, I>::tags)
       .def_property_readonly("index", &ak::UnionArrayOf<T, I>::index)
       .def_property_readonly("contents", &ak::UnionArrayOf<T, I>::contents)
-      .def_property_readonly("numcontents", &ak::UnionArrayOf<T, I>::numcontents)
+      .def_property_readonly("numcontents",
+                             &ak::UnionArrayOf<T, I>::numcontents)
       .def("content", &ak::UnionArrayOf<T, I>::content)
       .def("project", &ak::UnionArrayOf<T, I>::project)
-      .def("simplify", [](const ak::UnionArrayOf<T, I>& self, bool mergebool) -> py::object {
+      .def("simplify",
+           [](const ak::UnionArrayOf<T, I>& self, bool mergebool)
+           -> py::object {
         return box(self.simplify_uniontype(mergebool));
       }, py::arg("mergebool") = false)
 
   );
 }
 
-template py::class_<ak::UnionArray8_32, std::shared_ptr<ak::UnionArray8_32>, ak::Content> make_UnionArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::UnionArray8_U32, std::shared_ptr<ak::UnionArray8_U32>, ak::Content> make_UnionArrayOf(const py::handle& m, const std::string& name);
-template py::class_<ak::UnionArray8_64, std::shared_ptr<ak::UnionArray8_64>, ak::Content> make_UnionArrayOf(const py::handle& m, const std::string& name);
+template py::class_<ak::UnionArray8_32,
+                    std::shared_ptr<ak::UnionArray8_32>,
+                    ak::Content>
+make_UnionArrayOf(const py::handle& m, const std::string& name);
+
+template py::class_<ak::UnionArray8_U32,
+                    std::shared_ptr<ak::UnionArray8_U32>,
+                    ak::Content>
+make_UnionArrayOf(const py::handle& m, const std::string& name);
+
+template py::class_<ak::UnionArray8_64,
+                    std::shared_ptr<ak::UnionArray8_64>,
+                    ak::Content>
+make_UnionArrayOf(const py::handle& m, const std::string& name);

--- a/src/python/layout/identities.cpp
+++ b/src/python/layout/identities.cpp
@@ -8,11 +8,16 @@
 #include "awkward/python/identities.h"
 
 template <typename T>
-py::class_<ak::IdentitiesOf<T>> make_IdentitiesOf(const py::handle& m, const std::string& name) {
-  return (py::class_<ak::IdentitiesOf<T>>(m, name.c_str(), py::buffer_protocol())
+py::class_<ak::IdentitiesOf<T>>
+make_IdentitiesOf(const py::handle& m, const std::string& name) {
+  return (py::class_<ak::IdentitiesOf<T>>(m,
+                                          name.c_str(),
+                                          py::buffer_protocol())
       .def_buffer([](const ak::IdentitiesOf<T>& self) -> py::buffer_info {
         return py::buffer_info(
-          reinterpret_cast<void*>(reinterpret_cast<ssize_t>(self.ptr().get()) + self.offset()*sizeof(T)),
+          reinterpret_cast<void*>(
+            reinterpret_cast<ssize_t>(
+              self.ptr().get()) + self.offset()*sizeof(T)),
           sizeof(T),
           py::format_descriptor<T>::format(),
           2,
@@ -22,20 +27,36 @@ py::class_<ak::IdentitiesOf<T>> make_IdentitiesOf(const py::handle& m, const std
 
       .def_static("newref", &ak::Identities::newref)
 
-      .def(py::init([](ak::Identities::Ref ref, const ak::Identities::FieldLoc& fieldloc, int64_t width, int64_t length) {
+      .def(py::init([](ak::Identities::Ref ref,
+                       const ak::Identities::FieldLoc& fieldloc,
+                       int64_t width,
+                       int64_t length) {
         return ak::IdentitiesOf<T>(ref, fieldloc, width, length);
       }))
 
-      .def(py::init([name](ak::Identities::Ref ref, ak::Identities::FieldLoc fieldloc, py::array_t<T, py::array::c_style | py::array::forcecast> array) {
+      .def(py::init([name](ak::Identities::Ref ref,
+                           ak::Identities::FieldLoc fieldloc,
+                           py::array_t<T,
+                           py::array::c_style | py::array::forcecast> array) {
         py::buffer_info info = array.request();
         if (info.ndim != 2) {
-          throw std::invalid_argument(name + std::string(" must be built from a two-dimensional array"));
+          throw std::invalid_argument(
+            name + std::string(" must be built from a two-dimensional array"));
         }
-        if (info.strides[0] != sizeof(T)*info.shape[1]  ||  info.strides[1] != sizeof(T)) {
-          throw std::invalid_argument(name + std::string(" must be built from a contiguous array (array.stries == (array.shape[1]*array.itemsize, array.itemsize)); try array.copy()"));
+        if (info.strides[0] != sizeof(T)*info.shape[1]  ||
+            info.strides[1] != sizeof(T)) {
+          throw std::invalid_argument(
+            name + std::string(" must be built from a contiguous array (array"
+                               ".stries == (array.shape[1]*array.itemsize, "
+                               "array.itemsize)); try array.copy()"));
         }
-        return ak::IdentitiesOf<T>(ref, fieldloc, 0, info.shape[1], info.shape[0],
-            std::shared_ptr<T>(reinterpret_cast<T*>(info.ptr), pyobject_deleter<T>(array.ptr())));
+        return ak::IdentitiesOf<T>(ref,
+                                   fieldloc,
+                                   0,
+                                   info.shape[1],
+                                   info.shape[0],
+            std::shared_ptr<T>(reinterpret_cast<T*>(info.ptr),
+                               pyobject_deleter<T>(array.ptr())));
       }))
 
       .def("__repr__", &ak::IdentitiesOf<T>::tostring)
@@ -51,7 +72,8 @@ py::class_<ak::IdentitiesOf<T>> make_IdentitiesOf(const py::handle& m, const std
         return py::array(self);
       })
       .def("identity_at_str", &ak::IdentitiesOf<T>::identity_at)
-      .def("identity_at", [](const ak::Identities& self, int64_t at) -> py::tuple {
+      .def("identity_at",
+           [](const ak::Identities& self, int64_t at) -> py::tuple {
         ak::Identities::FieldLoc fieldloc = self.fieldloc();
         py::tuple out((size_t)self.width() + fieldloc.size());
         size_t j = 0;
@@ -71,5 +93,8 @@ py::class_<ak::IdentitiesOf<T>> make_IdentitiesOf(const py::handle& m, const std
   );
 }
 
-template py::class_<ak::Identities32> make_IdentitiesOf(const py::handle& m, const std::string& name);
-template py::class_<ak::Identities64> make_IdentitiesOf(const py::handle& m, const std::string& name);
+template py::class_<ak::Identities32>
+make_IdentitiesOf(const py::handle& m, const std::string& name);
+
+template py::class_<ak::Identities64>
+make_IdentitiesOf(const py::handle& m, const std::string& name);

--- a/src/python/layout/index.cpp
+++ b/src/python/layout/index.cpp
@@ -7,11 +7,13 @@
 #include "awkward/python/index.h"
 
 template <typename T>
-py::class_<ak::IndexOf<T>> make_IndexOf(const py::handle& m, const std::string& name) {
+py::class_<ak::IndexOf<T>>
+make_IndexOf(const py::handle& m, const std::string& name) {
   return (py::class_<ak::IndexOf<T>>(m, name.c_str(), py::buffer_protocol())
       .def_buffer([](const ak::IndexOf<T>& self) -> py::buffer_info {
         return py::buffer_info(
-          reinterpret_cast<void*>(reinterpret_cast<ssize_t>(self.ptr().get()) + self.offset()*sizeof(T)),
+          reinterpret_cast<void*>(reinterpret_cast<ssize_t>(self.ptr().get())
+                                  + self.offset()*sizeof(T)),
           sizeof(T),
           py::format_descriptor<T>::format(),
           1,
@@ -19,16 +21,22 @@ py::class_<ak::IndexOf<T>> make_IndexOf(const py::handle& m, const std::string& 
           { (ssize_t)sizeof(T) });
         })
 
-      .def(py::init([name](py::array_t<T, py::array::c_style | py::array::forcecast> array) -> ak::IndexOf<T> {
+      .def(py::init([name](py::array_t<T,
+                           py::array::c_style |
+                           py::array::forcecast> array) -> ak::IndexOf<T> {
         py::buffer_info info = array.request();
         if (info.ndim != 1) {
-          throw std::invalid_argument(name + std::string(" must be built from a one-dimensional array; try array.ravel()"));
+          throw std::invalid_argument(name + std::string(
+            " must be built from a one-dimensional array; try array.ravel()"));
         }
         if (info.strides[0] != sizeof(T)) {
-          throw std::invalid_argument(name + std::string(" must be built from a contiguous array (array.strides == (array.itemsize,)); try array.copy()"));
+          throw std::invalid_argument(name + std::string(
+            " must be built from a contiguous array (array.strides == "
+            "(array.itemsize,)); try array.copy()"));
         }
         return ak::IndexOf<T>(
-          std::shared_ptr<T>(reinterpret_cast<T*>(info.ptr), pyobject_deleter<T>(array.ptr())),
+          std::shared_ptr<T>(reinterpret_cast<T*>(info.ptr),
+                             pyobject_deleter<T>(array.ptr())),
           0,
           (int64_t)info.shape[0]);
       }))
@@ -41,8 +49,17 @@ py::class_<ak::IndexOf<T>> make_IndexOf(const py::handle& m, const std::string& 
   );
 }
 
-template py::class_<ak::Index8> make_IndexOf<int8_t>(const py::handle& m, const std::string& name);
-template py::class_<ak::IndexU8> make_IndexOf<uint8_t>(const py::handle& m, const std::string& name);
-template py::class_<ak::Index32> make_IndexOf<int32_t>(const py::handle& m, const std::string& name);
-template py::class_<ak::IndexU32> make_IndexOf<uint32_t>(const py::handle& m, const std::string& name);
-template py::class_<ak::Index64> make_IndexOf<int64_t>(const py::handle& m, const std::string& name);
+template py::class_<ak::Index8>
+make_IndexOf<int8_t>(const py::handle& m, const std::string& name);
+
+template py::class_<ak::IndexU8>
+make_IndexOf<uint8_t>(const py::handle& m, const std::string& name);
+
+template py::class_<ak::Index32>
+make_IndexOf<int32_t>(const py::handle& m, const std::string& name);
+
+template py::class_<ak::IndexU32>
+make_IndexOf<uint32_t>(const py::handle& m, const std::string& name);
+
+template py::class_<ak::Index64>
+make_IndexOf<int64_t>(const py::handle& m, const std::string& name);

--- a/src/python/types.cpp
+++ b/src/python/types.cpp
@@ -17,31 +17,40 @@
 namespace py = pybind11;
 namespace ak = awkward;
 
-/////////////////////////////////////////////////////////////// boxing
+////////// boxing
 
-py::object box(const std::shared_ptr<ak::Type>& t) {
-  if (ak::ArrayType* raw = dynamic_cast<ak::ArrayType*>(t.get())) {
+py::object
+box(const std::shared_ptr<ak::Type>& t) {
+  if (ak::ArrayType* raw =
+      dynamic_cast<ak::ArrayType*>(t.get())) {
     return py::cast(*raw);
   }
-  else if (ak::ListType* raw = dynamic_cast<ak::ListType*>(t.get())) {
+  else if (ak::ListType* raw =
+           dynamic_cast<ak::ListType*>(t.get())) {
     return py::cast(*raw);
   }
-  else if (ak::OptionType* raw = dynamic_cast<ak::OptionType*>(t.get())) {
+  else if (ak::OptionType* raw =
+           dynamic_cast<ak::OptionType*>(t.get())) {
     return py::cast(*raw);
   }
-  else if (ak::PrimitiveType* raw = dynamic_cast<ak::PrimitiveType*>(t.get())) {
+  else if (ak::PrimitiveType* raw =
+           dynamic_cast<ak::PrimitiveType*>(t.get())) {
     return py::cast(*raw);
   }
-  else if (ak::RecordType* raw = dynamic_cast<ak::RecordType*>(t.get())) {
+  else if (ak::RecordType* raw =
+           dynamic_cast<ak::RecordType*>(t.get())) {
     return py::cast(*raw);
   }
-  else if (ak::RegularType* raw = dynamic_cast<ak::RegularType*>(t.get())) {
+  else if (ak::RegularType* raw =
+           dynamic_cast<ak::RegularType*>(t.get())) {
     return py::cast(*raw);
   }
-  else if (ak::UnionType* raw = dynamic_cast<ak::UnionType*>(t.get())) {
+  else if (ak::UnionType* raw =
+           dynamic_cast<ak::UnionType*>(t.get())) {
     return py::cast(*raw);
   }
-  else if (ak::UnknownType* raw = dynamic_cast<ak::UnknownType*>(t.get())) {
+  else if (ak::UnknownType* raw =
+           dynamic_cast<ak::UnknownType*>(t.get())) {
     return py::cast(*raw);
   }
   else {
@@ -85,20 +94,24 @@ std::shared_ptr<ak::Type> unbox_type(const py::handle& obj) {
   throw std::invalid_argument("argument must be a Type subtype");
 }
 
-/////////////////////////////////////////////////////////////// Type
+////////// Type
 
-py::class_<ak::Type, std::shared_ptr<ak::Type>> make_Type(const py::handle& m, const std::string& name) {
+py::class_<ak::Type, std::shared_ptr<ak::Type>>
+make_Type(const py::handle& m, const std::string& name) {
   return (py::class_<ak::Type, std::shared_ptr<ak::Type>>(m, name.c_str())
-      .def("__eq__", [](const std::shared_ptr<ak::Type>& self, const std::shared_ptr<ak::Type>& other) -> bool {
+      .def("__eq__", [](const std::shared_ptr<ak::Type>& self,
+                        const std::shared_ptr<ak::Type>& other) -> bool {
         return self.get()->equal(other, true);
       })
-      .def("__ne__", [](const std::shared_ptr<ak::Type>& self, const std::shared_ptr<ak::Type>& other) -> bool {
+      .def("__ne__", [](const std::shared_ptr<ak::Type>& self,
+                        const std::shared_ptr<ak::Type>& other) -> bool {
         return !self.get()->equal(other, true);
       })
   );
 }
 
-ak::util::Parameters dict2parameters(const py::object& in) {
+ak::util::Parameters
+dict2parameters(const py::object& in) {
   ak::util::Parameters out;
   if (in.is(py::none())) {
     // None is equivalent to an empty dict
@@ -116,13 +129,18 @@ ak::util::Parameters dict2parameters(const py::object& in) {
   return out;
 }
 
-py::dict parameters2dict(const ak::util::Parameters& in) {
+py::dict
+parameters2dict(const ak::util::Parameters& in) {
   py::dict out;
   for (auto pair : in) {
     std::string cppkey = pair.first;
     std::string cppvalue = pair.second;
-    py::str pykey(PyUnicode_DecodeUTF8(cppkey.data(), cppkey.length(), "surrogateescape"));
-    py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(), cppvalue.length(), "surrogateescape"));
+    py::str pykey(PyUnicode_DecodeUTF8(cppkey.data(),
+                                       cppkey.length(),
+                                       "surrogateescape"));
+    py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(),
+                                         cppvalue.length(),
+                                         "surrogateescape"));
     out[pykey] = py::module::import("json").attr("loads")(pyvalue);
   }
   return out;
@@ -134,26 +152,34 @@ py::dict getparameters(const T& self) {
 }
 
 template <typename T>
-py::object parameter(const T& self, const std::string& key) {
+py::object
+parameter(const T& self, const std::string& key) {
   std::string cppvalue = self.parameter(key);
-  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(), cppvalue.length(), "surrogateescape"));
+  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(),
+                                       cppvalue.length(),
+                                       "surrogateescape"));
   return py::module::import("json").attr("loads")(pyvalue);
 }
 
 template <typename T>
-py::object purelist_parameter(const T& self, const std::string& key) {
+py::object
+purelist_parameter(const T& self, const std::string& key) {
   std::string cppvalue = self.purelist_parameter(key);
-  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(), cppvalue.length(), "surrogateescape"));
+  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(),
+                                       cppvalue.length(),
+                                       "surrogateescape"));
   return py::module::import("json").attr("loads")(pyvalue);
 }
 
 template <typename T>
-void setparameters(T& self, const py::object& parameters) {
+void
+setparameters(T& self, const py::object& parameters) {
   self.setparameters(dict2parameters(parameters));
 }
 
 template <typename T>
-void setparameter(T& self, const std::string& key, const py::object& value) {
+void
+setparameter(T& self, const std::string& key, const py::object& value) {
   py::object valuestr = py::module::import("json").attr("dumps")(value);
   self.setparameter(key, valuestr.cast<std::string>());
 }
@@ -167,22 +193,27 @@ std::string typestr2str(const py::object& in) {
   }
 }
 
-py::object str2typestr(const std::string& in) {
+py::object
+str2typestr(const std::string& in) {
   if (in.empty()) {
     return py::none();
   }
   else {
-    py::str pyvalue(PyUnicode_DecodeUTF8(in.data(), in.length(), "surrogateescape"));
+    py::str pyvalue(PyUnicode_DecodeUTF8(in.data(),
+                                         in.length(),
+                                         "surrogateescape"));
     return pyvalue;
   }
 }
 
 template <typename T>
-py::class_<T, ak::Type> type_methods(py::class_<T, std::shared_ptr<T>, ak::Type>& x) {
+py::class_<T, ak::Type>
+type_methods(py::class_<T, std::shared_ptr<T>, ak::Type>& x) {
   return x.def("__repr__", &T::tostring)
           .def_property("parameters", &getparameters<T>, &setparameters<T>)
           .def("setparameter", &setparameter<T>)
-          .def_property_readonly("typestr", [](const ak::Type& self) -> py::object {
+          .def_property_readonly("typestr",
+                                 [](const ak::Type& self) -> py::object {
             return str2typestr(self.typestr());
           })
           .def_property_readonly("numfields", &T::numfields)
@@ -194,98 +225,174 @@ py::class_<T, ak::Type> type_methods(py::class_<T, std::shared_ptr<T>, ak::Type>
   ;
 }
 
-/////////////////////////////////////////////////////////////// ArrayType
+////////// ArrayType
 
-py::class_<ak::ArrayType, std::shared_ptr<ak::ArrayType>, ak::Type> make_ArrayType(const py::handle& m, const std::string& name) {
-  return type_methods(py::class_<ak::ArrayType, std::shared_ptr<ak::ArrayType>, ak::Type>(m, name.c_str())
-      .def(py::init([](const std::shared_ptr<ak::Type>& type, int64_t length, const py::object& parameters, const py::object& typestr) -> ak::ArrayType {
-        return ak::ArrayType(dict2parameters(parameters), typestr2str(typestr), type, length);
-      }), py::arg("type"), py::arg("length"), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
+py::class_<ak::ArrayType, std::shared_ptr<ak::ArrayType>, ak::Type>
+make_ArrayType(const py::handle& m, const std::string& name) {
+  return type_methods(py::class_<ak::ArrayType,
+                      std::shared_ptr<ak::ArrayType>,
+                      ak::Type>(m, name.c_str())
+      .def(py::init([](const std::shared_ptr<ak::Type>& type,
+                       int64_t length,
+                       const py::object& parameters,
+                       const py::object& typestr) -> ak::ArrayType {
+        return ak::ArrayType(dict2parameters(parameters),
+                             typestr2str(typestr),
+                             type,
+                             length);
+      }), py::arg("type"),
+           py::arg("length"),
+           py::arg("parameters") = py::none(),
+           py::arg("typestr") = py::none())
       .def_property_readonly("type", &ak::ArrayType::type)
       .def_property_readonly("length", &ak::ArrayType::length)
       .def(py::pickle([](const ak::ArrayType& self) {
-        return py::make_tuple(parameters2dict(self.parameters()), str2typestr(self.typestr()), box(self.type()), py::cast(self.length()));
+        return py::make_tuple(parameters2dict(self.parameters()),
+                              str2typestr(self.typestr()),
+                              box(self.type()),
+                              py::cast(self.length()));
       }, [](const py::tuple& state) {
-        return ak::ArrayType(dict2parameters(state[0]), typestr2str(state[1]), unbox_type(state[2]), state[3].cast<int64_t>());
+        return ak::ArrayType(dict2parameters(state[0]),
+                             typestr2str(state[1]),
+                             unbox_type(state[2]),
+                             state[3].cast<int64_t>());
       }))
   );
 }
 
-/////////////////////////////////////////////////////////////// ListType
+////////// ListType
 
-py::class_<ak::ListType, std::shared_ptr<ak::ListType>, ak::Type> make_ListType(const py::handle& m, const std::string& name) {
-  return type_methods(py::class_<ak::ListType, std::shared_ptr<ak::ListType>, ak::Type>(m, name.c_str())
-      .def(py::init([](const std::shared_ptr<ak::Type>& type, const py::object& parameters, const py::object& typestr) -> ak::ListType {
-        return ak::ListType(dict2parameters(parameters), typestr2str(typestr), type);
-      }), py::arg("type"), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
+py::class_<ak::ListType, std::shared_ptr<ak::ListType>, ak::Type>
+make_ListType(const py::handle& m, const std::string& name) {
+  return type_methods(py::class_<ak::ListType,
+                      std::shared_ptr<ak::ListType>,
+                      ak::Type>(m, name.c_str())
+      .def(py::init([](const std::shared_ptr<ak::Type>& type,
+                       const py::object& parameters,
+                       const py::object& typestr) -> ak::ListType {
+        return ak::ListType(dict2parameters(parameters),
+                            typestr2str(typestr),
+                            type);
+      }),
+           py::arg("type"),
+           py::arg("parameters") = py::none(),
+           py::arg("typestr") = py::none())
       .def_property_readonly("type", &ak::ListType::type)
       .def(py::pickle([](const ak::ListType& self) {
-        return py::make_tuple(parameters2dict(self.parameters()), str2typestr(self.typestr()), box(self.type()));
+        return py::make_tuple(parameters2dict(self.parameters()),
+                              str2typestr(self.typestr()),
+                              box(self.type()));
       }, [](const py::tuple& state) {
-        return ak::ListType(dict2parameters(state[0]), typestr2str(state[1]), unbox_type(state[2]));
+        return ak::ListType(dict2parameters(state[0]),
+                            typestr2str(state[1]),
+                            unbox_type(state[2]));
       }))
   );
 }
 
-/////////////////////////////////////////////////////////////// OptionType
+////////// OptionType
 
-py::class_<ak::OptionType, std::shared_ptr<ak::OptionType>, ak::Type> make_OptionType(const py::handle& m, const std::string& name) {
-  return type_methods(py::class_<ak::OptionType, std::shared_ptr<ak::OptionType>, ak::Type>(m, name.c_str())
-      .def(py::init([](const std::shared_ptr<ak::Type>& type, const py::object& parameters, const py::object& typestr) -> ak::OptionType {
-        return ak::OptionType(dict2parameters(parameters), typestr2str(typestr), type);
-      }), py::arg("type"), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
+py::class_<ak::OptionType, std::shared_ptr<ak::OptionType>, ak::Type>
+make_OptionType(const py::handle& m, const std::string& name) {
+  return type_methods(py::class_<ak::OptionType,
+                      std::shared_ptr<ak::OptionType>,
+                      ak::Type>(m, name.c_str())
+      .def(py::init([](const std::shared_ptr<ak::Type>& type,
+                       const py::object& parameters,
+                       const py::object& typestr) -> ak::OptionType {
+        return ak::OptionType(dict2parameters(parameters),
+                              typestr2str(typestr),
+                              type);
+      }), py::arg("type"),
+          py::arg("parameters") = py::none(),
+          py::arg("typestr") = py::none())
       .def_property_readonly("type", &ak::OptionType::type)
       .def(py::pickle([](const ak::OptionType& self) {
-        return py::make_tuple(parameters2dict(self.parameters()), str2typestr(self.typestr()), box(self.type()));
+        return py::make_tuple(parameters2dict(self.parameters()),
+                              str2typestr(self.typestr()),
+                              box(self.type()));
       }, [](const py::tuple& state) {
-        return ak::OptionType(dict2parameters(state[0]), typestr2str(state[1]), unbox_type(state[2]));
+        return ak::OptionType(dict2parameters(state[0]),
+                              typestr2str(state[1]),
+                              unbox_type(state[2]));
       }))
   );
 }
 
-/////////////////////////////////////////////////////////////// PrimitiveType
+////////// PrimitiveType
 
-py::class_<ak::PrimitiveType, std::shared_ptr<ak::PrimitiveType>, ak::Type> make_PrimitiveType(const py::handle& m, const std::string& name) {
-  return type_methods(py::class_<ak::PrimitiveType, std::shared_ptr<ak::PrimitiveType>, ak::Type>(m, name.c_str())
-      .def(py::init([](const std::string& dtype, const py::object& parameters, const py::object& typestr) -> ak::PrimitiveType {
+py::class_<ak::PrimitiveType, std::shared_ptr<ak::PrimitiveType>, ak::Type>
+make_PrimitiveType(const py::handle& m, const std::string& name) {
+  return type_methods(py::class_<ak::PrimitiveType,
+                      std::shared_ptr<ak::PrimitiveType>,
+                      ak::Type>(m, name.c_str())
+      .def(py::init([](const std::string& dtype,
+                       const py::object& parameters,
+                       const py::object& typestr) -> ak::PrimitiveType {
         if (dtype == std::string("bool")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::boolean);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::boolean);
         }
         else if (dtype == std::string("int8")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::int8);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::int8);
         }
         else if (dtype == std::string("int16")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::int16);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::int16);
         }
         else if (dtype == std::string("int32")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::int32);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::int32);
         }
         else if (dtype == std::string("int64")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::int64);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::int64);
         }
         else if (dtype == std::string("uint8")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::uint8);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::uint8);
         }
         else if (dtype == std::string("uint16")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::uint16);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::uint16);
         }
         else if (dtype == std::string("uint32")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::uint32);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::uint32);
         }
         else if (dtype == std::string("uint64")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::uint64);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::uint64);
         }
         else if (dtype == std::string("float32")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::float32);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::float32);
         }
         else if (dtype == std::string("float64")) {
-          return ak::PrimitiveType(dict2parameters(parameters), typestr2str(typestr), ak::PrimitiveType::float64);
+          return ak::PrimitiveType(dict2parameters(parameters),
+                                   typestr2str(typestr),
+                                   ak::PrimitiveType::float64);
         }
         else {
-          throw std::invalid_argument(std::string("unrecognized primitive type: ") + dtype);
+          throw std::invalid_argument(
+            std::string("unrecognized primitive type: ") + dtype);
         }
-      }), py::arg("dtype"), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
-      .def_property_readonly("dtype", [](const ak::PrimitiveType& self) -> std::string {
+      }), py::arg("dtype"),
+           py::arg("parameters") = py::none(),
+           py::arg("typestr") = py::none())
+      .def_property_readonly("dtype",
+                             [](const ak::PrimitiveType& self) -> std::string {
         switch (self.dtype()) {
           case ak::PrimitiveType::boolean: return std::string("bool");
           case ak::PrimitiveType::int8: return std::string("int8");
@@ -299,60 +406,97 @@ py::class_<ak::PrimitiveType, std::shared_ptr<ak::PrimitiveType>, ak::Type> make
           case ak::PrimitiveType::float32: return std::string("float32");
           case ak::PrimitiveType::float64: return std::string("float64");
           default:
-          throw std::invalid_argument(std::string("unrecognized primitive type: ") + std::to_string(self.dtype()));
+          throw std::invalid_argument(
+            std::string("unrecognized primitive type: ")
+            + std::to_string(self.dtype()));
         }
       })
       .def(py::pickle([](const ak::PrimitiveType& self) {
-        return py::make_tuple(parameters2dict(self.parameters()), str2typestr(self.typestr()), py::cast((int64_t)self.dtype()));
+        return py::make_tuple(parameters2dict(self.parameters()),
+                              str2typestr(self.typestr()),
+                              py::cast((int64_t)self.dtype()));
       }, [](const py::tuple& state) {
-        return ak::PrimitiveType(dict2parameters(state[0]), typestr2str(state[1]), (ak::PrimitiveType::DType)state[2].cast<int64_t>());
+        return ak::PrimitiveType(
+          dict2parameters(state[0]),
+          typestr2str(state[1]),
+          (ak::PrimitiveType::DType)state[2].cast<int64_t>());
       }))
   );
 }
 
-/////////////////////////////////////////////////////////////// RecordType
+////////// RecordType
 
-ak::RecordType iterable_to_RecordType(const py::iterable& types, const py::object& keys, const py::object& parameters, const py::object& typestr) {
+ak::RecordType
+iterable_to_RecordType(const py::iterable& types,
+                       const py::object& keys,
+                       const py::object& parameters,
+                       const py::object& typestr) {
   std::vector<std::shared_ptr<ak::Type>> out;
   for (auto x : types) {
     out.push_back(unbox_type(x));
   }
   if (keys.is(py::none())) {
-    return ak::RecordType(dict2parameters(parameters), typestr2str(typestr), out, std::shared_ptr<ak::util::RecordLookup>(nullptr));
+    return ak::RecordType(dict2parameters(parameters),
+                          typestr2str(typestr),
+                          out,
+                          std::shared_ptr<ak::util::RecordLookup>(nullptr));
   }
   else {
-    std::shared_ptr<ak::util::RecordLookup> recordlookup = std::make_shared<ak::util::RecordLookup>();
+    std::shared_ptr<ak::util::RecordLookup> recordlookup =
+      std::make_shared<ak::util::RecordLookup>();
     for (auto x : keys.cast<py::iterable>()) {
       recordlookup.get()->push_back(x.cast<std::string>());
     }
     if (out.size() != recordlookup.get()->size()) {
-      throw std::invalid_argument("if provided, 'keys' must have the same length as 'types'");
+      throw std::invalid_argument(
+        "if provided, 'keys' must have the same length as 'types'");
     }
-    return ak::RecordType(dict2parameters(parameters), typestr2str(typestr), out, recordlookup);
+    return ak::RecordType(dict2parameters(parameters),
+                          typestr2str(typestr),
+                          out,
+                          recordlookup);
   }
 }
 
-py::class_<ak::RecordType, std::shared_ptr<ak::RecordType>, ak::Type> make_RecordType(const py::handle& m, const std::string& name) {
-  return type_methods(py::class_<ak::RecordType, std::shared_ptr<ak::RecordType>, ak::Type>(m, name.c_str())
-      .def(py::init([](const py::dict& types, const py::object& parameters, const py::object& typestr) -> ak::RecordType {
-        std::shared_ptr<ak::util::RecordLookup> recordlookup = std::make_shared<ak::util::RecordLookup>();
+py::class_<ak::RecordType, std::shared_ptr<ak::RecordType>, ak::Type>
+make_RecordType(const py::handle& m, const std::string& name) {
+  return type_methods(py::class_<ak::RecordType,
+                      std::shared_ptr<ak::RecordType>,
+                      ak::Type>(m, name.c_str())
+      .def(py::init([](const py::dict& types,
+                       const py::object& parameters,
+                       const py::object& typestr) -> ak::RecordType {
+        std::shared_ptr<ak::util::RecordLookup> recordlookup =
+          std::make_shared<ak::util::RecordLookup>();
         std::vector<std::shared_ptr<ak::Type>> out;
         for (auto x : types) {
           std::string key = x.first.cast<std::string>();
           recordlookup.get()->push_back(key);
           out.push_back(unbox_type(x.second));
         }
-        return ak::RecordType(dict2parameters(parameters), typestr2str(typestr), out, recordlookup);
-      }), py::arg("types"), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
-      .def(py::init(&iterable_to_RecordType), py::arg("types"), py::arg("keys") = py::none(), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
-      .def("__getitem__", [](const ak::RecordType& self, int64_t fieldindex) -> py::object {
+        return ak::RecordType(dict2parameters(parameters),
+                              typestr2str(typestr),
+                              out, recordlookup);
+      }), py::arg("types"),
+          py::arg("parameters") = py::none(),
+          py::arg("typestr") = py::none())
+      .def(py::init(&iterable_to_RecordType),
+           py::arg("types"),
+           py::arg("keys") = py::none(),
+           py::arg("parameters") = py::none(),
+           py::arg("typestr") = py::none())
+      .def("__getitem__",
+           [](const ak::RecordType& self, int64_t fieldindex) -> py::object {
         return box(self.field(fieldindex));
       })
-      .def("__getitem__", [](const ak::RecordType& self, const std::string& key) -> py::object {
+      .def("__getitem__",
+           [](const ak::RecordType& self, const std::string& key)
+           -> py::object {
         return box(self.field(key));
       })
       .def_property_readonly("istuple", &ak::RecordType::istuple)
-      .def_property_readonly("types", [](const ak::RecordType& self) -> py::object {
+      .def_property_readonly("types",
+                             [](const ak::RecordType& self) -> py::object {
         std::vector<std::shared_ptr<ak::Type>> types = self.types();
         py::tuple pytypes(types.size());
         for (size_t i = 0;  i < types.size();  i++) {
@@ -360,10 +504,13 @@ py::class_<ak::RecordType, std::shared_ptr<ak::RecordType>, ak::Type> make_Recor
         }
         return pytypes;
       })
-      .def("field", [](const ak::RecordType& self, int64_t fieldindex) -> py::object {
+      .def("field",
+           [](const ak::RecordType& self, int64_t fieldindex) -> py::object {
         return box(self.field(fieldindex));
       })
-      .def("field", [](const ak::RecordType& self, const std::string& key) -> py::object {
+      .def("field",
+           [](const ak::RecordType& self, const std::string& key)
+           -> py::object {
         return box(self.field(key));
       })
       .def("fields", [](const ak::RecordType& self) -> py::object {
@@ -390,53 +537,91 @@ py::class_<ak::RecordType, std::shared_ptr<ak::RecordType>, ak::Type> make_Recor
         for (int64_t i = 0;  i < self.numfields();  i++) {
           pytypes[(size_t)i] = box(self.field(i));
         }
-        std::shared_ptr<ak::util::RecordLookup> recordlookup = self.recordlookup();
+        std::shared_ptr<ak::util::RecordLookup> recordlookup =
+          self.recordlookup();
         if (recordlookup.get() == nullptr) {
-          return py::make_tuple(pytypes, py::none(), parameters2dict(self.parameters()), str2typestr(self.typestr()));
+          return py::make_tuple(pytypes,
+                                py::none(),
+                                parameters2dict(self.parameters()),
+                                str2typestr(self.typestr()));
         }
         else {
           py::tuple pyrecordlookup((size_t)self.numfields());
           for (size_t i = 0;  i < (size_t)self.numfields();  i++) {
             pyrecordlookup[i] = py::cast(recordlookup.get()->at(i));
           }
-          return py::make_tuple(pytypes, pyrecordlookup, parameters2dict(self.parameters()), str2typestr(self.typestr()));
+          return py::make_tuple(pytypes,
+                                pyrecordlookup,
+                                parameters2dict(self.parameters()),
+                                str2typestr(self.typestr()));
         }
       }, [](const py::tuple& state) {
-        return iterable_to_RecordType(state[0].cast<py::iterable>(), state[1], state[2], state[3]);
+        return iterable_to_RecordType(state[0].cast<py::iterable>(),
+                                      state[1],
+                                      state[2],
+                                      state[3]);
       }))
   );
 }
 
-/////////////////////////////////////////////////////////////// RegularType
+////////// RegularType
 
-py::class_<ak::RegularType, std::shared_ptr<ak::RegularType>, ak::Type> make_RegularType(const py::handle& m, const std::string& name) {
-  return type_methods(py::class_<ak::RegularType, std::shared_ptr<ak::RegularType>, ak::Type>(m, name.c_str())
-      .def(py::init([](const std::shared_ptr<ak::Type>& type, int64_t size, const py::object& parameters, const py::object& typestr) -> ak::RegularType {
-        return ak::RegularType(dict2parameters(parameters), typestr2str(typestr), type, size);
-      }), py::arg("type"), py::arg("size"), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
+py::class_<ak::RegularType, std::shared_ptr<ak::RegularType>, ak::Type>
+make_RegularType(const py::handle& m, const std::string& name) {
+  return type_methods(py::class_<ak::RegularType,
+                      std::shared_ptr<ak::RegularType>,
+                      ak::Type>(m, name.c_str())
+      .def(py::init([](const std::shared_ptr<ak::Type>& type,
+                       int64_t size,
+                       const py::object& parameters,
+                       const py::object& typestr) -> ak::RegularType {
+        return ak::RegularType(dict2parameters(parameters),
+                               typestr2str(typestr),
+                               type,
+                               size);
+      }), py::arg("type"),
+          py::arg("size"),
+          py::arg("parameters") = py::none(),
+          py::arg("typestr") = py::none())
       .def_property_readonly("type", &ak::RegularType::type)
       .def_property_readonly("size", &ak::RegularType::size)
       .def(py::pickle([](const ak::RegularType& self) {
-        return py::make_tuple(parameters2dict(self.parameters()), str2typestr(self.typestr()), box(self.type()), py::cast(self.size()));
+        return py::make_tuple(parameters2dict(self.parameters()),
+                              str2typestr(self.typestr()),
+                              box(self.type()),
+                              py::cast(self.size()));
       }, [](const py::tuple& state) {
-        return ak::RegularType(dict2parameters(state[0]), typestr2str(state[1]), unbox_type(state[2]), state[3].cast<int64_t>());
+        return ak::RegularType(dict2parameters(state[0]),
+                               typestr2str(state[1]),
+                               unbox_type(state[2]),
+                               state[3].cast<int64_t>());
       }))
   );
 }
 
-/////////////////////////////////////////////////////////////// UnionType
+////////// UnionType
 
-py::class_<ak::UnionType, std::shared_ptr<ak::UnionType>, ak::Type> make_UnionType(const py::handle& m, const std::string& name) {
-  return type_methods(py::class_<ak::UnionType, std::shared_ptr<ak::UnionType>, ak::Type>(m, name.c_str())
-      .def(py::init([](const py::iterable& types, const py::object& parameters, const py::object& typestr) -> ak::UnionType {
+py::class_<ak::UnionType, std::shared_ptr<ak::UnionType>, ak::Type>
+make_UnionType(const py::handle& m, const std::string& name) {
+  return type_methods(py::class_<ak::UnionType,
+                      std::shared_ptr<ak::UnionType>,
+                      ak::Type>(m, name.c_str())
+      .def(py::init([](const py::iterable& types,
+                       const py::object& parameters,
+                       const py::object& typestr) -> ak::UnionType {
         std::vector<std::shared_ptr<ak::Type>> out;
         for (auto x : types) {
           out.push_back(unbox_type(x));
         }
-        return ak::UnionType(dict2parameters(parameters), typestr2str(typestr), out);
-      }), py::arg("types"), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
+        return ak::UnionType(dict2parameters(parameters),
+                             typestr2str(typestr),
+                             out);
+      }), py::arg("types"),
+          py::arg("parameters") = py::none(),
+          py::arg("typestr") = py::none())
       .def_property_readonly("numtypes", &ak::UnionType::numtypes)
-      .def_property_readonly("types", [](const ak::UnionType& self) -> py::tuple {
+      .def_property_readonly("types",
+                             [](const ak::UnionType& self) -> py::tuple {
         py::tuple types((size_t)self.numtypes());
         for (int64_t i = 0;  i < self.numtypes();  i++) {
           types[(size_t)i] = box(self.type(i));
@@ -449,33 +634,44 @@ py::class_<ak::UnionType, std::shared_ptr<ak::UnionType>, ak::Type> make_UnionTy
         for (int64_t i = 0;  i < self.numtypes();  i++) {
           types[(size_t)i] = box(self.type(i));
         }
-        return py::make_tuple(parameters2dict(self.parameters()), str2typestr(self.typestr()), types);
+        return py::make_tuple(parameters2dict(self.parameters()),
+                              str2typestr(self.typestr()),
+                              types);
       }, [](const py::tuple& state) {
         std::vector<std::shared_ptr<ak::Type>> types;
         for (auto x : state[2]) {
           types.push_back(unbox_type(x));
         }
-        return ak::UnionType(dict2parameters(state[0]), typestr2str(state[1]), types);
+        return ak::UnionType(dict2parameters(state[0]),
+                             typestr2str(state[1]),
+                             types);
       }))
   );
 }
 
-/////////////////////////////////////////////////////////////// UnknownType
+////////// UnknownType
 
-py::class_<ak::UnknownType, std::shared_ptr<ak::UnknownType>, ak::Type> make_UnknownType(const py::handle& m, const std::string& name) {
-  return type_methods(py::class_<ak::UnknownType, std::shared_ptr<ak::UnknownType>, ak::Type>(m, name.c_str())
-      .def(py::init([](const py::object& parameters, const py::object& typestr) -> ak::UnknownType {
-        return ak::UnknownType(dict2parameters(parameters), typestr2str(typestr));
+py::class_<ak::UnknownType, std::shared_ptr<ak::UnknownType>, ak::Type>
+make_UnknownType(const py::handle& m, const std::string& name) {
+  return type_methods(py::class_<ak::UnknownType,
+                      std::shared_ptr<ak::UnknownType>,
+                      ak::Type>(m, name.c_str())
+      .def(py::init([](const py::object& parameters,
+                       const py::object& typestr) -> ak::UnknownType {
+        return ak::UnknownType(dict2parameters(parameters),
+                               typestr2str(typestr));
       }), py::arg("parameters") = py::none(), py::arg("typestr") = py::none())
       .def(py::pickle([](const ak::UnknownType& self) {
-        return py::make_tuple(parameters2dict(self.parameters()), str2typestr(self.typestr()));
+        return py::make_tuple(parameters2dict(self.parameters()),
+                              str2typestr(self.typestr()));
       }, [](const py::tuple& state) {
-        return ak::UnknownType(dict2parameters(state[0]), typestr2str(state[1]));
+        return ak::UnknownType(dict2parameters(state[0]),
+                               typestr2str(state[1]));
       }))
   );
 }
 
-/////////////////////////////////////////////////////////////// module
+////////// module
 
 namespace py = pybind11;
 PYBIND11_MODULE(types, m) {


### PR DESCRIPTION
For the Python code, this is one item in the [PEP 8 style](https://www.python.org/dev/peps/pep-0008/#maximum-line-length). But I'm going to do the same thing for C++.

It seems that most of the Python world agrees with this: [80 is a drop-off point in the distribution](https://jakevdp.github.io/blog/2017/11/09/exploring-line-lengths-in-python-packages/).

![image](https://user-images.githubusercontent.com/1852447/77114809-2d8acb80-69fb-11ea-83d6-5b36cf2bc9ce.png)

```
I don't find the arguments for this compelling; of course I know that we want t\
o put code side-by-side on our wide screens. Our text editors simply shouldn't \
be set up for horizontal scrolling: it should reflow with the window width. How\
ever, I don't mean that awful reflow that Atom does (and I can't seem to turn i\
t off), in which it breaks at word boundaries and tries to indent the remainder\
---that makes it even more unreadable. I mean it should reflow the way Emacs do\
es: the last character that fits in the window should turn into a "\" and the r\
est goes on the next line. Sure words will be broken, but we've all learned to \
read that from using terminals all these years, right? When lines are hard-wrap\
ped at some number of characters, they can't make full use of wider windows and\
 become completely unusable when the window is less than the fixed number of ch\
aracters, because soft reflow doesn't mix well with hard line breaks. But that'\
s why I checked the histogram above: if everyone _agrees_ with the same choice,\
 then it's not quite as terrible.
```