### PR TITLE
libawkward: pin vtables to the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ endif()
 # Second tier: libawkward (object files, static library, and dynamic library).
 add_library(awkward-objects OBJECT ${LIBAWKWARD_SOURCES})
 set_target_properties(awkward-objects PROPERTIES POSITION_INDEPENDENT_CODE 1)
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  # Avoid emitting vtables in the dependent libraries
+  target_compile_options(awkward-objects PRIVATE -Werror=weak-vtables -Wweak-vtables)
+endif()
 add_library(awkward-static STATIC $<TARGET_OBJECTS:awkward-objects>)
 set_property(TARGET awkward-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_library(awkward        SHARED $<TARGET_OBJECTS:awkward-objects>)

--- a/include/awkward/Identities.h
+++ b/include/awkward/Identities.h
@@ -91,6 +91,11 @@ namespace awkward {
                int64_t width,
                int64_t length);
 
+    /// @brief Virtual destructor acts as a first non-inline virtual function
+    /// that determines a specific translation unit in which vtable shall be
+    /// emitted.
+    virtual ~Identities();
+
     /// @brief A globally unique reference to this set of identities.
     const Ref
       ref() const;

--- a/include/awkward/Identities.h
+++ b/include/awkward/Identities.h
@@ -367,6 +367,11 @@ namespace awkward {
     const std::shared_ptr<T> ptr_;
   };
 
+#ifndef AWKWARD_IDENTITIES_NO_EXTERN_TEMPLATE
+  extern template class IdentitiesOf<int32_t>;
+  extern template class IdentitiesOf<int64_t>;
+#endif
+
   using Identities32 = IdentitiesOf<int32_t>;
   using Identities64 = IdentitiesOf<int64_t>;
 }

--- a/include/awkward/Identities.h
+++ b/include/awkward/Identities.h
@@ -367,7 +367,7 @@ namespace awkward {
     const std::shared_ptr<T> ptr_;
   };
 
-#ifndef AWKWARD_IDENTITIES_NO_EXTERN_TEMPLATE
+#if !defined AWKWARD_IDENTITIES_NO_EXTERN_TEMPLATE && !defined _MSC_VER
   extern template class IdentitiesOf<int32_t>;
   extern template class IdentitiesOf<int64_t>;
 #endif

--- a/include/awkward/Index.h
+++ b/include/awkward/Index.h
@@ -188,7 +188,7 @@ namespace awkward {
     const int64_t length_;
   };
 
-#ifndef AWKWARD_INDEX_NO_EXTERN_TEMPLATE
+#if !defined AWKWARD_INDEX_NO_EXTERN_TEMPLATE && !defined _MSC_VER
   extern template class IndexOf<int8_t>;
   extern template class IndexOf<uint8_t>;
   extern template class IndexOf<int32_t>;

--- a/include/awkward/Index.h
+++ b/include/awkward/Index.h
@@ -188,6 +188,14 @@ namespace awkward {
     const int64_t length_;
   };
 
+#ifndef AWKWARD_INDEX_NO_EXTERN_TEMPLATE
+  extern template class IndexOf<int8_t>;
+  extern template class IndexOf<uint8_t>;
+  extern template class IndexOf<int32_t>;
+  extern template class IndexOf<uint32_t>;
+  extern template class IndexOf<int64_t>;
+#endif
+
   using Index8   = IndexOf<int8_t>;
   using IndexU8  = IndexOf<uint8_t>;
   using Index32  = IndexOf<int32_t>;

