### PR TITLE
Put the Awkward-in-Pandas feature up for a vote.

### DIFF
--- a/tests/test_0090-as-pandas-extension.py
+++ b/tests/test_0090-as-pandas-extension.py
@@ -14,6 +14,8 @@ py27 = (sys.version_info[0] < 3)
 
 pandas = pytest.importorskip("pandas")
 
+awkward1.pandas.register()
+
 def test_numpy_structured_arrays_cant_be_pandas_printed():
     a = awkward1.Array([{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}])
     df = pandas.DataFrame({"column": a})


### PR DESCRIPTION
Users are requested to explain their Awkward-in-Pandas use-cases on #350. If there aren't any applications (that couldn't be done in other ways), then this feature will be removed before Awkward1 really becomes 1.0.

```python
>>> import awkward1 as ak
>>> import pandas as pd
>>> pd.DataFrame({"array": ak.Array([[1, 2, 3], [], [4, 5]])})
```

```
RuntimeError: You seem to be trying to use an Awkward Array as a Pandas Series or DataFrame column. This is
currently allowed if you first call

    ak.pandas.register()

but it is being considered for deprecation. See

    https://github.com/scikit-hep/awkward-1.0/issues/350

for reasons why it may be removed and explain your use-case there if you don't want it to be removed. Note
that this is distinct from

    ak.pandas.df(array)
    ak.pandas.dfs(array)

which may work better for you anyway, depending on what you're trying to accomplish.
```

```python
>>> ak.pandas.register()
>>> pd.DataFrame({"array": ak.Array([[1, 2, 3], [], [4, 5]])})
       array
0  [1, 2, 3]
1         []
2     [4, 5]
```