### PR TITLE
Broaden access to ArrayGenerator attributes in Python

### DIFF
--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -59,10 +59,20 @@ namespace awkward {
 
     /// @brief Returns `true` if this Form is equal to the other Form; `false`
     /// otherwise.
+    ///
+    /// @param check_identities If `true`, Forms are not equal unless they both
+    /// #has_identities.
+    /// @param check_parameters If `true`, Forms are not equal unless they have
+    /// the same #parameters.
+    /// @param compatibility_check If `true`, this is part of a compatibility
+    /// check between an expected Form (`this`) and a generated array's Form
+    /// (`other`). When the expected Form is a VirtualForm, it's allowed to be
+    /// less specific than the `other` VirtualForm.
     virtual bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const = 0;
+            bool check_parameters,
+            bool compatibility_check) const = 0;
 
     /// @brief The parameter associated with `key` at the first level
     /// that has a non-null value, descending only as deep as the first

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -85,7 +85,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     Index::Form mask_;

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -79,7 +79,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     Index::Form mask_;

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -65,7 +65,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
   };
 
   /// @class EmptyArray

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -73,7 +73,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     Index::Form index_;
@@ -137,7 +138,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     Index::Form index_;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -75,7 +75,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     Index::Form starts_;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -71,7 +71,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     Index::Form offsets_;

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -88,7 +88,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     const std::vector<int64_t> inner_shape_;

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -117,7 +117,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const {
+            bool check_parameters,
+            bool compatibility_check) const {
       throw std::runtime_error("FIXME: RawForm::equal");
     }
 

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -84,7 +84,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     const util::RecordLookupPtr recordlookup_;

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -71,7 +71,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     const FormPtr content_;

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -83,7 +83,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     Index::Form tags_;

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -68,7 +68,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     const FormPtr content_;

--- a/include/awkward/array/VirtualArray.h
+++ b/include/awkward/array/VirtualArray.h
@@ -76,7 +76,8 @@ namespace awkward {
     bool
       equal(const FormPtr& other,
             bool check_identities,
-            bool check_parameters) const override;
+            bool check_parameters,
+            bool compatibility_check) const override;
 
   private:
     const FormPtr form_;

--- a/include/awkward/python/virtual.h
+++ b/include/awkward/python/virtual.h
@@ -27,16 +27,34 @@ public:
   const py::tuple
     args() const;
 
-  const py::kwargs
+  const py::dict
     kwargs() const;
 
   const ak::ContentPtr
     generate() const override;
 
   const std::string
-  tostring_part(const std::string& indent,
-                const std::string& pre,
-                const std::string& post) const override;
+    tostring_part(const std::string& indent,
+                  const std::string& pre,
+                  const std::string& post) const override;
+
+  const std::shared_ptr<ak::ArrayGenerator>
+    shallow_copy() const override;
+
+  const std::shared_ptr<ak::ArrayGenerator>
+    with_form(const ak::FormPtr& form) const override;
+
+  const std::shared_ptr<ak::ArrayGenerator>
+    with_length(int64_t length) const override;
+
+  const std::shared_ptr<ak::ArrayGenerator>
+    with_callable(const py::object& callable) const;
+
+  const std::shared_ptr<ak::ArrayGenerator>
+    with_args(const py::tuple& args) const;
+
+  const std::shared_ptr<ak::ArrayGenerator>
+    with_kwargs(const py::dict& kwargs) const;
 
 private:
   const py::object callable_;

