### PR TITLE
Fix some typos in cpu-kernels

### DIFF
--- a/src/cpu-kernels/reducers.cpp
+++ b/src/cpu-kernels/reducers.cpp
@@ -1718,7 +1718,7 @@ ERROR awkward_reduce_argmin(
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     int64_t parent = parents[parentsoffset + i];
-    int64_t start = starts[parent];
+    int64_t start = starts[startsoffset + parent];
     if (toptr[parent] == -1  ||
         fromptr[fromptroffset + i] <
           fromptr[fromptroffset + toptr[parent] + start]) {
@@ -1742,7 +1742,7 @@ ERROR awkward_reduce_argmin_bool_64(
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     int64_t parent = parents[parentsoffset + i];
-    int64_t start = starts[parent];
+    int64_t start = starts[startsoffset + parent];
     if (toptr[parent] == -1  ||
         (fromptr[fromptroffset + i] != 0) <
           (fromptr[fromptroffset + toptr[parent] + start] != 0)) {
@@ -1978,7 +1978,7 @@ ERROR awkward_reduce_argmax(
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     int64_t parent = parents[parentsoffset + i];
-    int64_t start = starts[parent];
+    int64_t start = starts[startsoffset + parent];
     if (toptr[parent] == -1  ||
         fromptr[fromptroffset + i] >
           fromptr[fromptroffset + toptr[parent] + start]) {
@@ -2002,7 +2002,7 @@ ERROR awkward_reduce_argmax_bool_64(
   }
   for (int64_t i = 0;  i < lenparents;  i++) {
     int64_t parent = parents[parentsoffset + i];
-    int64_t start = starts[parent];
+    int64_t start = starts[startsoffset + parent];
     if (toptr[parent] == -1  ||
         (fromptr[fromptroffset + i] != 0) >
           (fromptr[fromptroffset + toptr[parent] + start] != 0)) {


### PR DESCRIPTION
`starts[parent]` should be `starts[startsoffset + parent]`