### PR TITLE
Attach docstrings to newly created highlevel arrays

### DIFF
--- a/src/awkward1/highlevel.py
+++ b/src/awkward1/highlevel.py
@@ -234,6 +234,9 @@ class Array(
 
         self.layout = layout
         self.behavior = behavior
+        docstr = self.layout.purelist_parameter("__doc__")
+        if isinstance(docstr, str):
+            self.__doc__ = docstr
         if check_valid:
             awkward1.operations.describe.validity_error(self, exception=True)
 


### PR DESCRIPTION
There's no way to do this from the mixin since there is no initialize hook.
A possible alternative, which might also be useful for other things, would be to rewrite `Array.__init__` using `__new__` and allowing the mixin to override initialization.