--- a/include/awkward/Index.h
+++ b/include/awkward/Index.h
@@ -28,6 +28,13 @@ namespace awkward {
   ///    - {@link IndexOf IndexU32}, which is `IndexOf<uint32_t>`
   ///    - {@link IndexOf Index64}, which is `IndexOf<int64_t>`
   class EXPORT_SYMBOL Index {
+  public:
+    /// @brief Virtual destructor acts as a first non-inline virtual function
+    /// that determines a specific translation unit in which vtable shall be
+    /// emitted.
+    virtual ~Index();
+
+  private:
     /// @brief Copies this Index node without copying its buffer.
     ///
     /// See also #deep_copy.

--- a/include/awkward/Slice.h
+++ b/include/awkward/Slice.h
@@ -21,8 +21,10 @@ namespace awkward {
   /// passed to an array's `__getitem__` in Python.
   class EXPORT_SYMBOL SliceItem {
   public:
-    /// @brief Empty destructor; required for some C++ reason.
-    virtual ~SliceItem() { }
+    /// @brief Virtual destructor acts as a first non-inline virtual function
+    /// that determines a specific translation unit in which vtable shall be
+    /// emitted.
+    virtual ~SliceItem();
 
     /// @brief Copies this node without copying any associated arrays.
     virtual const SliceItemPtr

--- a/include/awkward/Slice.h
+++ b/include/awkward/Slice.h
@@ -302,6 +302,10 @@ namespace awkward {
     bool frombool_;
   };
 
+#ifndef AWKWARD_SLICE_NO_EXTERN_TEMPLATE
+  extern template class SliceArrayOf<int64_t>;
+#endif
+
   using SliceArray64 = SliceArrayOf<int64_t>;
 
   /// @class SliceField

--- a/include/awkward/Slice.h
+++ b/include/awkward/Slice.h
@@ -302,7 +302,7 @@ namespace awkward {
     bool frombool_;
   };
 
-#ifndef AWKWARD_SLICE_NO_EXTERN_TEMPLATE
+#if !defined AWKWARD_SLICE_NO_EXTERN_TEMPLATE && !defined _MSC_VER
   extern template class SliceArrayOf<int64_t>;
 #endif
 
@@ -456,6 +456,10 @@ namespace awkward {
     const SliceItemPtr content_;
   };
 
+#if !defined AWKWARD_SLICE_NO_EXTERN_TEMPLATE && !defined _MSC_VER
+  extern template class SliceMissingOf<int64_t>;
+#endif
+
   using SliceMissing64 = SliceMissingOf<int64_t>;
 
   /// @class SliceJaggedOf
@@ -522,6 +526,10 @@ namespace awkward {
     /// @brief See #content.
     const SliceItemPtr content_;
   };
+
+#if !defined AWKWARD_SLICE_NO_EXTERN_TEMPLATE && !defined _MSC_VER
+  extern template class SliceJaggedOf<int64_t>;
+#endif
 
   using SliceJagged64 = SliceJaggedOf<int64_t>;
 

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -317,19 +317,19 @@ namespace awkward {
     const ContentPtr content_;
   };
 
-#ifndef AWKWARD_INDEXEDARRAY_NO_EXTERN_TEMPLATE
-  extern template class IndexedArrayOf<int32_t, false>;
+#if !defined AWKWARD_INDEXEDARRAY_NO_EXTERN_TEMPLATE && !defined _MSC_VER
+  extern template class IndexedArrayOf<int32_t,  false>;
   extern template class IndexedArrayOf<uint32_t, false>;
-  extern template class IndexedArrayOf<int64_t, false>;
-  extern template class IndexedArrayOf<int32_t, true>;
-  extern template class IndexedArrayOf<int64_t, true>;
+  extern template class IndexedArrayOf<int64_t,  false>;
+  extern template class IndexedArrayOf<int32_t,  true>;
+  extern template class IndexedArrayOf<int64_t,  true>;
 #endif
 
-  using IndexedArray32       = IndexedArrayOf<int32_t, false>;
+  using IndexedArray32       = IndexedArrayOf<int32_t,  false>;
   using IndexedArrayU32      = IndexedArrayOf<uint32_t, false>;
-  using IndexedArray64       = IndexedArrayOf<int64_t, false>;
-  using IndexedOptionArray32 = IndexedArrayOf<int32_t, true>;
-  using IndexedOptionArray64 = IndexedArrayOf<int64_t, true>;
+  using IndexedArray64       = IndexedArrayOf<int64_t,  false>;
+  using IndexedOptionArray32 = IndexedArrayOf<int32_t,  true>;
+  using IndexedOptionArray64 = IndexedArrayOf<int64_t,  true>;
 }
 
 #endif // AWKWARD_INDEXEDARRAY_H_

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -317,6 +317,14 @@ namespace awkward {
     const ContentPtr content_;
   };
 
+#ifndef AWKWARD_INDEXEDARRAY_NO_EXTERN_TEMPLATE
+  extern template class IndexedArrayOf<int32_t, false>;
+  extern template class IndexedArrayOf<uint32_t, false>;
+  extern template class IndexedArrayOf<int64_t, false>;
+  extern template class IndexedArrayOf<int32_t, true>;
+  extern template class IndexedArrayOf<int64_t, true>;
+#endif
+
   using IndexedArray32       = IndexedArrayOf<int32_t, false>;
   using IndexedArrayU32      = IndexedArrayOf<uint32_t, false>;
   using IndexedArray64       = IndexedArrayOf<int64_t, false>;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -325,6 +325,12 @@ namespace awkward {
     const ContentPtr content_;
   };
 
+#ifndef AWKWARD_LISTARRAY_NO_EXTERN_TEMPLATE
+  extern template class ListArrayOf<int32_t>;
+  extern template class ListArrayOf<uint32_t>;
+  extern template class ListArrayOf<int64_t>;
+#endif
+
   using ListArray32  = ListArrayOf<int32_t>;
   using ListArrayU32 = ListArrayOf<uint32_t>;
   using ListArray64  = ListArrayOf<int64_t>;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -71,7 +71,7 @@ namespace awkward {
       stops() const;
 
     /// @brief Data referenced by the #starts and #stops to build nested lists.
-    /// 
+    ///
     /// The `content` does not necessarily represent a flattened version of
     /// this array because a single element may belong to multiple lists or
     /// no list at all.
@@ -325,7 +325,7 @@ namespace awkward {
     const ContentPtr content_;
   };
 
-#ifndef AWKWARD_LISTARRAY_NO_EXTERN_TEMPLATE
+#if !defined AWKWARD_LISTARRAY_NO_EXTERN_TEMPLATE && !defined _MSC_VER
   extern template class ListArrayOf<int32_t>;
   extern template class ListArrayOf<uint32_t>;
   extern template class ListArrayOf<int64_t>;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -315,6 +315,12 @@ namespace awkward {
     const ContentPtr content_;
   };
 
+#ifndef AWKWARD_LISTOFFSETARRAY_NO_EXTERN_TEMPLATE
+  extern template class ListOffsetArrayOf<int32_t>;
+  extern template class ListOffsetArrayOf<uint32_t>;
+  extern template class ListOffsetArrayOf<int64_t>;
+#endif
+
   using ListOffsetArray32  = ListOffsetArrayOf<int32_t>;
   using ListOffsetArrayU32 = ListOffsetArrayOf<uint32_t>;
   using ListOffsetArray64  = ListOffsetArrayOf<int64_t>;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -315,7 +315,7 @@ namespace awkward {
     const ContentPtr content_;
   };
 
-#ifndef AWKWARD_LISTOFFSETARRAY_NO_EXTERN_TEMPLATE
+#if !defined AWKWARD_LISTOFFSETARRAY_NO_EXTERN_TEMPLATE && !defined _MSC_VER
   extern template class ListOffsetArrayOf<int32_t>;
   extern template class ListOffsetArrayOf<uint32_t>;
   extern template class ListOffsetArrayOf<int64_t>;

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -15,7 +15,7 @@ namespace awkward {
   class EXPORT_SYMBOL Record: public Content {
   public:
     /// @brief Creates a Record from a full set of parameters.
-    /// 
+    ///
     /// @param array A reference to the array in which this tuple/record
     /// resides (not a copy, shares reference count).
     /// @param at The position in the #array where this tuple/record

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -30,7 +30,7 @@ namespace awkward {
     public std::enable_shared_from_this<RecordArray> {
   public:
     /// @brief Creates a RecordArray from a full set of parameters.
-    /// 
+    ///
     /// @param identities Optional Identities for each element of the array
     /// (may be `nullptr`).
     /// @param parameters String-to-JSON map that augments the meaning of this

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -311,6 +311,12 @@ namespace awkward {
     const ContentPtrVec contents_;
   };
 
+#ifndef AWKWARD_UNIONARRAY_NO_EXTERN_TEMPLATE
+  extern template class UnionArrayOf<int8_t, int32_t>;
+  extern template class UnionArrayOf<int8_t, uint32_t>;
+  extern template class UnionArrayOf<int8_t, int64_t>;
+#endif
+
   using UnionArray8_32  = UnionArrayOf<int8_t, int32_t>;
   using UnionArray8_U32 = UnionArrayOf<int8_t, uint32_t>;
   using UnionArray8_64  = UnionArrayOf<int8_t, int64_t>;

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -36,7 +36,7 @@ namespace awkward {
       regular_index(const IndexOf<T>& tags);
 
     /// @brief Creates a UnionArrayOf from a full set of parameters.
-    /// 
+    ///
     /// @param identities Optional Identities for each element of the array
     /// (may be `nullptr`).
     /// @param parameters String-to-JSON map that augments the meaning of this
@@ -311,7 +311,7 @@ namespace awkward {
     const ContentPtrVec contents_;
   };
 
-#ifndef AWKWARD_UNIONARRAY_NO_EXTERN_TEMPLATE
+#if !defined AWKWARD_UNIONARRAY_NO_EXTERN_TEMPLATE && !defined _MSC_VER
   extern template class UnionArrayOf<int8_t, int32_t>;
   extern template class UnionArrayOf<int8_t, uint32_t>;
   extern template class UnionArrayOf<int8_t, int64_t>;

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -20,8 +20,10 @@ namespace awkward {
   /// cumulatively discover an array's type and fill it.
   class EXPORT_SYMBOL Builder {
   public:
-    /// @brief Empty destructor; required for some C++ reason.
-    virtual ~Builder() { }
+    /// @brief Virtual destructor acts as a first non-inline virtual function
+    /// that determines a specific translation unit in which vtable shall be
+    /// emitted.
+    virtual ~Builder();
 
     /// @brief User-friendly name of this class.
     virtual const std::string

--- a/include/awkward/io/json.h
+++ b/include/awkward/io/json.h
@@ -39,6 +39,11 @@ namespace awkward {
   /// Abstract base class for producing JSON data.
   class EXPORT_SYMBOL ToJson {
   public:
+    /// @brief Virtual destructor acts as a first non-inline virtual function
+    /// that determines a specific translation unit in which vtable shall be
+    /// emitted.
+    virtual ~ToJson();
+
     /// @brief Append a `null` value.
     virtual void
       null() = 0;

--- a/include/awkward/partition/PartitionedArray.h
+++ b/include/awkward/partition/PartitionedArray.h
@@ -18,8 +18,10 @@ namespace awkward {
   public:
     PartitionedArray(const ContentPtrVec& partitions);
 
-    /// @brief Empty destructor; required for some C++ reason.
-    virtual ~PartitionedArray() { }
+    /// @brief Virtual destructor acts as a first non-inline virtual function
+    /// that determines a specific translation unit in which vtable shall be
+    /// emitted.
+    virtual ~PartitionedArray();
 
     /// @brief The partitions as a `std::vector<std::shared_ptr<Content>>`.
     const ContentPtrVec

--- a/include/awkward/type/Type.h
+++ b/include/awkward/type/Type.h
@@ -25,8 +25,10 @@ namespace awkward {
     /// #typestr upon construction.
     Type(const util::Parameters& parameters, const std::string& typestr);
 
-    /// @brief Empty destructor; required for some C++ reason.
-    virtual ~Type() { }
+    /// @brief Virtual destructor acts as a first non-inline virtual function
+    /// that determines a specific translation unit in which vtable shall be
+    /// emitted.
+    virtual ~Type();
 
     /// @brief Internal function to build an output string for #tostring.
     ///

--- a/include/awkward/util.h
+++ b/include/awkward/util.h
@@ -208,7 +208,7 @@ namespace awkward {
         int64_t tolength,
         int64_t fromlength,
         int64_t fromwidth);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -225,7 +225,7 @@ namespace awkward {
         int64_t tolength,
         int64_t fromlength,
         int64_t fromwidth);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -242,7 +242,7 @@ namespace awkward {
         int64_t tolength,
         int64_t fromlength,
         int64_t fromwidth);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -257,7 +257,7 @@ namespace awkward {
         int64_t tolength,
         int64_t fromlength,
         int64_t fromwidth);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -272,7 +272,7 @@ namespace awkward {
         int64_t tolength,
         int64_t fromlength,
         int64_t fromwidth);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -290,7 +290,7 @@ namespace awkward {
         int64_t fromlength,
         int64_t fromwidth,
         int64_t which);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -308,7 +308,7 @@ namespace awkward {
         int64_t fromlength,
         int64_t fromwidth,
         int64_t which);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -320,7 +320,7 @@ namespace awkward {
         int64_t fromindexoffset,
         int64_t lenfromindex,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -331,7 +331,7 @@ namespace awkward {
         const int64_t* carry,
         int64_t fromindexoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -344,7 +344,7 @@ namespace awkward {
         int64_t startsoffset,
         int64_t stopsoffset,
         int64_t at);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -359,7 +359,7 @@ namespace awkward {
         int64_t start,
         int64_t stop,
         int64_t step);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -375,7 +375,7 @@ namespace awkward {
         int64_t start,
         int64_t stop,
         int64_t step);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -384,7 +384,7 @@ namespace awkward {
         int64_t* total,
         const T* fromoffsets,
         int64_t lenstarts);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -394,7 +394,7 @@ namespace awkward {
         const int64_t* fromadvanced,
         const T* fromoffsets,
         int64_t lenstarts);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -410,7 +410,7 @@ namespace awkward {
         int64_t lenstarts,
         int64_t lenarray,
         int64_t lencontent);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -427,7 +427,7 @@ namespace awkward {
         int64_t lenstarts,
         int64_t lenarray,
         int64_t lencontent);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -442,7 +442,7 @@ namespace awkward {
         int64_t stopsoffset,
         int64_t lenstarts,
         int64_t lencarry);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -454,7 +454,7 @@ namespace awkward {
         const T* fromstops,
         int64_t stopsoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -467,7 +467,7 @@ namespace awkward {
         const int64_t* inneroffsets,
         int64_t inneroffsetsoffset,
         int64_t inneroffsetslen);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -480,7 +480,7 @@ namespace awkward {
         const int64_t* offsets,
         int64_t offsetsoffset,
         int64_t offsetslength);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -494,7 +494,7 @@ namespace awkward {
         int64_t length,
         int64_t** offsetsraws,
         int64_t* offsetsoffsets);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -510,7 +510,7 @@ namespace awkward {
         int64_t length,
         int64_t** offsetsraws,
         int64_t* offsetsoffsets);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -521,7 +521,7 @@ namespace awkward {
         int64_t indexoffset,
         int64_t lenindex,
         int64_t lencontent);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -531,7 +531,7 @@ namespace awkward {
         const T* fromindex,
         int64_t indexoffset,
         int64_t lenindex);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -543,7 +543,7 @@ namespace awkward {
         int64_t indexoffset,
         int64_t lenindex,
         int64_t lencontent);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -555,7 +555,7 @@ namespace awkward {
         int64_t indexoffset,
         int64_t lenindex,
         int64_t lencontent);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -566,7 +566,7 @@ namespace awkward {
         int64_t indexoffset,
         int64_t lenindex,
         int64_t lencontent);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -578,7 +578,7 @@ namespace awkward {
         int64_t indexoffset,
         int64_t lenindex,
         int64_t lencarry);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -590,7 +590,7 @@ namespace awkward {
         const T* fromindex,
         int64_t indexoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -600,7 +600,7 @@ namespace awkward {
         const T* fromindex,
         int64_t indexoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -613,7 +613,7 @@ namespace awkward {
         const int32_t* innerindex,
         int64_t inneroffset,
         int64_t innerlength);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -626,7 +626,7 @@ namespace awkward {
         const uint32_t* innerindex,
         int64_t inneroffset,
         int64_t innerlength);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -639,7 +639,7 @@ namespace awkward {
         const int64_t* innerindex,
         int64_t inneroffset,
         int64_t innerlength);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -649,7 +649,7 @@ namespace awkward {
         const T* fromtags,
         int64_t tagsoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -663,7 +663,7 @@ namespace awkward {
         int64_t indexoffset,
         int64_t length,
         int64_t which);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -675,7 +675,7 @@ namespace awkward {
         int64_t startsoffset,
         int64_t stopsoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -685,7 +685,7 @@ namespace awkward {
         const T* fromoffsets,
         int64_t offsetsoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -700,7 +700,7 @@ namespace awkward {
         const T* fromstops,
         int64_t stopsoffset,
         int64_t lencontent);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -710,7 +710,7 @@ namespace awkward {
         const T* fromoffsets,
         int64_t offsetsoffset,
         int64_t offsetslength);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -731,7 +731,7 @@ namespace awkward {
         int64_t outerwhich,
         int64_t length,
         int64_t base);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -752,7 +752,7 @@ namespace awkward {
         int64_t outerwhich,
         int64_t length,
         int64_t base);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -773,7 +773,7 @@ namespace awkward {
         int64_t outerwhich,
         int64_t length,
         int64_t base);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -789,7 +789,7 @@ namespace awkward {
         int64_t fromwhich,
         int64_t length,
         int64_t base);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -805,7 +805,7 @@ namespace awkward {
         int64_t fromstopsoffset,
         int64_t jaggedsize,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -826,7 +826,7 @@ namespace awkward {
         const T* fromstops,
         int64_t fromstopsoffset,
         int64_t contentlen);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -842,7 +842,7 @@ namespace awkward {
         int64_t fromstartsoffset,
         const T* fromstops,
         int64_t fromstopsoffset);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -856,7 +856,7 @@ namespace awkward {
         int64_t* parents,
         int64_t parentsoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -866,7 +866,7 @@ namespace awkward {
         const T* fromindex,
         int64_t offset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -878,7 +878,7 @@ namespace awkward {
         int64_t lenstarts,
         int64_t startsoffset,
         int64_t stopsoffset);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -893,7 +893,7 @@ namespace awkward {
         int64_t length,
         int64_t startsoffset,
         int64_t stopsoffset);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -906,7 +906,7 @@ namespace awkward {
         int64_t lenstarts,
         int64_t startsoffset,
         int64_t stopsoffset);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -918,7 +918,7 @@ namespace awkward {
         int64_t fromlength,
         int64_t target,
         int64_t* tolength);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -929,7 +929,7 @@ namespace awkward {
         int64_t offsetsoffset,
         int64_t fromlength,
         int64_t target);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -940,7 +940,7 @@ namespace awkward {
         int64_t offsetsoffset,
         int64_t length,
         int64_t target);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -952,7 +952,7 @@ namespace awkward {
         int64_t stopsoffset,
         int64_t length,
         int64_t lencontent);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -963,7 +963,7 @@ namespace awkward {
         int64_t length,
         int64_t lencontent,
         bool isoption);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T, typename I>
@@ -976,7 +976,7 @@ namespace awkward {
         int64_t length,
         int64_t numcontents,
         const int64_t* lencontents);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -986,7 +986,7 @@ namespace awkward {
         const T* offsets,
         int64_t offsetsoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -1001,7 +1001,7 @@ namespace awkward {
         const T* stops,
         int64_t stopsoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template <typename T>
@@ -1015,7 +1015,7 @@ namespace awkward {
         const T* stops,
         int64_t stopsoffset,
         int64_t length);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template<typename T>
@@ -1024,7 +1024,7 @@ namespace awkward {
         const T* ptr,
         int64_t offset,
         int64_t at);
-    
+
     /// @brief Wraps several cpu-kernels from the C interface with a template
     /// to make it easier and more type-safe to call.
     template<typename T>

--- a/localbuild.py
+++ b/localbuild.py
@@ -24,13 +24,8 @@ args = arguments.parse_args()
 args.buildpython = not args.no_buildpython
 args.dependencies = not args.no_dependencies
 
-try:
-    git_config = open(".git/config").read()
-except:
-    git_config = ""
-
-if "github.com/scikit-hep/awkward-1.0" not in git_config:
-    arguments.error("localbuild must be executed in the head of the awkward-1.0 tree")
+git_root = subprocess.run(["git", "rev-parse", "--show-toplevel"], stdout=subprocess.PIPE)
+os.chdir(git_root.stdout.decode().strip())
 
 if args.clean:
     for x in ("localbuild", "awkward1", ".pytest_cache", "tests/__pycache__"):

--- a/src/libawkward/Identities.cpp
+++ b/src/libawkward/Identities.cpp
@@ -10,6 +10,7 @@
 #include "awkward/cpu-kernels/getitem.h"
 #include "awkward/Slice.h"
 
+#define AWKWARD_IDENTITIES_NO_EXTERN_TEMPLATE
 #include "awkward/Identities.h"
 
 namespace awkward {

--- a/src/libawkward/Identities.cpp
+++ b/src/libawkward/Identities.cpp
@@ -36,6 +36,8 @@ namespace awkward {
       , width_(width)
       , length_(length) { }
 
+  Identities::~Identities() = default;
+
   const Identities::Ref
   Identities::ref() const {
     return ref_;

--- a/src/libawkward/Index.cpp
+++ b/src/libawkward/Index.cpp
@@ -10,6 +10,8 @@
 #include "awkward/Index.h"
 
 namespace awkward {
+  Index::~Index() = default;
+
   template <typename T>
   IndexOf<T>::IndexOf(int64_t length)
       : ptr_(std::shared_ptr<T>(length == 0 ? nullptr : new T[(size_t)length],

--- a/src/libawkward/Index.cpp
+++ b/src/libawkward/Index.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <type_traits>
 
+#define AWKWARD_INDEX_NO_EXTERN_TEMPLATE
 #include "awkward/Slice.h"
 
 #include "awkward/Index.h"

--- a/src/libawkward/Slice.cpp
+++ b/src/libawkward/Slice.cpp
@@ -7,6 +7,7 @@
 #include "awkward/cpu-kernels/getitem.h"
 #include "awkward/util.h"
 
+#define AWKWARD_SLICE_NO_EXTERN_TEMPLATE
 #include "awkward/Slice.h"
 
 namespace awkward {

--- a/src/libawkward/Slice.cpp
+++ b/src/libawkward/Slice.cpp
@@ -10,6 +10,10 @@
 #include "awkward/Slice.h"
 
 namespace awkward {
+  ////////// SliceItem
+
+  SliceItem::~SliceItem() = default;
+
   ////////// SliceAt
 
   SliceAt::SliceAt(int64_t at)

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -22,6 +22,7 @@
 #include "awkward/array/RegularArray.h"
 #include "awkward/array/ListOffsetArray.h"
 
+#define AWKWARD_INDEXEDARRAY_NO_EXTERN_TEMPLATE
 #include "awkward/array/IndexedArray.h"
 
 namespace awkward {

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -21,6 +21,7 @@
 #include "awkward/array/BitMaskedArray.h"
 #include "awkward/array/UnmaskedArray.h"
 
+#define AWKWARD_LISTARRAY_NO_EXTERN_TEMPLATE
 #include "awkward/array/ListArray.h"
 
 namespace awkward {

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -22,6 +22,7 @@
 #include "awkward/array/BitMaskedArray.h"
 #include "awkward/array/UnmaskedArray.h"
 
+#define AWKWARD_LISTOFFSETARRAY_NO_EXTERN_TEMPLATE
 #include "awkward/array/ListOffsetArray.h"
 
 namespace awkward {

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -12,9 +12,10 @@
 #include "awkward/Slice.h"
 #include "awkward/array/EmptyArray.h"
 #include "awkward/array/IndexedArray.h"
-
 #include "awkward/array/NumpyArray.h"
 #include "awkward/array/RegularArray.h"
+
+#define AWKWARD_UNIONARRAY_NO_EXTERN_TEMPLATE
 #include "awkward/array/UnionArray.h"
 
 namespace awkward {

--- a/src/libawkward/builder/Builder.cpp
+++ b/src/libawkward/builder/Builder.cpp
@@ -3,6 +3,8 @@
 #include "awkward/builder/Builder.h"
 
 namespace awkward {
+  Builder::~Builder() = default;
+
   void
   Builder::setthat(const BuilderPtr& that) {
     that_ = that;

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -17,6 +17,7 @@ namespace rj = rapidjson;
 
 namespace awkward {
   ////////// writing to JSON
+  ToJson::~ToJson() = default;
 
   class ToJsonString::Impl {
   public:

--- a/src/libawkward/partition/PartitionedArray.cpp
+++ b/src/libawkward/partition/PartitionedArray.cpp
@@ -13,6 +13,8 @@ namespace awkward {
     }
   }
 
+  PartitionedArray::~PartitionedArray() = default;
+
   const ContentPtrVec
   PartitionedArray::partitions() const {
     return partitions_;

--- a/src/libawkward/type/Type.cpp
+++ b/src/libawkward/type/Type.cpp
@@ -16,6 +16,8 @@ namespace awkward {
       : parameters_(parameters)
       , typestr_(typestr) { }
 
+  Type::~Type() = default;
+
   const util::Parameters
   Type::parameters() const {
     return parameters_;


### PR DESCRIPTION
When trying to solve #211 by using dynamic linking I was trying to understand how compiler decides where to emit typeinfo for a given class. Many workarounds for the typeinfo mismatches will rely on virtual calls. Turns out the vtable are also emitted without any control. Because the rules for emitting vtable seem to be outlined better than those for typeinfo, it seems like they are a good choice to start working on.

This PR is taking a bite at reducing the symbol duplication across the translation units. For example, this leaves no defined "vtable for awkward::" symbols from the translation units of the python extension as well as some of the typeinfo and template methods. This should give some benefits for smaller object files and speedier linking times. This only deals with libawkward for now.