### PR TITLE
Convert 64-bit unsigned 32-bit Awkward arrays into 32-bit Arrow arrays if their indexes are small enough.

### DIFF
--- a/src/awkward1/operations/convert.py
+++ b/src/awkward1/operations/convert.py
@@ -1326,6 +1326,16 @@ def to_arrow(array):
             layout,
             (awkward1.layout.ListOffsetArray64, awkward1.layout.ListOffsetArrayU32),
         ):
+            offsets = numpy.asarray(layout.offsets)
+
+            if len(offsets) == 0 or numpy.max(offsets) <= numpy.iinfo(numpy.int32).max:
+                small_layout = awkward1.layout.ListOffsetArray32(
+                    awkward1.layout.Index32(offsets.astype(numpy.int32)),
+                    layout.content,
+                    parameters=layout.parameters,
+                )
+                return recurse(small_layout, mask=mask)
+
             offsets = numpy.asarray(layout.offsets, dtype=numpy.int64)
 
             if layout.parameter("__array__") == "bytestring":

--- a/tests/test_0224-arrow-to-awkward.py
+++ b/tests/test_0224-arrow-to-awkward.py
@@ -45,7 +45,7 @@ def test_toarrow():
         numpy.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]))
     offsets = awkward1.layout.Index64(numpy.array([0, 3, 3, 5, 6, 9]))
     array = awkward1.layout.ListOffsetArray64(offsets, content)
-    assert isinstance(awkward1.to_arrow(array), (pyarrow.LargeListArray))
+    assert isinstance(awkward1.to_arrow(array), (pyarrow.ListArray))
     assert awkward1.to_arrow(array).to_pylist() == [[1.1, 2.2, 3.3], [], [
         4.4, 5.5], [6.6], [7.7, 8.8, 9.9]]
 
@@ -53,7 +53,7 @@ def test_toarrow():
         numpy.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]))
     offsets = awkward1.layout.IndexU32(numpy.array([0, 3, 3, 5, 6, 9]))
     array = awkward1.layout.ListOffsetArrayU32(offsets, content)
-    assert isinstance(awkward1.to_arrow(array), (pyarrow.LargeListArray))
+    assert isinstance(awkward1.to_arrow(array), (pyarrow.ListArray))
     assert awkward1.to_arrow(array).to_pylist() == [[1.1, 2.2, 3.3], [], [
         4.4, 5.5], [6.6], [7.7, 8.8, 9.9]]
 
@@ -74,12 +74,11 @@ def test_toarrow():
     stops = awkward1.layout.Index64(numpy.array([2, 3]))
     listarray = awkward1.layout.ListArray64(starts, stops, regulararray)
 
-    assert isinstance(awkward1.to_arrow(listarray), (pyarrow.LargeListArray))
+    assert isinstance(awkward1.to_arrow(listarray), (pyarrow.ListArray))
     assert awkward1.to_arrow(listarray).to_pylist() == [[[[0.0, 1.1, 2.2], []], [
         [3.3, 4.4], [5.5]]], [[[3.3, 4.4], [5.5]], [[6.6, 7.7, 8.8, 9.9], []]]]
 
-    assert isinstance(awkward1.to_arrow(regulararray),
-                      (pyarrow.LargeListArray))
+    assert isinstance(awkward1.to_arrow(regulararray), (pyarrow.ListArray))
     assert awkward1.to_arrow(regulararray).to_pylist() == [[[0.0, 1.1, 2.2], []], [
         [3.3, 4.4], [5.5]], [[6.6, 7.7, 8.8, 9.9], []]]
 


### PR DESCRIPTION
Fixes #312, as preparation for adding Parquet input and output.