### PR TITLE
Add brackets around ID cast

### DIFF
--- a/src/cpu-kernels/identities.cpp
+++ b/src/cpu-kernels/identities.cpp
@@ -68,7 +68,7 @@ ERROR awkward_identities_from_listoffsetarray(
         toptr[j*(fromwidth + 1) + k] =
           fromptr[fromptroffset + i*(fromwidth) + k];
       }
-      toptr[j*(fromwidth + 1) + fromwidth] = ID(j - start);
+      toptr[j*(fromwidth + 1) + fromwidth] = (ID)(j - start);
     }
   }
   return success();
@@ -219,7 +219,7 @@ ERROR awkward_identities_from_listarray(
         toptr[j*(fromwidth + 1) + k] =
           fromptr[fromptroffset + i*(fromwidth) + k];
       }
-      toptr[j*(fromwidth + 1) + fromwidth] = ID(j - start);
+      toptr[j*(fromwidth + 1) + fromwidth] = (ID)(j - start);
     }
   }
   *uniquecontents = true;
@@ -391,7 +391,7 @@ ERROR awkward_identities_from_regulararray(
         toptr[(i*size + j)*(fromwidth + 1) + k] =
           fromptr[fromptroffset + i*fromwidth + k];
       }
-      toptr[(i*size + j)*(fromwidth + 1) + fromwidth] = ID(j);
+      toptr[(i*size + j)*(fromwidth + 1) + fromwidth] = (ID)(j);
     }
   }
   for (int64_t k = (fromlength + 1)*size*(fromwidth + 1);


### PR DESCRIPTION
ID is always a primitive type. 
Makes it easier to generate code that can be parsed by pycparser.

Since this commit _might_ have implications outside of #269 I decided to open it as a separate PR. 