### PR TITLE
[WIP] Implement `is_none()` with axis parameter in C++

### DIFF
--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -416,6 +416,9 @@ namespace awkward {
     virtual const ContentPtr
       fillna(const ContentPtr& value) const = 0;
 
+    virtual const ContentPtr
+      is_none(int64_t axis, int64_t depth) const = 0;
+
     /// @brief If `axis = 0`, returns a view of this array padded on the
     /// right with `None` values to have a minimum length; otherwise, returns
     /// an array with nested lists all padded to the minimum length.
@@ -752,6 +755,9 @@ namespace awkward {
     /// defined universally in the Content class.
     const ContentPtr
       localindex_axis0() const;
+
+    const ContentPtr
+      isnone_axis0() const;
 
     /// @brief Internal function to handle the `axis = 0` case of
     /// #combinations.

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -416,6 +416,16 @@ namespace awkward {
     virtual const ContentPtr
       fillna(const ContentPtr& value) const = 0;
 
+    /// @brief Returns an array whose value is True where an element of array is None;
+    /// False otherwise.
+    ///
+    /// @param axis The axis at which to apply padding.
+    /// Negative `axis` counts backward from the deepest levels (`-1` is
+    /// the last valid `axis`)
+    /// @param depth The current depth while stepping into the array: this
+    /// value is set to `0` on the array node where the user starts the
+    /// process and is increased at each level of list-depth (instead of
+    /// decreasing the user-specified `axis`).
     virtual const ContentPtr
       is_none(int64_t axis, int64_t depth) const = 0;
 
@@ -755,9 +765,6 @@ namespace awkward {
     /// defined universally in the Content class.
     const ContentPtr
       localindex_axis0() const;
-
-    const ContentPtr
-      isnone_axis0() const;
 
     /// @brief Internal function to handle the `axis = 0` case of
     /// #combinations.

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -257,6 +257,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -229,6 +229,9 @@ namespace awkward {
 
     const ContentPtr
       fillna(const ContentPtr& value) const override;
+    
+    const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
 
     const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -158,6 +158,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -234,6 +234,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -251,6 +251,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -243,6 +243,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -178,6 +178,9 @@ namespace awkward {
     const ContentPtr
       fillna(const ContentPtr& value) const override;
 
+    const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
     /// @exception std::runtime_error is always thrown
     const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -411,6 +411,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -779,6 +779,12 @@ namespace awkward {
       fillna(const ContentPtr& value) const override {
       return shallow_copy();
     }
+    
+    const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override{
+          //Return array of false 
+          return nullptr;
+      }
 
     const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override {

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -188,6 +188,9 @@ namespace awkward {
     const ContentPtr
       fillna(const ContentPtr& value) const override;
 
+    const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
     /// @exception std::runtime_error is always thrown
     const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -222,6 +222,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -208,6 +208,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -232,6 +232,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -192,6 +192,9 @@ namespace awkward {
       fillna(const ContentPtr& value) const override;
 
     const ContentPtr
+      is_none(int64_t axis, int64_t depth) const override;
+
+    const ContentPtr
       rpad(int64_t target, int64_t axis, int64_t depth) const override;
 
     const ContentPtr

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -1147,7 +1147,7 @@ def fill_none(array, value, highlevel=True):
         return out
 
 def is_none(array, axis = 1, highlevel=True):
-    """ TODO
+    """
     Args:
         array: Data to check for missing values (None).
         axis (int): The dimension at which this operation is applied. The

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -1146,8 +1146,8 @@ def fill_none(array, value, highlevel=True):
     else:
         return out
 
-def is_none(array, highlevel=True):
-    """
+def is_none(array, axis = 1, highlevel=True):
+    """ TODO
     Args:
         array: Data to check for missing values (None).
         highlevel (bool): If True, return an #ak.Array; otherwise, return
@@ -1156,41 +1156,49 @@ def is_none(array, highlevel=True):
     Returns an array whose value is True where an element of `array` is None;
     False otherwise.
     """
-    def apply(layout):
-        if isinstance(layout, awkward1._util.unknowntypes):
-            return apply(awkward1.layout.NumpyArray(numpy.array([])))
-
-        elif isinstance(layout, awkward1._util.indexedtypes):
-            return apply(layout.project())
-
-        elif isinstance(layout, awkward1._util.uniontypes):
-            contents = [apply(layout.project(i))
-                          for i in range(layout.numcontents)]
-            out = numpy.empty(len(layout), dtype=numpy.bool_)
-            tags = numpy.asarray(layout.tags)
-            for tag, content in enumerate(contents):
-                out[tags == tag] = content
-            return out
-
-        elif isinstance(layout, awkward1._util.optiontypes):
-            return numpy.asarray(layout.bytemask()).view(numpy.bool_)
-
-        else:
-            return numpy.zeros(len(layout), dtype=numpy.bool_)
-
     layout = awkward1.operations.convert.to_layout(array, allow_record=False)
-
-    if isinstance(layout, awkward1.partition.PartitionedArray):
-        out = awkward1.partition.apply(
-            lambda x: awkward1.layout.NumpyArray(apply(x)), layout)
-    else:
-        out = awkward1.layout.NumpyArray(apply(layout))
+    out = layout.is_none(axis=axis)
 
     if highlevel:
-        return awkward1._util.wrap(out,
-                                   behavior=awkward1._util.behaviorof(array))
-    else:
-        return out
+        return  awkward1._util.wrap(
+                 out, behavior=awkward1._util.behaviorof(array)) 
+    return out
+    
+    # def apply(layout):
+    #     if isinstance(layout, awkward1._util.unknowntypes):
+    #         return apply(awkward1.layout.NumpyArray(numpy.array([])))
+
+    #     elif isinstance(layout, awkward1._util.indexedtypes):
+    #         return apply(layout.project())
+
+    #     elif isinstance(layout, awkward1._util.uniontypes):
+    #         contents = [apply(layout.project(i))
+    #                       for i in range(layout.numcontents)]
+    #         out = numpy.empty(len(layout), dtype=numpy.bool_)
+    #         tags = numpy.asarray(layout.tags)
+    #         for tag, content in enumerate(contents):
+    #             out[tags == tag] = content
+    #         return out
+
+    #     elif isinstance(layout, awkward1._util.optiontypes):
+    #         return numpy.asarray(layout.bytemask()).view(numpy.bool_)
+
+    #     else:
+    #         return numpy.zeros(len(layout), dtype=numpy.bool_)
+
+    # layout = awkward1.operations.convert.to_layout(array, allow_record=False)
+
+    # if isinstance(layout, awkward1.partition.PartitionedArray):
+    #     out = awkward1.partition.apply(
+    #         lambda x: awkward1.layout.NumpyArray(apply(x)), layout)
+    # else:
+    #     out = awkward1.layout.NumpyArray(apply(layout))
+
+    # if highlevel:
+    #     return awkward1._util.wrap(out,
+    #                                behavior=awkward1._util.behaviorof(array))
+    # else:
+    #     return out
 
 def singletons(array, highlevel=True):
     """

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -1150,6 +1150,10 @@ def is_none(array, axis = 1, highlevel=True):
     """ TODO
     Args:
         array: Data to check for missing values (None).
+        axis (int): The dimension at which this operation is applied. The
+            outermost dimension is `0`, followed by `1`, etc., and negative
+            values count backward from the innermost: `-1` is the innermost
+            dimension, `-2` is the next level up, etc.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.layout.Content subclass.
 
@@ -1163,42 +1167,6 @@ def is_none(array, axis = 1, highlevel=True):
         return  awkward1._util.wrap(
                  out, behavior=awkward1._util.behaviorof(array)) 
     return out
-    
-    # def apply(layout):
-    #     if isinstance(layout, awkward1._util.unknowntypes):
-    #         return apply(awkward1.layout.NumpyArray(numpy.array([])))
-
-    #     elif isinstance(layout, awkward1._util.indexedtypes):
-    #         return apply(layout.project())
-
-    #     elif isinstance(layout, awkward1._util.uniontypes):
-    #         contents = [apply(layout.project(i))
-    #                       for i in range(layout.numcontents)]
-    #         out = numpy.empty(len(layout), dtype=numpy.bool_)
-    #         tags = numpy.asarray(layout.tags)
-    #         for tag, content in enumerate(contents):
-    #             out[tags == tag] = content
-    #         return out
-
-    #     elif isinstance(layout, awkward1._util.optiontypes):
-    #         return numpy.asarray(layout.bytemask()).view(numpy.bool_)
-
-    #     else:
-    #         return numpy.zeros(len(layout), dtype=numpy.bool_)
-
-    # layout = awkward1.operations.convert.to_layout(array, allow_record=False)
-
-    # if isinstance(layout, awkward1.partition.PartitionedArray):
-    #     out = awkward1.partition.apply(
-    #         lambda x: awkward1.layout.NumpyArray(apply(x)), layout)
-    # else:
-    #     out = awkward1.layout.NumpyArray(apply(layout))
-
-    # if highlevel:
-    #     return awkward1._util.wrap(out,
-    #                                behavior=awkward1._util.behaviorof(array))
-    # else:
-    #     return out
 
 def singletons(array, highlevel=True):
     """

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -257,6 +257,11 @@ namespace awkward {
   }
 
   const ContentPtr
+  Content::isnone_axis0() const{
+      return nullptr;
+  }
+
+  const ContentPtr
   Content::localindex_axis0() const {
     Index64 localindex(length());
     struct Error err = awkward_localindex_64(

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -257,11 +257,6 @@ namespace awkward {
   }
 
   const ContentPtr
-  Content::isnone_axis0() const{
-      return nullptr;
-  }
-
-  const ContentPtr
   Content::localindex_axis0() const {
     Index64 localindex(length());
     struct Error err = awkward_localindex_64(

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -609,7 +609,7 @@ namespace awkward {
   const ContentPtr
   BitMaskedArray::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -607,6 +607,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  BitMaskedArray::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   BitMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     return toByteMaskedArray().get()->rpad(target, axis, depth);
   }

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -608,9 +608,7 @@ namespace awkward {
 
   const ContentPtr
   BitMaskedArray::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    return toByteMaskedArray().get()->is_none(axis, depth);
   }
 
   const ContentPtr

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -708,6 +708,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  ByteMaskedArray::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   ByteMaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -709,9 +709,27 @@ namespace awkward {
 
   const ContentPtr
   ByteMaskedArray::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(toaxis == depth){
+      Index8 mask = bytemask();
+      return std::make_shared<NumpyArray>(mask, "?");
+    }
+    else{
+      int64_t numnull;
+      std::pair<Index64, Index64> pair = nextcarry_outindex(numnull);
+      Index64 nextcarry = pair.first;
+      Index64 outindex = pair.second;
+
+      ContentPtr next = content_.get()->carry(nextcarry);
+
+      ContentPtr out = next.get()->is_none(axis, depth);
+      IndexedOptionArray64 out2(Identities::none(),
+                                util::Parameters(),
+                                outindex,
+                                out);
+      return out2.simplify_optiontype();
+    }
+
   }
 
   const ContentPtr

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -710,7 +710,7 @@ namespace awkward {
   const ContentPtr
   ByteMaskedArray::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -295,9 +295,11 @@ namespace awkward {
 
   const ContentPtr
   EmptyArray::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    if(axis = depth){
+      Index8 out(0);
+      return std::make_shared<NumpyArray>(out, "?");
+    }
+    throw std::runtime_error("axis exceeds the depth of this array");
   }
 
   const ContentPtr

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -296,7 +296,7 @@ namespace awkward {
   const ContentPtr
   EmptyArray::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -295,11 +295,8 @@ namespace awkward {
 
   const ContentPtr
   EmptyArray::is_none(int64_t axis, int64_t depth) const {
-    if(axis = depth){
-      Index8 out(0);
-      return std::make_shared<NumpyArray>(out, "?");
-    }
-    throw std::runtime_error("axis exceeds the depth of this array");
+    Index8 out(0);
+    return std::make_shared<NumpyArray>(out, "?");
   }
 
   const ContentPtr

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -294,6 +294,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  EmptyArray::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   EmptyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis != depth) {

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -1469,9 +1469,24 @@ namespace awkward {
   template <typename T, bool ISOPTION>
   const ContentPtr
   IndexedArrayOf<T, ISOPTION>::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(axis == depth){
+      Index8 index(bytemask());
+      return std::make_shared<NumpyArray>(index, "?");
+    }
+    else if(ISOPTION){
+      int64_t numnull;
+      struct Error err1 = util::awkward_indexedarray_numnull<T>(
+        &numnull,
+        index_.ptr().get(),
+        index_.offset(),
+        index_.length());
+      util::handle_error(err1, classname(), identities_.get());
+      if(numnull != 0) std::runtime_error("axis exceeds the depth of certain nodes");
+    }
+    return project().get()->is_none(axis,
+                                    depth);
+    //Simplify Optiontype ? Mostly not.
   }
 
   template <typename T, bool ISOPTION>

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -1470,7 +1470,7 @@ namespace awkward {
   const ContentPtr
   IndexedArrayOf<T, ISOPTION>::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -1468,6 +1468,14 @@ namespace awkward {
 
   template <typename T, bool ISOPTION>
   const ContentPtr
+  IndexedArrayOf<T, ISOPTION>::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  template <typename T, bool ISOPTION>
+  const ContentPtr
   IndexedArrayOf<T, ISOPTION>::rpad(int64_t target,
                                     int64_t axis,
                                     int64_t depth) const {

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1024,9 +1024,25 @@ namespace awkward {
   template <typename T>
   const ContentPtr
   ListArrayOf<T>::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(axis == depth){
+      Index8 index(length());
+      struct Error err = awkward_zero_mask8(
+        index.ptr().get(),
+        length());
+      util::handle_error(err, classname(), identities_.get());
+      return std::make_shared<NumpyArray>(index, "?");
+    }
+    
+    ContentPtr compact = toListOffsetArray64(true);
+    ListOffsetArray64* rawcompact =
+    dynamic_cast<ListOffsetArray64*>(compact.get());
+    ContentPtr next = rawcompact->content().get()->is_none(axis,
+                                                           depth + 1);
+    return std::make_shared<ListOffsetArray64>(identities_,
+                                               util::Parameters(),
+                                               rawcompact->offsets(),
+                                               next);
   }
 
   template <typename T>

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1025,7 +1025,7 @@ namespace awkward {
   const ContentPtr
   ListArrayOf<T>::is_none(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
-    if(axis == depth){
+    if(toaxis == depth){
       Index8 index(length());
       struct Error err = awkward_zero_mask8(
         index.ptr().get(),
@@ -1033,16 +1033,14 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
       return std::make_shared<NumpyArray>(index, "?");
     }
-    
-    ContentPtr compact = toListOffsetArray64(true);
-    ListOffsetArray64* rawcompact =
-    dynamic_cast<ListOffsetArray64*>(compact.get());
-    ContentPtr next = rawcompact->content().get()->is_none(axis,
-                                                           depth + 1);
-    return std::make_shared<ListOffsetArray64>(identities_,
-                                               util::Parameters(),
-                                               rawcompact->offsets(),
-                                               next);
+    else{
+      return std::make_shared<ListArrayOf<T>>(
+        Identities::none(),
+        parameters_,
+        starts_,
+        stops_,
+        content_.get()->is_none(axis, depth + 1));
+    }
   }
 
   template <typename T>

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1020,6 +1020,14 @@ namespace awkward {
                                             stops_,
                                             content_.get()->fillna(value));
   }
+  
+  template <typename T>
+  const ContentPtr
+  ListArrayOf<T>::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
 
   template <typename T>
   const ContentPtr

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1025,7 +1025,7 @@ namespace awkward {
   const ContentPtr
   ListArrayOf<T>::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1177,10 +1177,27 @@ namespace awkward {
   template <typename T>
   const ContentPtr
   ListOffsetArrayOf<T>::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(axis == depth){
+      Index8 index(length());
+      struct Error err = awkward_zero_mask8(
+        index.ptr().get(),
+        length());
+      util::handle_error(err, classname(), identities_.get());
+      return std::make_shared<NumpyArray>(index, "?");
+    }
+    
+    ContentPtr compact = toListOffsetArray64(true);
+    ListOffsetArray64* rawcompact =
+    dynamic_cast<ListOffsetArray64*>(compact.get());
+    ContentPtr next = rawcompact->content().get()->is_none(axis,
+                                                           depth + 1);
+    return std::make_shared<ListOffsetArray64>(identities_,
+                                               util::Parameters(),
+                                               rawcompact->offsets(),
+                                               next);
   }
+
   template <typename T>
   const ContentPtr
   ListOffsetArrayOf<T>::rpad(int64_t target,

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1173,7 +1173,14 @@ namespace awkward {
     return std::make_shared<ListOffsetArrayOf<T>>(
       identities_, parameters_, offsets_, content().get()->fillna(value));
   }
-
+  
+  template <typename T>
+  const ContentPtr
+  ListOffsetArrayOf<T>::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
   template <typename T>
   const ContentPtr
   ListOffsetArrayOf<T>::rpad(int64_t target,

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1178,7 +1178,7 @@ namespace awkward {
   const ContentPtr
   ListOffsetArrayOf<T>::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
   template <typename T>

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1178,7 +1178,7 @@ namespace awkward {
   const ContentPtr
   ListOffsetArrayOf<T>::is_none(int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
-    if(axis == depth){
+    if(toaxis == depth){
       Index8 index(length());
       struct Error err = awkward_zero_mask8(
         index.ptr().get(),
@@ -1186,16 +1186,14 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
       return std::make_shared<NumpyArray>(index, "?");
     }
-    
-    ContentPtr compact = toListOffsetArray64(true);
-    ListOffsetArray64* rawcompact =
-    dynamic_cast<ListOffsetArray64*>(compact.get());
-    ContentPtr next = rawcompact->content().get()->is_none(axis,
-                                                           depth + 1);
-    return std::make_shared<ListOffsetArray64>(identities_,
-                                               util::Parameters(),
-                                               rawcompact->offsets(),
-                                               next);
+    else{
+      ContentPtr next = content_.get()->is_none(axis, depth + 1);
+      Index64 offsets = compact_offsets64(true);
+      return std::make_shared<ListOffsetArray64>(Identities::none(),
+                                                 util::Parameters(),
+                                                 offsets,
+                                                 next);
+    }
   }
 
   template <typename T>

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -203,19 +203,18 @@ namespace awkward {
 
   const SliceItemPtr
   None::asslice() const {
-    throw std::runtime_error("undefined opteration: None::asslice");
+    throw std::runtime_error("undefined operation: None::asslice");
   }
 
   const ContentPtr
   None::fillna(const ContentPtr& value) const {
-    throw std::runtime_error("undefined opteration: None::fillna");
+    throw std::runtime_error("undefined operation: None::fillna");
   }
 
   const ContentPtr
   None::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    // TODO: Maybe None should actually return for the function `is_none` (?).
+    throw std::runtime_error("undefined operation: None::is_none");
   }
 
   const ContentPtr

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -212,6 +212,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  None::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   None::rpad(int64_t length, int64_t axis, int64_t depth) const {
     throw std::runtime_error("undefined operation: None::rpad");
   }

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -214,7 +214,7 @@ namespace awkward {
   const ContentPtr
   None::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -213,7 +213,6 @@ namespace awkward {
 
   const ContentPtr
   None::is_none(int64_t axis, int64_t depth) const {
-    // TODO: Maybe None should actually return for the function `is_none` (?).
     throw std::runtime_error("undefined operation: None::is_none");
   }
 

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -2070,7 +2070,7 @@ namespace awkward {
   const ContentPtr
   NumpyArray::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -2068,6 +2068,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  NumpyArray::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   NumpyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     if (ndim() == 0) {
       throw std::runtime_error("cannot rpad a scalar");

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -2069,7 +2069,8 @@ namespace awkward {
 
   const ContentPtr
   NumpyArray::is_none(int64_t axis, int64_t depth) const {
-    if(axis == depth){
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(toaxis == depth){
       Index8 index(length());
       struct Error err = awkward_zero_mask8(
         index.ptr().get(),
@@ -2077,7 +2078,9 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
       return std::make_shared<NumpyArray>(index, "?");
     }
-    throw std::runtime_error("axis exceeds the depth of this array");
+    else{
+      throw std::invalid_argument("'axis' out of range for 'num'");
+    }
   }
 
   const ContentPtr

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -2079,7 +2079,7 @@ namespace awkward {
       return std::make_shared<NumpyArray>(index, "?");
     }
     else{
-      throw std::invalid_argument("'axis' out of range for 'num'");
+      throw std::invalid_argument("'axis' out of range for 'is_none'");
     }
   }
 

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -2069,9 +2069,15 @@ namespace awkward {
 
   const ContentPtr
   NumpyArray::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    if(axis == depth){
+      Index8 index(length());
+      struct Error err = awkward_zero_mask8(
+        index.ptr().get(),
+        length());
+      util::handle_error(err, classname(), identities_.get());
+      return std::make_shared<NumpyArray>(index, "?");
+    }
+    throw std::runtime_error("axis exceeds the depth of this array");
   }
 
   const ContentPtr

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -316,9 +316,15 @@ namespace awkward {
 
   const ContentPtr
   Record::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(toaxis == depth){
+       throw std::invalid_argument(
+        "cannot call 'num' with an 'axis' of 0 on a Record");
+    }
+    else{
+      ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
+      return singleton.get()->is_none(axis, depth).get()->getitem_at_nowrap(0);
+    }
   }
 
   const ContentPtr

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -315,6 +315,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  Record::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   Record::rpad(int64_t length, int64_t axis, int64_t depth) const {
     throw std::invalid_argument(
       "Record cannot be padded because it is not an array");

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -319,7 +319,7 @@ namespace awkward {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if(toaxis == depth){
        throw std::invalid_argument(
-        "cannot call 'num' with an 'axis' of 0 on a Record");
+        "cannot call 'is_none' with an 'axis' of 0 on a Record");
     }
     else{
       ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -317,7 +317,7 @@ namespace awkward {
   const ContentPtr
   Record::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -842,7 +842,7 @@ namespace awkward {
   const ContentPtr
   RecordArray::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -840,6 +840,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  RecordArray::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   RecordArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -841,9 +841,26 @@ namespace awkward {
 
   const ContentPtr
   RecordArray::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(toaxis == depth) {
+      Index8 index(length());
+      struct Error err = awkward_zero_mask8(
+        index.ptr().get(),
+        length());
+      util::handle_error(err, classname(), identities_.get());
+      return std::make_shared<NumpyArray>(index, "?");
+    }
+    else{
+      ContentPtrVec contents;
+      for (auto content : contents_) {
+        contents.push_back(content.get()->is_none(axis, depth));
+      }
+      return std::make_shared<RecordArray>(Identities::none(),
+                                           util::Parameters(),
+                                           contents,
+                                           recordlookup_,
+                                           length_);
+    }
   }
 
   const ContentPtr

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -687,6 +687,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  RegularArray::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   RegularArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -688,9 +688,22 @@ namespace awkward {
 
   const ContentPtr
   RegularArray::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(axis == depth){
+      Index8 index(length());
+      struct Error err = awkward_zero_mask8(
+        index.ptr().get(),
+        length());
+      util::handle_error(err, classname(), identities_.get());
+      return std::make_shared<NumpyArray>(index, "?");
+    }
+    else{
+      return std::make_shared<RegularArray>(
+      Identities::none(),
+      parameters_,
+      content_.get()->is_none(axis, depth + 1),
+      size_);
+    }
   }
 
   const ContentPtr

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -689,7 +689,7 @@ namespace awkward {
   const ContentPtr
   RegularArray::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -1471,7 +1471,7 @@ namespace awkward {
     else{
       ContentPtrVec contents;
       for (auto content : contents_) {
-        contents.push_back(content.get()->is_none(axis, depth));
+        contents.push_back(content.get()->is_none(axis, depth + 1));
       }
       UnionArrayOf<T, I> out(Identities::none(),
                              util::Parameters(),

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -1460,7 +1460,7 @@ namespace awkward {
   const ContentPtr
   UnionArrayOf<T, I>::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -1458,6 +1458,14 @@ namespace awkward {
 
   template <typename T, typename I>
   const ContentPtr
+  UnionArrayOf<T, I>::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  template <typename T, typename I>
+  const ContentPtr
   UnionArrayOf<T, I>::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -1459,9 +1459,27 @@ namespace awkward {
   template <typename T, typename I>
   const ContentPtr
   UnionArrayOf<T, I>::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if(toaxis == depth){
+      Index8 index(length());
+      struct Error err = awkward_zero_mask8(
+        index.ptr().get(),
+        length());
+      util::handle_error(err, classname(), identities_.get());
+      return std::make_shared<NumpyArray>(index, "?");
+    }
+    else{
+      ContentPtrVec contents;
+      for (auto content : contents_) {
+        contents.push_back(content.get()->is_none(axis, depth));
+      }
+      UnionArrayOf<T, I> out(Identities::none(),
+                             util::Parameters(),
+                             tags_,
+                             index_,
+                             contents);
+      return out.simplify_uniontype(false);
+    }
   }
 
   template <typename T, typename I>

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -554,7 +554,7 @@ namespace awkward {
   const ContentPtr
   UnmaskedArray::is_none(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "wubba lubba dub dub");
+      "TODO: Not implemented yet");
     return nullptr;
   }
 

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -553,9 +553,21 @@ namespace awkward {
 
   const ContentPtr
   UnmaskedArray::is_none(int64_t axis, int64_t depth) const {
-    throw std::runtime_error(
-      "TODO: Not implemented yet");
-    return nullptr;
+    int64_t toaxis = axis_wrap_if_negative(axis);
+    if (toaxis == depth) {
+      Index8 index(length());
+      struct Error err = awkward_zero_mask8(
+        index.ptr().get(),
+        length());
+      util::handle_error(err, classname(), identities_.get());
+      return std::make_shared<NumpyArray>(index, "?");
+    }
+    else {
+      return std::make_shared<UnmaskedArray>(
+        Identities::none(),
+        util::Parameters(),
+        content_.get()->is_none(axis, depth));
+    }
   }
 
   const ContentPtr

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -552,6 +552,13 @@ namespace awkward {
   }
 
   const ContentPtr
+  UnmaskedArray::is_none(int64_t axis, int64_t depth) const {
+    throw std::runtime_error(
+      "wubba lubba dub dub");
+    return nullptr;
+  }
+
+  const ContentPtr
   UnmaskedArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t toaxis = axis_wrap_if_negative(axis);
     if (toaxis == depth) {

--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -1106,6 +1106,10 @@ content_methods(py::class_<T, std::shared_ptr<T>, ak::Content>& x) {
                [](const T&self, const py::object&  value) -> py::object {
             return box(self.fillna(unbox_content(value)));
           })
+          .def("is_none",
+                [](const T&self, int64_t axis) -> py::object {
+            return box(self.is_none(axis, 0));
+          }, py::arg("axis") = 1)
           .def("num", [](const T& self, int64_t axis) -> py::object {
             return box(self.num(axis, 0));
           }, py::arg("axis") = 1)


### PR DESCRIPTION
As discussed in #193 , this PR rewrites `is_none()` in C++ and also implements an `axis` parameter. 

I don't want help on this one unless I explicitly ask or do something very wrong. I will be documenting progress here in steps rather making a big PR.

The main idea is to internally have two functions 
```C++ 
isnone(int64_t axis, int64_t depth);
isnone_axis0();
```
As far as I can tell only `IndexedOptionArray` is capable of storing `None` at it's own level (?). So if `axis = depth` we call `isnone_axis0()` else we return a `NumpyArray` of booleans with the same length as the current array.
Many other functions use `axis` and `depth` to iterate downwards which can serve as a helpful reference (eg. [pad_none](https://awkward-array.readthedocs.io/en/latest/_auto/ak.pad_none.html)). 
`IndexedOptionArray` also has a [`bytemask()`](https://awkward-array.readthedocs.io/en/latest/_static/classawkward_1_1IndexedArrayOf.html#a059a33ea0c250d17075bd20ebd6a4d10) function which directly gives us the mask. The mask is of type `Index8` and 1 &rarr; None, 0 &rarr; Not None so it needs flipping after which a `NumpyArray` can be created. 

Sub-tasks:
- [ ] Tests
- [x] Documentation
- [x] `IndexedArray`
- [x]  `ListArray`
- [x] `ListOffsetArray`
- [x] `RecordArray`
- [x] `Record`
- [x] `UnionArray`
- [x] Remaining types
