### PR TITLE
VirtualArray has correct __record__ parameter

### DIFF
--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -223,6 +223,16 @@ namespace awkward {
     void
       form_key_tojson(ToJson& builder, bool verbose) const;
 
+    /// @brief Internal function for extracting record field
+    ///
+    /// WARNING: this function returns the field from the innermost record
+    /// form it finds, and does not wrap it with the context.
+    /// Used by VirtualArray::getitem_field to determine certain parameters
+    /// without materialization. A possible extension would be to wrap output
+    /// at each layer to fully specify the form.
+    virtual const FormPtr
+      getitem_field(const std::string& key) const = 0;
+
     protected:
     /// @brief See #has_identities
     bool has_identities_;

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -90,6 +90,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     Index::Form mask_;
     const FormPtr content_;

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -85,6 +85,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     Index::Form mask_;
     const FormPtr content_;

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -69,6 +69,10 @@ namespace awkward {
             bool check_parameters,
             bool check_form_key,
             bool compatibility_check) const override;
+
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   };
 
   /// @class EmptyArray

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -79,6 +79,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     Index::Form index_;
     const FormPtr content_;
@@ -145,6 +148,9 @@ namespace awkward {
             bool check_parameters,
             bool check_form_key,
             bool compatibility_check) const override;
+
+    const FormPtr
+      getitem_field(const std::string& key) const override;
 
   private:
     Index::Form index_;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -81,6 +81,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     Index::Form starts_;
     Index::Form stops_;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -77,6 +77,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     Index::Form offsets_;
     const FormPtr content_;

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -99,6 +99,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     const std::vector<int64_t> inner_shape_;
     int64_t itemsize_;

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -130,6 +130,13 @@ namespace awkward {
       throw std::runtime_error("FIXME: RawForm::equal");
     }
 
+    const FormPtr
+      getitem_field(const std::string& key) const override {
+      throw std::invalid_argument(std::string("key ") + util::quote(key, true)
+        + std::string(" does not exist (data are not records)"));
+    }
+
+
   private:
     const std::string T_;
   };

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -89,6 +89,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     const util::RecordLookupPtr recordlookup_;
     const std::vector<FormPtr> contents_;

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -76,6 +76,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     const FormPtr content_;
     int64_t size_;

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -89,6 +89,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     Index::Form tags_;
     Index::Form index_;

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -73,6 +73,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     const FormPtr content_;
   };

