### PR TITLE
Example of Identities_to_Identities64 integration with the codebase.

### DIFF
--- a/include/awkward/cuda-kernels/cuda_identities.h
+++ b/include/awkward/cuda-kernels/cuda_identities.h
@@ -1,0 +1,17 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+
+#ifndef AWKWARD_IDENTITIES_H
+#define AWKWARD_IDENTITIES_H
+
+#include "awkward/common.h"
+
+extern "C" {
+  ERROR awkward_cuda_Identities32_to_Identities64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t length,
+  int64_t width);
+};
+
+#endif //AWKWARD_IDENTITIES_H

--- a/src/cuda-kernels/identities.cu
+++ b/src/cuda-kernels/identities.cu
@@ -1,0 +1,43 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+#include "awkward/cuda-kernels/cuda_identities.h"
+#include <stdio.h>
+
+__global__
+void cuda_Identities32_toIdentities64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t length) {
+  int64_t block_id = blockIdx.x + blockIdx.y * gridDim.x + gridDim.x * gridDim.y * blockIdx.z;
+  int64_t thread_id = block_id * blockDim.x + threadIdx.x;
+  if(thread_id < length) {
+    toptr[thread_id] = (int64_t)(fromptr[thread_id]);
+  }
+}
+
+ERROR awkward_cuda_Identities32_to_Identities64(
+  int64_t* toptr,
+  const int32_t* fromptr,
+  int64_t length,
+  int64_t width) {
+
+  dim3 blocks_per_grid;
+  dim3 threads_per_block;
+
+  if (length > 1024) {
+    blocks_per_grid = dim3(ceil((length) / 1024.0), 1, 1);
+    threads_per_block = dim3(1024, 1, 1);
+  } else {
+    blocks_per_grid = dim3(1, 1, 1);
+    threads_per_block = dim3(length, 1, 1);
+  }
+
+  cuda_Identities32_toIdentities64<<<blocks_per_grid, threads_per_block>>>(
+    toptr,
+    fromptr,
+    length * width);
+
+  cudaDeviceSynchronize();
+
+  return success();
+}

--- a/src/libawkward/Identities.cpp
+++ b/src/libawkward/Identities.cpp
@@ -148,7 +148,7 @@ namespace awkward {
                                                          length_);
       Identities64* raw = reinterpret_cast<Identities64*>(out.get());
       kernel::Identities_to_Identities64<int32_t>(
-        kernel::lib::cpu,   // DERIVE
+        ptr_lib(),
         raw->data(),
         reinterpret_cast<int32_t*>(data()),
         length_,

--- a/src/libawkward/kernel.cpp
+++ b/src/libawkward/kernel.cpp
@@ -4399,8 +4399,14 @@ namespace awkward {
           width);
       }
       else if (ptr_lib == kernel::lib::cuda) {
-        throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_to_Identities64");
+        FORM_KERNEL(awkward_Identities32_to_Identities64,
+                    awkward_cuda_Identities32_to_Identities64,
+                    ptr_lib);
+        return (*awkward_cuda_Identities32_to_Identities64_t)(
+          toptr,
+          fromptr,
+          length,
+          width);
       }
       else {
         throw std::runtime_error(


### PR DESCRIPTION
@reikdas I have shown an example as to how you could go about integrating functions into the codebase. @jpivarski This can be merged if you want. But if you'd like to merge this, can you give me an example for writing tests for `Identities`(I'd like to have a integration test in place although since it's just casting it should pass)