### PR TITLE
Fixes #207 (missing files in tarball)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,6 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# This should be set by "PROPERTIES CXX_VISIBILITY_PRESET hidden" in every project,
-# but MacOS doesn't seem to be getting it.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
-
 # VERSION_INFO is the version stamp for everything (all C++, all Python).
 file(READ "VERSION_INFO" VERSION_INFO)
 string(STRIP ${VERSION_INFO} VERSION_INFO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# This should be set by "PROPERTIES CXX_VISIBILITY_PRESET hidden" in every project,
+# but MacOS doesn't seem to be getting it.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
+
 # VERSION_INFO is the version stamp for everything (all C++, all Python).
 file(READ "VERSION_INFO" VERSION_INFO)
 string(STRIP ${VERSION_INFO} VERSION_INFO)

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,10 @@ from setuptools import setup, Extension
 install_requires = open("requirements.txt").read().strip().split()
 
 extras = {"test": open("requirements-test.txt").read().strip().split(),
-          "docs": open("requirements-docs.txt").read().strip().split(),
-          "dev":  open("requirements-dev.txt").read().strip().split()}
+          "dev":  ['numba>=0.46.0;python_version>="3"',
+                   'pandas>=0.24.0;python_version>="3"',
+                   'numexpr;python_version>="3"',
+                   'autograd;python_version>="3"']}
 extras["all"] = sum(extras.values(), [])
 
 tests_require = extras["test"]


### PR DESCRIPTION
This should include all the files it needs to fix #207.

I'm also _attempting_ to fix the visibility warnings when compiling on MacOS. It shouldn't be complaining about "different symbol visibility" because CMake explicitly says `PROPERTIES CXX_VISIBILITY_PRESET hidden` on every project. But just in case, I'm also adding `-fvisibility=hidden -fvisibility-inlines-hidden`.

At least this shouldn't break the build. (Check!)