--- a/include/awkward/array/VirtualArray.h
+++ b/include/awkward/array/VirtualArray.h
@@ -225,9 +225,6 @@ namespace awkward {
     const ContentPtr
       carry(const Index64& carry, bool allow_lazy) const override;
 
-    const std::string
-      purelist_parameter(const std::string& key) const override;
-
     int64_t
       numfields() const override;
 

--- a/include/awkward/array/VirtualArray.h
+++ b/include/awkward/array/VirtualArray.h
@@ -81,6 +81,9 @@ namespace awkward {
             bool check_form_key,
             bool compatibility_check) const override;
 
+    const FormPtr
+      getitem_field(const std::string& key) const override;
+
   private:
     const FormPtr form_;
     bool has_length_;

--- a/include/awkward/virtual/ArrayGenerator.h
+++ b/include/awkward/virtual/ArrayGenerator.h
@@ -50,8 +50,10 @@ namespace awkward {
       generate() const = 0;
 
     /// @brief Creates an array and checks it against the #form.
+    /// If form was not available intially, no check is made and the form
+    /// inferred from the result is saved in case it is useful later
     const ContentPtr
-      generate_and_check() const;
+      generate_and_check();
 
     /// @brief Returns a string representation of this ArrayGenerator.
     virtual const std::string
@@ -75,6 +77,7 @@ namespace awkward {
 
   protected:
     const FormPtr form_;
+    FormPtr inferred_form_{nullptr};
     int64_t length_;
   };
 

--- a/src/awkward1/_connect/_numba/layout.py
+++ b/src/awkward1/_connect/_numba/layout.py
@@ -2302,6 +2302,9 @@ class VirtualArrayType(ContentType):
             elif isinstance(form, awkward1.forms.UnionForm):
                 raise TypeError("union types cannot be accessed in Numba")
 
+            elif isinstance(form, awkward1.forms.VirtualForm):
+                return getitem_at(form.form)
+
             else:
                 raise AssertionError("unrecognized Form type: {0}".format(type(form)))
 

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -2363,7 +2363,7 @@ def virtual(
         generating
         <Array [4.4, 5.5] type='2 * float64'>
     """
-    if form in (
+    if isinstance(form, str) and form in (
         "float64",
         "float32",
         "int64",

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -184,6 +184,11 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  BitMaskedForm::getitem_field(const std::string& key) const {
+    return content_.get()->getitem_field(key);
+  }
+
   ////////// BitMaskedArray
 
   BitMaskedArray::BitMaskedArray(const IdentitiesPtr& identities,

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -177,6 +177,11 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  ByteMaskedForm::getitem_field(const std::string& key) const {
+    return content_.get()->getitem_field(key);
+  }
+
   ////////// ByteMaskedArray
 
   ByteMaskedArray::ByteMaskedArray(const IdentitiesPtr& identities,

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -126,6 +126,13 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  EmptyForm::getitem_field(const std::string& key) const {
+    throw std::invalid_argument(
+      std::string("key ") + util::quote(key, true)
+      + std::string(" does not exist (data might not be records)"));
+  }
+
   ////////// EmptyArray
 
   EmptyArray::EmptyArray(const IdentitiesPtr& identities,

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -179,6 +179,11 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  IndexedForm::getitem_field(const std::string& key) const {
+    return content_.get()->getitem_field(key);
+  }
+
   ////////// IndexedOptionForm
 
   IndexedOptionForm::IndexedOptionForm(bool has_identities,
@@ -325,6 +330,11 @@ namespace awkward {
     else {
       return false;
     }
+  }
+
+  const FormPtr
+  IndexedOptionForm::getitem_field(const std::string& key) const {
+    return content_.get()->getitem_field(key);
   }
 
   ////////// IndexedArray

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -193,6 +193,11 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  ListForm::getitem_field(const std::string& key) const {
+    return content_.get()->getitem_field(key);
+  }
+
   ////////// ListArray
 
   template <typename T>

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -185,6 +185,11 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  ListOffsetForm::getitem_field(const std::string& key) const {
+    return content_.get()->getitem_field(key);
+  }
+
   ////////// ListOffsetArray
 
   template <typename T>

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -253,6 +253,13 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  NumpyForm::getitem_field(const std::string& key) const {
+    throw std::invalid_argument(
+      std::string("key ") + util::quote(key, true)
+      + std::string(" does not exist (data are not records)"));
+  }
+
   ////////// NumpyArray
 
   NumpyArray::NumpyArray(const IdentitiesPtr& identities,

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -298,6 +298,11 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  RecordForm::getitem_field(const std::string& key) const {
+    return content(key);
+  }
+
   ////////// RecordArray
 
   RecordArray::RecordArray(const IdentitiesPtr& identities,

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -170,6 +170,11 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  RegularForm::getitem_field(const std::string& key) const {
+    return content_.get()->getitem_field(key);
+  }
+
   ////////// RegularArray
 
   RegularArray::RegularArray(const IdentitiesPtr& identities,

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -291,6 +291,13 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  UnionForm::getitem_field(const std::string& key) const {
+    throw std::invalid_argument(
+      "UnionForm breaks the one-to-one relationship "
+      "between fieldindexes and keys");
+  }
+
   ////////// UnionArray
 
   template <>

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -152,6 +152,11 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  UnmaskedForm::getitem_field(const std::string& key) const {
+    return content_.get()->getitem_field(key);
+  }
+
   ////////// UnmaskedArray
 
   UnmaskedArray::UnmaskedArray(const IdentitiesPtr& identities,

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -80,8 +80,7 @@ namespace awkward {
     std::string out = parameter(key);
     if (out == std::string("null")) {
       if (form_.get() == nullptr) {
-        throw std::invalid_argument(
-            "VirtualForm cannot determine its type without an expected Form");
+        return out;
       }
       return form_.get()->purelist_parameter(key);
     }
@@ -580,11 +579,6 @@ namespace awkward {
                                           parameters_,
                                           generator,
                                           cache);
-  }
-
-  const std::string
-  VirtualArray::purelist_parameter(const std::string& key) const {
-    return form(true).get()->purelist_parameter(key);
   }
 
   int64_t

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -248,6 +248,17 @@ namespace awkward {
     }
   }
 
+  const FormPtr
+  VirtualForm::getitem_field(const std::string& key) const {
+    if (form_.get() == nullptr) {
+      throw std::invalid_argument(
+          "Cannot determine field without an expected Form");
+    }
+    else {
+      return form_.get()->getitem_field(key);
+    }
+  }
+
   ////////// VirtualArray
 
   VirtualArray::VirtualArray(const IdentitiesPtr& identities,
@@ -529,12 +540,16 @@ namespace awkward {
     Slice slice;
     slice.append(SliceField(key));
     slice.become_sealed();
-    FormPtr form(nullptr);
+    FormPtr sliceform(nullptr);
+    util::Parameters params;
+    if ( not has_virtual_form() ) {
+      params["__record__"] = form(false).get()->getitem_field(key)->purelist_parameter("__record__");
+    }
     ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
-                 form, generator_.get()->length(), shallow_copy(), slice);
+                 sliceform, generator_.get()->length(), shallow_copy(), slice);
     ArrayCachePtr cache(nullptr);
     return std::make_shared<VirtualArray>(Identities::none(),
-                                          util::Parameters(),
+                                          params,
                                           generator,
                                           cache);
   }
@@ -549,12 +564,14 @@ namespace awkward {
     Slice slice;
     slice.append(SliceFields(keys));
     slice.become_sealed();
+    util::Parameters params;
+    params["__record__"] = purelist_parameter("__record__");
     FormPtr form(nullptr);
     ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
                  form, generator_.get()->length(), shallow_copy(), slice);
     ArrayCachePtr cache(nullptr);
     return std::make_shared<VirtualArray>(Identities::none(),
-                                          util::Parameters(),
+                                          params,
                                           generator,
                                           cache);
   }

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -77,7 +77,17 @@ namespace awkward {
 
   const std::string
   VirtualForm::purelist_parameter(const std::string& key) const {
-    return parameter(key);
+    std::string out = parameter(key);
+    if (out == std::string("null")) {
+      if (form_.get() == nullptr) {
+        throw std::invalid_argument(
+            "VirtualForm cannot determine its type without an expected Form");
+      }
+      return form_.get()->purelist_parameter(key);
+    }
+    else {
+      return out;
+    }
   }
 
   bool
@@ -574,7 +584,7 @@ namespace awkward {
 
   const std::string
   VirtualArray::purelist_parameter(const std::string& key) const {
-    return parameter(key);
+    return form(true).get()->purelist_parameter(key);
   }
 
   int64_t

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -542,8 +542,13 @@ namespace awkward {
     slice.become_sealed();
     FormPtr sliceform(nullptr);
     util::Parameters params;
-    if ( ! has_virtual_form() ) {
-      params["__record__"] = form(false).get()->getitem_field(key)->purelist_parameter("__record__");
+    if (!has_virtual_form()) {
+      std::string record =
+          form(false).get()->getitem_field(key)->purelist_parameter(
+              "__record__");
+      if (record != std::string("null")) {
+        params["__record__"] = record;
+      }
     }
     ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
                  sliceform, generator_.get()->length(), shallow_copy(), slice);
@@ -564,14 +569,12 @@ namespace awkward {
     Slice slice;
     slice.append(SliceFields(keys));
     slice.become_sealed();
-    util::Parameters params;
-    params["__record__"] = purelist_parameter("__record__");
     FormPtr form(nullptr);
     ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
                  form, generator_.get()->length(), shallow_copy(), slice);
     ArrayCachePtr cache(nullptr);
     return std::make_shared<VirtualArray>(Identities::none(),
-                                          params,
+                                          util::Parameters(),
                                           generator,
                                           cache);
   }
@@ -592,8 +595,13 @@ namespace awkward {
     ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
                  form, carry.length(), shallow_copy(), slice);
     ArrayCachePtr cache(nullptr);
+    util::Parameters params(parameters_);
+    std::string record = purelist_parameter("__record__");
+    if (record != std::string("null")) {
+      params["__record__"] = record;
+    }
     return std::make_shared<VirtualArray>(Identities::none(),
-                                          parameters_,
+                                          params,
                                           generator,
                                           cache);
   }
@@ -785,9 +793,14 @@ namespace awkward {
           FormPtr form(nullptr);
           ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
                      form, length, shallow_copy(), where);
+          util::Parameters params;
+          std::string record = purelist_parameter("__record__");
+          if (record != std::string("null")) {
+            params["__record__"] = record;
+          }
           ArrayCachePtr cache(nullptr);
           return std::make_shared<VirtualArray>(Identities::none(),
-                                                util::Parameters(),
+                                                params,
                                                 generator,
                                                 cache);
         }
@@ -801,9 +814,14 @@ namespace awkward {
         FormPtr form(nullptr);
         ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
                      form, generator_.get()->length(), shallow_copy(), where);
+        util::Parameters params;
+        std::string record = purelist_parameter("__record__");
+        if (record != std::string("null")) {
+          params["__record__"] = record;
+        }
         ArrayCachePtr cache(nullptr);
         return std::make_shared<VirtualArray>(Identities::none(),
-                                              util::Parameters(),
+                                              params,
                                               generator,
                                               cache);
       }
@@ -813,9 +831,14 @@ namespace awkward {
         FormPtr form(nullptr);
         ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
                      form, 1, shallow_copy(), where);
+        util::Parameters params;
+        std::string record = purelist_parameter("__record__");
+        if (record != std::string("null")) {
+          params["__record__"] = record;
+        }
         ArrayCachePtr cache(nullptr);
         return std::make_shared<VirtualArray>(Identities::none(),
-                                              util::Parameters(),
+                                              params,
                                               generator,
                                               cache);
       }
@@ -825,9 +848,14 @@ namespace awkward {
         FormPtr form(nullptr);
         ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(
                      form, slicearray->length(), shallow_copy(), where);
+        util::Parameters params;
+        std::string record = purelist_parameter("__record__");
+        if (record != std::string("null")) {
+          params["__record__"] = record;
+        }
         ArrayCachePtr cache(nullptr);
         return std::make_shared<VirtualArray>(Identities::none(),
-                                              util::Parameters(),
+                                              params,
                                               generator,
                                               cache);
       }

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -542,7 +542,7 @@ namespace awkward {
     slice.become_sealed();
     FormPtr sliceform(nullptr);
     util::Parameters params;
-    if ( not has_virtual_form() ) {
+    if ( ! has_virtual_form() ) {
       params["__record__"] = form(false).get()->getitem_field(key)->purelist_parameter("__record__");
     }
     ArrayGeneratorPtr generator = std::make_shared<SliceGenerator>(

--- a/src/libawkward/virtual/ArrayGenerator.cpp
+++ b/src/libawkward/virtual/ArrayGenerator.cpp
@@ -15,6 +15,9 @@ namespace awkward {
 
   const FormPtr
   ArrayGenerator::form() const {
+    if ( form_.get() == nullptr && inferred_form_.get() != nullptr ) {
+      return inferred_form_;
+    }
     return form_;
   }
 
@@ -24,7 +27,7 @@ namespace awkward {
   }
 
   const ContentPtr
-  ArrayGenerator::generate_and_check() const {
+  ArrayGenerator::generate_and_check() {
     ContentPtr out = generate();
     if (length_ >= 0  &&  length_ > out.get()->length()) {
       throw std::invalid_argument(
@@ -39,6 +42,9 @@ namespace awkward {
           std::string("generated array does not conform to expected form:\n\n")
           + form_.get()->tostring() + std::string("\n\nbut generated:\n\n")
           + out.get()->form(true).get()->tostring());
+    }
+    if (form_.get() == nullptr) {
+      inferred_form_ = out.get()->form(true);
     }
     return out;
   }

--- a/src/python/virtual.cpp
+++ b/src/python/virtual.cpp
@@ -196,7 +196,7 @@ make_PyArrayGenerator(const py::handle& m, const std::string& name) {
           return py::cast(length);
         }
       })
-      .def("__call__", [](const PyArrayGenerator& self) -> py::object {
+      .def("__call__", [](PyArrayGenerator& self) -> py::object {
         return box(self.generate_and_check());
       })
       .def("__repr__", [](const PyArrayGenerator& self) -> std::string {
@@ -290,7 +290,7 @@ make_SliceGenerator(const py::handle& m, const std::string& name) {
         }
       })
       .def_property_readonly("content", &ak::SliceGenerator::content)
-      .def("__call__", [](const ak::SliceGenerator& self) -> py::object {
+      .def("__call__", [](ak::SliceGenerator& self) -> py::object {
         return box(self.generate_and_check());
       })
       .def("__repr__", [](const ak::SliceGenerator& self) -> std::string {

--- a/tests/test_0274-access-ArrayGenerator-in-Python.py
+++ b/tests/test_0274-access-ArrayGenerator-in-Python.py
@@ -13,27 +13,31 @@ import awkward1
 def test():
     content = awkward1.Array([1, 2, 3, 4, 5])
     generator1 = awkward1.layout.ArrayGenerator(lambda a, b: a*content + b, (100,), {"b": 3})
+    assert generator1.form is None
     assert awkward1.to_list(generator1()) == [103, 203, 303, 403, 503]
     assert generator1.args == (100,)
     assert generator1.kwargs == {"b": 3}
-    assert generator1.form is None
+    assert generator1.form is not None
     assert generator1.length is None
 
     generator2 = generator1.with_args((1000,))
+    assert generator2.form is None
     assert awkward1.to_list(generator2()) == [1003, 2003, 3003, 4003, 5003]
     assert generator2.args == (1000,)
     assert generator2.kwargs == {"b": 3}
-    assert generator2.form is None
+    assert generator2.form is not None
     assert generator2.length is None
 
     generator3 = generator1.with_kwargs({"b": 4})
+    assert generator3.form is None
     assert awkward1.to_list(generator3()) == [104, 204, 304, 404, 504]
     assert generator3.args == (100,)
     assert generator3.kwargs == {"b": 4}
-    assert generator3.form is None
+    assert generator3.form is not None
     assert generator3.length is None
 
     generator4 = generator1.with_form(awkward1.forms.Form.fromjson('"int64"'))
+    assert generator4.form is not None
     assert awkward1.to_list(generator4()) == [103, 203, 303, 403, 503]
     assert generator4.args == (100,)
     assert generator4.kwargs == {"b": 3}
@@ -41,8 +45,9 @@ def test():
     assert generator4.length is None
 
     generator5 = generator1.with_length(5)
+    assert generator5.form is None
     assert awkward1.to_list(generator5()) == [103, 203, 303, 403, 503]
     assert generator5.args == (100,)
     assert generator5.kwargs == {"b": 3}
-    assert generator5.form is None
+    assert generator5.form is not None
     assert generator5.length == 5

--- a/tests/test_0390-virtual-forms.py
+++ b/tests/test_0390-virtual-forms.py
@@ -3,74 +3,74 @@
 from __future__ import absolute_import
 from collections import defaultdict
 
+import pytest
 import awkward1
-import numba
 
 
-def test_virtual_slicearray_numba():
+def test_virtual_record():
     materialize_count = defaultdict(int)
 
     def gen(x, name):
         materialize_count[name] += 1
         return x
 
-    array = awkward1.Array([1, 2, 3, 4, 5])
-    virtual = awkward1.virtual(lambda: gen(array, "array"), length=len(array), form=array.layout.form)
-    slicearray = awkward1.Array([True, False, False, True, False])
-    slicedvirtual = virtual[slicearray]
-
-    @numba.njit
-    def dostuff(array):
-        x = 0
-        for item in array:
-            x += item
-        return x
-
-    assert slicedvirtual.layout.form.form is None
-    assert materialize_count["array"] == 0
-    assert dostuff(slicedvirtual) == 5
-    assert materialize_count["array"] == 2
-    materialize_count.clear()
-
-    x = awkward1.Array([1, 2, 3, 4, 5])
-    y = x * 10.
+    x1 = awkward1.Array([1, 2, 3, 4, 5])
+    x2 = awkward1.Array([1, 2, 3, 4, 5])
+    x = awkward1.zip({"x1": x1, "x2": x2}, with_name="xthing")
+    assert x.layout.purelist_parameter("__record__") == "xthing"
     xv = awkward1.virtual(lambda: gen(x, "x"), length=len(x), form=x.layout.form)
+    assert xv.layout.purelist_parameter("__record__") == "xthing"
+    y = x1 * 10.
     yv = awkward1.virtual(lambda: gen(y, "y"), length=len(y), form=y.layout.form)
-    array = awkward1.zip({"x": xv, "y": yv})
+    array = awkward1.zip({"x": xv, "y": yv}, with_name="Point", depth_limit=1)
+    assert array.layout.purelist_parameter("__record__") == "Point"
     virtual = awkward1.virtual(lambda: gen(array, "array"), length=len(array), form=array.layout.form)
-    slicedvirtual = virtual[slicearray]
+    assert virtual.layout.purelist_parameter("__record__") == "Point"
+    assert len(materialize_count) == 0
 
-    @numba.njit
-    def dostuff(array):
-        x = 0
-        for item in array:
-            x += item.x
-        return x
-
-    assert materialize_count["x"] == 0
-    assert materialize_count["y"] == 0
-    assert materialize_count["array"] == 0
-    assert dostuff(slicedvirtual) == 5
-    assert materialize_count["x"] == 1
-    assert materialize_count["y"] == 0
-    assert materialize_count["array"] == 2
-    materialize_count.clear()
-
-
-def test_virtual_slicefield_numba():
-    materialize_count = defaultdict(int)
-
-    def gen(x, name):
-        materialize_count[name] += 1
-        return x
-
-    x = awkward1.Array([1, 2, 3, 4, 5])
-    y = x * 10.
-    xv = awkward1.virtual(lambda: gen(x, "x"), length=len(x), form=x.layout.form)
-    yv = awkward1.virtual(lambda: gen(y, "y"), length=len(y), form=y.layout.form)
-    array = awkward1.zip({"x": xv, "y": yv})
-    virtual = awkward1.virtual(lambda: gen(array, "array"), length=len(array), form=array.layout.form)
     slicedvirtual = virtual.x
+    assert len(materialize_count) == 0
+    assert slicedvirtual.layout.purelist_parameter("__record__") == "xthing"
+    assert len(materialize_count) == 0
+
+    slicedvirtual = virtual[["x", "y"]]
+    assert len(materialize_count) == 0
+    assert slicedvirtual.layout.purelist_parameter("__record__") == None
+    assert len(materialize_count) == 0
+
+    slicedvirtual = virtual[::2]
+    assert len(materialize_count) == 0
+    assert slicedvirtual.layout.purelist_parameter("__record__") == "Point"
+    assert len(materialize_count) == 0
+
+    slicedvirtual = virtual[:3]
+    assert len(materialize_count) == 0
+    assert slicedvirtual.layout.purelist_parameter("__record__") == "Point"
+    assert len(materialize_count) == 0
+
+    slicedvirtual = virtual[awkward1.Array([True, False, False, True, False])]
+    assert len(materialize_count) == 0
+    assert slicedvirtual.layout.purelist_parameter("__record__") == "Point"
+    assert len(materialize_count) == 0
+
+
+def test_virtual_slice_numba():
+    numba = pytest.importorskip("numba")
+    materialize_count = defaultdict(int)
+
+    def gen(x, name):
+        materialize_count[name] += 1
+        return x
+
+    x1 = awkward1.Array([1, 2, 3, 4, 5])
+    x2 = awkward1.Array([1, 2, 3, 4, 5])
+    x = awkward1.zip({"x1": x1, "x2": x2}, with_name="xthing")
+    xv = awkward1.virtual(lambda: gen(x, "x"), length=len(x), form=x.layout.form)
+    y = x1 * 10.
+    yv = awkward1.virtual(lambda: gen(y, "y"), length=len(y), form=y.layout.form)
+    array = awkward1.zip({"x": xv, "y": yv}, with_name="Point", depth_limit=1)
+    virtual = awkward1.virtual(lambda: gen(array, "array"), length=len(array), form=array.layout.form)
+
 
     @numba.njit
     def dostuff(array):
@@ -79,10 +79,30 @@ def test_virtual_slicefield_numba():
             x += item
         return x
 
-    assert materialize_count["x"] == 0
-    assert materialize_count["y"] == 0
-    assert materialize_count["array"] == 0
-    assert dostuff(slicedvirtual) == 15
-    assert materialize_count["x"] == 1
-    assert materialize_count["y"] == 0
-    assert materialize_count["array"] == 2
+    assert dostuff(virtual.x.x1) == 15
+    assert dict(materialize_count) == {"x": 3, "array": 3}
+    materialize_count.clear()
+
+    @numba.njit
+    def dostuff(array):
+        x = 0
+        for item in array:
+            x += item.x.x1
+        return x
+
+    assert dostuff(virtual[["x"]]) == 15
+    assert dict(materialize_count) == {"x": 1, "array": 2}
+    materialize_count.clear()
+
+    assert dostuff(virtual[::2]) == 9
+    assert dict(materialize_count) == {"x": 1, "array": 2}
+    materialize_count.clear()
+
+    assert dostuff(virtual[:3]) == 6
+    assert dict(materialize_count) == {"x": 1, "array": 1}
+    materialize_count.clear()
+
+    slicedvirtual = virtual[awkward1.Array([True, False, False, True, False])]
+    assert dostuff(slicedvirtual) == 5
+    assert dict(materialize_count) == {"x": 1, "array": 2}
+    materialize_count.clear()

--- a/tests/test_0390-virtual-forms.py
+++ b/tests/test_0390-virtual-forms.py
@@ -1,0 +1,88 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+from collections import defaultdict
+
+import awkward1
+import numba
+
+
+def test_virtual_slicearray_numba():
+    materialize_count = defaultdict(int)
+
+    def gen(x, name):
+        materialize_count[name] += 1
+        return x
+
+    array = awkward1.Array([1, 2, 3, 4, 5])
+    virtual = awkward1.virtual(lambda: gen(array, "array"), length=len(array), form=array.layout.form)
+    slicearray = awkward1.Array([True, False, False, True, False])
+    slicedvirtual = virtual[slicearray]
+
+    @numba.njit
+    def dostuff(array):
+        x = 0
+        for item in array:
+            x += item
+        return x
+
+    assert slicedvirtual.layout.form.form is None
+    assert materialize_count["array"] == 0
+    assert dostuff(slicedvirtual) == 5
+    assert materialize_count["array"] == 2
+    materialize_count.clear()
+
+    x = awkward1.Array([1, 2, 3, 4, 5])
+    y = x * 10.
+    xv = awkward1.virtual(lambda: gen(x, "x"), length=len(x), form=x.layout.form)
+    yv = awkward1.virtual(lambda: gen(y, "y"), length=len(y), form=y.layout.form)
+    array = awkward1.zip({"x": xv, "y": yv})
+    virtual = awkward1.virtual(lambda: gen(array, "array"), length=len(array), form=array.layout.form)
+    slicedvirtual = virtual[slicearray]
+
+    @numba.njit
+    def dostuff(array):
+        x = 0
+        for item in array:
+            x += item.x
+        return x
+
+    assert materialize_count["x"] == 0
+    assert materialize_count["y"] == 0
+    assert materialize_count["array"] == 0
+    assert dostuff(slicedvirtual) == 5
+    assert materialize_count["x"] == 1
+    assert materialize_count["y"] == 0
+    assert materialize_count["array"] == 2
+    materialize_count.clear()
+
+
+def test_virtual_slicefield_numba():
+    materialize_count = defaultdict(int)
+
+    def gen(x, name):
+        materialize_count[name] += 1
+        return x
+
+    x = awkward1.Array([1, 2, 3, 4, 5])
+    y = x * 10.
+    xv = awkward1.virtual(lambda: gen(x, "x"), length=len(x), form=x.layout.form)
+    yv = awkward1.virtual(lambda: gen(y, "y"), length=len(y), form=y.layout.form)
+    array = awkward1.zip({"x": xv, "y": yv})
+    virtual = awkward1.virtual(lambda: gen(array, "array"), length=len(array), form=array.layout.form)
+    slicedvirtual = virtual.x
+
+    @numba.njit
+    def dostuff(array):
+        x = 0
+        for item in array:
+            x += item
+        return x
+
+    assert materialize_count["x"] == 0
+    assert materialize_count["y"] == 0
+    assert materialize_count["array"] == 0
+    assert dostuff(slicedvirtual) == 15
+    assert materialize_count["x"] == 1
+    assert materialize_count["y"] == 0
+    assert materialize_count["array"] == 2


### PR DESCRIPTION
Sliced virtual arrays could have a form if the original virtual array does, but this requires duplicating the entire getitem logic in parallel for Form classes. This is a big task, which can be put off. However, we need at least to be able to find `purelist_parameter("__record__")` to properly type the highlevel virtual arrays, so this implements just enough Form traversal to always be able to extract the `__record__` type.

In parallel (probably should have been a separate PR) numba needs a Form to type sliced VirtualArrays. Since they are materialized on entry into the numba function, we can cache the Form in ArrayGenerator when it was not previously available.