### PR TITLE
Add stubs for Numba documentation.

### DIFF
--- a/docs-src/_toc.yml
+++ b/docs-src/_toc.yml
@@ -41,6 +41,15 @@
     - file: how-to-create-lazy-dask
       title: "Lazy arrays and Dask"
 
+- file: how-to-use-in-numba
+  title: "Using arrays in Numba"
+  expand_sections: true
+  sections:
+    - file: how-to-use-in-numba-features
+      title: "Supported features"
+    - file: how-to-use-in-numba-arraybuilder
+      title: "Building array output"
+
 - file: how-to-examine
   title: "Examining arrays"
   expand_sections: true

--- a/docs-src/how-to-use-in-numba-arraybuilder.md
+++ b/docs-src/how-to-use-in-numba-arraybuilder.md
@@ -1,0 +1,23 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: '0.8'
+    jupytext_version: 1.4.2
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+How to output Awkward Array structures from a Numba-compiled function
+=====================================================================
+
+**This is a stub:** I intend to write this article, but haven't yet.
+
+If you need it soon, create an issue saying so and I'll make it a higher priority.
+
+[![](img/github-issues-documentation.png)](https://github.com/scikit-hep/awkward-1.0/issues/new?assignees=&labels=docs&template=documentation.md&title=)
+
+The text of your issue doesn't have to be much more than a link to this page, so I can be sure which page you're referring to. If you add details about how and why you need it, however, I may be able to tailor the text to help you more.

--- a/docs-src/how-to-use-in-numba-features.md
+++ b/docs-src/how-to-use-in-numba-features.md
@@ -1,0 +1,23 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: '0.8'
+    jupytext_version: 1.4.2
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+Awkward Array features that are supported in Numba-compiled functions
+=====================================================================
+
+**This is a stub:** I intend to write this article, but haven't yet.
+
+If you need it soon, create an issue saying so and I'll make it a higher priority.
+
+[![](img/github-issues-documentation.png)](https://github.com/scikit-hep/awkward-1.0/issues/new?assignees=&labels=docs&template=documentation.md&title=)
+
+The text of your issue doesn't have to be much more than a link to this page, so I can be sure which page you're referring to. If you add details about how and why you need it, however, I may be able to tailor the text to help you more.

--- a/docs-src/how-to-use-in-numba.md
+++ b/docs-src/how-to-use-in-numba.md
@@ -1,0 +1,18 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: '0.8'
+    jupytext_version: 1.4.2
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+Using arrays in Numba
+=====================
+
+   * **[Supported features](how-to-use-in-numba-features)**
+   * **[Building array output](how-to-use-in-numba-arraybuilder)**


### PR DESCRIPTION
This was inspired by #267. I can't write it at the moment, but clearly there needs to be a prominent place for "which Awkward features work and which don't in Numba."