--- a/include/awkward/virtual/ArrayGenerator.h
+++ b/include/awkward/virtual/ArrayGenerator.h
@@ -53,10 +53,25 @@ namespace awkward {
     const ContentPtr
       generate_and_check() const;
 
+    /// @brief Returns a string representation of this ArrayGenerator.
     virtual const std::string
       tostring_part(const std::string& indent,
                     const std::string& pre,
                     const std::string& post) const = 0;
+
+    /// @brief Copies this ArrayGenerator, referencing any contents.
+    virtual const std::shared_ptr<ArrayGenerator>
+      shallow_copy() const = 0;
+
+    /// @brief Return a copy of this ArrayGenerator with a different form
+    /// (or a now-known form, whereas it might have been unknown before).
+    virtual const std::shared_ptr<ArrayGenerator>
+      with_form(const FormPtr& form) const = 0;
+
+    /// @brief Return a copy of this ArrayGenerator with a different length
+    /// (or a now-known length, whereas it might have been unknown before).
+    virtual const std::shared_ptr<ArrayGenerator>
+      with_length(int64_t length) const = 0;
 
   protected:
     const FormPtr form_;
@@ -92,6 +107,15 @@ namespace awkward {
       tostring_part(const std::string& indent,
                     const std::string& pre,
                     const std::string& post) const override;
+
+    const std::shared_ptr<ArrayGenerator>
+      shallow_copy() const override;
+
+    const std::shared_ptr<ArrayGenerator>
+      with_form(const FormPtr& form) const override;
+
+    const std::shared_ptr<ArrayGenerator>
+      with_length(int64_t length) const override;
 
   protected:
     const ContentPtr content_;

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -151,7 +151,8 @@ namespace awkward {
   bool
   BitMaskedForm::equal(const FormPtr& other,
                        bool check_identities,
-                       bool check_parameters) const {
+                       bool check_parameters,
+                       bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -164,7 +165,8 @@ namespace awkward {
       return (mask_ == t->mask()  &&
               content_.get()->equal(t->content(),
                                     check_identities,
-                                    check_parameters)  &&
+                                    check_parameters,
+                                    compatibility_check)  &&
               valid_when_ == t->valid_when()  &&
               lsb_order_ == t->lsb_order());
     }

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -145,7 +145,8 @@ namespace awkward {
   bool
   ByteMaskedForm::equal(const FormPtr& other,
                         bool check_identities,
-                        bool check_parameters) const {
+                        bool check_parameters,
+                        bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -158,7 +159,8 @@ namespace awkward {
       return (mask_ == t->mask()  &&
               content_.get()->equal(t->content(),
                                     check_identities,
-                                    check_parameters)  &&
+                                    check_parameters,
+                                    compatibility_check)  &&
               valid_when_ == t->valid_when());
     }
     else {

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -100,7 +100,8 @@ namespace awkward {
   bool
   EmptyForm::equal(const FormPtr& other,
                    bool check_identities,
-                   bool check_parameters) const {
+                   bool check_parameters,
+                   bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -146,7 +146,8 @@ namespace awkward {
   bool
   IndexedForm::equal(const FormPtr& other,
                      bool check_identities,
-                     bool check_parameters) const {
+                     bool check_parameters,
+                     bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -159,7 +160,8 @@ namespace awkward {
       return (index_ == t->index()  &&
               content_.get()->equal(t->content(),
                                     check_identities,
-                                    check_parameters));
+                                    check_parameters,
+                                    compatibility_check));
     }
     else {
       return false;
@@ -283,7 +285,8 @@ namespace awkward {
   bool
   IndexedOptionForm::equal(const FormPtr& other,
                            bool check_identities,
-                           bool check_parameters) const {
+                           bool check_parameters,
+                           bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -296,7 +299,8 @@ namespace awkward {
       return (index_ == t->index()  &&
               content_.get()->equal(t->content(),
                                     check_identities,
-                                    check_parameters));
+                                    check_parameters,
+                                    compatibility_check));
     }
     else {
       return false;

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -160,7 +160,8 @@ namespace awkward {
   bool
   ListForm::equal(const FormPtr& other,
                   bool check_identities,
-                  bool check_parameters) const {
+                  bool check_parameters,
+                  bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -174,7 +175,8 @@ namespace awkward {
               stops_ == t->stops()  &&
               content_.get()->equal(t->content(),
                                     check_identities,
-                                    check_parameters));
+                                    check_parameters,
+                                    compatibility_check));
     }
     else {
       return false;

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -151,7 +151,8 @@ namespace awkward {
   bool
   ListOffsetForm::equal(const FormPtr& other,
                         bool check_identities,
-                        bool check_parameters) const {
+                        bool check_parameters,
+                        bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -164,7 +165,8 @@ namespace awkward {
       return (offsets_ == t->offsets()  &&
               content_.get()->equal(t->content(),
                                     check_identities,
-                                    check_parameters));
+                                    check_parameters,
+                                    compatibility_check));
     }
     else {
       return false;

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -337,7 +337,8 @@ namespace awkward {
   bool
   NumpyForm::equal(const FormPtr& other,
                    bool check_identities,
-                   bool check_parameters) const {
+                   bool check_parameters,
+                   bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -223,7 +223,8 @@ namespace awkward {
   bool
   RecordForm::equal(const FormPtr& other,
                     bool check_identities,
-                    bool check_parameters) const {
+                    bool check_parameters,
+                    bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -260,7 +261,8 @@ namespace awkward {
           }
           if (!content(i).get()->equal(t->content(j),
                                        check_identities,
-                                       check_parameters)) {
+                                       check_parameters,
+                                       compatibility_check)) {
             return false;
           }
         }
@@ -273,7 +275,8 @@ namespace awkward {
         for (int64_t i = 0;  i < numfields();  i++) {
           if (!content(i).get()->equal(t->content(i),
                                        check_identities,
-                                       check_parameters)) {
+                                       check_parameters,
+                                       compatibility_check)) {
             return false;
           }
         }

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -139,7 +139,8 @@ namespace awkward {
   bool
   RegularForm::equal(const FormPtr& other,
                      bool check_identities,
-                     bool check_parameters) const {
+                     bool check_parameters,
+                     bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -151,7 +152,8 @@ namespace awkward {
     if (RegularForm* t = dynamic_cast<RegularForm*>(other.get())) {
       return (content_.get()->equal(t->content(),
                                     check_identities,
-                                    check_parameters)  &&
+                                    check_parameters,
+                                    compatibility_check)  &&
               size_ == t->size());
     }
     else {

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -250,7 +250,8 @@ namespace awkward {
   bool
   UnionForm::equal(const FormPtr& other,
                    bool check_identities,
-                   bool check_parameters) const {
+                   bool check_parameters,
+                   bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -269,7 +270,8 @@ namespace awkward {
       for (int64_t i = 0;  i < numcontents();  i++) {
         if (!content(i).get()->equal(t->content(i),
                                      check_identities,
-                                     check_parameters)) {
+                                     check_parameters,
+                                     compatibility_check)) {
           return false;
         }
       }

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -121,7 +121,8 @@ namespace awkward {
   bool
   UnmaskedForm::equal(const FormPtr& other,
                       bool check_identities,
-                      bool check_parameters) const {
+                      bool check_parameters,
+                      bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -133,7 +134,8 @@ namespace awkward {
     if (UnmaskedForm* t = dynamic_cast<UnmaskedForm*>(other.get())) {
       return (content_.get()->equal(t->content(),
                                     check_identities,
-                                    check_parameters));
+                                    check_parameters,
+                                    compatibility_check));
     }
     else {
       return false;

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -178,8 +178,9 @@ namespace awkward {
 
   bool
   VirtualForm::equal(const FormPtr& other,
-                      bool check_identities,
-                      bool check_parameters) const {
+                     bool check_identities,
+                     bool check_parameters,
+                     bool compatibility_check) const {
     if (check_identities  &&
         has_identities_ != other.get()->has_identities()) {
       return false;
@@ -188,22 +189,42 @@ namespace awkward {
         !util::parameters_equal(parameters_, other.get()->parameters())) {
       return false;
     }
+
     if (VirtualForm* t = dynamic_cast<VirtualForm*>(other.get())) {
-      if (form_.get() == nullptr  &&  t->form().get() != nullptr) {
-        return false;
+      if (compatibility_check) {
+        // Called by ArrayGenerator::generate_and_check; `this` is the expected
+        // Form and `t` is the Form of the generated array, so `this` is allowed
+        // to have less information than `t`.
+        if (form_.get() != nullptr  &&  t->form().get() != nullptr) {
+          if (!form_.get()->equal(t->form(),
+                                  check_identities,
+                                  check_parameters,
+                                  compatibility_check)) {
+            return false;
+          }
+        }
+        return true;
       }
-      else if (form_.get() != nullptr  &&  t->form().get() == nullptr) {
-        return false;
-      }
-      else if (form_.get() != nullptr  &&  t->form().get() != nullptr) {
-        if (!form_.get()->equal(t->form(),
-                                check_identities,
-                                check_parameters)) {
+      else {
+        // Called by Form.__eq__ in Python; should be an equivalence relation.
+        if (form_.get() == nullptr  &&  t->form().get() != nullptr) {
           return false;
         }
+        else if (form_.get() != nullptr  &&  t->form().get() == nullptr) {
+          return false;
+        }
+        else if (form_.get() != nullptr  &&  t->form().get() != nullptr) {
+          if (!form_.get()->equal(t->form(),
+                                  check_identities,
+                                  check_parameters,
+                                  compatibility_check)) {
+            return false;
+          }
+        }
+        return has_length_ == t->has_length();
       }
-      return has_length_ == t->has_length();
     }
+
     else {
       return false;
     }

--- a/src/libawkward/virtual/ArrayGenerator.cpp
+++ b/src/libawkward/virtual/ArrayGenerator.cpp
@@ -95,4 +95,28 @@ namespace awkward {
     out << indent << "</SliceGenerator>" << post;
     return out.str();
   }
+
+  const std::shared_ptr<ArrayGenerator>
+  SliceGenerator::shallow_copy() const {
+    return std::make_shared<SliceGenerator>(form_,
+                                            length_,
+                                            content_,
+                                            slice_);
+  }
+
+  const std::shared_ptr<ArrayGenerator>
+  SliceGenerator::with_form(const FormPtr& form) const {
+    return std::make_shared<SliceGenerator>(form,
+                                            length_,
+                                            content_,
+                                            slice_);
+  }
+
+  const std::shared_ptr<ArrayGenerator>
+  SliceGenerator::with_length(int64_t length) const {
+    return std::make_shared<SliceGenerator>(form_,
+                                            length,
+                                            content_,
+                                            slice_);
+  }
 }

--- a/src/libawkward/virtual/ArrayGenerator.cpp
+++ b/src/libawkward/virtual/ArrayGenerator.cpp
@@ -33,7 +33,7 @@ namespace awkward {
           + std::to_string(out.get()->length()));
     }
     if (form_.get() != nullptr  &&
-        !form_.get()->equal(out.get()->form(true), true, true)) {
+        !form_.get()->equal(out.get()->form(true), true, true, true)) {
       throw std::invalid_argument(
           std::string("generated array does not conform to expected form:\n\n")
           + form_.get()->tostring() + std::string("\n\nbut generated:\n\n")

--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -2051,7 +2051,7 @@ make_VirtualArray(const py::handle& m, const std::string& name) {
           }
           catch (py::cast_error err) {
             throw std::invalid_argument(
-                "VirtualArray 'generator' must be a PyArrayGenerator or a "
+                "VirtualArray 'generator' must be an ArrayGenerator or a "
                 "SliceGenerator");
           }
         }

--- a/src/python/forms.cpp
+++ b/src/python/forms.cpp
@@ -12,11 +12,11 @@ make_Form(const py::handle& m, const std::string& name) {
   return (py::class_<ak::Form, std::shared_ptr<ak::Form>>(m, name.c_str())
       .def("__eq__", [](const std::shared_ptr<ak::Form>& self,
                         const std::shared_ptr<ak::Form>& other) -> bool {
-        return self.get()->equal(other, true, true);
+        return self.get()->equal(other, true, true, false);
       })
       .def("__ne__", [](const std::shared_ptr<ak::Form>& self,
                         const std::shared_ptr<ak::Form>& other) -> bool {
-        return !self.get()->equal(other, true, true);
+        return !self.get()->equal(other, true, true, false);
       })
       .def_static("fromjson", &ak::Form::fromjson)
   );

--- a/src/python/virtual.cpp
+++ b/src/python/virtual.cpp
@@ -30,7 +30,7 @@ PyArrayGenerator::args() const {
   return args_;
 }
 
-const py::kwargs
+const py::dict
 PyArrayGenerator::kwargs() const {
   return kwargs_;
 }
@@ -83,6 +83,61 @@ PyArrayGenerator::tostring_part(const std::string& indent,
   return out.str();
 }
 
+const std::shared_ptr<ak::ArrayGenerator>
+PyArrayGenerator::shallow_copy() const {
+  return std::make_shared<PyArrayGenerator>(form_,
+                                            length_,
+                                            callable_,
+                                            args_,
+                                            kwargs_);
+}
+
+const std::shared_ptr<ak::ArrayGenerator>
+PyArrayGenerator::with_form(const std::shared_ptr<ak::Form>& form) const {
+  return std::make_shared<PyArrayGenerator>(form,
+                                            length_,
+                                            callable_,
+                                            args_,
+                                            kwargs_);
+}
+
+const std::shared_ptr<ak::ArrayGenerator>
+PyArrayGenerator::with_length(int64_t length) const {
+  return std::make_shared<PyArrayGenerator>(form_,
+                                            length,
+                                            callable_,
+                                            args_,
+                                            kwargs_);
+}
+
+
+const std::shared_ptr<ak::ArrayGenerator>
+PyArrayGenerator::with_callable(const py::object& callable) const {
+  return std::make_shared<PyArrayGenerator>(form_,
+                                            length_,
+                                            callable,
+                                            args_,
+                                            kwargs_);
+}
+
+const std::shared_ptr<ak::ArrayGenerator>
+PyArrayGenerator::with_args(const py::tuple& args) const {
+  return std::make_shared<PyArrayGenerator>(form_,
+                                            length_,
+                                            callable_,
+                                            args,
+                                            kwargs_);
+}
+
+const std::shared_ptr<ak::ArrayGenerator>
+PyArrayGenerator::with_kwargs(const py::dict& kwargs) const {
+  return std::make_shared<PyArrayGenerator>(form_,
+                                            length_,
+                                            callable_,
+                                            args_,
+                                            kwargs);
+}
+
 py::class_<PyArrayGenerator, std::shared_ptr<PyArrayGenerator>>
 make_PyArrayGenerator(const py::handle& m, const std::string& name) {
   return (py::class_<PyArrayGenerator,
@@ -118,6 +173,9 @@ make_PyArrayGenerator(const py::handle& m, const std::string& name) {
         , py::arg("kwargs") = py::dict()
         , py::arg("form") = py::none()
         , py::arg("length") = py::none())
+      .def_property_readonly("callable", &PyArrayGenerator::callable)
+      .def_property_readonly("args", &PyArrayGenerator::args)
+      .def_property_readonly("kwargs", &PyArrayGenerator::kwargs)
       .def_property_readonly("form", [](const PyArrayGenerator& self)
                                      -> py::object {
         ak::FormPtr form = self.form();
@@ -143,6 +201,31 @@ make_PyArrayGenerator(const py::handle& m, const std::string& name) {
       })
       .def("__repr__", [](const PyArrayGenerator& self) -> std::string {
         return self.tostring_part("", "", "");
+      })
+      .def("with_form", [](const PyArrayGenerator& self,
+                           const std::shared_ptr<ak::Form>& form) -> py::object {
+        std::shared_ptr<ak::ArrayGenerator> out = self.with_form(form);
+        return py::cast(out);
+      })
+      .def("with_length", [](const PyArrayGenerator& self,
+                             int64_t length) -> py::object {
+        std::shared_ptr<ak::ArrayGenerator> out = self.with_length(length);
+        return py::cast(out);
+      })
+      .def("with_callable", [](const PyArrayGenerator& self,
+                               const py::object& callable) -> py::object {
+        std::shared_ptr<ak::ArrayGenerator> out = self.with_callable(callable);
+        return py::cast(out);
+      })
+      .def("with_args", [](const PyArrayGenerator& self,
+                           const py::tuple& args) -> py::object {
+        std::shared_ptr<ak::ArrayGenerator> out = self.with_args(args);
+        return py::cast(out);
+      })
+      .def("with_kwargs", [](const PyArrayGenerator& self,
+                             const py::dict& kwargs) -> py::object {
+        std::shared_ptr<ak::ArrayGenerator> out = self.with_kwargs(kwargs);
+        return py::cast(out);
       })
   );
 }
@@ -212,6 +295,16 @@ make_SliceGenerator(const py::handle& m, const std::string& name) {
       })
       .def("__repr__", [](const ak::SliceGenerator& self) -> std::string {
         return self.tostring_part("", "", "");
+      })
+      .def("with_form", [](const ak::SliceGenerator& self,
+                           const std::shared_ptr<ak::Form>& form) -> py::object {
+        std::shared_ptr<ak::ArrayGenerator> out = self.with_form(form);
+        return py::cast(out);
+      })
+      .def("with_length", [](const ak::SliceGenerator& self,
+                             int64_t length) -> py::object {
+        std::shared_ptr<ak::ArrayGenerator> out = self.with_length(length);
+        return py::cast(out);
       })
   );
 }

--- a/tests/test_0274-access-ArrayGenerator-in-Python.py
+++ b/tests/test_0274-access-ArrayGenerator-in-Python.py
@@ -1,0 +1,48 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+import json
+
+import pytest
+import numpy
+
+import awkward1
+
+def test():
+    content = awkward1.Array([1, 2, 3, 4, 5])
+    generator1 = awkward1.layout.ArrayGenerator(lambda a, b: a*content + b, (100,), {"b": 3})
+    assert awkward1.to_list(generator1()) == [103, 203, 303, 403, 503]
+    assert generator1.args == (100,)
+    assert generator1.kwargs == {"b": 3}
+    assert generator1.form is None
+    assert generator1.length is None
+
+    generator2 = generator1.with_args((1000,))
+    assert awkward1.to_list(generator2()) == [1003, 2003, 3003, 4003, 5003]
+    assert generator2.args == (1000,)
+    assert generator2.kwargs == {"b": 3}
+    assert generator2.form is None
+    assert generator2.length is None
+
+    generator3 = generator1.with_kwargs({"b": 4})
+    assert awkward1.to_list(generator3()) == [104, 204, 304, 404, 504]
+    assert generator3.args == (100,)
+    assert generator3.kwargs == {"b": 4}
+    assert generator3.form is None
+    assert generator3.length is None
+
+    generator4 = generator1.with_form(awkward1.forms.Form.fromjson('"int64"'))
+    assert awkward1.to_list(generator4()) == [103, 203, 303, 403, 503]
+    assert generator4.args == (100,)
+    assert generator4.kwargs == {"b": 3}
+    assert json.loads(generator4.form.tojson()) == json.loads(awkward1.forms.Form.fromjson('"int64"').tojson())
+    assert generator4.length is None
+
+    generator5 = generator1.with_length(5)
+    assert awkward1.to_list(generator5()) == [103, 203, 303, 403, 503]
+    assert generator5.args == (100,)
+    assert generator5.kwargs == {"b": 3}
+    assert generator5.form is None
+    assert generator5.length == 5


### PR DESCRIPTION
This is for #272.