### PR TITLE
Fixes #264, reductions at axis=N inside empty lists at axis=N-1 at the end of the N-1 array.

### DIFF
--- a/src/cpu-kernels/reducers.cpp
+++ b/src/cpu-kernels/reducers.cpp
@@ -2398,7 +2398,6 @@ ERROR awkward_listoffsetarray_reduce_local_outoffsets_64(
   int64_t parentsoffset,
   int64_t lenparents,
   int64_t outlength) {
-  outoffsets[outlength] = lenparents;
   int64_t k = 0;
   int64_t last = -1;
   for (int64_t i = 0;  i < lenparents;  i++) {
@@ -2407,6 +2406,10 @@ ERROR awkward_listoffsetarray_reduce_local_outoffsets_64(
       k++;
       last++;
     }
+  }
+  while (k <= outlength) {
+    outoffsets[k] = lenparents;
+    k++;
   }
   return success();
 }

--- a/tests/test_0264-reduce-last-empty.py
+++ b/tests/test_0264-reduce-last-empty.py
@@ -1,0 +1,16 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+import itertools
+
+import pytest
+import numpy
+
+import awkward1
+
+def test():
+    assert awkward1.to_list(awkward1.prod(awkward1.Array([[[2, 3, 5]], [[7], [11]], [[]]]), axis=-1)) == [[30], [7, 11], [1]]
+
+    assert awkward1.to_list(awkward1.prod(awkward1.Array([[[2, 3, 5]], [[7], [11]], []]), axis=-1)) == [[30], [7, 11], []]


### PR DESCRIPTION
The entire fix:

```diff
index 1740b74..18c7c68 100644
--- a/src/cpu-kernels/reducers.cpp
+++ b/src/cpu-kernels/reducers.cpp
@@ -2398,7 +2398,6 @@ ERROR awkward_listoffsetarray_reduce_local_outoffsets_64(
   int64_t parentsoffset,
   int64_t lenparents,
   int64_t outlength) {
-  outoffsets[outlength] = lenparents;
   int64_t k = 0;
   int64_t last = -1;
   for (int64_t i = 0;  i < lenparents;  i++) {
@@ -2408,6 +2407,10 @@ ERROR awkward_listoffsetarray_reduce_local_outoffsets_64(
       last++;
     }
   }
+  while (k <= outlength) {
+    outoffsets[k] = lenparents;
+    k++;
+  }
   return success();
 }
```

We shouldn't just set the last value, but all values past the end of `parents`.