### PR TITLE
Fixes #395: IndexedArray was updating both the ArrayView viewport and 'nextat'; only one is allowed.

### DIFF
--- a/src/awkward1/_connect/_numba/layout.py
+++ b/src/awkward1/_connect/_numba/layout.py
@@ -935,12 +935,12 @@ class IndexedArrayType(ContentType):
         )
         proxynext = context.make_helper(builder, nextviewtype)
         proxynext.pos = nextpos
-        proxynext.start = viewproxy.start
+        proxynext.start = context.get_constant(numba.intp, 0)
         proxynext.stop = builder.add(
             awkward1._connect._numba.castint(
                 context, builder, self.indextype.dtype, numba.intp, nextat
             ),
-            builder.add(viewproxy.start, context.get_constant(numba.intp, 1)),
+            context.get_constant(numba.intp, 1),
         )
         proxynext.arrayptrs = viewproxy.arrayptrs
         proxynext.sharedptrs = viewproxy.sharedptrs

--- a/tests/test_0395-fix-numba-indexedarray.py
+++ b/tests/test_0395-fix-numba-indexedarray.py
@@ -23,6 +23,54 @@ def test():
                 break
         return out
 
+    numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))
+    indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)
+    listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 1, 4])), indexedarray)
+    array = awkward1.Array(listoffsetarray)
+
+    assert reproduce(array).tolist() == [150, 140]
+    assert numba.njit(reproduce)(array).tolist() == [150, 140]
+
+    numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))
+    indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)
+    listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 2, 4])), indexedarray)
+    array = awkward1.Array(listoffsetarray)
+
+    assert reproduce(array).tolist() == [150, 130]
+    assert numba.njit(reproduce)(array).tolist() == [150, 130]
+
+    numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))
+    indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)[2:]
+    listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 1, 4])), indexedarray)
+    array = awkward1.Array(listoffsetarray)
+
+    assert reproduce(array).tolist() == [130, 120]
+    assert numba.njit(reproduce)(array).tolist() == [130, 120]
+
+    numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))
+    indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)[2:]
+    listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 2, 4])), indexedarray)
+    array = awkward1.Array(listoffsetarray)
+
+    assert reproduce(array).tolist() == [130, 110]
+    assert numba.njit(reproduce)(array).tolist() == [130, 110]
+
+    numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))[3:]
+    indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)
+    listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 1, 4])), indexedarray)
+    array = awkward1.Array(listoffsetarray)
+
+    assert reproduce(array).tolist() == [180, 170]
+    assert numba.njit(reproduce)(array).tolist() == [180, 170]
+
+    numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))[3:]
+    indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)
+    listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 2, 4])), indexedarray)
+    array = awkward1.Array(listoffsetarray)
+
+    assert reproduce(array).tolist() == [180, 160]
+    assert numba.njit(reproduce)(array).tolist() == [180, 160]
+
     numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))[3:]
     indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)[2:]
     listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 1, 4])), indexedarray)

--- a/tests/test_0395-fix-numba-indexedarray.py
+++ b/tests/test_0395-fix-numba-indexedarray.py
@@ -1,0 +1,40 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+
+import pytest
+
+import numpy
+import awkward1
+
+numba = pytest.importorskip("numba")
+
+
+def test():
+    def reproduce(arrays):
+        out = numpy.zeros(len(arrays), numpy.int64)
+        i = 0
+        for values in arrays:
+            for p in values:
+                out[i] = p
+                i += 1
+                break
+        return out
+
+    numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))[3:]
+    indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)[2:]
+    listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 1, 4])), indexedarray)
+    array = awkward1.Array(listoffsetarray)
+
+    assert reproduce(array).tolist() == [160, 150]
+    assert numba.njit(reproduce)(array).tolist() == [160, 150]
+
+    numpyarray = awkward1.layout.NumpyArray(numpy.arange(100, 200, 10))[3:]
+    indexedarray = awkward1.layout.IndexedArray64(awkward1.layout.Index64(numpy.array([5, 4, 3, 2, 1, 0])), numpyarray)[2:]
+    listoffsetarray = awkward1.layout.ListOffsetArray64(awkward1.layout.Index64(numpy.array([0, 2, 4])), indexedarray)
+    array = awkward1.Array(listoffsetarray)
+
+    assert reproduce(array).tolist() == [160, 140]
+    assert numba.njit(reproduce)(array).tolist() == [160, 140]


### PR DESCRIPTION
This managed to escape earlier Numba IndexedArray tests because it's only invoked when there's an index and a viewport that doesn't start at `0`, such as an IndexedArray inside of a ListOffsetArray. The new test tests this and also non-zero offsets.