### PR TITLE
All exceptions should report their version, file, and line number as GitHub links.

### DIFF
--- a/cuda-build.sh
+++ b/cuda-build.sh
@@ -6,7 +6,7 @@ set -e
 PLATFORM="manylinux2014_x86_64"
 CUDA_VERSION=9.0
 
-AWKWARD_VERSION=`cat VERSION_INFO`
+AWKWARD_VERSION=`cat VERSION_INFO | tr -d '[:space:]'`
 
 if [[ "$CUDA_VERSION" == "11.0" ]]; then
     export DOCKER_IMAGE_TAG="11.0-devel-ubuntu18.04"
@@ -38,7 +38,7 @@ echo "cuda_version ='"$CUDA_VERSION"'" >> build/awkward1_cuda_kernels/__init__.p
 echo "docker_image ='docker.io/nvidia/cuda:"$DOCKER_IMAGE_TAG"'" >> build/awkward1_cuda_kernels/__init__.py
 
 export DOCKER_ARGS="-v`pwd`:/home -w/home docker.io/nvidia/cuda:"$DOCKER_IMAGE_TAG
-export BUILD_SHARED_LIBRARY="nvcc -std=c++11 -Xcompiler -fPIC -Iinclude src/cuda-kernels/*.cu --shared -o build/awkward1_cuda_kernels/libawkward-cuda-kernels.so"
+export BUILD_SHARED_LIBRARY="nvcc -std=c++11 -Xcompiler -fPIC -Xcompiler -DVERSION_INFO="$AWKWARD_VERSION" -Iinclude src/cuda-kernels/*.cu --shared -o build/awkward1_cuda_kernels/libawkward-cuda-kernels.so"
 
 docker run $DOCKER_ARGS $BUILD_SHARED_LIBRARY
 

--- a/dev/generate-kernelspec.py
+++ b/dev/generate-kernelspec.py
@@ -319,6 +319,8 @@ def preprocess(filename, skip_implementation=False):
                                 line = line.replace(x, "float")
                             elif "awkward_" in line and "(" in line:
                                 line = "int".join(line.rsplit(x, 1))
+                            elif "FILENAME(__LINE__)" in line:
+                                pass
                             else:
                                 line = line.replace(x, "int")
             if func is True and (

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("include/awkward/array/RawArray.h", line)
+
 #ifndef AWKWARD_RAWARRAY_H_
 #define AWKWARD_RAWARRAY_H_
 
@@ -52,12 +54,14 @@ namespace awkward {
 
     const TypePtr
       type(const util::TypeStrs& typestrs) const override {
-      throw std::runtime_error("RawForm::type");
+      throw std::runtime_error(
+        std::string("RawForm::type") + FILENAME(__LINE__));
     }
 
     void
       tojson_part(ToJson& builder, bool verbose) const override {
-      throw std::runtime_error("RawForm::tojson_part");
+      throw std::runtime_error(
+        std::string("RawForm::tojson_part") + FILENAME(__LINE__));
     }
 
     const FormPtr
@@ -101,14 +105,14 @@ namespace awkward {
     int64_t
       fieldindex(const std::string& key) const override {
       throw std::invalid_argument(std::string("key ") + util::quote(key, true)
-        + std::string(" does not exist (data are not records)"));
+        + std::string(" does not exist (data are not records)") + FILENAME(__LINE__));
     }
 
     const std::string
       key(int64_t fieldindex) const override {
       throw std::invalid_argument(std::string("fieldindex \"")
         + std::to_string(fieldindex)
-        + std::string("\" does not exist (data are not records)"));
+        + std::string("\" does not exist (data are not records)") + FILENAME(__LINE__));
     }
 
     bool
@@ -127,7 +131,8 @@ namespace awkward {
             bool check_parameters,
             bool check_form_key,
             bool compatibility_check) const override {
-      throw std::runtime_error("FIXME: RawForm::equal");
+      throw std::runtime_error(
+        std::string("FIXME: RawForm::equal") + FILENAME(__LINE__));
     }
 
   private:
@@ -206,7 +211,8 @@ namespace awkward {
         , length_(length)
         , itemsize_(itemsize) {
       if (sizeof(T) != itemsize) {
-        throw std::invalid_argument("sizeof(T) != itemsize");
+        throw std::invalid_argument(
+          std::string("sizeof(T) != itemsize") + FILENAME(__LINE__));
       }
     }
 
@@ -358,7 +364,8 @@ namespace awkward {
       if (identities.get() != nullptr  &&
           length() != identities.get()->length()) {
         throw std::invalid_argument(
-          "content and its identities must have the same length");
+          std::string("content and its identities must have the same length")
+          + FILENAME(__LINE__));
       }
       identities_ = identities;
     }
@@ -410,8 +417,10 @@ namespace awkward {
           util::gettypestr(parameters_, typestrs), util::dtype::boolean);
       }
       else {
-        throw std::invalid_argument(std::string("RawArrayOf<") +
-          typeid(T).name() + std::string("> does not have a known type"));
+        throw std::invalid_argument(
+          std::string("RawArrayOf<") + typeid(T).name()
+          + std::string("> does not have a known type")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -544,8 +553,9 @@ namespace awkward {
                        length());
       }
       else {
-        throw std::invalid_argument(std::string("cannot convert RawArrayOf<")
-          + typeid(T).name() + std::string("> into JSON"));
+        throw std::invalid_argument(
+          std::string("cannot convert RawArrayOf<") + typeid(T).name()
+          + std::string("> into JSON") + FILENAME(__LINE__));
       }
     }
 
@@ -660,14 +670,16 @@ namespace awkward {
 
     const ContentPtr
       getitem_field(const std::string& key) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname()
-        + std::string(" by field name"));
+      throw std::invalid_argument(
+        std::string("cannot slice ") + classname() + std::string(" by field name")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
       getitem_fields(const std::vector<std::string>& keys) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname()
-        + std::string(" by field names"));
+      throw std::invalid_argument(
+        std::string("cannot slice ") + classname() + std::string(" by field names")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
@@ -683,7 +695,8 @@ namespace awkward {
                    const Slice& tail,
                    const Index64& advanced) const override {
       if (tail.length() != 0) {
-        throw std::invalid_argument("too many indexes for array");
+        throw std::invalid_argument(
+          std::string("too many indexes for array") + FILENAME(__LINE__));
       }
       return Content::getitem_next(head, tail, advanced);
     }
@@ -724,15 +737,19 @@ namespace awkward {
 
     int64_t
       fieldindex(const std::string& key) const override {
-      throw std::invalid_argument(std::string("key ") + util::quote(key, true)
-        + std::string(" does not exist (data are not records)"));
+      throw std::invalid_argument(
+        std::string("key ") + util::quote(key, true)
+        + std::string(" does not exist (data are not records)")
+        + FILENAME(__LINE__));
     }
 
     const std::string
       key(int64_t fieldindex) const override {
-      throw std::invalid_argument(std::string("fieldindex \"")
+      throw std::invalid_argument(
+        std::string("fieldindex \"")
         + std::to_string(fieldindex)
-        + std::string("\" does not exist (data are not records)"));
+        + std::string("\" does not exist (data are not records)")
+        + FILENAME(__LINE__));
     }
 
     bool
@@ -773,7 +790,8 @@ namespace awkward {
                                                      sizeof(int64_t));
       }
       else {
-        throw std::invalid_argument("'axis' out of range for 'num'");
+        throw std::invalid_argument(
+          std::string("'axis' out of range for 'num'") + FILENAME(__LINE__));
       }
     }
 
@@ -781,10 +799,12 @@ namespace awkward {
       offsets_and_flattened(int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis == depth) {
-        throw std::invalid_argument("axis=0 not allowed for flatten");
+        throw std::invalid_argument(
+          std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
       }
       else {
-        throw std::invalid_argument("axis out of range for flatten");
+        throw std::invalid_argument(
+          std::string("axis out of range for flatten") + FILENAME(__LINE__));
       }
     }
 
@@ -896,14 +916,17 @@ namespace awkward {
                                                itemsize_);
       }
       else {
-        throw std::invalid_argument(std::string("cannot merge ") + classname()
-          + std::string(" with ") + other.get()->classname());
+        throw std::invalid_argument(
+          std::string("cannot merge ") + classname() + std::string(" with ")
+          + other.get()->classname() + FILENAME(__LINE__));
       }
     }
 
     const SliceItemPtr
       asslice() const override {
-      throw std::invalid_argument("cannot use RawArray as a slice");
+      throw std::invalid_argument(
+        std::string("cannot use RawArray as a slice")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
@@ -915,7 +938,9 @@ namespace awkward {
       rpad(int64_t target, int64_t axis, int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis != depth) {
-        throw std::invalid_argument("axis exceeds the depth of this array");
+        throw std::invalid_argument(
+          std::string("axis exceeds the depth of this array")
+          + FILENAME(__LINE__));
       }
       if (target < length()) {
         return shallow_copy();
@@ -931,7 +956,9 @@ namespace awkward {
                     int64_t depth) const override {
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis != depth) {
-        throw std::invalid_argument("axis exceeds the depth of this array");
+        throw std::invalid_argument(
+          std::string("axis exceeds the depth of this array")
+          + FILENAME(__LINE__));
       }
       Index64 index(target);
       struct Error err = kernel::index_rpad_and_clip_axis0_64(
@@ -955,7 +982,9 @@ namespace awkward {
                   int64_t outlength,
                   bool mask,
                   bool keepdims) const override {
-      throw std::runtime_error("FIXME: RawArray:reduce_next");
+      throw std::runtime_error(
+        std::string("FIXME: RawArray:reduce_next")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
@@ -1050,7 +1079,9 @@ namespace awkward {
         return localindex_axis0();
       }
       else {
-        throw std::invalid_argument("'axis' out of range for localindex");
+        throw std::invalid_argument(
+          std::string("'axis' out of range for localindex")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1062,14 +1093,18 @@ namespace awkward {
                    int64_t axis,
                    int64_t depth) const override {
       if (n < 1) {
-        throw std::invalid_argument("in combinations, 'n' must be at least 1");
+        throw std::invalid_argument(
+          std::string("in combinations, 'n' must be at least 1")
+          + FILENAME(__LINE__));
       }
       int64_t toaxis = axis_wrap_if_negative(axis);
       if (toaxis == depth) {
         return combinations_axis0(n, replacement, recordlookup, parameters);
       }
       else {
-        throw std::invalid_argument("'axis' out of range for combinations");
+        throw std::invalid_argument(
+          std::string("'axis' out of range for combinations")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1095,7 +1130,8 @@ namespace awkward {
           step = 1;
         }
         else if (step == 0) {
-          throw std::invalid_argument("slice step must not be 0");
+          throw std::invalid_argument(
+            std::string("slice step must not be 0") + FILENAME(__LINE__));
         }
         kernel::regularize_rangeslice(&start, &stop, step > 0,
           range.hasstart(), range.hasstop(), length_);
@@ -1122,10 +1158,12 @@ namespace awkward {
                    const Index64& advanced) const override {
       if (advanced.length() != 0) {
         throw std::runtime_error(
-          "RawArray::getitem_next(SliceAt): advanced.length() != 0");
+          std::string("RawArray::getitem_next(SliceAt): advanced.length() != 0")
+          + FILENAME(__LINE__));
       }
       if (array.shape().size() != 1) {
-        throw std::runtime_error("array.ndim != 1");
+        throw std::runtime_error(
+          std::string("array.ndim != 1") + FILENAME(__LINE__));
       }
       Index64 flathead = array.ravel();
       struct Error err = kernel::regularize_arrayslice_64(
@@ -1141,24 +1179,30 @@ namespace awkward {
       getitem_next(const SliceField& field,
                    const Slice& tail,
                    const Index64& advanced) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname()
-        + std::string(" by a field name because it has no fields"));
+      throw std::invalid_argument(
+        std::string("cannot slice ") + classname()
+        + std::string(" by a field name because it has no fields")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
       getitem_next(const SliceFields& fields,
                    const Slice& tail,
                    const Index64& advanced) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname()
-        + std::string(" by field names because it has no fields"));
+      throw std::invalid_argument(
+        std::string("cannot slice ") + classname()
+        + std::string(" by field names because it has no fields")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
       getitem_next(const SliceJagged64& jagged,
                    const Slice& tail,
                    const Index64& advanced) const override {
-      throw std::invalid_argument(std::string("cannot slice ") + classname()
-        + std::string(" by a jagged array because it is one-dimensional"));
+      throw std::invalid_argument(
+        std::string("cannot slice ") + classname()
+        + std::string(" by a jagged array because it is one-dimensional")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
@@ -1167,7 +1211,8 @@ namespace awkward {
                           const SliceArray64& slicecontent,
                           const Slice& tail) const override {
       throw std::runtime_error(
-        "undefined operation: RawArray::getitem_next_jagged(array)");
+        std::string("undefined operation: RawArray::getitem_next_jagged(array)")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
@@ -1176,7 +1221,8 @@ namespace awkward {
                           const SliceMissing64& slicecontent,
                           const Slice& tail) const override {
       throw std::runtime_error(
-        "undefined operation: RawArray::getitem_next_jagged(missing)");
+        std::string("undefined operation: RawArray::getitem_next_jagged(missing)")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
@@ -1185,7 +1231,8 @@ namespace awkward {
                           const SliceJagged64& slicecontent,
                           const Slice& tail) const override {
       throw std::runtime_error(
-        "undefined operation: RawArray::getitem_next_jagged(jagged)");
+        std::string("undefined operation: RawArray::getitem_next_jagged(jagged)")
+        + FILENAME(__LINE__));
     }
 
     const ContentPtr
@@ -1219,7 +1266,8 @@ namespace awkward {
     const ContentPtr
       numbers_to_type(const std::string& name) const override {
       throw std::runtime_error(
-        "FIXME: unimplemented operation: RawArray::numbers_to_type");
+        std::string("FIXME: unimplemented operation: RawArray::numbers_to_type")
+        + FILENAME(__LINE__));
     }
 
   private:

--- a/include/awkward/common.h
+++ b/include/awkward/common.h
@@ -28,7 +28,11 @@
   #define ERROR struct Error
 #endif
 
+#define QUOTE(x) #x
+
 #define FILENAME_FOR_EXCEPTIONS(filename, line) std::string("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/" VERSION_INFO "/" filename "#L" #line ")")
+#define FILENAME_FOR_EXCEPTIONS_C(filename, line) ("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/" VERSION_INFO "/" filename "#L" #line ")")
+#define FILENAME_FOR_EXCEPTIONS_CUDA(filename, line) ("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/" QUOTE(VERSION_INFO) "/" filename "#L" #line ")")
 
 #include <iostream>
 #include <algorithm>
@@ -41,6 +45,7 @@
 extern "C" {
   struct EXPORT_SYMBOL Error {
     const char* str;
+    const char* filename;
     int64_t identity;
     int64_t attempt;
     bool pass_through;
@@ -58,6 +63,7 @@ extern "C" {
     success() {
         struct Error out;
         out.str = nullptr;
+        out.filename = nullptr;
         out.identity = kSliceNone;
         out.attempt = kSliceNone;
         out.pass_through = false;
@@ -65,12 +71,32 @@ extern "C" {
     };
 
   inline struct Error
-    failure(const char* str, int64_t identity, int64_t attempt, bool pass_through = false) {
+    failure(
+      const char* str,
+      int64_t identity,
+      int64_t attempt,
+      const char* filename = nullptr) {
         struct Error out;
         out.str = str;
+        out.filename = filename;
         out.identity = identity;
         out.attempt = attempt;
-        out.pass_through = pass_through;
+        out.pass_through = false;
+        return out;
+    };
+
+  inline struct Error
+    failure_pass_through(
+      const char* str,
+      int64_t identity,
+      int64_t attempt,
+      const char* filename = nullptr) {
+        struct Error out;
+        out.str = str;
+        out.filename = filename;
+        out.identity = identity;
+        out.attempt = attempt;
+        out.pass_through = true;
         return out;
     };
 }

--- a/include/awkward/common.h
+++ b/include/awkward/common.h
@@ -28,6 +28,8 @@
   #define ERROR struct Error
 #endif
 
+#define FILENAME_FOR_EXCEPTIONS(filename, line) std::string("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/" VERSION_INFO "/" filename "#L" #line ")")
+
 #include <iostream>
 #include <algorithm>
 #include <map>

--- a/include/awkward/kernel-dispatch.h
+++ b/include/awkward/kernel-dispatch.h
@@ -181,7 +181,9 @@ namespace awkward {
           kernel::cuda_array_deleter<T>());
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in ptr_alloc<bool>");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in ptr_alloc<bool>")
+          + FILENAME_FOR_EXCEPTIONS("include/awkward/kernel-dispatch.h", __LINE__));
       }
     }
 

--- a/src/awkward1/_connect/_numba/__init__.py
+++ b/src/awkward1/_connect/_numba/__init__.py
@@ -6,6 +6,7 @@ import distutils.version
 
 import awkward1.highlevel
 import awkward1.layout
+import awkward1._util
 
 
 checked_version = False
@@ -93,7 +94,10 @@ def castint(context, builder, fromtype, totype, val):
         elif fromtype.width == 64:
             fromtype = numba.int64
     if not isinstance(fromtype, numba.types.Integer):
-        raise AssertionError("unrecognized integer type: {0}".format(repr(fromtype)))
+        raise AssertionError(
+            "unrecognized integer type: {0}".format(repr(fromtype))
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     if fromtype.bitwidth < totype.bitwidth:
         if fromtype.signed:

--- a/src/awkward1/_connect/_numba/arrayview.py
+++ b/src/awkward1/_connect/_numba/arrayview.py
@@ -222,6 +222,7 @@ def tolookup(layout, positions, sharedptrs, arrays):
     else:
         raise AssertionError(
             "unrecognized Content or Form type: {0}".format(type(layout))
+            + awkward1._util.exception_suffix(__file__)
         )
 
 
@@ -262,7 +263,10 @@ def tonumbatype(form):
         return awkward1._connect._numba.layout.VirtualArrayType.from_form(form)
 
     else:
-        raise AssertionError("unrecognized Form type: {0}".format(type(form)))
+        raise AssertionError(
+            "unrecognized Form type: {0}".format(type(form))
+            + awkward1._util.exception_suffix(__file__)
+        )
 
 
 @numba.extending.typeof_impl.register(Lookup)
@@ -330,6 +334,7 @@ class ArrayView(object):
                     raise ValueError(
                         "partitioned arrays can only be used in Numba if all "
                         "partitions have the same numba_type"
+                        + awkward1._util.exception_suffix(__file__)
                     )
             return PartitionedView(
                 numba.typeof(part),
@@ -535,6 +540,7 @@ class type_getitem(numba.core.typing.templates.AbstractTemplate):
                     "only an integer, start:stop range, or a *constant* "
                     "field name string may be used as awkward1.Array "
                     "slices in compiled code"
+                    + awkward1._util.exception_suffix(__file__)
                 )
 
 
@@ -807,6 +813,7 @@ class type_getitem_record(numba.core.typing.templates.AbstractTemplate):
                 raise TypeError(
                     "only a *constant* field name string may be used as "
                     "awkward1.Record slices in compiled code"
+                    + awkward1._util.exception_suffix(__file__)
                 )
 
 
@@ -1219,6 +1226,7 @@ class type_getitem_partitioned(numba.core.typing.templates.AbstractTemplate):
                     "only an integer, start:stop range, or a *constant* "
                     "field name string may be used as awkward1.Array "
                     "slices in compiled code"
+                    + awkward1._util.exception_suffix(__file__)
                 )
 
 

--- a/src/awkward1/_connect/_numba/builder.py
+++ b/src/awkward1/_connect/_numba/builder.py
@@ -144,14 +144,20 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.clear")
+            raise TypeError(
+                "wrong number of arguments for ArrayBuilder.clear"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @numba.core.typing.templates.bound_function("null")
     def resolve_null(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.null")
+            raise TypeError(
+                "wrong number of arguments for ArrayBuilder.null"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @numba.core.typing.templates.bound_function("boolean")
     def resolve_boolean(self, arraybuildertype, args, kwargs):
@@ -163,7 +169,8 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
             return numba.types.none(args[0])
         else:
             raise TypeError(
-                "wrong number or types of arguments for " "ArrayBuilder.boolean"
+                "wrong number or types of arguments for ArrayBuilder.boolean"
+                + awkward1._util.exception_suffix(__file__)
             )
 
     @numba.core.typing.templates.bound_function("integer")
@@ -176,7 +183,8 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
             return numba.types.none(args[0])
         else:
             raise TypeError(
-                "wrong number or types of arguments for " "ArrayBuilder.integer"
+                "wrong number or types of arguments for ArrayBuilder.integer"
+                + awkward1._util.exception_suffix(__file__)
             )
 
     @numba.core.typing.templates.bound_function("real")
@@ -188,21 +196,30 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.real")
+            raise TypeError(
+                "wrong number or types of arguments for ArrayBuilder.real"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @numba.core.typing.templates.bound_function("begin_list")
     def resolve_begin_list(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.begin_list")
+            raise TypeError(
+                "wrong number of arguments for ArrayBuilder.begin_list"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @numba.core.typing.templates.bound_function("end_list")
     def resolve_end_list(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.end_list")
+            raise TypeError(
+                "wrong number of arguments for ArrayBuilder.end_list"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @numba.core.typing.templates.bound_function("begin_tuple")
     def resolve_begin_tuple(self, arraybuildertype, args, kwargs):
@@ -214,7 +231,8 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
             return numba.types.none(args[0])
         else:
             raise TypeError(
-                "wrong number or types of arguments for " "ArrayBuilder.begin_tuple"
+                "wrong number or types of arguments for ArrayBuilder.begin_tuple"
+                + awkward1._util.exception_suffix(__file__)
             )
 
     @numba.core.typing.templates.bound_function("index")
@@ -227,7 +245,8 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
             return arraybuildertype(args[0])
         else:
             raise TypeError(
-                "wrong number or types of arguments for " "ArrayBuilder.index"
+                "wrong number or types of arguments for ArrayBuilder.index"
+                + awkward1._util.exception_suffix(__file__)
             )
 
     @numba.core.typing.templates.bound_function("end_tuple")
@@ -235,7 +254,10 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.end_tuple")
+            raise TypeError(
+                "wrong number of arguments for ArrayBuilder.end_tuple"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @numba.core.typing.templates.bound_function("begin_record")
     def resolve_begin_record(self, arraybuildertype, args, kwargs):
@@ -249,7 +271,8 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
             return numba.types.none(args[0])
         else:
             raise TypeError(
-                "wrong number or types of arguments for " "ArrayBuilder.begin_record"
+                "wrong number or types of arguments for ArrayBuilder.begin_record"
+                + awkward1._util.exception_suffix(__file__)
             )
 
     @numba.core.typing.templates.bound_function("field")
@@ -262,7 +285,8 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
             return arraybuildertype(args[0])
         else:
             raise TypeError(
-                "wrong number or types of arguments for " "ArrayBuilder.field"
+                "wrong number or types of arguments for ArrayBuilder.field"
+                + awkward1._util.exception_suffix(__file__)
             )
 
     @numba.core.typing.templates.bound_function("end_record")
@@ -270,7 +294,10 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.end_record")
+            raise TypeError(
+                "wrong number of arguments for ArrayBuilder.end_record"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @numba.core.typing.templates.bound_function("append")
     def resolve_append(self, arraybuildertype, args, kwargs):
@@ -335,7 +362,8 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
                         return numba.types.none(args[0])
 
             raise TypeError(
-                "wrong number or types of arguments for " "ArrayBuilder.append"
+                "wrong number or types of arguments for ArrayBuilder.append"
+                + awkward1._util.exception_suffix(__file__)
             )
 
     @numba.core.typing.templates.bound_function("extend")
@@ -349,6 +377,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         else:
             raise TypeError(
                 "wrong number or types of arguments for ArrayBuilder.extend"
+                + awkward1._util.exception_suffix(__file__)
             )
 
 
@@ -672,7 +701,10 @@ def lower_append_optional(context, builder, sig, args):
                     (arraybuilderval, optproxy.data),
                 )
             else:
-                raise AssertionError(opttype.type)
+                raise AssertionError(
+                    repr(opttype.type)
+                    + awkward1._util.exception_suffix(__file__)
+                )
 
         with is_not_valid:
             lower_null(

--- a/src/awkward1/_connect/_numba/layout.py
+++ b/src/awkward1/_connect/_numba/layout.py
@@ -131,9 +131,15 @@ def typeof_UnionArray(obj, c):
 @numba.extending.typeof_impl.register(awkward1.layout.VirtualArray)
 def typeof_VirtualArray(obj, c):
     if obj.form.form is None:
-        raise ValueError("VirtualArrays without a known 'form' can't be used in Numba")
+        raise ValueError(
+            "VirtualArrays without a known 'form' can't be used in Numba"
+            + awkward1._util.exception_suffix(__file__)
+        )
     if obj.form.has_identities:
-        raise NotImplementedError("TODO: identities in VirtualArray")
+        raise NotImplementedError(
+            "TODO: identities in VirtualArray"
+            + awkward1._util.exception_suffix(__file__)
+        )
     return VirtualArrayType(obj.form.form, numba.none, obj.parameters)
 
 
@@ -163,7 +169,10 @@ class ContentType(numba.types.Type):
         if not form.has_identities:
             return numba.none
         else:
-            raise NotImplementedError("TODO: identities in VirtualArray")
+            raise NotImplementedError(
+                "TODO: identities in VirtualArray"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @classmethod
     def from_form_index(cls, index_string):
@@ -180,6 +189,7 @@ class ContentType(numba.types.Type):
         else:
             raise AssertionError(
                 "unrecognized Form index type: {0}".format(index_string)
+                + awkward1._util.exception_suffix(__file__)
             )
 
     def form_fill_identities(self, pos, layout, lookup):
@@ -201,7 +211,10 @@ class ContentType(numba.types.Type):
         elif arraytype.dtype.bitwidth == 64 and arraytype.dtype.signed:
             return awkward1.layout.Index64
         else:
-            raise AssertionError("no Index* type for array: {0}".format(arraytype))
+            raise AssertionError(
+                "no Index* type for array: {0}".format(arraytype)
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     def getitem_at_check(self, viewtype):
         typer = awkward1._util.numba_array_typer(viewtype.type, viewtype.behavior)
@@ -221,6 +234,7 @@ class ContentType(numba.types.Type):
         else:
             raise TypeError(
                 "array does not have a field with key {0}".format(repr(key))
+                + awkward1._util.exception_suffix(__file__)
             )
 
     def lower_getitem_at_check(
@@ -396,6 +410,7 @@ class NumpyArrayType(ContentType):
             raise NotImplementedError(
                 "NumpyForm is multidimensional; TODO: convert to RegularForm,"
                 " just as NumpyArrays are converted to RegularArrays"
+                + awkward1._util.exception_suffix(__file__)
             )
         pos = len(positions)
         cls.form_tolookup_identities(form, positions, sharedptrs, arrays)
@@ -411,6 +426,7 @@ class NumpyArrayType(ContentType):
             raise NotImplementedError(
                 "NumpyForm is multidimensional; TODO: convert to RegularForm,"
                 " just as NumpyArrays are converted to RegularArrays"
+                + awkward1._util.exception_suffix(__file__)
             )
         if form.primitive == "float64":
             arraytype = numba.types.Array(numba.float64, 1, "A")
@@ -437,6 +453,7 @@ class NumpyArrayType(ContentType):
         else:
             raise ValueError(
                 "unrecognized NumpyForm.primitive type: {0}".format(form.primitive)
+                + awkward1._util.exception_suffix(__file__)
             )
         return NumpyArrayType(
             arraytype, cls.from_form_identities(form), form.parameters
@@ -740,6 +757,7 @@ class ListArrayType(ContentType):
         else:
             raise AssertionError(
                 "no ListArray* type for array: {0}".format(self.indextype)
+                + awkward1._util.exception_suffix(__file__)
             )
 
     def tolayout(self, lookup, pos, fields):
@@ -885,6 +903,7 @@ class IndexedArrayType(ContentType):
         else:
             raise AssertionError(
                 "no IndexedArray* type for array: {0}".format(self.indextype)
+                + awkward1._util.exception_suffix(__file__)
             )
 
     def tolayout(self, lookup, pos, fields):
@@ -1039,6 +1058,7 @@ class IndexedOptionArrayType(ContentType):
         else:
             raise AssertionError(
                 "no IndexedOptionArray* type for array: {0}".format(self.indextype)
+                + awkward1._util.exception_suffix(__file__)
             )
 
     def tolayout(self, lookup, pos, fields):
@@ -1757,6 +1777,7 @@ class RecordArrayType(ContentType):
                         "no field {0} in tuples with {1} fields".format(
                             repr(key), len(self.contenttypes)
                         )
+                        + awkward1._util.exception_suffix(__file__)
                     )
                 else:
                     raise ValueError(
@@ -1764,6 +1785,7 @@ class RecordArrayType(ContentType):
                         "fields: [{1}]".format(
                             repr(key), ", ".join(repr(x) for x in self.recordlookup)
                         )
+                        + awkward1._util.exception_suffix(__file__)
                     )
             contenttype = self.contenttypes[index]
             subviewtype = awkward1._connect._numba.arrayview.wrap(
@@ -1779,12 +1801,14 @@ class RecordArrayType(ContentType):
                     "no field {0} in tuples with {1} fields".format(
                         repr(key), len(self.contenttypes)
                     )
+                    + awkward1._util.exception_suffix(__file__)
                 )
             else:
                 raise ValueError(
                     "no field {0} in records with fields: [{1}]".format(
                         repr(key), ", ".join(repr(x) for x in self.recordlookup)
                     )
+                    + awkward1._util.exception_suffix(__file__)
                 )
         contenttype = self.contenttypes[index]
         subviewtype = awkward1._connect._numba.arrayview.wrap(
@@ -1800,12 +1824,14 @@ class RecordArrayType(ContentType):
                     "no field {0} in tuple with {1} fields".format(
                         repr(key), len(self.contenttypes)
                     )
+                    + awkward1._util.exception_suffix(__file__)
                 )
             else:
                 raise ValueError(
                     "no field {0} in record with fields: [{1}]".format(
                         repr(key), ", ".join(repr(x) for x in self.recordlookup)
                     )
+                    + awkward1._util.exception_suffix(__file__)
                 )
         contenttype = self.contenttypes[index]
         subviewtype = awkward1._connect._numba.arrayview.wrap(
@@ -2080,10 +2106,12 @@ class UnionArrayType(ContentType):
             else:
                 raise AssertionError(
                     "no UnionArray* type for index array: {0}".format(self.indextype)
+                    + awkward1._util.exception_suffix(__file__)
                 )
         else:
             raise AssertionError(
                 "no UnionArray* type for tags array: {0}".format(self.tagstype)
+                + awkward1._util.exception_suffix(__file__)
             )
 
     def tolayout(self, lookup, pos, fields):
@@ -2104,15 +2132,24 @@ class UnionArrayType(ContentType):
 
     def getitem_at(self, viewtype):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise TypeError("union types cannot be accessed in Numba")
+            raise TypeError(
+                "union types cannot be accessed in Numba"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     def getitem_range(self, viewtype):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise TypeError("union types cannot be accessed in Numba")
+            raise TypeError(
+                "union types cannot be accessed in Numba"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     def getitem_field(self, viewtype, key):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise TypeError("union types cannot be accessed in Numba")
+            raise TypeError(
+                "union types cannot be accessed in Numba"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     def lower_getitem_at(
         self,
@@ -2129,6 +2166,7 @@ class UnionArrayType(ContentType):
     ):
         raise NotImplementedError(
             type(self).__name__ + ".lower_getitem_at not implemented"
+            + awkward1._util.exception_suffix(__file__)
         )
 
     def lower_getitem_range(
@@ -2145,11 +2183,13 @@ class UnionArrayType(ContentType):
     ):
         raise NotImplementedError(
             type(self).__name__ + ".lower_getitem_range not implemented"
+            + awkward1._util.exception_suffix(__file__)
         )
 
     def lower_getitem_field(self, context, builder, viewtype, viewval, viewproxy, key):
         raise NotImplementedError(
             type(self).__name__ + ".lower_getitem_field not implemented"
+            + awkward1._util.exception_suffix(__file__)
         )
 
 
@@ -2166,6 +2206,7 @@ class VirtualArrayType(ContentType):
         if layout.form is None:
             raise ValueError(
                 "VirtualArrays without a known 'form' can't be used in Numba"
+                + awkward1._util.exception_suffix(__file__)
             )
         pyptr = ctypes.py_object(layout)
         ctypes.pythonapi.Py_IncRef(pyptr)
@@ -2188,6 +2229,7 @@ class VirtualArrayType(ContentType):
         if form.form is None:
             raise ValueError(
                 "VirtualArrays without a known 'form' can't be used in Numba"
+                + awkward1._util.exception_suffix(__file__)
             )
         positions.append(0)
         sharedptrs.append(None)
@@ -2204,6 +2246,7 @@ class VirtualArrayType(ContentType):
             raise ValueError(
                 "VirtualArrays without a known 'form' can't be used in Numba "
                 "(including nested)"
+                + awkward1._util.exception_suffix(__file__)
             )
         return VirtualArrayType(
             form.form, cls.from_form_identities(form), form.parameters
@@ -2213,6 +2256,7 @@ class VirtualArrayType(ContentType):
         if generator_form is None:
             raise ValueError(
                 "VirtualArrays without a known 'form' can't be used in Numba"
+                + awkward1._util.exception_suffix(__file__)
             )
         super(VirtualArrayType, self).__init__(
             name="awkward1.VirtualArrayType({0}, {1}, {2})".format(
@@ -2276,6 +2320,7 @@ class VirtualArrayType(ContentType):
                         "unrecognized NumpyForm.primitive type: {0}".format(
                             form.primitive
                         )
+                        + awkward1._util.exception_suffix(__file__)
                     )
 
             elif isinstance(
@@ -2307,10 +2352,16 @@ class VirtualArrayType(ContentType):
                 return arrayview.type.getitem_at(arrayview)
 
             elif isinstance(form, awkward1.forms.UnionForm):
-                raise TypeError("union types cannot be accessed in Numba")
+                raise TypeError(
+                    "union types cannot be accessed in Numba"
+                    + awkward1._util.exception_suffix(__file__)
+                )
 
             else:
-                raise AssertionError("unrecognized Form type: {0}".format(type(form)))
+                raise AssertionError(
+                    "unrecognized Form type: {0}".format(type(form))
+                    + awkward1._util.exception_suffix(__file__)
+                )
 
         def wrap(out):
             if isinstance(out, awkward1.forms.Form):

--- a/src/awkward1/_connect/_numexpr.py
+++ b/src/awkward1/_connect/_numexpr.py
@@ -124,7 +124,10 @@ def re_evaluate(local_dict=None):
     try:
         compiled_ex = numexpr.necompiler._numexpr_last["ex"]  # noqa: F841
     except KeyError:
-        raise RuntimeError("not a previous evaluate() execution found")
+        raise RuntimeError(
+            "not a previous evaluate() execution found"
+            + awkward1._util.exception_suffix(__file__)
+        )
     names = numexpr.necompiler._numexpr_last["argnames"]
     arguments = getArguments(names, local_dict)
 

--- a/src/awkward1/_connect/_pandas.py
+++ b/src/awkward1/_connect/_pandas.py
@@ -94,6 +94,7 @@ def get_dtype():
                 else:
                     raise TypeError(
                         "cannot construct a {0} from {1}".format(cls, string)
+                        + awkward1._util.exception_suffix(__file__)
                     )
 
             @classmethod
@@ -153,7 +154,10 @@ class PandasMixin(PandasNotImportedYet):
     def _from_factorized(cls, values, original):
         # https://pandas.pydata.org/pandas-docs/version/1.0.0/reference/api/pandas.api.extensions.ExtensionArray._from_factorized.html
         vote()
-        raise NotImplementedError("_from_factorized")
+        raise NotImplementedError(
+            "_from_factorized"
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     # __getitem__(self)
     # __len__(self)
@@ -169,6 +173,7 @@ class PandasMixin(PandasNotImportedYet):
                 raise ValueError(
                     "partitioned arrays cannot be Pandas columns; "
                     "try ak.repartition(array, None)"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             else:
                 return AwkwardDtype()

--- a/src/awkward1/_util.py
+++ b/src/awkward1/_util.py
@@ -32,6 +32,19 @@ else:
     unicode = None
 
 
+def exception_suffix(filename):
+    line = ""
+    if hasattr(sys, "_getframe"):
+        line = "#L" + str(sys._getframe(1).f_lineno)
+    filename = filename.replace("\\", "/")
+    filename = "/src/awkward1/" + filename.split("awkward1/")[1]
+    return ("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/"
+            + awkward1.__version__
+            + filename
+            + line
+            + ")")
+
+
 virtualtypes = (awkward1.layout.VirtualArray,)
 
 unknowntypes = (awkward1.layout.EmptyArray,)
@@ -394,7 +407,10 @@ def key2index(keys, key):
             attempt = m.group(0)
 
     if attempt is None:
-        raise ValueError("key {0} not found in record".format(repr(key)))
+        raise ValueError(
+            "key {0} not found in record".format(repr(key))
+            + exception_suffix(__file__)
+        )
     else:
         return attempt
 
@@ -441,7 +457,10 @@ def completely_flatten(array):
         return (awkward1.nplike.of(array).asarray(array),)
 
     else:
-        raise RuntimeError("cannot completely flatten: {0}".format(type(array)))
+        raise RuntimeError(
+            "cannot completely flatten: {0}".format(type(array))
+            + exception_suffix(__file__)
+        )
 
 
 def broadcast_and_apply(inputs, getfunction, behavior):
@@ -454,6 +473,7 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                     "length {3}".format(
                         type(inputs[0]).__name__, length, type(x).__name__, len(x)
                     )
+                    + exception_suffix(__file__)
                 )
 
     def apply(inputs, depth):
@@ -543,6 +563,7 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                             "with UnionArray of length {1}".format(
                                 length, len(tagslist[-1])
                             )
+                            + exception_suffix(__file__)
                         )
 
             combos = nplike.stack(tagslist, axis=-1)
@@ -660,6 +681,7 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                                 "{0} with RegularArray of size {1}".format(
                                     x.size, maxsize
                                 )
+                                + exception_suffix(__file__)
                             )
                     else:
                         nextinputs.append(x)
@@ -732,6 +754,7 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                             "match:\n    {0}\n    {1}".format(
                                 ", ".join(sorted(keys)), ", ".join(sorted(x.keys()))
                             )
+                            + exception_suffix(__file__)
                         )
                     if length is None:
                         length = len(x)
@@ -739,6 +762,7 @@ def broadcast_and_apply(inputs, getfunction, behavior):
                         raise ValueError(
                             "cannot broadcast RecordArray of length {0} "
                             "with RecordArray of length {1}".format(length, len(x))
+                            + exception_suffix(__file__)
                         )
                     if not x.istuple:
                         istuple = False
@@ -769,6 +793,7 @@ def broadcast_and_apply(inputs, getfunction, behavior):
         else:
             raise ValueError(
                 "cannot broadcast: {0}".format(", ".join(repr(type(x)) for x in inputs))
+                + exception_suffix(__file__)
             )
 
     if any(isinstance(x, awkward1.partition.PartitionedArray) for x in inputs):
@@ -1109,7 +1134,10 @@ def recursively_apply(layout, getfunction, args=(), depth=1, keep_parameters=Tru
         )
 
     else:
-        raise AssertionError("unrecognized Content type: {0}".format(type(layout)))
+        raise AssertionError(
+            "unrecognized Content type: {0}".format(type(layout))
+            + exception_suffix(__file__)
+        )
 
 
 def highlevel_type(layout, behavior, isarray):

--- a/src/awkward1/behaviors/mixins.py
+++ b/src/awkward1/behaviors/mixins.py
@@ -61,7 +61,10 @@ def mixin_class_method(ufunc, rhs=None, transpose=True):
 
     def register(method):
         if not isinstance(rhs, (set, type(None))):
-            raise ValueError("Expected a set of right-hand-side argument types")
+            raise ValueError(
+                "expected a set of right-hand-side argument types"
+                + awkward1._util.exception_suffix(__file__)
+            )
         if transpose and rhs is not None:
 
             def transposed(left, right):

--- a/src/awkward1/highlevel.py
+++ b/src/awkward1/highlevel.py
@@ -231,7 +231,10 @@ class Array(
         if not isinstance(
             layout, (awkward1.layout.Content, awkward1.partition.PartitionedArray)
         ):
-            raise TypeError("could not convert data into an awkward1.Array")
+            raise TypeError(
+                "could not convert data into an awkward1.Array"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
         if with_name is not None:
             layout = awkward1.operations.structure.with_name(
@@ -302,7 +305,10 @@ class Array(
             self._layout = layout
             self._numbaview = None
         else:
-            raise TypeError("layout must be a subclass of awkward1.layout.Content")
+            raise TypeError(
+                "layout must be a subclass of awkward1.layout.Content"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @property
     def behavior(self):
@@ -328,7 +334,10 @@ class Array(
         if behavior is None or isinstance(behavior, dict):
             self._behavior = behavior
         else:
-            raise TypeError("behavior must be None or a dict")
+            raise TypeError(
+                "behavior must be None or a dict"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @property
     def cache(self):
@@ -339,7 +348,10 @@ class Array(
         if value is None or isinstance(value, MutableMapping):
             self._cache = value
         else:
-            raise TypeError("cache must be None or a MutableMapping")
+            raise TypeError(
+                "cache must be None or a MutableMapping"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     class Mask(object):
         def __init__(self, array, valid_when):
@@ -943,7 +955,10 @@ class Array(
             isinstance(where, str)
             or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
         ):
-            raise TypeError("only fields may be assigned in-place (by field name)")
+            raise TypeError(
+                "only fields may be assigned in-place (by field name)"
+                + awkward1._util.exception_suffix(__file__)
+            )
         self._layout = awkward1.operations.structure.with_field(
             self._layout, what, where
         ).layout
@@ -998,9 +1013,13 @@ class Array(
                     raise AttributeError(
                         "while trying to get field {0}, an exception "
                         "occurred:\n{1}: {2}".format(repr(where), type(err), str(err))
+                        + awkward1._util.exception_suffix(__file__)
                     )
             else:
-                raise AttributeError("no field named {0}".format(repr(where)))
+                raise AttributeError(
+                    "no field named {0}".format(repr(where))
+                    + awkward1._util.exception_suffix(__file__)
+                )
 
     def __dir__(self):
         """
@@ -1419,13 +1438,17 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
         elif isinstance(data, Iterable):
             raise TypeError(
                 "could not convert non-dict into an awkward1.Record; try awkward1.Array"
+                + awkward1._util.exception_suffix(__file__)
             )
 
         else:
             layout = None
 
         if not isinstance(layout, awkward1.layout.Record):
-            raise TypeError("could not convert data into an awkward1.Record")
+            raise TypeError(
+                "could not convert data into an awkward1.Record"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
         if self.__class__ is Record:
             self.__class__ = awkward1._util.recordclass(layout, behavior)
@@ -1491,7 +1514,10 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
             self._layout = layout
             self._numbaview = None
         else:
-            raise TypeError("layout must be a subclass of awkward1.layout.Record")
+            raise TypeError(
+                "layout must be a subclass of awkward1.layout.Record"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @property
     def behavior(self):
@@ -1517,7 +1543,10 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
         if behavior is None or isinstance(behavior, dict):
             self._behavior = behavior
         else:
-            raise TypeError("behavior must be None or a dict")
+            raise TypeError(
+                "behavior must be None or a dict"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     @property
     def cache(self):
@@ -1528,7 +1557,10 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
         if value is None or isinstance(value, MutableMapping):
             self._cache = value
         else:
-            raise TypeError("cache must be None or a MutableMapping")
+            raise TypeError(
+                "cache must be None or a MutableMapping"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     def tolist(self):
         """
@@ -1665,7 +1697,10 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
             isinstance(where, str)
             or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
         ):
-            raise TypeError("only fields may be assigned in-place (by field name)")
+            raise TypeError(
+                "only fields may be assigned in-place (by field name)"
+                + awkward1._util.exception_suffix(__file__)
+            )
         self._layout = awkward1.operations.structure.with_field(
             self._layout, what, where
         ).layout
@@ -1709,9 +1744,13 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
                     raise AttributeError(
                         "while trying to get field {0}, an exception "
                         "occurred:\n{1}: {2}".format(repr(where), type(err), str(err))
+                        + awkward1._util.exception_suffix(__file__)
                     )
             else:
-                raise AttributeError("no field named {0}".format(repr(where)))
+                raise AttributeError(
+                    "no field named {0}".format(repr(where))
+                    + awkward1._util.exception_suffix(__file__)
+                )
 
     def __dir__(self):
         """
@@ -2116,7 +2155,10 @@ class ArrayBuilder(object):
         if behavior is None or isinstance(behavior, dict):
             self._behavior = behavior
         else:
-            raise TypeError("behavior must be None or a dict")
+            raise TypeError(
+                "behavior must be None or a dict"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     def __len__(self):
         """
@@ -2467,6 +2509,7 @@ class ArrayBuilder(object):
                 raise TypeError(
                     "'append' method can only be used with 'at' when "
                     "'obj' is an ak.Array"
+                    + awkward1._util.exception_suffix(__file__)
                 )
 
     def extend(self, obj):
@@ -2480,7 +2523,10 @@ class ArrayBuilder(object):
         if isinstance(obj, Array):
             self._layout.extend(obj.layout)
         else:
-            raise TypeError("'extend' method requires an ak.Array")
+            raise TypeError(
+                "'extend' method requires an ak.Array"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     class _Nested(object):
         def __init__(self, arraybuilder):

--- a/src/awkward1/nplike.py
+++ b/src/awkward1/nplike.py
@@ -264,7 +264,9 @@ or
     @property
     def ma(self):
         raise ValueError(
-            "CUDA arrays cannot have missing values until CuPy implements numpy.ma.MaskedArray"
+            "CUDA arrays cannot have missing values until CuPy implements "
+            "numpy.ma.MaskedArray"
+            + awkward1._util.exception_suffix(__file__)
         )
 
     def frombuffer(self, *args, **kwargs):

--- a/src/awkward1/operations/convert.py
+++ b/src/awkward1/operations/convert.py
@@ -213,12 +213,16 @@ def to_numpy(array, allow_missing=True):
             except Exception:
                 raise ValueError(
                     "cannot convert {0} into numpy.ma.MaskedArray".format(array)
+                    + awkward1._util.exception_suffix(__file__)
                 )
         else:
             try:
                 out = numpy.concatenate(contents)
             except Exception:
-                raise ValueError("cannot convert {0} into np.ndarray".format(array))
+                raise ValueError(
+                    "cannot convert {0} into np.ndarray".format(array)
+                    + awkward1._util.exception_suffix(__file__)
+                )
 
         tags = numpy.asarray(array.tags)
         for tag, content in enumerate(contents):
@@ -257,6 +261,7 @@ def to_numpy(array, allow_missing=True):
                     "to_numpy cannot convert 'None' values to "
                     "np.ma.MaskedArray unless the "
                     "'allow_missing' parameter is set to True"
+                    + awkward1._util.exception_suffix(__file__)
                 )
         else:
             if allow_missing:
@@ -281,7 +286,10 @@ def to_numpy(array, allow_missing=True):
             for i in range(array.numfields)
         ]
         if any(len(x.shape) != 1 for x in contents):
-            raise ValueError("cannot convert {0} into np.ndarray".format(array))
+            raise ValueError(
+                "cannot convert {0} into np.ndarray".format(array)
+                + awkward1._util.exception_suffix(__file__)
+            )
         out = numpy.empty(
             len(contents[0]),
             dtype=[(str(n), x.dtype) for n, x in zip(array.keys(), contents)],
@@ -294,13 +302,19 @@ def to_numpy(array, allow_missing=True):
         return numpy.asarray(array)
 
     elif isinstance(array, awkward1.layout.Content):
-        raise AssertionError("unrecognized Content type: {0}".format(type(array)))
+        raise AssertionError(
+            "unrecognized Content type: {0}".format(type(array))
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     elif isinstance(array, Iterable):
         return numpy.asarray(array)
 
     else:
-        raise ValueError("cannot convert {0} into np.ndarray".format(array))
+        raise ValueError(
+            "cannot convert {0} into np.ndarray".format(array)
+            + awkward1._util.exception_suffix(__file__)
+        )
 
 
 def from_iter(
@@ -358,7 +372,10 @@ def from_iter(
                 resize=resize,
             )[0]
         else:
-            raise ValueError("cannot produce an array from a dict")
+            raise ValueError(
+                "cannot produce an array from a dict"
+                + awkward1._util.exception_suffix(__file__)
+            )
     out = awkward1.layout.ArrayBuilder(initial=initial, resize=resize)
     for x in iterable:
         out.fromiter(x)
@@ -447,7 +464,10 @@ def to_list(array):
         return [to_list(x) for x in array]
 
     else:
-        raise TypeError("unrecognized array type: {0}".format(type(array)))
+        raise TypeError(
+            "unrecognized array type: {0}".format(type(array))
+            + awkward1._util.exception_suffix(__file__)
+        )
 
 
 def from_json(
@@ -555,7 +575,10 @@ def to_json(array, destination=None, pretty=False, maxdecimals=None, buffersize=
         out = array
 
     else:
-        raise TypeError("unrecognized array type: {0}".format(repr(array)))
+        raise TypeError(
+            "unrecognized array type: {0}".format(repr(array))
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     if destination is None:
         return out.tojson(pretty=pretty, maxdecimals=maxdecimals)
@@ -855,6 +878,7 @@ def from_awkward0(
                 raise ValueError(
                     "awkward1.SparseArray hasn't been written (if at all); "
                     "try keep_layout=False"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             return recurse(array.dense, level + 1)
 
@@ -870,6 +894,7 @@ def from_awkward0(
             else:
                 raise ValueError(
                     "unsupported encoding: {0}".format(repr(array.encoding))
+                    + awkward1._util.exception_suffix(__file__)
                 )
             return out
 
@@ -879,6 +904,7 @@ def from_awkward0(
                 raise ValueError(
                     "there isn't (and won't ever be) an awkward1 equivalent "
                     "of awkward0.ObjectArray; try keep_layout=False"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             out = recurse(array.content, level + 1)
             out.setparameter(
@@ -898,6 +924,7 @@ def from_awkward0(
                     "awkward1 PartitionedArrays are only allowed "
                     "at the root of a data structure, unlike "
                     "awkward0.ChunkedArray; try keep_layout=False"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             elif level == 0:
                 return awkward1.partition.IrregularlyPartitionedArray(
@@ -914,17 +941,24 @@ def from_awkward0(
                 "the awkward1 equivalent of awkward0.AppendableArray is "
                 "awkward1.ArrayBuilder, but it is not a Content type, not "
                 "mixable with immutable array elements"
+                + awkward1._util.exception_suffix(__file__)
             )
 
         elif isinstance(array, awkward0.VirtualArray):
             # generator, args, kwargs, cache, persistentkey, type, nbytes, persistvirtual
             if keep_layout:
-                raise NotImplementedError("FIXME")
+                raise NotImplementedError(
+                    "FIXME"
+                    + awkward1._util.exception_suffix(__file__)
+                )
             else:
                 return recurse(array.array, level + 1)
 
         else:
-            raise TypeError("not an awkward0 array: {0}".format(repr(array)))
+            raise TypeError(
+                "not an awkward0 array: {0}".format(repr(array))
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     out = recurse(array, 0)
     if highlevel:
@@ -972,6 +1006,7 @@ def to_awkward0(array, keep_layout=False):
                 raise ValueError(
                     "awkward0 has no equivalent of RegularArray; "
                     "try keep_layout=False"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             offsets = numpy.arange(0, (len(layout) + 1) * layout.size, layout.size)
             return awkward0.JaggedArray.fromoffsets(offsets, recurse(layout.content))
@@ -1040,6 +1075,7 @@ def to_awkward0(array, keep_layout=False):
                 raise ValueError(
                     "cannot convert zero-field, nonzero-length RecordArray "
                     "to awkward0.Table (limitation in awkward0)"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             keys = layout.keys()
             values = [recurse(x) for x in layout.contents]
@@ -1131,11 +1167,15 @@ def to_awkward0(array, keep_layout=False):
             return recurse(layout.content)  # no equivalent in awkward0
 
         elif isinstance(layout, awkward1.layout.VirtualArray):
-            raise NotImplementedError("FIXME")
+            raise NotImplementedError(
+                "FIXME"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
         else:
             raise AssertionError(
                 "missing converter for {0}".format(type(layout).__name__)
+                + awkward1._util.exception_suffix(__file__)
             )
 
     layout = to_layout(
@@ -1208,7 +1248,10 @@ def to_layout(
 
     elif isinstance(array, np.ndarray):
         if not issubclass(array.dtype.type, numpytype):
-            raise ValueError("NumPy {0} not allowed".format(repr(array.dtype)))
+            raise ValueError(
+                "NumPy {0} not allowed".format(repr(array.dtype))
+                + awkward1._util.exception_suffix(__file__)
+            )
         out = awkward1.layout.NumpyArray(array.reshape(-1))
         for size in array.shape[:0:-1]:
             out = awkward1.layout.RegularArray(out, size)
@@ -1223,7 +1266,10 @@ def to_layout(
         return from_iter(array, highlevel=False)
 
     elif not allow_other:
-        raise TypeError("{0} cannot be converted into an Awkward Array".format(array))
+        raise TypeError(
+            "{0} cannot be converted into an Awkward Array".format(array)
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     else:
         return array
@@ -1627,7 +1673,10 @@ def to_arrow(array):
             return recurse(layout.content)
 
         else:
-            raise TypeError("unrecognized array type: {0}".format(repr(layout)))
+            raise TypeError(
+                "unrecognized array type: {0}".format(repr(layout))
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     return recurse(layout)
 
@@ -1661,7 +1710,10 @@ def from_arrow(array, highlevel=True, behavior=None):
             if array is not None:
                 content = recurse(array.dictionary)
             else:
-                raise NotImplementedError("Arrow dictionary inside of UnionArray")
+                raise NotImplementedError(
+                    "Arrow dictionary inside of UnionArray"
+                    + awkward1._util.exception_suffix(__file__)
+                )
 
             if isinstance(index, awkward1.layout.BitMaskedArray):
                 return awkward1.layout.BitMaskedArray(
@@ -1941,7 +1993,10 @@ def from_arrow(array, highlevel=True, behavior=None):
                 return out
 
         else:
-            raise TypeError("unrecognized Arrow array type: {0}".format(repr(tpe)))
+            raise TypeError(
+                "unrecognized Arrow array type: {0}".format(repr(tpe))
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     def recurse(obj):
         if isinstance(obj, pyarrow.lib.Array):
@@ -1979,7 +2034,10 @@ def from_arrow(array, highlevel=True, behavior=None):
                 )
 
         else:
-            raise TypeError("unrecognized Arrow type: {0}".format(type(obj)))
+            raise TypeError(
+                "unrecognized Arrow type: {0}".format(type(obj))
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     if highlevel:
         return awkward1._util.wrap(recurse(array), behavior)
@@ -2149,6 +2207,7 @@ def from_parquet(
         if x not in all_columns:
             raise ValueError(
                 "column {0} does not exist in file {1}".format(repr(x), repr(source))
+                + awkward1._util.exception_suffix(__file__)
             )
 
     if file.num_row_groups == 0:
@@ -2237,6 +2296,7 @@ def _arrayset_key(
     if form_key is None:
         raise ValueError(
             "cannot read from arrayset using Forms without form_keys"
+            + awkward1._util.exception_suffix(__file__)
         )
     if attribute is None:
         attribute = ""
@@ -2436,7 +2496,10 @@ def to_arrayset(
         elif isinstance(index, awkward1.layout.IndexU8):
             return "u8"
         else:
-            raise AssertionError("unrecognized index: " + repr(index))
+            raise AssertionError(
+                "unrecognized index: " + repr(index)
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     if prefix is None:
         prefix = ""
@@ -2482,6 +2545,7 @@ def to_arrayset(
         if has_identities:
             raise NotImplementedError(
                 "ak.to_arrayset for an array with Identities"
+                + awkward1._util.exception_suffix(__file__)
             )
 
         if isinstance(layout, awkward1.layout.EmptyArray):
@@ -2660,8 +2724,10 @@ def to_arrayset(
             return fill(layout.array, part)
 
         else:
-            raise AssertionError("unrecognized layout node type: "
-                                 + str(type(layout)))
+            raise AssertionError(
+                "unrecognized layout node type: " + str(type(layout))
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     layout = to_layout(array, allow_record=False, allow_other=False)
 
@@ -2670,6 +2736,7 @@ def to_arrayset(
             raise ValueError(
                 "array is partitioned; an explicit 'partition' should not be "
                 "assigned"
+                + awkward1._util.exception_suffix(__file__)
             )
         form = None
         for part, content in enumerate(layout.partitions):
@@ -2688,6 +2755,7 @@ def to_arrayset(
 differs from the first Form:
 
     {2}""".format(part, f.tojson(True, False), form.tojson(True, False))
+                    + awkward1._util.exception_suffix(__file__)
                 )
 
         num_partitions = len(layout.partitions)
@@ -2771,6 +2839,7 @@ def _form_to_layout(
     if form.has_identities:
         raise NotImplementedError(
             "ak.from_arrayset for an array with Identities"
+            + awkward1._util.exception_suffix(__file__)
         )
     else:
         identities = None
@@ -3125,7 +3194,10 @@ def _form_to_layout(
         return awkward1.layout.VirtualArray(generator, cache, cache_key + sep + node_cache_key)
 
     else:
-        raise AssertionError("unexpected form node type: " + str(type(form)))
+        raise AssertionError(
+            "unexpected form node type: " + str(type(form))
+            + awkward1._util.exception_suffix(__file__)
+        )
 
 
 _from_arrayset_key_number = 0
@@ -3305,6 +3377,7 @@ def from_arrayset(
                 raise TypeError(
                     "for lazy=True and num_partitions=None, lazy_lengths "
                     "must be an integer, not " + repr(lazy_lengths)
+                    + awkward1._util.exception_suffix(__file__)
                 )
 
             generator = awkward1.layout.ArrayGenerator(
@@ -3334,6 +3407,7 @@ def from_arrayset(
                     "for lazy=True, lazy_lengths must be an integer or "
                     "iterable of 'num_partitions' integers, not "
                     + repr(lazy_lengths)
+                    + awkward1._util.exception_suffix(__file__)
                 )
 
         partitions = []

--- a/src/awkward1/operations/describe.py
+++ b/src/awkward1/operations/describe.py
@@ -63,7 +63,10 @@ def validity_error(array, exception=False):
     ):
         out = array.validityerror()
         if out is not None and exception:
-            raise ValueError(out)
+            raise ValueError(
+                out
+                + awkward1._util.exception_suffix(__file__)
+            )
         else:
             return out
 
@@ -71,7 +74,10 @@ def validity_error(array, exception=False):
         return validity_error(array.snapshot(), exception=exception)
 
     else:
-        raise TypeError("not an awkward array: {0}".format(repr(array)))
+        raise TypeError(
+            "not an awkward array: {0}".format(repr(array))
+            + awkward1._util.exception_suffix(__file__)
+        )
 
 
 def type(array):
@@ -181,7 +187,10 @@ def type(array):
         return array.type(awkward1._util.typestrs(None))
 
     else:
-        raise TypeError("unrecognized array type: {0}".format(repr(array)))
+        raise TypeError(
+            "unrecognized array type: {0}".format(repr(array))
+            + awkward1._util.exception_suffix(__file__)
+        )
 
 
 type.dtype2primitive = {

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -108,6 +108,7 @@ def mask(array, mask, valid_when=True, highlevel=True):
             if not issubclass(m.dtype.type, (np.bool, np.bool_)):
                 raise ValueError(
                     "mask must have boolean type, not " "{0}".format(repr(m.dtype))
+                    + awkward1._util.exception_suffix(__file__)
                 )
             bytemask = awkward1.layout.Index8(m.view(np.int8))
             return lambda: (
@@ -293,7 +294,10 @@ def zip(arrays, depth_limit=None, parameters=None, with_name=None, highlevel=Tru
     structure or not.
     """
     if depth_limit is not None and depth_limit <= 0:
-        raise ValueError("depth_limit must be None or at least 1")
+        raise ValueError(
+            "depth_limit must be None or at least 1"
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     if isinstance(arrays, dict):
         recordlookup = []
@@ -444,6 +448,7 @@ def with_field(base, what, where=None, highlevel=True):
         raise TypeError(
             "New fields may only be assigned by field name(s) "
             "or as a new integer slot by passing None for 'where'"
+            + awkward1._util.exception_suffix(__file__)
         )
     if (
         not isinstance(where, str)
@@ -466,7 +471,10 @@ def with_field(base, what, where=None, highlevel=True):
             base, allow_record=True, allow_other=False
         )
         if base.numfields < 0:
-            raise ValueError("no tuples or records in array; cannot add a new " "field")
+            raise ValueError(
+                "no tuples or records in array; cannot add a new field"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
         what = awkward1.operations.convert.to_layout(
             what, allow_record=True, allow_other=True
@@ -713,7 +721,10 @@ def concatenate(arrays, axis=0, mergebool=True, highlevel=True):
     element for element, and similarly for deeper levels.
     """
     if axis != 0:
-        raise NotImplementedError("axis={0}".format(axis))
+        raise NotImplementedError(
+            "axis={0}".format(axis)
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     contents = [
         awkward1.operations.convert.to_layout(x, allow_record=False) for x in arrays
@@ -725,7 +736,10 @@ def concatenate(arrays, axis=0, mergebool=True, highlevel=True):
     ]
 
     if len(contents) == 0:
-        raise ValueError("need at least one array to concatenate")
+        raise ValueError(
+            "need at least one array to concatenate"
+            + awkward1._util.exception_suffix(__file__)
+        )
     out = contents[0]
     for x in contents[1:]:
         if not out.mergeable(x, mergebool=mergebool):
@@ -804,7 +818,10 @@ def where(condition, *args, **kwargs):
             return tuple(awkward1.layout.NumpyArray(x) for x in out)
 
     elif len(args) == 1:
-        raise ValueError("either both or neither of x and y should be given")
+        raise ValueError(
+            "either both or neither of x and y should be given"
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     elif len(args) == 2:
         nplike = awkward1.nplike.of(akcondition, args[0], args[1])
@@ -853,6 +870,7 @@ def where(condition, *args, **kwargs):
         raise TypeError(
             "where() takes from 1 to 3 positional arguments but {0} were "
             "given".format(len(args) + 1)
+            + awkward1._util.exception_suffix(__file__)
         )
 
 
@@ -1420,7 +1438,10 @@ def firsts(array, axis=1, highlevel=True):
     See #ak.singletons to invert this function.
     """
     if axis <= 0:
-        raise NotImplementedError("ak.firsts with axis={0}".format(axis))
+        raise NotImplementedError(
+            "ak.firsts with axis={0}".format(axis)
+            + awkward1._util.exception_suffix(__file__)
+        )
     toslice = (slice(None, None, None),) * axis + (0,)
     out = awkward1.mask(array, awkward1.num(array, axis=axis) > 0, highlevel=False)[
         toslice
@@ -1663,7 +1684,10 @@ def cartesian(
         parameters["__record__"] = with_name
 
     if axis < 0:
-        raise ValueError("the 'axis' of cartesian must be non-negative")
+        raise ValueError(
+            "the 'axis' of cartesian must be non-negative"
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     elif axis == 0:
         if nested is None or nested is False:
@@ -1676,6 +1700,7 @@ def cartesian(
                 raise ValueError(
                     "the 'nested' parameter of cartesian must be dict keys "
                     "for a dict of arrays"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             recordlookup = []
             layouts = []
@@ -1697,6 +1722,7 @@ def cartesian(
                 raise ValueError(
                     "the 'nested' prarmeter of cartesian must be integers in "
                     "[0, len(arrays) - 1) for an iterable of arrays"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             recordlookup = None
             layouts = []
@@ -1804,6 +1830,7 @@ def cartesian(
                 raise ValueError(
                     "the 'nested' parameter of cartesian must be dict keys "
                     "for a dict of arrays"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             recordlookup = []
             layouts = []
@@ -1823,6 +1850,7 @@ def cartesian(
                 raise ValueError(
                     "the 'nested' parameter of cartesian must be integers in "
                     "[0, len(arrays) - 1) for an iterable of arrays"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             recordlookup = None
             layouts = []
@@ -1913,7 +1941,10 @@ def argcartesian(
     so see the #ak.cartesian documentation for a more complete description.
     """
     if axis < 0:
-        raise ValueError("the 'axis' of argcartesian must be non-negative")
+        raise ValueError(
+            "the 'axis' of argcartesian must be non-negative"
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     else:
         if isinstance(arrays, dict):
@@ -2166,7 +2197,10 @@ def argcombinations(
         parameters["__record__"] = with_name
 
     if axis < 0:
-        raise ValueError("the 'axis' for argcombinations must be non-negative")
+        raise ValueError(
+            "the 'axis' for argcombinations must be non-negative"
+            + awkward1._util.exception_suffix(__file__)
+        )
     else:
         layout = awkward1.operations.convert.to_layout(
             array, allow_record=False, allow_other=False
@@ -2283,7 +2317,8 @@ def repartition(array, lengths, highlevel=True):
         if isinstance(lengths, (int, numbers.Integral, np.integer)):
             if lengths < 1:
                 raise ValueError(
-                    "lengths must be at least 1 (and probably " "considerably more)"
+                    "lengths must be at least 1 (and probably considerably more)"
+                    + awkward1._util.exception_suffix(__file__)
                 )
 
             howmany = len(layout) // lengths
@@ -2303,6 +2338,7 @@ def repartition(array, lengths, highlevel=True):
             raise ValueError(
                 "cannot repartition array of length {0} into "
                 "these lengths".format(len(layout))
+                + awkward1._util.exception_suffix(__file__)
             )
 
         if isinstance(layout, awkward1.partition.PartitionedArray):
@@ -2480,7 +2516,10 @@ def with_cache(array, cache, chain=None, highlevel=True):
     elif chain is False:
         chain = None
     elif chain is not None and chain not in ("first", "last"):
-        raise ValueError("chain must be None, 'first', 'last', or bool")
+        raise ValueError(
+            "chain must be None, 'first', 'last', or bool"
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     if not isinstance(cache, awkward1.layout.ArrayCache):
         cache = awkward1.layout.ArrayCache(cache)
@@ -2574,7 +2613,10 @@ def size(array, axis=None):
     error), then this function raise an error.
     """
     if axis is not None and axis < 0:
-        raise NotImplementedError("ak.size with axis < 0")
+        raise NotImplementedError(
+            "ak.size with axis < 0"
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     def recurse(layout, axis, sizes):
         nplike = awkward1.nplike.of(layout)
@@ -2595,6 +2637,7 @@ def size(array, axis=None):
                 elif compare != inner:
                     raise ValueError(
                         "ak.size is ambiguous due to union of different " "sizes"
+                        + awkward1._util.exception_suffix(__file__)
                     )
             sizes.extend(compare)
         elif isinstance(layout, awkward1._util.optiontypes):
@@ -2618,6 +2661,7 @@ def size(array, axis=None):
                 elif compare != inner:
                     raise ValueError(
                         "ak.size is ambiguous due to record of different " "sizes"
+                        + awkward1._util.exception_suffix(__file__)
                     )
             sizes.extend(compare)
         elif isinstance(layout, awkward1.layout.NumpyArray):
@@ -2626,7 +2670,10 @@ def size(array, axis=None):
             else:
                 sizes.extend(nplike.asarray(layout).shape[1 : axis + 2])
         else:
-            raise AssertionError("unrecognized Content type")
+            raise AssertionError(
+                "unrecognized Content type"
+                + awkward1._util.exception_suffix(__file__)
+            )
 
     layout = awkward1.operations.convert.to_layout(array, allow_record=False)
     if isinstance(layout, awkward1.partition.PartitionedArray):
@@ -2644,6 +2691,7 @@ def size(array, axis=None):
                     "ak.size is ambiguous due to variable-length arrays "
                     "(try ak.flatten to remove structure or ak.to_numpy "
                     "to force regularity, if possible)"
+                    + awkward1._util.exception_suffix(__file__)
                 )
             else:
                 out *= size
@@ -2654,6 +2702,7 @@ def size(array, axis=None):
                 "ak.size is ambiguous due to variable-length arrays at "
                 "axis {0} (try ak.flatten to remove structure or "
                 "ak.to_numpy to force regularity, if possible)".format(axis)
+                + awkward1._util.exception_suffix(__file__)
             )
         else:
             return sizes[-1]
@@ -2722,7 +2771,10 @@ def values_astype(array, to, highlevel=True):
     to_dtype = np.dtype(to)
     to_str = _dtype_to_string.get(to_dtype)
     if to_str is None:
-        raise ValueError("cannot use {0} to cast the numeric type of an array".format(to_dtype))
+        raise ValueError(
+            "cannot use {0} to cast the numeric type of an array".format(to_dtype)
+            + awkward1._util.exception_suffix(__file__)
+        )
 
     layout = awkward1.operations.convert.to_layout(
         array, allow_record=False, allow_other=False

--- a/src/awkward1/partition.py
+++ b/src/awkward1/partition.py
@@ -150,7 +150,10 @@ class PartitionedArray(object):
             if out is None:
                 out = x.type(typestrs)
             elif out != x.type(typestrs):
-                raise ValueError("inconsistent types in PartitionedArray")
+                raise ValueError(
+                    "inconsistent types in PartitionedArray"
+                    + awkward1._util.exception_suffix(__file__)
+                )
         return out
 
     @property
@@ -398,6 +401,7 @@ class PartitionedArray(object):
                 if not 0 <= head < len(self):
                     raise ValueError(
                         "{0} index out of range".format(type(self).__name__)
+                        + awkward1._util.exception_suffix(__file__)
                     )
                 partitionid, index = self._ext.partitionid_index_at(head)
                 return self.partition(partitionid)[(index,) + tail]

--- a/src/cpu-kernels/allocators.cpp
+++ b/src/cpu-kernels/allocators.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/allocators.cpp", line)
+
 #include "awkward/kernels/allocators.h"
 
 void* awkward_malloc(int64_t bytelength) {

--- a/src/cpu-kernels/getitem.cpp
+++ b/src/cpu-kernels/getitem.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/getitem.cpp", line)
+
 #include "awkward/kernels/getitem.h"
 
 void awkward_regularize_rangeslice(
@@ -47,7 +49,7 @@ ERROR awkward_regularize_arrayslice(
       flatheadptr[i] += length;
     }
     if (flatheadptr[i] < 0  ||  flatheadptr[i] >= length) {
-      return failure("index out of range", kSliceNone, original);
+      return failure("index out of range", kSliceNone, original, FILENAME(__LINE__));
     }
   }
   return success();
@@ -109,7 +111,7 @@ ERROR awkward_index_carry(
   for (int64_t i = 0;  i < length;  i++) {
     T j = carry[i];
     if (j > lenfromindex) {
-      return failure("index out of range", kSliceNone, j);
+      return failure("index out of range", kSliceNone, j, FILENAME(__LINE__));
     }
     toindex[i] = fromindex[(size_t)(j)];
   }
@@ -348,7 +350,7 @@ ERROR awkward_Identities_getitem_carry(
   int64_t length) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     if (carryptr[i] >= length) {
-      return failure("index out of range", kSliceNone, carryptr[i]);
+      return failure("index out of range", kSliceNone, carryptr[i], FILENAME(__LINE__));
     }
     for (int64_t j = 0;  j < width;  j++) {
       newidentitiesptr[width*i + j] =
@@ -707,7 +709,7 @@ ERROR awkward_ListArray_getitem_next_at(
       regular_at += length;
     }
     if (!(0 <= regular_at  &&  regular_at < length)) {
-      return failure("index out of range", i, at);
+      return failure("index out of range", i, at, FILENAME(__LINE__));
     }
     tocarry[i] = fromstarts[i] + regular_at;
   }
@@ -1036,11 +1038,11 @@ ERROR awkward_ListArray_getitem_next_array(
   int64_t lencontent) {
   for (int64_t i = 0;  i < lenstarts;  i++) {
     if (fromstops[i] < fromstarts[i]) {
-      return failure("stops[i] < starts[i]", i, kSliceNone);
+      return failure("stops[i] < starts[i]", i, kSliceNone, FILENAME(__LINE__));
     }
     if ((fromstarts[i] != fromstops[i])  &&
         (fromstops[i] > lencontent)) {
-      return failure("stops[i] > len(content)", i, kSliceNone);
+      return failure("stops[i] > len(content)", i, kSliceNone, FILENAME(__LINE__));
     }
     int64_t length = fromstops[i] - fromstarts[i];
     for (int64_t j = 0;  j < lenarray;  j++) {
@@ -1049,7 +1051,7 @@ ERROR awkward_ListArray_getitem_next_array(
         regular_at += length;
       }
       if (!(0 <= regular_at  &&  regular_at < length)) {
-        return failure("index out of range", i, fromarray[j]);
+        return failure("index out of range", i, fromarray[j], FILENAME(__LINE__));
       }
       tocarry[i*lenarray + j] = fromstarts[i] + regular_at;
       toadvanced[i*lenarray + j] = j;
@@ -1128,11 +1130,11 @@ ERROR awkward_ListArray_getitem_next_array_advanced(
   int64_t lencontent) {
   for (int64_t i = 0;  i < lenstarts;  i++) {
     if (fromstops[i] < fromstarts[i]) {
-      return failure("stops[i] < starts[i]", i, kSliceNone);
+      return failure("stops[i] < starts[i]", i, kSliceNone, FILENAME(__LINE__));
     }
     if ((fromstarts[i] != fromstops[i])  &&
         (fromstops[i] > lencontent)) {
-      return failure("stops[i] > len(content)", i, kSliceNone);
+      return failure("stops[i] > len(content)", i, kSliceNone, FILENAME(__LINE__));
     }
     int64_t length = fromstops[i] - fromstarts[i];
     int64_t regular_at = fromarray[fromadvanced[i]];
@@ -1140,7 +1142,7 @@ ERROR awkward_ListArray_getitem_next_array_advanced(
       regular_at += length;
     }
     if (!(0 <= regular_at  &&  regular_at < length)) {
-      return failure("index out of range", i, fromarray[fromadvanced[i]]);
+      return failure("index out of range", i, fromarray[fromadvanced[i]], FILENAME(__LINE__));
     }
     tocarry[i] = fromstarts[i] + regular_at;
     toadvanced[i] = i;
@@ -1222,7 +1224,7 @@ ERROR awkward_ListArray_getitem_carry(
   int64_t lencarry) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     if (fromcarry[i] >= lenstarts) {
-      return failure("index out of range", i, fromcarry[i]);
+      return failure("index out of range", i, fromcarry[i], FILENAME(__LINE__));
     }
     tostarts[i] = (C)(fromstarts[fromcarry[i]]);
     tostops[i] = (C)(fromstops[fromcarry[i]]);
@@ -1292,7 +1294,7 @@ ERROR awkward_RegularArray_getitem_next_at(
     regular_at += size;
   }
   if (!(0 <= regular_at  &&  regular_at < size)) {
-    return failure("index out of range", kSliceNone, at);
+    return failure("index out of range", kSliceNone, at, FILENAME(__LINE__));
   }
   for (int64_t i = 0;  i < length;  i++) {
     tocarry[i] = i*size + regular_at;
@@ -1379,7 +1381,7 @@ ERROR awkward_RegularArray_getitem_next_array_regularize(
       toarray[j] += size;
     }
     if (!(0 <= toarray[j]  &&  toarray[j] < size)) {
-      return failure("index out of range", kSliceNone, fromarray[j]);
+      return failure("index out of range", kSliceNone, fromarray[j], FILENAME(__LINE__));
     }
   }
   return success();
@@ -1538,7 +1540,7 @@ ERROR awkward_IndexedArray_getitem_nextcarry_outindex(
   for (int64_t i = 0;  i < lenindex;  i++) {
     C j = fromindex[i];
     if (j >= lencontent) {
-      return failure("index out of range", i, j);
+      return failure("index out of range", i, j, FILENAME(__LINE__));
     }
     else if (j < 0) {
       toindex[i] = -1;
@@ -1602,7 +1604,7 @@ ERROR awkward_IndexedArray_getitem_nextcarry_outindex_mask(
   for (int64_t i = 0;  i < lenindex;  i++) {
     C j = fromindex[i];
     if (j >= lencontent) {
-      return failure("index out of range", i, j);
+      return failure("index out of range", i, j, FILENAME(__LINE__));
     }
     else if (j < 0) {
       toindex[i] = -1;
@@ -1815,7 +1817,7 @@ ERROR awkward_IndexedArray_getitem_nextcarry(
   for (int64_t i = 0;  i < lenindex;  i++) {
     C j = fromindex[i];
     if (j < 0  ||  j >= lencontent) {
-      return failure("index out of range", i, j);
+      return failure("index out of range", i, j, FILENAME(__LINE__));
     }
     else {
       tocarry[k] = j;
@@ -1867,7 +1869,7 @@ ERROR awkward_IndexedArray_getitem_carry(
   int64_t lencarry) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     if (fromcarry[i] >= lenindex) {
-      return failure("index out of range", i, fromcarry[i]);
+      return failure("index out of range", i, fromcarry[i], FILENAME(__LINE__));
     }
     toindex[i] = (C)(fromindex[fromcarry[i]]);
   }
@@ -2133,11 +2135,10 @@ ERROR awkward_ListArray_getitem_jagged_expand(
     C start = fromstarts[i];
     C stop = fromstops[i];
     if (stop < start) {
-      return failure("stops[i] < starts[i]", i, kSliceNone);
+      return failure("stops[i] < starts[i]", i, kSliceNone, FILENAME(__LINE__));
     }
     if (stop - start != jaggedsize) {
-      return failure(
-        "cannot fit jagged slice into nested list", i, kSliceNone);
+      return failure("cannot fit jagged slice into nested list", i, kSliceNone, FILENAME(__LINE__));
     }
     for (int64_t j = 0;  j < jaggedsize;  j++) {
       multistarts[i*jaggedsize + j] = singleoffsets[j];
@@ -2248,19 +2249,18 @@ ERROR awkward_ListArray_getitem_jagged_apply(
     tooffsets[i] = (T)k;
     if (slicestart != slicestop) {
       if (slicestop < slicestart) {
-        return failure("jagged slice's stops[i] < starts[i]", i, kSliceNone);
+        return failure("jagged slice's stops[i] < starts[i]", i, kSliceNone, FILENAME(__LINE__));
       }
       if (slicestop > sliceinnerlen) {
-        return failure(
-          "jagged slice's offsets extend beyond its content", i, slicestop);
+        return failure("jagged slice's offsets extend beyond its content", i, slicestop, FILENAME(__LINE__));
       }
       int64_t start = (int64_t)fromstarts[i];
       int64_t stop = (int64_t)fromstops[i];
       if (stop < start) {
-        return failure("stops[i] < starts[i]", i, kSliceNone);
+        return failure("stops[i] < starts[i]", i, kSliceNone, FILENAME(__LINE__));
       }
       if (start != stop  &&  stop > contentlen) {
-        return failure("stops[i] > len(content)", i, kSliceNone);
+        return failure("stops[i] > len(content)", i, kSliceNone, FILENAME(__LINE__));
       }
       int64_t count = stop - start;
       for (int64_t j = slicestart;  j < slicestop;  j++) {
@@ -2269,10 +2269,7 @@ ERROR awkward_ListArray_getitem_jagged_apply(
           index += count;
         }
         if (!(0 <= index  &&  index < count)) {
-          return failure(
-            "index out of range",
-            i,
-            (int64_t)sliceindex[j]);
+          return failure("index out of range", i, (int64_t)sliceindex[j], FILENAME(__LINE__));
         }
         tocarry[k] = start + index;
         k++;
@@ -2366,11 +2363,10 @@ ERROR awkward_ListArray_getitem_jagged_numvalid(
     T slicestop = slicestops[i];
     if (slicestart != slicestop) {
       if (slicestop < slicestart) {
-        return failure("jagged slice's stops[i] < starts[i]", i, kSliceNone);
+        return failure("jagged slice's stops[i] < starts[i]", i, kSliceNone, FILENAME(__LINE__));
       }
       if (slicestop > missinglength) {
-        return failure(
-          "jagged slice's offsets extend beyond its content", i, slicestop);
+        return failure("jagged slice's offsets extend beyond its content", i, slicestop, FILENAME(__LINE__));
       }
       for (int64_t j = slicestart;  j < slicestop;  j++) {
         *numvalid = *numvalid + (missing[j] >= 0 ? 1 : 0);
@@ -2472,10 +2468,7 @@ ERROR awkward_ListArray_getitem_jagged_descend(
     int64_t count = (int64_t)(fromstops[i] -
                               fromstarts[i]);
     if (slicecount != count) {
-      return failure(
-        "jagged slice inner length differs from array inner length",
-        i,
-        kSliceNone);
+      return failure("jagged slice inner length differs from array inner length", i, kSliceNone, FILENAME(__LINE__));
     }
     tooffsets[i + 1] = tooffsets[i] + (T)count;
   }
@@ -2638,7 +2631,7 @@ ERROR awkward_ByteMaskedArray_getitem_carry(
   int64_t lencarry) {
   for (int64_t i = 0;  i < lencarry;  i++) {
     if (fromcarry[i] >= lenmask) {
-      return failure("index out of range", i, fromcarry[i]);
+      return failure("index out of range", i, fromcarry[i], FILENAME(__LINE__));
     }
     tomask[i] = frommask[fromcarry[i]];
   }

--- a/src/cpu-kernels/identities.cpp
+++ b/src/cpu-kernels/identities.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/identities.cpp", line)
+
 #include "awkward/kernels/identities.h"
 
 template <typename T>
@@ -59,7 +61,7 @@ ERROR awkward_Identities_from_ListOffsetArray(
     int64_t start = fromoffsets[i];
     int64_t stop = fromoffsets[i + 1];
     if (start != stop  &&  stop > tolength) {
-      return failure("max(stop) > len(content)", i, kSliceNone);
+      return failure("max(stop) > len(content)", i, kSliceNone, FILENAME(__LINE__));
     }
     for (int64_t j = start;  j < stop;  j++) {
       for (int64_t k = 0;  k < fromwidth;  k++) {
@@ -179,7 +181,7 @@ ERROR awkward_Identities_from_ListArray(
     int64_t start = fromstarts[i];
     int64_t stop = fromstops[i];
     if (start != stop  &&  stop > tolength) {
-      return failure("max(stop) > len(content)", i, kSliceNone);
+      return failure("max(stop) > len(content)", i, kSliceNone, FILENAME(__LINE__));
     }
     for (int64_t j = start;  j < stop;  j++) {
       if (toptr[j*(fromwidth + 1) + fromwidth] != -1) {
@@ -381,7 +383,7 @@ ERROR awkward_Identities_from_IndexedArray(
   for (int64_t i = 0;  i < fromlength;  i++) {
     T j = fromindex[i];
     if (j >= tolength) {
-      return failure("max(index) > len(content)", i, j);
+      return failure("max(index) > len(content)", i, j, FILENAME(__LINE__));
     }
     else if (j >= 0) {
       if (toptr[j*fromwidth] != -1) {
@@ -517,10 +519,10 @@ ERROR awkward_Identities_from_UnionArray(
     if (fromtags[i] == which) {
       I j = fromindex[i];
       if (j >= tolength) {
-        return failure("max(index) > len(content)", i, j);
+        return failure("max(index) > len(content)", i, j, FILENAME(__LINE__));
       }
       else if (j < 0) {
-        return failure("min(index) < 0", i, j);
+        return failure("min(index) < 0", i, j, FILENAME(__LINE__));
       }
       else {
         if (toptr[j*fromwidth] != -1) {

--- a/src/cpu-kernels/operations.cpp
+++ b/src/cpu-kernels/operations.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/operations.cpp", line)
+
 #include "awkward/kernels/operations.h"
 
 template <typename T, typename C>
@@ -138,7 +140,7 @@ ERROR awkward_IndexedArray_flatten_none2empty(
       k++;
     }
     else if (idx + 1 >= offsetslength) {
-      return failure("flattening offset out of range", i, kSliceNone);
+      return failure("flattening offset out of range", i, kSliceNone, FILENAME(__LINE__));
     }
     else {
       T count =
@@ -337,7 +339,7 @@ ERROR awkward_IndexedArray_flatten_nextcarry(
   for (int64_t i = 0;  i < lenindex;  i++) {
     C j = fromindex[i];
     if (j >= lencontent) {
-      return failure("index out of range", i, j);
+      return failure("index out of range", i, j, FILENAME(__LINE__));
     }
     else if (j >= 0) {
       tocarry[k] = j;
@@ -515,7 +517,7 @@ ERROR awkward_IndexedArray_simplify(
       toindex[i] = -1;
     }
     else if (j >= innerlength) {
-      return failure("index out of range", i, j);
+      return failure("index out of range", i, j, FILENAME(__LINE__));
     }
     else {
       toindex[i] = innerindex[j];
@@ -673,7 +675,7 @@ ERROR awkward_ListArray_compact_offsets(
     C start = fromstarts[i];
     C stop = fromstops[i];
     if (stop < start) {
-      return failure("stops[i] < starts[i]", i, kSliceNone);
+      return failure("stops[i] < starts[i]", i, kSliceNone, FILENAME(__LINE__));
     }
     tooffsets[i + 1] = tooffsets[i] + (stop - start);
   }
@@ -766,15 +768,14 @@ ERROR awkward_ListArray_broadcast_tooffsets(
     int64_t start = (int64_t)fromstarts[i];
     int64_t stop = (int64_t)fromstops[i];
     if (start != stop  &&  stop > lencontent) {
-      return failure("stops[i] > len(content)", i, stop);
+      return failure("stops[i] > len(content)", i, stop, FILENAME(__LINE__));
     }
     int64_t count = (int64_t)(fromoffsets[i + 1] - fromoffsets[i]);
     if (count < 0) {
-      return failure(
-        "broadcast's offsets must be monotonically increasing", i, kSliceNone);
+      return failure("broadcast's offsets must be monotonically increasing", i, kSliceNone, FILENAME(__LINE__));
     }
     if (stop - start != count) {
-      return failure("cannot broadcast nested list", i, kSliceNone);
+      return failure("cannot broadcast nested list", i, kSliceNone, FILENAME(__LINE__));
     }
     for (int64_t j = start;  j < stop;  j++) {
       tocarry[k] = (T)j;
@@ -837,11 +838,10 @@ ERROR awkward_RegularArray_broadcast_tooffsets(
   for (int64_t i = 0;  i < offsetslength - 1;  i++) {
     int64_t count = (int64_t)(fromoffsets[i + 1] - fromoffsets[i]);
     if (count < 0) {
-      return failure(
-        "broadcast's offsets must be monotonically increasing", i, kSliceNone);
+      return failure("broadcast's offsets must be monotonically increasing", i, kSliceNone, FILENAME(__LINE__));
     }
     if (size != count) {
-      return failure("cannot broadcast nested list", i, kSliceNone);
+      return failure("cannot broadcast nested list", i, kSliceNone, FILENAME(__LINE__));
     }
   }
   return success();
@@ -865,8 +865,7 @@ ERROR awkward_RegularArray_broadcast_tooffsets_size1(
   for (int64_t i = 0;  i < offsetslength - 1;  i++) {
     int64_t count = (int64_t)(fromoffsets[i + 1] - fromoffsets[i]);
     if (count < 0) {
-      return failure(
-        "broadcast's offsets must be monotonically increasing", i, kSliceNone);
+      return failure("broadcast's offsets must be monotonically increasing", i, kSliceNone, FILENAME(__LINE__));
     }
     for (int64_t j = 0;  j < count;  j++) {
       tocarry[k] = (T)i;
@@ -894,18 +893,13 @@ ERROR awkward_ListOffsetArray_toRegularArray(
   for (int64_t i = 0;  i < offsetslength - 1;  i++) {
     int64_t count = (int64_t)fromoffsets[i + 1] - (int64_t)fromoffsets[i];
     if (count < 0) {
-      return failure(
-        "offsets must be monotonically increasing", i, kSliceNone);
+      return failure("offsets must be monotonically increasing", i, kSliceNone, FILENAME(__LINE__));
     }
     if (*size == -1) {
       *size = count;
     }
     else if (*size != count) {
-      return failure(
-        "cannot convert to RegularArray because subarray lengths are not "
-        "regular",
-        i,
-        kSliceNone);
+      return failure("cannot convert to RegularArray because subarray lengths are not " "regular", i, kSliceNone, FILENAME(__LINE__));
     }
   }
   if (*size == -1) {
@@ -2563,13 +2557,13 @@ ERROR awkward_ListArray_validity(
     C stop = stops[i];
     if (start != stop) {
       if (start > stop) {
-        return failure("start[i] > stop[i]", i, kSliceNone);
+        return failure("start[i] > stop[i]", i, kSliceNone, FILENAME(__LINE__));
       }
       if (start < 0) {
-        return failure("start[i] < 0", i, kSliceNone);
+        return failure("start[i] < 0", i, kSliceNone, FILENAME(__LINE__));
       }
       if (stop > lencontent) {
-        return failure("stop[i] > len(content)", i, kSliceNone);
+        return failure("stop[i] > len(content)", i, kSliceNone, FILENAME(__LINE__));
       }
     }
   }
@@ -2620,11 +2614,11 @@ ERROR awkward_IndexedArray_validity(
     C idx = index[i];
     if (!isoption) {
       if (idx < 0) {
-        return failure("index[i] < 0", i, kSliceNone);
+        return failure("index[i] < 0", i, kSliceNone, FILENAME(__LINE__));
       }
     }
     if (idx >= lencontent) {
-      return failure("index[i] >= len(content)", i, kSliceNone);
+      return failure("index[i] >= len(content)", i, kSliceNone, FILENAME(__LINE__));
     }
   }
   return success();
@@ -2674,17 +2668,17 @@ ERROR awkward_UnionArray_validity(
     T tag = tags[i];
     I idx = index[i];
     if (tag < 0) {
-      return failure("tags[i] < 0", i, kSliceNone);
+      return failure("tags[i] < 0", i, kSliceNone, FILENAME(__LINE__));
     }
     if (idx < 0) {
-      return failure("index[i] < 0", i, kSliceNone);
+      return failure("index[i] < 0", i, kSliceNone, FILENAME(__LINE__));
     }
     if (tag >= numcontents) {
-      return failure("tags[i] >= len(contents)", i, kSliceNone);
+      return failure("tags[i] >= len(contents)", i, kSliceNone, FILENAME(__LINE__));
     }
     int64_t lencontent = lencontents[tag];
     if (idx >= lencontent) {
-      return failure("index[i] >= len(content[tags[i]])", i, kSliceNone);
+      return failure("index[i] >= len(content[tags[i]])", i, kSliceNone, FILENAME(__LINE__));
     }
   }
   return success();
@@ -3307,7 +3301,7 @@ ERROR awkward_combinations(
   int64_t n,
   bool replacement,
   int64_t singlelen) {
-  return failure("FIXME: awkward_combinations", 0, kSliceNone);
+  return failure("FIXME: awkward_combinations", 0, kSliceNone, FILENAME(__LINE__));
 }
 ERROR awkward_combinations_64(
   int64_t* toindex,

--- a/src/cpu-kernels/reducers.cpp
+++ b/src/cpu-kernels/reducers.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/reducers.cpp", line)
+
 #include "awkward/kernels/reducers.h"
 
 ERROR awkward_reduce_count_64(

--- a/src/cpu-kernels/sorting.cpp
+++ b/src/cpu-kernels/sorting.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/jpivarski/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/sorting.cpp", line)
+
 #include <algorithm>
 #include <cstring>
 #include <numeric>

--- a/src/cuda-kernels/allocators.cu
+++ b/src/cuda-kernels/allocators.cu
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_CUDA("src/cuda-kernels/allocators.cu", line)
+
 #include "awkward/kernels/allocators.h"
 
 void* awkward_malloc(int64_t bytelength) {

--- a/src/cuda-kernels/cuda-utils.cu
+++ b/src/cuda-kernels/cuda-utils.cu
@@ -1,12 +1,14 @@
 // BSD 3-Clause License; see https://github.com/jpivarski/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_CUDA("src/cuda-kernels/cuda-utils.cu", line)
+
 #include "awkward/kernels/cuda-utils.h"
 
 ERROR awkward_cuda_ptr_device_num(int64_t* num, void* ptr) {
   cudaPointerAttributes att;
   cudaError_t status = cudaPointerGetAttributes(&att, ptr);
   if (status != cudaError::cudaSuccess) {
-    return failure(cudaGetErrorString(status), kSliceNone, kSliceNone, true);
+    return failure_pass_through(cudaGetErrorString(status), kSliceNone, kSliceNone, FILENAME(__LINE__));
   }
   *num = att.device;
   return success();
@@ -16,12 +18,12 @@ ERROR awkward_cuda_ptr_device_name(char* name, void* ptr) {
   cudaPointerAttributes att;
   cudaError_t status = cudaPointerGetAttributes(&att, ptr);
   if (status != cudaError::cudaSuccess) {
-    return failure(cudaGetErrorString(status), kSliceNone, kSliceNone, true);
+    return failure_pass_through(cudaGetErrorString(status), kSliceNone, kSliceNone, FILENAME(__LINE__));
   }
   cudaDeviceProp dev_prop;
   status = cudaGetDeviceProperties(&dev_prop, att.device);
   if (status != cudaError::cudaSuccess) {
-    return failure(cudaGetErrorString(status), kSliceNone, kSliceNone, true);
+    return failure_pass_through(cudaGetErrorString(status), kSliceNone, kSliceNone, FILENAME(__LINE__));
   }
   strcpy(name, dev_prop.name);
   return success();
@@ -31,12 +33,10 @@ ERROR awkward_cuda_host_to_device(
   void* to_ptr,
   void* from_ptr,
   int64_t bytelength) {
-  cudaError_t memcpy_stat = cudaMemcpy(to_ptr,
-                                       from_ptr,
-                                       bytelength,
-                                       cudaMemcpyHostToDevice);
+  cudaError_t memcpy_stat = cudaMemcpy(
+    to_ptr, from_ptr, bytelength, cudaMemcpyHostToDevice);
   if (memcpy_stat != cudaError_t::cudaSuccess) {
-    return failure(cudaGetErrorString(memcpy_stat), kSliceNone, kSliceNone, true);
+    return failure_pass_through(cudaGetErrorString(memcpy_stat), kSliceNone, kSliceNone, FILENAME(__LINE__));
   }
   else {
     return success();
@@ -52,7 +52,7 @@ ERROR awkward_cuda_device_to_host(
                                        bytelength,
                                        cudaMemcpyDeviceToHost);
   if (memcpy_stat != cudaError_t::cudaSuccess) {
-    return failure(cudaGetErrorString(memcpy_stat), kSliceNone, kSliceNone, true);
+    return failure_pass_through(cudaGetErrorString(memcpy_stat), kSliceNone, kSliceNone, FILENAME(__LINE__));
   }
   else {
     return success();

--- a/src/cuda-kernels/getitem.cu
+++ b/src/cuda-kernels/getitem.cu
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_CUDA("src/cuda-kernels/getitem.cu", line)
+
 #include "awkward/kernels/getitem.h"
 #include <iostream>
 

--- a/src/cuda-kernels/operations.cu
+++ b/src/cuda-kernels/operations.cu
@@ -1,8 +1,9 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_CUDA("src/cuda-kernels/operations.cu", line)
+
 #include "awkward/kernels/operations.h"
 #include <stdio.h>
-
 
 template <typename T, typename C>
 __global__

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/Content.cpp", line)
+
 #include <sstream>
 
 #include "rapidjson/document.h"
@@ -48,8 +50,9 @@ namespace awkward {
       }
       else {
         throw std::invalid_argument(
-          std::string("cannot convert NumPy bool dtype with itemsize ") +
-          std::to_string(itemsize) + std::string(" into a NumpyForm"));
+          std::string("cannot convert NumPy bool dtype with itemsize ")
+          + std::to_string(itemsize) + std::string(" into a NumpyForm")
+          + FILENAME(__LINE__));
       }
     case 'i':
       switch (itemsize) {
@@ -91,8 +94,9 @@ namespace awkward {
                  util::dtype::int64);
       default:
         throw std::invalid_argument(
-          std::string("cannot convert NumPy int dtype with itemsize ") +
-          std::to_string(itemsize) + std::string(" into a NumpyForm"));
+          std::string("cannot convert NumPy int dtype with itemsize ")
+          + std::to_string(itemsize) + std::string(" into a NumpyForm")
+          + FILENAME(__LINE__));
       }
     case 'u':
       switch (itemsize) {
@@ -134,8 +138,9 @@ namespace awkward {
                  util::dtype::uint64);
       default:
         throw std::invalid_argument(
-          std::string("cannot convert NumPy int dtype with itemsize ") +
-          std::to_string(itemsize) + std::string(" into a NumpyForm"));
+          std::string("cannot convert NumPy int dtype with itemsize ")
+          + std::to_string(itemsize) + std::string(" into a NumpyForm")
+          + FILENAME(__LINE__));
       }
     case 'f':
       switch (itemsize) {
@@ -177,8 +182,9 @@ namespace awkward {
                  util::dtype::float128);
       default:
         throw std::invalid_argument(
-          std::string("cannot convert NumPy floating-point dtype with itemsize ") +
-          std::to_string(itemsize) + std::string(" into a NumpyForm"));
+          std::string("cannot convert NumPy floating-point dtype with itemsize ")
+          + std::to_string(itemsize) + std::string(" into a NumpyForm")
+          + FILENAME(__LINE__));
       }
 
     case 'c':
@@ -212,8 +218,9 @@ namespace awkward {
                  util::dtype::complex256);
       default:
         throw std::invalid_argument(
-          std::string("cannot convert NumPy complex dtype with itemsize ") +
-          std::to_string(itemsize) + std::string(" into a NumpyForm"));
+          std::string("cannot convert NumPy complex dtype with itemsize ")
+          + std::to_string(itemsize) + std::string(" into a NumpyForm")
+          + FILENAME(__LINE__));
       }
 
     // case 'M': handle datetime64
@@ -221,8 +228,9 @@ namespace awkward {
 
     default:
       throw std::invalid_argument(
-        std::string("cannot convert NumPy dtype with kind ") +
-        std::string(1, kind) + std::string(" into a NumpyForm"));
+        std::string("cannot convert NumPy dtype with kind ")
+        + std::string(1, kind) + std::string(" into a NumpyForm")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -254,7 +262,8 @@ namespace awkward {
           h = json["has_identities"].GetBool();
         }
         else {
-          throw std::invalid_argument("'has_identities' must be boolean");
+          throw std::invalid_argument(
+            std::string("'has_identities' must be boolean") + FILENAME(__LINE__));
         }
       }
 
@@ -269,7 +278,8 @@ namespace awkward {
           }
         }
         else {
-          throw std::invalid_argument("'parameters' must be a JSON object");
+          throw std::invalid_argument(
+            std::string("'parameters' must be a JSON object") + FILENAME(__LINE__));
         }
       }
 
@@ -280,7 +290,8 @@ namespace awkward {
           f = std::make_shared<std::string>(json["form_key"].GetString());
         }
         else {
-          throw std::invalid_argument("'form_key' must be null or a string");
+          throw std::invalid_argument(
+            std::string("'form_key' must be null or a string") + FILENAME(__LINE__));
         }
       }
 
@@ -308,8 +319,9 @@ namespace awkward {
           dtype = util::format_to_dtype(format, itemsize);
         }
         else {
-          throw std::invalid_argument("NumpyForm must have a 'primitive' "
-                                      "field or 'format' and 'itemsize'");
+          throw std::invalid_argument(
+            std::string("NumpyForm must have a 'primitive' field or 'format' "
+                        "and 'itemsize'") + FILENAME(__LINE__));
         }
         std::vector<int64_t> s;
         if (json.HasMember("inner_shape")  &&  json["inner_shape"].IsArray()) {
@@ -318,8 +330,9 @@ namespace awkward {
               s.push_back(x.GetInt64());
             }
             else {
-              throw std::invalid_argument("NumpyForm 'inner_shape' must only "
-                                          "contain integers");
+              throw std::invalid_argument(
+                std::string("NumpyForm 'inner_shape' must only contain integers")
+                + FILENAME(__LINE__));
             }
           }
         }
@@ -342,8 +355,9 @@ namespace awkward {
           }
         }
         else {
-          throw std::invalid_argument("RecordArray 'contents' must be a JSON "
-                                      "list or a JSON object");
+          throw std::invalid_argument(
+            std::string("RecordArray 'contents' must be a JSON list or a "
+                        "JSON object") + FILENAME(__LINE__));
         }
         return std::make_shared<RecordForm>(h, p, f, recordlookup, contents);
       }
@@ -360,18 +374,19 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["offsets"].GetString());
           if (offsets != Index::Form::kNumIndexForm  &&  offsets != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'offsets' type: ")
-                      + json["offsets"].GetString());
+              cls + std::string(" has conflicting 'offsets' type: ")
+              + json["offsets"].GetString() + FILENAME(__LINE__));
           }
           offsets = tmp;
         }
         if (offsets == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing an 'offsets' specification"));
+            cls + std::string(" is missing an 'offsets' specification")
+            + FILENAME(__LINE__));
         }
         if (!json.HasMember("content")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'content'"));
+            cls + std::string(" is missing its 'content'") + FILENAME(__LINE__));
         }
         FormPtr content = fromjson_part(json["content"]);
         return std::make_shared<ListOffsetForm>(h, p, f, offsets, content);
@@ -393,8 +408,8 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["starts"].GetString());
           if (starts != Index::Form::kNumIndexForm  &&  starts != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'starts' type: ")
-                      + json["starts"].GetString());
+              cls + std::string(" has conflicting 'starts' type: ")
+              + json["starts"].GetString() + FILENAME(__LINE__));
           }
           starts = tmp;
         }
@@ -402,22 +417,25 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["stops"].GetString());
           if (stops != Index::Form::kNumIndexForm  &&  stops != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'stops' type: ")
-                      + json["stops"].GetString());
+              cls + std::string(" has conflicting 'stops' type: ")
+              + json["stops"].GetString() + FILENAME(__LINE__));
           }
           stops = tmp;
         }
         if (starts == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing a 'starts' specification"));
+            cls + std::string(" is missing a 'starts' specification")
+            + FILENAME(__LINE__));
         }
         if (stops == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing a 'stops' specification"));
+            cls + std::string(" is missing a 'stops' specification")
+            + FILENAME(__LINE__));
         }
         if (!json.HasMember("content")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'content'"));
+            cls + std::string(" is missing its 'content'")
+            + FILENAME(__LINE__));
         }
         FormPtr content = fromjson_part(json["content"]);
         return std::make_shared<ListForm>(h, p, f, starts, stops, content);
@@ -426,12 +444,12 @@ namespace awkward {
       if (cls == std::string("RegularArray")) {
         if (!json.HasMember("content")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'content'"));
+            cls + std::string(" is missing its 'content'") + FILENAME(__LINE__));
         }
         FormPtr content = fromjson_part(json["content"]);
         if (!json.HasMember("size")  ||  !json["size"].IsInt()) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'size'"));
+            cls + std::string(" is missing its 'size'") + FILENAME(__LINE__));
         }
         int64_t size = json["size"].GetInt64();
         return std::make_shared<RegularForm>(h, p, f, content, size);
@@ -447,18 +465,19 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["index"].GetString());
           if (index != Index::Form::kNumIndexForm  &&  index != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'index' type: ")
-                      + json["index"].GetString());
+              cls + std::string(" has conflicting 'index' type: ")
+              + json["index"].GetString() + FILENAME(__LINE__));
           }
           index = tmp;
         }
         if (index == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing an 'index' specification"));
+            cls + std::string(" is missing an 'index' specification")
+            + FILENAME(__LINE__));
         }
         if (!json.HasMember("content")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'content'"));
+            cls + std::string(" is missing its 'content'") + FILENAME(__LINE__));
         }
         FormPtr content = fromjson_part(json["content"]);
         return std::make_shared<IndexedOptionForm>(h, p, f, index, content);
@@ -476,18 +495,19 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["index"].GetString());
           if (index != Index::Form::kNumIndexForm  &&  index != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'index' type: ")
-                      + json["index"].GetString());
+              cls + std::string(" has conflicting 'index' type: ")
+              + json["index"].GetString() + FILENAME(__LINE__));
           }
           index = tmp;
         }
         if (index == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing an 'index' specification"));
+            cls + std::string(" is missing an 'index' specification")
+             + FILENAME(__LINE__));
         }
         if (!json.HasMember("content")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'content'"));
+            cls + std::string(" is missing its 'content'") + FILENAME(__LINE__));
         }
         FormPtr content = fromjson_part(json["content"]);
         return std::make_shared<IndexedForm>(h, p, f, index, content);
@@ -502,23 +522,24 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["mask"].GetString());
           if (mask != Index::Form::kNumIndexForm  &&  mask != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'mask' type: ")
-                      + json["mask"].GetString());
+              cls + std::string(" has conflicting 'mask' type: ")
+              + json["mask"].GetString() + FILENAME(__LINE__));
           }
           mask = tmp;
         }
         if (mask == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing a 'mask' specification"));
+            cls + std::string(" is missing a 'mask' specification")
+             + FILENAME(__LINE__));
         }
         if (!json.HasMember("content")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'content'"));
+            cls + std::string(" is missing its 'content'") + FILENAME(__LINE__));
         }
         FormPtr content = fromjson_part(json["content"]);
         if (!json.HasMember("valid_when")  ||  !json["valid_when"].IsBool()) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'valid_when'"));
+            cls + std::string(" is missing its 'valid_when'") + FILENAME(__LINE__));
         }
         bool valid_when = json["valid_when"].GetBool();
         return std::make_shared<ByteMaskedForm>(h, p, f, mask, content,
@@ -534,28 +555,32 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["mask"].GetString());
           if (mask != Index::Form::kNumIndexForm  &&  mask != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'mask' type: ")
-                      + json["mask"].GetString());
+              cls + std::string(" has conflicting 'mask' type: ")
+              + json["mask"].GetString() + FILENAME(__LINE__));
           }
           mask = tmp;
         }
         if (mask == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing a 'mask' specification"));
+            cls + std::string(" is missing a 'mask' specification")
+            + FILENAME(__LINE__));
         }
         if (!json.HasMember("content")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'content'"));
+            cls + std::string(" is missing its 'content'")
+            + FILENAME(__LINE__));
         }
         FormPtr content = fromjson_part(json["content"]);
         if (!json.HasMember("valid_when")  ||  !json["valid_when"].IsBool()) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'valid_when'"));
+            cls + std::string(" is missing its 'valid_when'")
+            + FILENAME(__LINE__));
         }
         bool valid_when = json["valid_when"].GetBool();
         if (!json.HasMember("lsb_order")  ||  !json["lsb_order"].IsBool()) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'lsb_order'"));
+            cls + std::string(" is missing its 'lsb_order'")
+            + FILENAME(__LINE__));
         }
         bool lsb_order = json["lsb_order"].GetBool();
         return std::make_shared<BitMaskedForm>(h, p, f, mask, content,
@@ -565,7 +590,7 @@ namespace awkward {
       if (cls == std::string("UnmaskedArray")) {
         if (!json.HasMember("content")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'content'"));
+            cls + std::string(" is missing its 'content'") + FILENAME(__LINE__));
         }
         FormPtr content = fromjson_part(json["content"]);
         return std::make_shared<UnmaskedForm>(h, p, f, content);
@@ -583,8 +608,8 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["tags"].GetString());
           if (tags != Index::Form::kNumIndexForm  &&  tags != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'tags' type: ")
-                      + json["tags"].GetString());
+              cls + std::string(" has conflicting 'tags' type: ")
+              + json["tags"].GetString() + FILENAME(__LINE__));
           }
           tags = tmp;
         }
@@ -596,18 +621,20 @@ namespace awkward {
           Index::Form tmp = Index::str2form(json["index"].GetString());
           if (index != Index::Form::kNumIndexForm  &&  index != tmp) {
             throw std::invalid_argument(
-                  cls + std::string(" has conflicting 'index' type: ")
-                      + json["index"].GetString());
+              cls + std::string(" has conflicting 'index' type: ")
+              + json["index"].GetString() + FILENAME(__LINE__));
           }
           index = tmp;
         }
         if (tags == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing a 'tags' specification"));
+            cls + std::string(" is missing a 'tags' specification")
+            + FILENAME(__LINE__));
         }
         if (index == Index::Form::kNumIndexForm) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing an 'index' specification"));
+            cls + std::string(" is missing an 'index' specification")
+            + FILENAME(__LINE__));
         }
         std::vector<FormPtr> contents;
         if (json.HasMember("contents")  &&  json["contents"].IsArray()) {
@@ -617,7 +644,8 @@ namespace awkward {
         }
         else {
           throw std::invalid_argument(
-                  cls + std::string(" 'contents' must be a JSON list"));
+            cls + std::string(" 'contents' must be a JSON list")
+            + FILENAME(__LINE__));
         }
         return std::make_shared<UnionForm>(h, p, f, tags, index, contents);
       }
@@ -629,7 +657,7 @@ namespace awkward {
       if (cls == std::string("VirtualArray")) {
         if (!json.HasMember("form")) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'form'"));
+            cls + std::string(" is missing its 'form'") + FILENAME(__LINE__));
         }
         FormPtr form(nullptr);
         if (!json["form"].IsNull()) {
@@ -637,7 +665,7 @@ namespace awkward {
         }
         if (!json.HasMember("has_length")  ||  !json["has_length"].IsBool()) {
           throw std::invalid_argument(
-                  cls + std::string(" is missing its 'has_length'"));
+            cls + std::string(" is missing its 'has_length'") + FILENAME(__LINE__));
         }
         bool has_length = json["has_length"].GetBool();
         return std::make_shared<VirtualForm>(h, p, f, form, has_length);
@@ -649,8 +677,8 @@ namespace awkward {
     rj::PrettyWriter<rj::StringBuffer> writer(stringbuffer);
     json.Accept(writer);
     throw std::invalid_argument(
-              std::string("JSON cannot be recognized as a Form:\n\n")
-              + stringbuffer.GetString());
+            std::string("JSON cannot be recognized as a Form:\n\n")
+            + stringbuffer.GetString() + FILENAME(__LINE__));
   }
 
   FormPtr
@@ -871,16 +899,18 @@ namespace awkward {
     if (branch) {
       if (negaxis <= 0) {
         throw std::invalid_argument(
-        "cannot use non-negative axis on a nested list structure "
-        "of variable depth (negative axis counts from the leaves of the tree; "
-        "non-negative from the root)");
+          std::string("cannot use non-negative axis on a nested list structure "
+                      "of variable depth (negative axis counts from the leaves "
+                      "of the tree; non-negative from the root)")
+          + FILENAME(__LINE__));
       }
       if (negaxis > depth) {
         throw std::invalid_argument(
           std::string("cannot use axis=") + std::to_string(axis)
           + std::string(" on a nested list structure that splits into "
                         "different depths, the minimum of which is depth=")
-          + std::to_string(depth) + std::string(" from the leaves"));
+          + std::to_string(depth) + std::string(" from the leaves")
+          + FILENAME(__LINE__));
       }
     }
     else {
@@ -892,7 +922,7 @@ namespace awkward {
           std::string("axis=") + std::to_string(axis)
           + std::string(" exceeds the depth of the nested list structure "
                         "(which is ")
-          + std::to_string(depth) + std::string(")"));
+          + std::to_string(depth) + std::string(")") + FILENAME(__LINE__));
       }
     }
 
@@ -925,15 +955,19 @@ namespace awkward {
 
     if (branch) {
       if (negaxis <= 0) {
-        throw std::invalid_argument("cannot use non-negative axis on a nested "
-        "list structure of variable depth (negative axis counts from "
-        "the leaves of the tree; non-negative from the root)");
+        throw std::invalid_argument(
+          std::string("cannot use non-negative axis on a nested list structure "
+                      "of variable depth (negative axis counts from the leaves "
+                      "of the tree; non-negative from the root)")
+          + FILENAME(__LINE__));
       }
       if (negaxis > depth) {
-        throw std::invalid_argument(std::string("cannot use axis=") +
-        std::to_string(axis) + std::string(" on a nested list structure "
-        "that splits into different depths, the minimum of which is depth=") +
-        std::to_string(depth) + std::string(" from the leaves"));
+        throw std::invalid_argument(
+          std::string("cannot use axis=") + std::to_string(axis)
+          + std::string(" on a nested list structure that splits into different "
+                        "depths, the minimum of which is depth=")
+          + std::to_string(depth) + std::string(" from the leaves")
+          + FILENAME(__LINE__));
       }
     }
     else {
@@ -941,10 +975,11 @@ namespace awkward {
         negaxis += depth;
       }
       if (!(0 < negaxis  &&  negaxis <= depth)) {
-        throw std::invalid_argument(std::string("axis=") +
+        throw std::invalid_argument(
+          std::string("axis=") +
         std::to_string(axis) + std::string(" exceeds the depth of the nested "
-        "list structure (which is ") + std::to_string(depth) +
-        std::string(")"));
+                                           "list structure (which is ")
+          + std::to_string(depth) + std::string(")") + FILENAME(__LINE__));
       }
     }
 
@@ -979,16 +1014,18 @@ namespace awkward {
     if (branch) {
       if (negaxis <= 0) {
         throw std::invalid_argument(
-          "cannot use non-negative axis on a nested list structure "
-          "of variable depth (negative axis counts from the leaves of the "
-          "tree; non-negative from the root)");
+          std::string("cannot use non-negative axis on a nested list structure "
+                      "of variable depth (negative axis counts from the leaves "
+                      "of the tree; non-negative from the root)")
+          + FILENAME(__LINE__));
       }
       if (negaxis > depth) {
         throw std::invalid_argument(
           std::string("cannot use axis=") + std::to_string(axis)
           + std::string(" on a nested list structure that splits into "
                         "different depths, the minimum of which is depth=")
-          + std::to_string(depth) + std::string(" from the leaves"));
+          + std::to_string(depth) + std::string(" from the leaves")
+          + FILENAME(__LINE__));
       }
     }
     else {
@@ -1000,7 +1037,8 @@ namespace awkward {
           std::string("axis=") + std::to_string(axis)
           + std::string(" exceeds the depth of the nested list structure "
                         "(which is ")
-          + std::to_string(depth) + std::string(")"));
+          + std::to_string(depth) + std::string(")")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1283,7 +1321,8 @@ namespace awkward {
       return getitem_next(*jagged, tail, advanced);
     }
     else {
-      throw std::runtime_error("unrecognized slice type");
+      throw std::runtime_error(
+        std::string("unrecognized slice type") + FILENAME(__LINE__));
     }
   }
 
@@ -1306,7 +1345,8 @@ namespace awkward {
     }
     else {
       throw std::runtime_error(
-        "unexpected slice type for getitem_next_jagged");
+        std::string("unexpected slice type for getitem_next_jagged")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -1328,8 +1368,8 @@ namespace awkward {
     else if (mindepth - 1 == tail.dimlength()  ||
              maxdepth - 1 == tail.dimlength()) {
       throw std::invalid_argument(
-        "ellipsis (...) can't be used on a data structure of "
-        "different depths");
+        std::string("ellipsis (...) can't be used on a data structure of "
+                    "different depths") + FILENAME(__LINE__));
     }
     else {
       std::vector<SliceItemPtr> tailitems = tail.items();
@@ -1414,16 +1454,17 @@ namespace awkward {
         dynamic_cast<SliceJagged64*>(missing.content().get());
     if (jagged == nullptr) {
       throw std::runtime_error(
-          "Logic error: calling getitem_next_missing_jagged with bad slice type");
+        std::string("Logic error: calling getitem_next_missing_jagged with bad "
+                    "slice type") + FILENAME(__LINE__));
     }
     const Index64 index = missing.index();
     ContentPtr content = that.get()->getitem_at_nowrap(0);
     if (content.get()->length() < index.length()) {
       throw std::invalid_argument(
-          std::string("cannot fit masked jagged slice with length ") +
-          std::to_string(index.length()) + std::string(" into ") +
-          that.get()->classname() + std::string(" of size ") +
-          std::to_string(content.get()->length()));
+        std::string("cannot fit masked jagged slice with length ") +
+        std::to_string(index.length()) + std::string(" into ") +
+        that.get()->classname() + std::string(" of size ") +
+        std::to_string(content.get()->length()) + FILENAME(__LINE__));
     }
     Index64 outputmask(index.length());
     Index64 starts(index.length());
@@ -1450,13 +1491,16 @@ namespace awkward {
                         const Slice& tail,
                         const Index64& advanced) const {
     if (advanced.length() != 0) {
-      throw std::invalid_argument("cannot mix missing values in slice "
-                                  "with NumPy-style advanced indexing");
+      throw std::invalid_argument(
+        std::string("cannot mix missing values in slice with NumPy-style "
+                    "advanced indexing") + FILENAME(__LINE__));
     }
 
     if (dynamic_cast<SliceJagged64*>(missing.content().get())) {
       if (length() != 1) {
-        throw std::runtime_error("Reached a not-well-considered code path");
+        throw std::runtime_error(
+          std::string("Reached a not-well-considered code path")
+          + FILENAME(__LINE__));
       }
       return getitem_next_missing_jagged(missing, tail, advanced,
                                          shallow_copy());
@@ -1491,7 +1535,7 @@ namespace awkward {
           throw std::runtime_error(
             std::string("FIXME: unhandled case of SliceMissing with ")
             + std::string("RecordArray containing\n")
-            + content.get()->tostring());
+            + content.get()->tostring() + FILENAME(__LINE__));
         }
       }
       return std::make_shared<RecordArray>(Identities::none(),
@@ -1503,7 +1547,7 @@ namespace awkward {
     else {
       throw std::runtime_error(
         std::string("FIXME: unhandled case of SliceMissing with\n")
-        + next.get()->tostring());
+        + next.get()->tostring() + FILENAME(__LINE__));
     }
   }
 
@@ -1519,14 +1563,14 @@ namespace awkward {
         throw std::invalid_argument(
           std::string("axis == ") + std::to_string(axis)
                       + std::string(" exceeds the depth == ") + std::to_string(depth)
-                      + std::string(" of this array"));
+                      + std::string(" of this array") + FILENAME(__LINE__));
       }
       return posaxis;
     } else if (axis < 0  &&  mindepth + axis == 0) {
       throw std::invalid_argument(
         std::string("axis == ") + std::to_string(axis)
                     + std::string(" exceeds the min depth == ") + std::to_string(mindepth)
-                    + std::string(" of this array"));
+                    + std::string(" of this array") + FILENAME(__LINE__));
     }
     return axis;
   }

--- a/src/libawkward/Identities.cpp
+++ b/src/libawkward/Identities.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/Identities.cpp", line)
+
 #include <cstring>
 #include <atomic>
 #include <iomanip>
@@ -192,8 +194,8 @@ namespace awkward {
     if (!(0 <= start  &&  start < length_  &&  0 <= stop  &&  stop <= length_)
         &&  start != stop) {
       throw std::runtime_error(
-        "Identities::getitem_range_nowrap with illegal start:stop "
-        "for this length");
+        std::string("Identities::getitem_range_nowrap with illegal start:stop "
+                    "for this length") + FILENAME(__LINE__));
     }
     return std::make_shared<IdentitiesOf<T>>(
       ref_,
@@ -276,7 +278,8 @@ namespace awkward {
       util::handle_error(err, classname(), nullptr);
     }
     else {
-      throw std::runtime_error("unrecognized Identities specialization");
+      throw std::runtime_error(
+        std::string("unrecognized Identities specialization") + FILENAME(__LINE__));
     }
 
     return out;
@@ -323,7 +326,8 @@ namespace awkward {
   IdentitiesOf<T>::getitem_at_nowrap(int64_t at) const {
     if (!(0 <= at  &&  at < length_)) {
       throw std::runtime_error(
-        "Identities::getitem_at_nowrap with illegal index for this length");
+        std::string("Identities::getitem_at_nowrap with illegal index for this length")
+        + FILENAME(__LINE__));
     }
     std::vector<T> out;
     for (size_t i = (size_t)(offset_ + at);

--- a/src/libawkward/Index.cpp
+++ b/src/libawkward/Index.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/Index.cpp", line)
+
 #include <cstring>
 #include <iomanip>
 #include <sstream>
@@ -30,7 +32,7 @@ namespace awkward {
     }
     else {
       throw std::invalid_argument(
-                std::string("unrecognized Index::Form: ") + str);
+        std::string("unrecognized Index::Form: ") + str + FILENAME(__LINE__));
     }
   }
 
@@ -48,7 +50,8 @@ namespace awkward {
     case Index::Form::i64:
       return "i64";
     default:
-      throw std::runtime_error("unrecognized Index::Form");
+      throw std::runtime_error(
+        std::string("unrecognized Index::Form") + FILENAME(__LINE__));
     }
   }
 
@@ -191,7 +194,8 @@ namespace awkward {
       return Index::Form::i64;
     }
     else {
-      throw std::runtime_error("unrecognized Index specialization");
+      throw std::runtime_error(
+        std::string("unrecognized Index specialization") + FILENAME(__LINE__));
     }
   }
 
@@ -245,7 +249,8 @@ namespace awkward {
     if (!(0 <= start  &&  start < length_  &&  0 <= stop  &&  stop <= length_)
         &&  start != stop) {
       throw std::runtime_error(
-        "Index::getitem_range_nowrap with illegal start:stop for this length");
+        std::string("Index::getitem_range_nowrap with illegal start:stop for this length")
+        + FILENAME(__LINE__));
     }
     return IndexOf<T>(ptr_, offset_ + start*(start != stop), stop - start);
   }

--- a/src/libawkward/Slice.cpp
+++ b/src/libawkward/Slice.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/Slice.cpp", line)
+
 #include <algorithm>
 #include <sstream>
 #include <type_traits>
@@ -47,7 +49,8 @@ namespace awkward {
       , stop_(stop)
       , step_(step == Slice::none() ? 1 : step) {
     if (step_ == 0) {
-      throw std::runtime_error("step must not be zero");
+      throw std::runtime_error(
+        std::string("step must not be zero") + FILENAME(__LINE__));
     }
   }
 
@@ -152,11 +155,13 @@ namespace awkward {
       , strides_(strides)
       , frombool_(frombool) {
     if (shape_.empty()) {
-      throw std::runtime_error("shape must not be zero-dimensional");
+      throw std::runtime_error(
+        std::string("shape must not be zero-dimensional") + FILENAME(__LINE__));
     }
     if (shape_.size() != strides_.size()) {
       throw std::runtime_error(
-        "shape must have the same number of dimensions as strides");
+        std::string("shape must have the same number of dimensions as strides")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -310,7 +315,9 @@ namespace awkward {
       util::handle_error(err);
     }
     else {
-      throw std::runtime_error("unrecognized SliceArrayOf<T> type");
+      throw std::runtime_error(
+        std::string("unrecognized SliceArrayOf<T> type")
+        + FILENAME(__LINE__));
     }
 
     return index;
@@ -638,7 +645,9 @@ namespace awkward {
   void
   Slice::append(const SliceItemPtr& item) {
     if (sealed_) {
-      throw std::runtime_error("Slice::append when sealed_ == true");
+      throw std::runtime_error(
+        std::string("Slice::append when sealed_ == true")
+        + FILENAME(__LINE__));
     }
     items_.push_back(item);
   }
@@ -691,7 +700,9 @@ namespace awkward {
   void
   Slice::become_sealed() {
     if (sealed_) {
-      throw std::runtime_error("Slice::become_sealed when sealed_ == true");
+      throw std::runtime_error(
+        std::string("Slice::become_sealed when sealed_ == true")
+        + FILENAME(__LINE__));
     }
 
     std::vector<int64_t> shape;
@@ -701,7 +712,9 @@ namespace awkward {
           shape = array->shape();
         }
         else if (shape.size() != (size_t)array->ndim()) {
-          throw std::invalid_argument("cannot broadcast arrays in slice");
+          throw std::invalid_argument(
+            std::string("cannot broadcast arrays in slice")
+            + FILENAME(__LINE__));
         }
         else {
           std::vector<int64_t> arrayshape = array->shape();
@@ -744,7 +757,9 @@ namespace awkward {
               strides.push_back(0);
             }
             else {
-              throw std::invalid_argument("cannot broadcast arrays in slice");
+              throw std::invalid_argument(
+                std::string("cannot broadcast arrays in slice")
+                + FILENAME(__LINE__));
             }
           }
           items_[i] = std::make_shared<SliceArray64>(array->index(),
@@ -787,7 +802,8 @@ namespace awkward {
 
       if (std::count(types.begin(), types.end(), '.') > 1) {
         throw std::invalid_argument(
-          "a slice can have no more than one ellipsis ('...')");
+          std::string("a slice can have no more than one ellipsis ('...')")
+          + FILENAME(__LINE__));
       }
 
       size_t numadvanced = (size_t)std::count(types.begin(), types.end(), 'A');
@@ -796,8 +812,9 @@ namespace awkward {
                      .substr(types.find_first_of('A'));
         if (numadvanced != types.size()) {
           throw std::invalid_argument(
-            "advanced indexes separated by basic indexes is not permitted "
-            "(simple integers are advanced when any arrays are present)");
+            std::string("advanced indexes separated by basic indexes is not permitted "
+                        "(simple integers are advanced when any arrays are present)")
+            + FILENAME(__LINE__));
         }
       }
     }
@@ -808,7 +825,9 @@ namespace awkward {
   bool
   Slice::isadvanced() const {
     if (!sealed_) {
-      throw std::runtime_error("Slice::isadvanced when sealed_ == false");
+      throw std::runtime_error(
+        std::string("Slice::isadvanced when sealed_ == false")
+        + FILENAME(__LINE__));
     }
     for (size_t i = 0;  i < items_.size();  i++) {
       if (dynamic_cast<SliceArray64*>(items_[i].get()) != nullptr) {

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/BitMaskedArray.cpp", line)
+
 #include <sstream>
 #include <type_traits>
 
@@ -202,11 +204,13 @@ namespace awkward {
     int64_t bitlength = ((length / 8) + ((length % 8) != 0));
     if (mask.length() < bitlength) {
       throw std::invalid_argument(
-        "BitMaskedArray mask must not be shorter than its ceil(length / 8.0)");
+        std::string("BitMaskedArray mask must not be shorter than its ceil(length / 8.0)")
+        + FILENAME(__LINE__));
     }
     if (content.get()->length() < length) {
       throw std::invalid_argument(
-        "BitMaskedArray content must not be shorter than its length");
+        std::string("BitMaskedArray content must not be shorter than its length")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -367,7 +371,9 @@ namespace awkward {
         content_.get()->setidentities(subidentities);
       }
       else {
-        throw std::runtime_error("unrecognized Identities specialization");
+        throw std::runtime_error(
+          std::string("unrecognized Identities specialization")
+          + FILENAME(__LINE__));
       }
     }
     identities_ = identities;
@@ -854,7 +860,8 @@ namespace awkward {
                                const Slice& tail,
                                const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: BitMaskedArraygetitem_next(at)");
+      std::string("undefined operation: BitMaskedArraygetitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -862,7 +869,8 @@ namespace awkward {
                                const Slice& tail,
                                const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: BitMaskedArraygetitem_next(range)");
+      std::string("undefined operation: BitMaskedArraygetitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -870,7 +878,8 @@ namespace awkward {
                                const Slice& tail,
                                const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: BitMaskedArraygetitem_next(array)");
+      std::string("undefined operation: BitMaskedArraygetitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -878,7 +887,8 @@ namespace awkward {
                                const Slice& tail,
                                const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: BitMaskedArraygetitem_next(jagged)");
+      std::string("undefined operation: BitMaskedArraygetitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/ByteMaskedArray.cpp", line)
+
 #include <sstream>
 #include <type_traits>
 
@@ -190,7 +192,8 @@ namespace awkward {
       , valid_when_(valid_when != 0) {
     if (content.get()->length() < mask.length()) {
       throw std::invalid_argument(
-        "ByteMaskedArray content must not be shorter than its mask");
+        std::string("ByteMaskedArray content must not be shorter than its mask")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -239,7 +242,7 @@ namespace awkward {
         std::string("mask length (") + std::to_string(mask.length())
         + std::string(") is not equal to ") + classname()
         + std::string(" length (") + std::to_string(length())
-        + std::string(")"));
+        + std::string(")") + FILENAME(__LINE__));
     }
 
     Index8 nextmask(length());
@@ -367,7 +370,9 @@ namespace awkward {
         content_.get()->setidentities(subidentities);
       }
       else {
-        throw std::runtime_error("unrecognized Identities specialization");
+        throw std::runtime_error(
+          std::string("unrecognized Identities specialization")
+          + FILENAME(__LINE__));
       }
     }
     identities_ = identities;
@@ -647,7 +652,8 @@ namespace awkward {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
-      throw std::runtime_error("unrecognized slice type");
+      throw std::runtime_error(
+        std::string("unrecognized slice type") + FILENAME(__LINE__));
     }
   }
 
@@ -737,7 +743,8 @@ namespace awkward {
   ByteMaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
-      throw std::invalid_argument("axis=0 not allowed for flatten");
+      throw std::invalid_argument(
+        std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
     }
     else {
       int64_t numnull;
@@ -974,8 +981,9 @@ namespace awkward {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
           throw std::runtime_error(
-            "reduce_next with unbranching depth > negaxis expects "
-            "a ListOffsetArray64 whose offsets start at zero");
+            std::string("reduce_next with unbranching depth > negaxis expects "
+                        "a ListOffsetArray64 whose offsets start at zero")
+            + FILENAME(__LINE__));
         }
         struct Error err3 = kernel::IndexedArray_reduce_next_fix_offsets_64(
           kernel::lib::cpu,   // DERIVE
@@ -999,7 +1007,7 @@ namespace awkward {
           std::string("reduce_next with unbranching depth > negaxis is only "
                       "expected to return RegularArray or ListOffsetArray64; "
                       "instead, it returned ")
-          + out.get()->classname());
+          + out.get()->classname() + FILENAME(__LINE__));
       }
     }
   }
@@ -1034,7 +1042,8 @@ namespace awkward {
                                 int64_t axis,
                                 int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1") + FILENAME(__LINE__));
     }
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
@@ -1115,8 +1124,9 @@ namespace awkward {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
           throw std::runtime_error(
-            "sort_next with unbranching depth > negaxis expects "
-            "a ListOffsetArray64 whose offsets start at zero");
+            std::string("sort_next with unbranching depth > negaxis expects "
+                        "a ListOffsetArray64 whose offsets start at zero")
+            + FILENAME(__LINE__));
         }
         struct Error err3 = kernel::IndexedArray_reduce_next_fix_offsets_64(
           kernel::lib::cpu,   // DERIVE
@@ -1140,7 +1150,7 @@ namespace awkward {
           std::string("sort_next with unbranching depth > negaxis is only "
                       "expected to return RegularArray or ListOffsetArray64; "
                       "instead, it returned ")
-          + out.get()->classname());
+          + out.get()->classname() + FILENAME(__LINE__));
       }
     }
   }
@@ -1199,8 +1209,9 @@ namespace awkward {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
           throw std::runtime_error(
-            "argsort_next with unbranching depth > negaxis expects "
-            "a ListOffsetArray64 whose offsets start at zero");
+            std::string("argsort_next with unbranching depth > negaxis expects "
+                        "a ListOffsetArray64 whose offsets start at zero")
+            + FILENAME(__LINE__));
         }
         struct Error err3 = kernel::IndexedArray_reduce_next_fix_offsets_64(
           kernel::lib::cpu,   // DERIVE
@@ -1224,7 +1235,7 @@ namespace awkward {
           std::string("argsort_next with unbranching depth > negaxis is only "
                       "expected to return RegularArray or ListOffsetArray64; "
                       "instead, it returned ")
-          + out.get()->classname());
+          + out.get()->classname() + FILENAME(__LINE__));
       }
     }
   }
@@ -1234,7 +1245,8 @@ namespace awkward {
                                 const Slice& tail,
                                 const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: ByteMaskedArray::getitem_next(at)");
+      std::string("undefined operation: ByteMaskedArray::getitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -1242,7 +1254,8 @@ namespace awkward {
                                 const Slice& tail,
                                 const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: ByteMaskedArray::getitem_next(range)");
+      std::string("undefined operation: ByteMaskedArray::getitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -1250,7 +1263,8 @@ namespace awkward {
                                 const Slice& tail,
                                 const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: ByteMaskedArray::getitem_next(array)");
+      std::string("undefined operation: ByteMaskedArray::getitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -1258,7 +1272,8 @@ namespace awkward {
                                 const Slice& tail,
                                 const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: ByteMaskedArray::getitem_next(jagged)");
+      std::string("undefined operation: ByteMaskedArray::getitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/EmptyArray.cpp", line)
+
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
@@ -80,14 +82,16 @@ namespace awkward {
   EmptyForm::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
       std::string("key ") + util::quote(key, true)
-      + std::string(" does not exist (data might not be records)"));
+      + std::string(" does not exist (data might not be records)")
+      + FILENAME(__LINE__));
   }
 
   const std::string
   EmptyForm::key(int64_t fieldindex) const {
     throw std::invalid_argument(
       std::string("fieldindex \"") + std::to_string(fieldindex)
-      + std::string("\" does not exist (data might not be records)"));
+      + std::string("\" does not exist (data might not be records)")
+      + FILENAME(__LINE__));
   }
 
   bool
@@ -296,14 +300,14 @@ namespace awkward {
   EmptyArray::getitem_field(const std::string& key) const {
     throw std::invalid_argument(
       std::string("cannot slice ") + classname()
-      + std::string(" by field name"));
+      + std::string(" by field name") + FILENAME(__LINE__));
   }
 
   const ContentPtr
   EmptyArray::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::invalid_argument(
       std::string("cannot slice ") + classname()
-      + std::string(" by field names"));
+      + std::string(" by field names") + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -320,14 +324,16 @@ namespace awkward {
   EmptyArray::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
       std::string("key ") + util::quote(key, true)
-      + std::string(" does not exist (data might not be records)"));
+      + std::string(" does not exist (data might not be records)")
+      + FILENAME(__LINE__));
   }
 
   const std::string
   EmptyArray::key(int64_t fieldindex) const {
     throw std::invalid_argument(
       std::string("fieldindex \"") + std::to_string(fieldindex)
-      + std::string("\" does not exist (data might not be records)"));
+      + std::string("\" does not exist (data might not be records)")
+      + FILENAME(__LINE__));
   }
 
   bool
@@ -367,7 +373,8 @@ namespace awkward {
   EmptyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
-      throw std::invalid_argument("axis=0 not allowed for flatten");
+      throw std::invalid_argument(
+        std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
     }
     else {
       Index64 offsets(1);
@@ -406,7 +413,8 @@ namespace awkward {
   EmptyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis != depth) {
-      throw std::invalid_argument("axis exceeds the depth of this array");
+      throw std::invalid_argument(
+        std::string("axis exceeds the depth of this array") + FILENAME(__LINE__));
     }
     else {
       return rpad_and_clip(target, posaxis, depth);
@@ -419,7 +427,8 @@ namespace awkward {
                             int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis != depth) {
-      throw std::invalid_argument("axis exceeds the depth of this array");
+      throw std::invalid_argument(
+        std::string("axis exceeds the depth of this array") + FILENAME(__LINE__));
     }
     else {
       return rpad_axis0(target, true);
@@ -460,7 +469,8 @@ namespace awkward {
                            int64_t axis,
                            int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1") + FILENAME(__LINE__));
     }
     return std::make_shared<EmptyArray>(identities_, util::Parameters());
   }
@@ -541,7 +551,8 @@ namespace awkward {
                            const Index64& advanced) const {
     throw std::invalid_argument(
       std::string("cannot slice ") + classname()
-      + std::string(" by a field name because it has no fields"));
+      + std::string(" by a field name because it has no fields")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -550,7 +561,8 @@ namespace awkward {
                            const Index64& advanced) const {
     throw std::invalid_argument(
       std::string("cannot slice ") + classname()
-      + std::string(" by field names because it has no fields"));
+      + std::string(" by field names because it has no fields")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -559,9 +571,11 @@ namespace awkward {
                            const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument(
-        "cannot mix jagged slice with NumPy-style advanced indexing");
+        std::string("cannot mix jagged slice with NumPy-style advanced indexing")
+        + FILENAME(__LINE__));
     }
-    throw std::runtime_error("FIXME: EmptyArray::getitem_next(jagged)");
+    throw std::runtime_error(
+      std::string("FIXME: EmptyArray::getitem_next(jagged)") + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -570,7 +584,8 @@ namespace awkward {
                                   const SliceArray64& slicecontent,
                                   const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: EmptyArray::getitem_next_jagged(array)");
+      std::string("undefined operation: EmptyArray::getitem_next_jagged(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -579,7 +594,8 @@ namespace awkward {
                                   const SliceMissing64& slicecontent,
                                   const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: EmptyArray::getitem_next_jagged(missing)");
+      std::string("undefined operation: EmptyArray::getitem_next_jagged(missing)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -588,7 +604,8 @@ namespace awkward {
                                   const SliceJagged64& slicecontent,
                                   const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: EmptyArray::getitem_next_jagged(jagged)");
+      std::string("undefined operation: EmptyArray::getitem_next_jagged(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/IndexedArray.cpp", line)
+
 #include <sstream>
 #include <type_traits>
 
@@ -402,7 +404,7 @@ namespace awkward {
         std::string("mask length (") + std::to_string(mask.length())
         + std::string(") is not equal to ") + classname()
         + std::string(" length (") + std::to_string(index_.length())
-        + std::string(")"));
+        + std::string(")") + FILENAME(__LINE__));
     }
 
     Index64 nextindex(index_.length());
@@ -853,7 +855,8 @@ namespace awkward {
         }
       }
       else {
-        throw std::runtime_error("unrecognized Identities specialization");
+        throw std::runtime_error(
+          std::string("unrecognized Identities specialization") + FILENAME(__LINE__));
       }
     }
     identities_ = identities;
@@ -1191,7 +1194,8 @@ namespace awkward {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
-      throw std::runtime_error("unrecognized slice type");
+      throw std::runtime_error(
+        std::string("unrecognized slice type") + FILENAME(__LINE__));
     }
   }
 
@@ -1306,7 +1310,8 @@ namespace awkward {
                                                      int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
-      throw std::invalid_argument("axis=0 not allowed for flatten");
+      throw std::invalid_argument(
+        std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
     }
     else if (ISOPTION) {
       int64_t numnull;
@@ -1455,7 +1460,8 @@ namespace awkward {
       util::handle_error(err2, classname(), identities_.get());
     }
     else {
-      throw std::runtime_error("unrecognized IndexedArray specialization");
+      throw std::runtime_error(
+        std::string("unrecognized IndexedArray specialization") + FILENAME(__LINE__));
     }
 
     return std::make_shared<IndexedArrayOf<int64_t, ISOPTION>>(
@@ -1527,7 +1533,8 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
     }
     else {
-      throw std::runtime_error("unrecognized IndexedArray specialization");
+      throw std::runtime_error(
+        std::string("unrecognized IndexedArray specialization") + FILENAME(__LINE__));
     }
 
     ContentPtr replaced_other = other;
@@ -1719,7 +1726,7 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("fillna value length (")
         + std::to_string(value.get()->length())
-        + std::string(") is not equal to 1"));
+        + std::string(") is not equal to 1") + FILENAME(__LINE__));
     }
     if (ISOPTION) {
       ContentPtrVec contents;
@@ -1887,7 +1894,8 @@ namespace awkward {
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
           throw std::runtime_error(
             std::string("reduce_next with unbranching depth > negaxis expects a "
-            "ListOffsetArray64 whose offsets start at zero "));
+                        "ListOffsetArray64 whose offsets start at zero ")
+            + FILENAME(__LINE__));
         }
         struct Error err3 = kernel::IndexedArray_reduce_next_fix_offsets_64(
           kernel::lib::cpu,   // DERIVE
@@ -1910,7 +1918,8 @@ namespace awkward {
         throw std::runtime_error(
           std::string("reduce_next with unbranching depth > negaxis is only "
                       "expected to return RegularArray or ListOffsetArray64; "
-                      "instead, it returned ") + out.get()->classname());
+                      "instead, it returned ") + out.get()->classname()
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1954,7 +1963,8 @@ namespace awkward {
     int64_t axis,
     int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1") + FILENAME(__LINE__));
     }
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
@@ -2060,8 +2070,9 @@ namespace awkward {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
           throw std::runtime_error(
-            "sort_next with unbranching depth > negaxis expects a "
-            "ListOffsetArray64 whose offsets start at zero");
+            std::string("sort_next with unbranching depth > negaxis expects a "
+                        "ListOffsetArray64 whose offsets start at zero")
+            + FILENAME(__LINE__));
         }
         struct Error err4 = kernel::IndexedArray_reduce_next_fix_offsets_64(
           kernel::lib::cpu,   // DERIVE
@@ -2085,7 +2096,8 @@ namespace awkward {
         throw std::runtime_error(
           std::string("sort_next with unbranching depth > negaxis is only "
                       "expected to return RegularArray or ListOffsetArray64; "
-                      "instead, it returned ") + out.get()->classname());
+                      "instead, it returned ") + out.get()->classname()
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2161,8 +2173,9 @@ namespace awkward {
         Index64 outoffsets(starts.length() + 1);
         if (starts.length() > 0  &&  starts.getitem_at_nowrap(0) != 0) {
           throw std::runtime_error(
-              "argsort_next with unbranching depth > negaxis expects a "
-              "ListOffsetArray64 whose offsets start at zero");
+            std::string("argsort_next with unbranching depth > negaxis expects a "
+                        "ListOffsetArray64 whose offsets start at zero")
+            + FILENAME(__LINE__));
         }
         struct Error err4 = kernel::IndexedArray_reduce_next_fix_offsets_64(
           kernel::lib::cpu,   // DERIVE
@@ -2185,8 +2198,9 @@ namespace awkward {
       else {
         throw std::runtime_error(
           std::string("argsort_next with unbranching depth > negaxis is only "
-                "expected to return RegularArray or ListOffsetArray64; "
-                "instead, it returned ") + out.get()->classname());
+                      "expected to return RegularArray or ListOffsetArray64; "
+                      "instead, it returned ") + out.get()->classname()
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2200,7 +2214,8 @@ namespace awkward {
                                          const Slice& tail,
                                          const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: IndexedArray::getitem_next(at)");
+      std::string("undefined operation: IndexedArray::getitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   template <typename T, bool ISOPTION>
@@ -2209,7 +2224,8 @@ namespace awkward {
                                             const Slice& tail,
                                             const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: IndexedArray::getitem_next(range)");
+      std::string("undefined operation: IndexedArray::getitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   template <typename T, bool ISOPTION>
@@ -2218,7 +2234,8 @@ namespace awkward {
                                             const Slice& tail,
                                             const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: IndexedArray::getitem_next(array)");
+      std::string("undefined operation: IndexedArray::getitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   template <typename T, bool ISOPTION>
@@ -2227,7 +2244,8 @@ namespace awkward {
                                             const Slice& tail,
                                             const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: IndexedArray::getitem_next(jagged)");
+      std::string("undefined operation: IndexedArray::getitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   template <typename T, bool ISOPTION>

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/ListArray.cpp", line)
+
 #include <sstream>
 #include <type_traits>
 
@@ -207,7 +209,8 @@ namespace awkward {
       , content_(content) {
     if (stops.length() < starts.length()) {
       throw std::invalid_argument(
-        "ListArray stops must not be shorter than its starts");
+        std::string("ListArray stops must not be shorter than its starts")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -249,13 +252,14 @@ namespace awkward {
   ListArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
       throw std::invalid_argument(
-        "broadcast_tooffsets64 can only be used with offsets that start at 0");
+        std::string("broadcast_tooffsets64 can only be used with offsets that start at 0")
+        + FILENAME(__LINE__));
     }
     if (offsets.length() - 1 > starts_.length()) {
       throw std::invalid_argument(
         std::string("cannot broadcast ListArray of length ")
         + std::to_string(starts_.length()) + (" to length ")
-        + std::to_string(offsets.length() - 1));
+        + std::to_string(offsets.length() - 1) + FILENAME(__LINE__));
     }
 
     int64_t carrylen = offsets.getitem_at_nowrap(offsets.length() - 1);
@@ -394,7 +398,8 @@ namespace awkward {
         }
       }
       else {
-        throw std::runtime_error("unrecognized Identities specialization");
+        throw std::runtime_error(
+          std::string("unrecognized Identities specialization") + FILENAME(__LINE__));
       }
     }
     identities_ = identities;
@@ -995,7 +1000,8 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
     }
     else {
-      throw std::runtime_error("unrecognized ListArray specialization");
+      throw std::runtime_error(
+        std::string("unrecognized ListArray specialization") + FILENAME(__LINE__));
     }
 
     int64_t mycontentlength = content_.get()->length();
@@ -1138,7 +1144,7 @@ namespace awkward {
     else {
       throw std::invalid_argument(
         std::string("cannot merge ") + classname() + std::string(" with ")
-        + other.get()->classname());
+        + other.get()->classname() + FILENAME(__LINE__));
     }
 
     return std::make_shared<ListArray64>(Identities::none(),
@@ -1300,7 +1306,8 @@ namespace awkward {
                                int64_t axis,
                                int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1") + FILENAME(__LINE__));
     }
 
     int64_t posaxis = axis_wrap_if_negative(axis);
@@ -1428,7 +1435,8 @@ namespace awkward {
 
     if (advanced.length() != 0) {
       throw std::runtime_error(
-        "ListArray::getitem_next(SliceAt): advanced.length() != 0");
+        std::string("ListArray::getitem_next(SliceAt): advanced.length() != 0")
+        + FILENAME(__LINE__));
     }
     SliceItemPtr nexthead = tail.head();
     Slice nexttail = tail.tail();
@@ -1591,7 +1599,8 @@ namespace awkward {
                                const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument(
-        "cannot mix jagged slice with NumPy-style advanced indexing");
+        std::string("cannot mix jagged slice with NumPy-style advanced indexing")
+        + FILENAME(__LINE__));
     }
     if (stops_.length() < starts_.length()) {
       util::handle_error(
@@ -1762,7 +1771,7 @@ namespace awkward {
       throw std::runtime_error(
         std::string("expected ListOffsetArray64 from "
                     "ListArray::getitem_next_jagged, got ")
-        + out.get()->classname());
+        + out.get()->classname() + FILENAME(__LINE__));
     }
   }
 

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/ListOffsetArray.cpp", line)
+
 #include <algorithm>
 #include <numeric>
 #include <sstream>
@@ -197,7 +199,8 @@ namespace awkward {
       , content_(content) {
     if (offsets.length() == 0) {
       throw std::invalid_argument(
-        "ListOffsetArray offsets length must be at least 1");
+        std::string("ListOffsetArray offsets length must be at least 1")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -265,13 +268,14 @@ namespace awkward {
   ListOffsetArrayOf<T>::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
       throw std::invalid_argument(
-        "broadcast_tooffsets64 can only be used with offsets that start at 0");
+        std::string("broadcast_tooffsets64 can only be used with offsets that start at 0")
+        + FILENAME(__LINE__));
     }
     if (offsets.length() - 1 > offsets_.length() - 1) {
       throw std::invalid_argument(
         std::string("cannot broadcast ListOffsetArray of length ")
         + std::to_string(offsets_.length() - 1) + (" to length ")
-        + std::to_string(offsets.length() - 1));
+        + std::to_string(offsets.length() - 1) + FILENAME(__LINE__));
     }
 
     IndexOf<T> starts = util::make_starts(offsets_);
@@ -415,7 +419,8 @@ namespace awkward {
         content_.get()->setidentities(subidentities);
       }
       else {
-        throw std::runtime_error("unrecognized Identities specialization");
+        throw std::runtime_error(
+          std::string("unrecognized Identities specialization") + FILENAME(__LINE__));
       }
     }
     identities_ = identities;
@@ -826,7 +831,8 @@ namespace awkward {
                                               int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
-      throw std::invalid_argument("axis=0 not allowed for flatten");
+      throw std::invalid_argument(
+        std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
     }
     else if (posaxis == depth + 1) {
       ContentPtr listoffsetarray = toListOffsetArray64(true);
@@ -1057,7 +1063,9 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
     }
     else {
-      throw std::runtime_error("unrecognized ListOffsetArray specialization");
+      throw std::runtime_error(
+        std::string("unrecognized ListOffsetArray specialization")
+        + FILENAME(__LINE__));
     }
 
     int64_t mycontentlength = content_.get()->length();
@@ -1199,9 +1207,9 @@ namespace awkward {
                          rawother->identities().get());
     }
     else {
-      throw std::invalid_argument(std::string("cannot merge ") + classname()
-                                  + std::string(" with ")
-                                  + other.get()->classname());
+      throw std::invalid_argument(
+        std::string("cannot merge ") + classname() + std::string(" with ") +
+        other.get()->classname() + FILENAME(__LINE__));
     }
 
     return std::make_shared<ListArray64>(Identities::none(),
@@ -1408,7 +1416,8 @@ namespace awkward {
 
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
       if (offsets_.length() - 1 != parents.length()) {
-        throw std::runtime_error("offsets_.length() - 1 != parents.length()");
+        throw std::runtime_error(
+          std::string("offsets_.length() - 1 != parents.length()") + FILENAME(__LINE__));
       }
 
       int64_t globalstart;
@@ -1598,7 +1607,8 @@ namespace awkward {
                                      int64_t axis,
                                      int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1") + FILENAME(__LINE__));
     }
 
     int64_t posaxis = axis_wrap_if_negative(axis);
@@ -1721,7 +1731,8 @@ namespace awkward {
 
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
       if (offsets_.length() - 1 != parents.length()) {
-        throw std::runtime_error("offsets_.length() - 1 != parents.length()");
+        throw std::runtime_error(
+          std::string("offsets_.length() - 1 != parents.length()" + FILENAME(__LINE__)));
       }
       int64_t globalstart;
       int64_t globalstop;
@@ -1869,13 +1880,15 @@ namespace awkward {
     // if this is array of strings, axis parameter is ignored
     // and this array is sorted
     if (util::parameter_isstring(parameters_, "__array__")) {
-      throw std::runtime_error("not implemented yet: argsort for strings");
+      throw std::runtime_error(
+        std::string("not implemented yet: argsort for strings") + FILENAME(__LINE__));
     }
 
     std::pair<bool, int64_t> branchdepth = branch_depth();
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
       if (offsets_.length() - 1 != parents.length()) {
-        throw std::runtime_error("offsets_.length() - 1 != parents.length()");
+        throw std::runtime_error(
+          std::string("offsets_.length() - 1 != parents.length()") + FILENAME(__LINE__));
       }
 
       int64_t globalstart;
@@ -2001,7 +2014,8 @@ namespace awkward {
                                      const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::runtime_error(
-        "ListOffsetArray::getitem_next(SliceAt): advanced.length() != 0");
+        std::string("ListOffsetArray::getitem_next(SliceAt): advanced.length() != 0")
+        + FILENAME(__LINE__));
     }
     int64_t lenstarts = offsets_.length() - 1;
     IndexOf<T> starts = util::make_starts(offsets_);

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/None.cpp", line)
+
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
@@ -26,32 +28,43 @@ namespace awkward {
   void
   None::setidentities(const IdentitiesPtr& identities) {
     throw std::runtime_error(
-      "undefined operation: None::setidentities(identities)");
+      std::string("undefined operation: None::setidentities(identities)")
+      + FILENAME(__LINE__));
   }
 
   void
   None::setidentities() {
-    throw std::runtime_error("undefined operation: None::setidentities()");
+    throw std::runtime_error(
+      std::string("undefined operation: None::setidentities()")
+      + FILENAME(__LINE__));
   }
 
   const TypePtr
   None::type(const util::TypeStrs& typestrs) const {
-    throw std::runtime_error("undefined operation: None::type");
+    throw std::runtime_error(
+      std::string("undefined operation: None::type")
+      + FILENAME(__LINE__));
   }
 
   const FormPtr
   None::form(bool materialize) const {
-    throw std::runtime_error("undefined operation: None::form");
+    throw std::runtime_error(
+      std::string("undefined operation: None::form")
+      + FILENAME(__LINE__));
   }
 
   bool
   None::has_virtual_form() const {
-    throw std::runtime_error("undefined operation: None::has_virtual_form");
+    throw std::runtime_error(
+      std::string("undefined operation: None::has_virtual_form")
+      + FILENAME(__LINE__));
   }
 
   bool
   None::has_virtual_length() const {
-    throw std::runtime_error("undefined operation: None::has_virtual_length");
+    throw std::runtime_error(
+      std::string("undefined operation: None::has_virtual_length")
+      + FILENAME(__LINE__));
   }
 
   const std::string
@@ -71,7 +84,9 @@ namespace awkward {
 
   void
   None::nbytes_part(std::map<size_t, int64_t>& largest) const {
-    throw std::runtime_error("undefined operation: None::nbytes_part");
+    throw std::runtime_error(
+      std::string("undefined operation: None::nbytes_part")
+      + FILENAME(__LINE__));
   }
 
   int64_t
@@ -96,119 +111,163 @@ namespace awkward {
 
   const ContentPtr
   None::getitem_nothing() const {
-    throw std::runtime_error("undefined operation: None::getitem_nothing");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_nothing")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_at(int64_t at) const {
-    throw std::runtime_error("undefined operation: None::getitem_at");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_at")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_at_nowrap(int64_t at) const {
-    throw std::runtime_error("undefined operation: None::getitem_at_nowrap");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_at_nowrap")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_range(int64_t start, int64_t stop) const {
-    throw std::runtime_error("undefined operation: None::getitem_range");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_range")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_range_nowrap(int64_t start, int64_t stop) const {
     throw std::runtime_error(
-      "undefined operation: None::getitem_range_nowrap");
+      std::string("undefined operation: None::getitem_range_nowrap")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_field(const std::string& key) const {
-    throw std::runtime_error("undefined operation: None::getitem_field");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_field")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_fields(const std::vector<std::string>& keys) const {
-    throw std::runtime_error("undefined operation: None::getitem_fields");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_fields")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::carry(const Index64& carry, bool allow_lazy) const {
-    throw std::runtime_error("undefined operation: None::carry");
+    throw std::runtime_error(
+      std::string("undefined operation: None::carry")
+      + FILENAME(__LINE__));
   }
 
   int64_t
   None::numfields() const {
-    throw std::runtime_error("undefined operatino: None::numfields");
+    throw std::runtime_error(
+      std::string("undefined operatino: None::numfields")
+      + FILENAME(__LINE__));
   }
 
   int64_t
   None::fieldindex(const std::string& key) const {
-    throw std::runtime_error("undefined operatino: None::fieldindex");
+    throw std::runtime_error(
+      std::string("undefined operatino: None::fieldindex")
+      + FILENAME(__LINE__));
   }
 
   const std::string
   None::key(int64_t fieldindex) const {
-    throw std::runtime_error("undefined operatino: None::key");
+    throw std::runtime_error(
+      std::string("undefined operatino: None::key")
+      + FILENAME(__LINE__));
   }
 
   bool
   None::haskey(const std::string& key) const {
-    throw std::runtime_error("undefined operatino: None::haskey");
+    throw std::runtime_error(
+      std::string("undefined operatino: None::haskey")
+      + FILENAME(__LINE__));
   }
 
   const std::vector<std::string>
   None::keys() const {
-    throw std::runtime_error("undefined operatino: None::keys");
+    throw std::runtime_error(
+      std::string("undefined operatino: None::keys")
+      + FILENAME(__LINE__));
   }
 
   const std::string
   None::validityerror(const std::string& path) const {
-    throw std::runtime_error("undefined operation: None::validityerror");
+    throw std::runtime_error(
+      std::string("undefined operation: None::validityerror")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::shallow_simplify() const {
-    throw std::runtime_error("undefined operation: None::shallow_simplify");
+    throw std::runtime_error(
+      std::string("undefined operation: None::shallow_simplify")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::num(int64_t axis, int64_t depth) const {
-    throw std::runtime_error("undefined operation: None::num");
+    throw std::runtime_error(
+      std::string("undefined operation: None::num")
+      + FILENAME(__LINE__));
   }
 
   const std::pair<Index64, ContentPtr>
   None::offsets_and_flattened(int64_t axis, int64_t depth) const {
     throw std::runtime_error(
-      "undefined operation: None::offsets_and_flattened");
+      std::string("undefined operation: None::offsets_and_flattened")
+      + FILENAME(__LINE__));
   }
 
   bool
   None::mergeable(const ContentPtr& other, bool mergebool) const {
-    throw std::runtime_error("undefined operation: None::mergeable");
+    throw std::runtime_error(
+      std::string("undefined operation: None::mergeable")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::merge(const ContentPtr& other) const {
-    throw std::runtime_error("undefined operation: None::merge");
+    throw std::runtime_error(
+      std::string("undefined operation: None::merge")
+      + FILENAME(__LINE__));
   }
 
   const SliceItemPtr
   None::asslice() const {
-    throw std::runtime_error("undefined opteration: None::asslice");
+    throw std::runtime_error(
+      std::string("undefined opteration: None::asslice")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::fillna(const ContentPtr& value) const {
-    throw std::runtime_error("undefined opteration: None::fillna");
+    throw std::runtime_error(
+      std::string("undefined opteration: None::fillna")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::rpad(int64_t length, int64_t axis, int64_t depth) const {
-    throw std::runtime_error("undefined operation: None::rpad");
+    throw std::runtime_error(
+      std::string("undefined operation: None::rpad")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
-    throw std::runtime_error("undefined operation: None::rpad_and_clip");
+    throw std::runtime_error(
+      std::string("undefined operation: None::rpad_and_clip")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -219,12 +278,16 @@ namespace awkward {
                     int64_t outlength,
                     bool mask,
                     bool keepdims) const {
-    throw std::runtime_error("undefined operation: None::reduce_next");
+    throw std::runtime_error(
+      std::string("undefined operation: None::reduce_next")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::localindex(int64_t axis, int64_t depth) const {
-    throw std::runtime_error("undefined operation: None:localindex");
+    throw std::runtime_error(
+      std::string("undefined operation: None:localindex")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -234,7 +297,9 @@ namespace awkward {
                      const util::Parameters& parameters,
                      int64_t axis,
                      int64_t depth) const {
-    throw std::runtime_error("undefined operation: None::combinations");
+    throw std::runtime_error(
+      std::string("undefined operation: None::combinations")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -245,7 +310,9 @@ namespace awkward {
                   bool ascending,
                   bool stable,
                   bool keepdims) const {
-    throw std::runtime_error("undefined operation: None::sort_next");
+    throw std::runtime_error(
+      std::string("undefined operation: None::sort_next")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -256,35 +323,45 @@ namespace awkward {
                      bool ascending,
                      bool stable,
                      bool keepdims) const {
-    throw std::runtime_error("undefined operation: None::argsort_next");
+    throw std::runtime_error(
+      std::string("undefined operation: None::argsort_next")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_next(const SliceAt& at,
                      const Slice& tail,
                      const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: None::getitem_next(at)");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_next(const SliceRange& range,
                      const Slice& tail,
                      const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: None::getitem_next(range)");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_next(const SliceArray64& array,
                      const Slice& tail,
                      const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: None::getitem_next(array)");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::getitem_next(const SliceField& field,
                      const Slice& tail,
                      const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: None::getitem_next(field)");
+    throw std::runtime_error(
+      std::string("undefined operation: None::getitem_next(field)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -292,7 +369,8 @@ namespace awkward {
                      const Slice& tail,
                      const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: None::getitem_next(fields)");
+      std::string("undefined operation: None::getitem_next(fields)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -300,7 +378,8 @@ namespace awkward {
                      const Slice& tail,
                      const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: None::getitem_next(jagged)");
+      std::string("undefined operation: None::getitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -309,7 +388,8 @@ namespace awkward {
                             const SliceArray64& slicecontent,
                             const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: None::getitem_next_jagged(array)");
+      std::string("undefined operation: None::getitem_next_jagged(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -318,7 +398,8 @@ namespace awkward {
                             const SliceMissing64& slicecontent,
                             const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: None::getitem_next_jagged(missing)");
+      std::string("undefined operation: None::getitem_next_jagged(missing)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -327,19 +408,22 @@ namespace awkward {
                             const SliceJagged64& slicecontent,
                             const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: None::getitem_next_jagged(jagged)");
+      std::string("undefined operation: None::getitem_next_jagged(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::copy_to(kernel::lib ptr_lib) const {
     throw std::runtime_error(
-      "undefined operation: None::copy_to(ptr_lib)");
+      std::string("undefined operation: None::copy_to(ptr_lib)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   None::numbers_to_type(const std::string& name) const {
     throw std::runtime_error(
-      "undefined operation: None::numbers_to_type");
+      std::string("undefined operation: None::numbers_to_type")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr none = std::make_shared<None>();

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/NumpyArray.cpp", line)
+
 #include <algorithm>
 #include <iomanip>
 #include <numeric>
@@ -74,7 +76,8 @@ namespace awkward {
     if (dtype_ == util::dtype::NOT_PRIMITIVE) {
       throw std::invalid_argument(
         std::string("Numpy format \"") + format_
-        + std::string("\" cannot be expressed as a PrimitiveType"));
+        + std::string("\" cannot be expressed as a PrimitiveType")
+        + FILENAME(__LINE__));
     }
     else {
       out = std::make_shared<PrimitiveType>(
@@ -207,14 +210,16 @@ namespace awkward {
   NumpyForm::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
       std::string("key ") + util::quote(key, true)
-      + std::string(" does not exist (data are not records)"));
+      + std::string(" does not exist (data are not records)")
+      + FILENAME(__LINE__));
   }
 
   const std::string
   NumpyForm::key(int64_t fieldindex) const {
     throw std::invalid_argument(
       std::string("fieldindex \"") + std::to_string(fieldindex)
-      + std::string("\" does not exist (data are not records)"));
+      + std::string("\" does not exist (data are not records)")
+      + FILENAME(__LINE__));
   }
 
   bool
@@ -278,7 +283,7 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("len(shape), which is ") + std::to_string(shape.size())
         + std::string(", must be equal to len(strides), which is ")
-        + std::to_string(strides.size()));
+        + std::to_string(strides.size()) + FILENAME(__LINE__));
     }
   }
 
@@ -832,7 +837,8 @@ namespace awkward {
           tojson_integer<uint64_t>(builder, include_beginendlist);
           break;
         case util::dtype::float16:
-          throw std::runtime_error("FIXME: float16 to JSON");
+          throw std::runtime_error(
+            std::string("FIXME: float16 to JSON") + FILENAME(__LINE__));
         case util::dtype::float32:
           tojson_real<float>(builder, include_beginendlist);
           break;
@@ -840,17 +846,21 @@ namespace awkward {
           tojson_real<double>(builder, include_beginendlist);
           break;
         case util::dtype::float128:
-          throw std::runtime_error("FIXME: float128 to JSON");
+          throw std::runtime_error(
+            std::string("FIXME: float128 to JSON") + FILENAME(__LINE__));
         case util::dtype::complex64:
-          throw std::runtime_error("FIXME: complex64 to JSON");
+          throw std::runtime_error(
+            std::string("FIXME: complex64 to JSON") + FILENAME(__LINE__));
         case util::dtype::complex128:
-          throw std::runtime_error("FIXME: complex128 to JSON");
+          throw std::runtime_error(
+            std::string("FIXME: complex128 to JSON") + FILENAME(__LINE__));
         case util::dtype::complex256:
-          throw std::runtime_error("FIXME: complex256 to JSON");
+          throw std::runtime_error(
+            std::string("FIXME: complex256 to JSON") + FILENAME(__LINE__));
         default:
           throw std::invalid_argument(
             std::string("cannot convert Numpy format \"") + format_
-            + std::string("\" into JSON"));
+            + std::string("\" into JSON") + FILENAME(__LINE__));
       }
     }
   }
@@ -1035,14 +1045,14 @@ namespace awkward {
   NumpyArray::getitem_field(const std::string& key) const {
     throw std::invalid_argument(
       std::string("cannot slice ") + classname()
-      + std::string(" by field name"));
+      + std::string(" by field name") + FILENAME(__LINE__));
   }
 
   const ContentPtr
   NumpyArray::getitem_fields(const std::vector<std::string>& keys) const {
     throw std::invalid_argument(
       std::string("cannot slice ") + classname()
-      + std::string(" by field names"));
+      + std::string(" by field names") + FILENAME(__LINE__));
   }
 
   bool getitem_too_general(const SliceItemPtr& head, const Slice& tail) {
@@ -1061,7 +1071,8 @@ namespace awkward {
   const ContentPtr
   NumpyArray::getitem(const Slice& where) const {
     if (isscalar()) {
-      throw std::runtime_error("cannot get-item on a scalar");
+      throw std::runtime_error(
+        std::string("cannot get-item on a scalar") + FILENAME(__LINE__));
     }
 
     if (getitem_too_general(where.head(), where.tail())) {
@@ -1214,14 +1225,16 @@ namespace awkward {
   NumpyArray::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
       std::string("key ") + util::quote(key, true)
-      + std::string(" does not exist (data are not records)"));
+      + std::string(" does not exist (data are not records)")
+      + FILENAME(__LINE__));
   }
 
   const std::string
   NumpyArray::key(int64_t fieldindex) const {
     throw std::invalid_argument(
       std::string("fieldindex \"") + std::to_string(fieldindex)
-      + std::string("\" does not exist (data are not records)"));
+      + std::string("\" does not exist (data are not records)")
+      + FILENAME(__LINE__));
   }
 
   bool
@@ -1281,7 +1294,8 @@ namespace awkward {
       depth++;
     }
     if (posaxis > depth) {
-      throw std::invalid_argument("'axis' out of range for 'num'");
+      throw std::invalid_argument(
+        std::string("'axis' out of range for 'num'") + FILENAME(__LINE__));
     }
 
     ssize_t x = sizeof(int64_t);
@@ -1339,13 +1353,15 @@ namespace awkward {
   NumpyArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
-      throw std::invalid_argument("axis=0 not allowed for flatten");
+      throw std::invalid_argument(
+        std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
     }
     else if (shape_.size() != 1  ||  !iscontiguous()) {
       return toRegularArray().get()->offsets_and_flattened(posaxis, depth);
     }
     else {
-      throw std::invalid_argument("axis out of range for flatten");
+      throw std::invalid_argument(
+        std::string("axis out of range for flatten") + FILENAME(__LINE__));
     }
   }
 
@@ -1531,7 +1547,8 @@ namespace awkward {
     }
 
     if (ndim() == 0) {
-      throw std::invalid_argument("cannot merge Numpy scalars");
+      throw std::invalid_argument(
+        std::string("cannot merge Numpy scalars") + FILENAME(__LINE__));
     }
 
     if ((parameter_equals("__array__", "\"byte\"")  ||
@@ -1553,7 +1570,8 @@ namespace awkward {
 
       if (ndim() != rawother->ndim()) {
         throw std::invalid_argument(
-          "cannot merge arrays with different shapes");
+          std::string("cannot merge arrays with different shapes")
+          + FILENAME(__LINE__));
       }
 
       if (dtype_ == util::dtype::complex256  ||
@@ -1707,7 +1725,8 @@ namespace awkward {
       else {
         throw std::invalid_argument(
           std::string("cannot merge Numpy format \"") + format_
-          + std::string("\" with \"") + rawother->format() + std::string("\""));
+          + std::string("\" with \"") + rawother->format() + std::string("\"")
+          + FILENAME(__LINE__));
       }
 
       int64_t itemsize = util::dtype_to_itemsize(dtype);
@@ -1722,7 +1741,8 @@ namespace awkward {
       for (int64_t i = ((int64_t)shape_.size()) - 1;  i > 0;  i--) {
         if (shape_[(size_t)i] != other_shape[(size_t)i]) {
           throw std::invalid_argument(
-            "cannot merge arrays with different shapes");
+            std::string("cannot merge arrays with different shapes")
+            + FILENAME(__LINE__));
         }
         shape.insert(std::next(shape.begin()), shape_[(size_t)i]);
         strides.insert(strides.begin(), strides[0]*shape_[(size_t)i]);
@@ -1758,12 +1778,16 @@ namespace awkward {
 
       // // to datetime64
       // case util::dtype::datetime64:
-      //   throw std::runtime_error("FIXME: merge to datetime64 not implemented");
+      //   throw std::runtime_error(
+      //     std::string("FIXME: merge to datetime64 not implemented")
+      //     + FILENAME(__LINE__));
       //   break;
 
       // // to timedelta64
       // case util::dtype::timedelta64:
-      //   throw std::runtime_error("FIXME: merge to timedelta64 not implemented");
+      //   throw std::runtime_error(
+      //     std::string("FIXME: merge to timedelta64 not implemented")
+      //     + FILENAME(__LINE__));
       //   break;
 
       // to int
@@ -1787,7 +1811,7 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-              "dtype_ not in {boolean, int8} (1)");
+              std::string("dtype_ not in {boolean, int8} (1)") + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -1809,7 +1833,7 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-              "dtype_ not in {boolean, int8} (2)");
+              std::string("dtype_ not in {boolean, int8} (2)") + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
@@ -1851,7 +1875,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, uint8} (1)");
+              std::string("dtype_ not in {boolean, int8, int16, uint8} (1)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -1889,7 +1914,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, uint8} (2)");
+              std::string("dtype_ not in {boolean, int8, int16, uint8} (2)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
@@ -1947,7 +1973,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, int32, uint8, uint16} (1)");
+              std::string("dtype_ not in {boolean, int8, int16, int32, uint8, uint16} (1)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -2001,7 +2028,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, int32, uint8, uint16} (2)");
+              std::string("dtype_ not in {boolean, int8, int16, int32, uint8, uint16} (2)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
@@ -2075,8 +2103,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, int32, int64, "
-                "uint8, uint16, uint32} (1)");
+              std::string("dtype_ not in {boolean, int8, int16, int32, int64, "
+                          "uint8, uint16, uint32} (1)") + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -2146,8 +2174,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, int32, int64, "
-                "uint8, uint16, uint32} (2)");
+              std::string("dtype_ not in {boolean, int8, int16, int32, int64, "
+                          "uint8, uint16, uint32} (2)") + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
@@ -2173,7 +2201,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, uint8} (1)");
+              std::string("dtype_ not in {boolean, uint8} (1)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -2195,7 +2224,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, uint8} (2)");
+              std::string("dtype_ not in {boolean, uint8} (2)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
@@ -2229,7 +2259,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, uint8, uint16} (1)");
+              std::string("dtype_ not in {boolean, uint8, uint16} (1)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -2259,7 +2290,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, uint8, uint16} (2)");
+              std::string("dtype_ not in {boolean, uint8, uint16} (2)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
@@ -2301,7 +2333,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, uint8, uint16, uint32} (1)");
+              std::string("dtype_ not in {boolean, uint8, uint16, uint32} (1)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -2339,7 +2372,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, uint8, uint16, uint32} (2)");
+              std::string("dtype_ not in {boolean, uint8, uint16, uint32} (2)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
@@ -2389,7 +2423,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, uint8, uint16, uint32, uint64} (1)");
+              std::string("dtype_ not in {boolean, uint8, uint16, uint32, uint64} (1)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -2435,14 +2470,16 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, uint8, uint16, uint32, uint64} (2)");
+              std::string("dtype_ not in {boolean, uint8, uint16, uint32, uint64} (2)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
 
       // to float16
       case util::dtype::float16:
-        throw std::runtime_error("FIXME: merge to float16 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: merge to float16 not implemented") + FILENAME(__LINE__));
         break;
 
       // to float32
@@ -2489,7 +2526,9 @@ namespace awkward {
               self_flatlength);
             break;
           case util::dtype::float16:
-            throw std::runtime_error("FIXME: merge from float16 not implemented");
+            throw std::runtime_error(
+              std::string("FIXME: merge from float16 not implemented")
+              + FILENAME(__LINE__));
           case util::dtype::float32:
             err = kernel::NumpyArray_fill<float, float>(
               kernel::lib::cpu,   // DERIVE
@@ -2500,8 +2539,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, uint8, uint16, "
-                "float16, float32} (1)");
+              std::string("dtype_ not in {boolean, int8, int16, uint8, uint16, "
+                          "float16, float32} (1)") + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -2546,7 +2585,9 @@ namespace awkward {
               other_flatlength);
             break;
           case util::dtype::float16:
-            throw std::runtime_error("FIXME: merge from float16 not implemented");
+            throw std::runtime_error(
+              std::string("FIXME: merge from float16 not implemented")
+              + FILENAME(__LINE__));
           case util::dtype::float32:
             err = kernel::NumpyArray_fill<float, float>(
               kernel::lib::cpu,   // DERIVE
@@ -2557,8 +2598,8 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, uint8, uint16, "
-                "float16, float32} (2)");
+              std::string("dtype_ not in {boolean, int8, int16, uint8, uint16, "
+                          "float16, float32} (2)") + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
@@ -2639,7 +2680,9 @@ namespace awkward {
               self_flatlength);
             break;
           case util::dtype::float16:
-            throw std::runtime_error("FIXME: merge from float16 not implemented");
+            throw std::runtime_error(
+              std::string("FIXME: merge from float16 not implemented")
+              + FILENAME(__LINE__));
           case util::dtype::float32:
             err = kernel::NumpyArray_fill<float, double>(
               kernel::lib::cpu,   // DERIVE
@@ -2658,8 +2701,9 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, int32, int64, "
-                "uint8, uint16, uint32, uint64 float16, float32, float64} (1)");
+              std::string("dtype_ not in {boolean, int8, int16, int32, int64, "
+                          "uint8, uint16, uint32, uint64 float16, float32, float64} (1)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         switch (rawother->dtype()) {
@@ -2736,7 +2780,9 @@ namespace awkward {
               other_flatlength);
             break;
           case util::dtype::float16:
-            throw std::runtime_error("FIXME: merge from float16 not implemented");
+            throw std::runtime_error(
+              std::string("FIXME: merge from float16 not implemented")
+              + FILENAME(__LINE__));
           case util::dtype::float32:
             err = kernel::NumpyArray_fill<float, double>(
               kernel::lib::cpu,   // DERIVE
@@ -2755,36 +2801,46 @@ namespace awkward {
             break;
           default:
             throw std::runtime_error(
-                "dtype_ not in {boolean, int8, int16, int32, int64, "
-                "uint8, uint16, uint32, uint64 float16, float32, float64} (2)");
+              std::string("dtype_ not in {boolean, int8, int16, int32, int64, "
+                          "uint8, uint16, uint32, uint64 float16, float32, float64} (2)")
+              + FILENAME(__LINE__));
         }
         util::handle_error(err, classname(), nullptr);
         break;
 
       // to float128
       case util::dtype::float128:
-        throw std::runtime_error("FIXME: merge to float128 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: merge to float128 not implemented")
+          + FILENAME(__LINE__));
         break;
 
       // to complex64
       case util::dtype::complex64:
-        throw std::runtime_error("FIXME: merge to complex64 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: merge to complex64 not implemented")
+          + FILENAME(__LINE__));
         break;
 
       // to complex128
       case util::dtype::complex128:
-        throw std::runtime_error("FIXME: merge to complex128 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: merge to complex128 not implemented")
+          + FILENAME(__LINE__));
         break;
 
       // to complex256
       case util::dtype::complex256:
-        throw std::runtime_error("FIXME: merge to complex256 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: merge to complex256 not implemented")
+          + FILENAME(__LINE__));
         break;
 
       // something's wrong
       default:
         throw std::runtime_error(
-          std::string("unhandled merge case: to ") + util::dtype_to_name(dtype));
+          std::string("unhandled merge case: to ") + util::dtype_to_name(dtype)
+          + FILENAME(__LINE__));
       }
 
       return std::make_shared<NumpyArray>(Identities::none(),
@@ -2801,7 +2857,7 @@ namespace awkward {
     else {
       throw std::invalid_argument(
         std::string("cannot merge ") + classname() + std::string(" with ")
-        + other.get()->classname());
+        + other.get()->classname() + FILENAME(__LINE__));
     }
   }
 
@@ -2848,9 +2904,10 @@ namespace awkward {
   NumpyArray::asslice() const {
     if (ndim() != 1) {
       throw std::invalid_argument(
-        "slice items can have all fixed-size dimensions (to follow NumPy's "
-        "slice rules) or they can have all var-sized dimensions (for jagged "
-        "indexing), but not both in the same slice item");
+        std::string("slice items can have all fixed-size dimensions (to follow "
+                    "NumPy's slice rules) or they can have all var-sized "
+                    "dimensions (for jagged indexing), but not both in the "
+                    "same slice item") + FILENAME(__LINE__));
     }
     if (dtype_ == util::dtype::int64) {
         int64_t* raw = reinterpret_cast<int64_t*>(ptr_.get());
@@ -2930,7 +2987,7 @@ namespace awkward {
       default:
         throw std::runtime_error(
           std::string("unexpected integer type in NumpyArray::asslice: ") +
-          util::dtype_to_name(dtype_));
+          util::dtype_to_name(dtype_) + FILENAME(__LINE__));
       }
       util::handle_error(err, classname(), identities_.get());
 
@@ -2964,7 +3021,8 @@ namespace awkward {
     }
     else {
       throw std::invalid_argument(
-        "only arrays of integers or booleans may be used as a slice");
+        std::string("only arrays of integers or booleans may be used as a slice")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -2976,14 +3034,16 @@ namespace awkward {
   const ContentPtr
   NumpyArray::rpad(int64_t target, int64_t axis, int64_t depth) const {
     if (ndim() == 0) {
-      throw std::runtime_error("cannot rpad a scalar");
+      throw std::runtime_error(
+        std::string("cannot rpad a scalar") + FILENAME(__LINE__));
     }
     else if (ndim() > 1  ||  !iscontiguous()) {
       return toRegularArray().get()->rpad(target, axis, depth);
     }
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis != depth) {
-      throw std::invalid_argument("axis exceeds the depth of this array");
+      throw std::invalid_argument(
+        std::string("axis exceeds the depth of this array") + FILENAME(__LINE__));
     }
     if (target < length()) {
       return shallow_copy();
@@ -2998,14 +3058,16 @@ namespace awkward {
                             int64_t axis,
                             int64_t depth) const {
     if (ndim() == 0) {
-      throw std::runtime_error("cannot rpad a scalar");
+      throw std::runtime_error(
+        std::string("cannot rpad a scalar") + FILENAME(__LINE__));
     }
     else if (ndim() > 1  ||  !iscontiguous()) {
       return toRegularArray().get()->rpad_and_clip(target, axis, depth);
     }
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis != depth) {
-      throw std::invalid_argument("axis exceeds the depth of this array");
+      throw std::invalid_argument(
+        std::string("axis exceeds the depth of this array") + FILENAME(__LINE__));
     }
     return rpad_axis0(target, true);
   }
@@ -3019,7 +3081,8 @@ namespace awkward {
                           bool mask,
                           bool keepdims) const {
     if (shape_.empty()) {
-      throw std::runtime_error("attempting to reduce a scalar");
+      throw std::runtime_error(
+        std::string("attempting to reduce a scalar") + FILENAME(__LINE__));
     }
     else if (shape_.size() != 1  ||  !iscontiguous()) {
       return toRegularArray().get()->reduce_next(reducer,
@@ -3088,7 +3151,8 @@ namespace awkward {
                                    outlength);
         break;
       case util::dtype::float16:
-        throw std::runtime_error("FIXME: reducers on float16");
+        throw std::runtime_error(
+          std::string("FIXME: reducers on float16") + FILENAME(__LINE__));
       case util::dtype::float32:
         ptr = reducer.apply_float32(reinterpret_cast<float*>(data()),
                                     starts,
@@ -3102,21 +3166,27 @@ namespace awkward {
                                     outlength);
         break;
       case util::dtype::float128:
-        throw std::runtime_error("FIXME: reducers on float128");
+        throw std::runtime_error(
+          std::string("FIXME: reducers on float128") + FILENAME(__LINE__));
       case util::dtype::complex64:
-        throw std::runtime_error("FIXME: reducers on complex64");
+        throw std::runtime_error(
+          std::string("FIXME: reducers on complex64") + FILENAME(__LINE__));
       case util::dtype::complex128:
-        throw std::runtime_error("FIXME: reducers on complex128");
+        throw std::runtime_error(
+          std::string("FIXME: reducers on complex128") + FILENAME(__LINE__));
       case util::dtype::complex256:
-        throw std::runtime_error("FIXME: reducers on complex256");
+        throw std::runtime_error(
+          std::string("FIXME: reducers on complex256") + FILENAME(__LINE__));
       // case util::dtype::datetime64:
-      //   throw std::runtime_error("FIXME: reducers on datetime64");
+      //   throw std::runtime_error(
+      //     std::string("FIXME: reducers on datetime64") + FILENAME(__LINE__));
       // case util::dtype:::timedelta64:
-      //   throw std::runtime_error("FIXME: reducers on timedelta64");
+      //   throw std::runtime_error(
+      //     std:string("FIXME: reducers on timedelta64") + FILENAME(__LINE__));
       default:
         throw std::invalid_argument(
           std::string("cannot apply reducers to NumpyArray with format \"")
-          + format_ + std::string("\""));
+          + format_ + std::string("\"") + FILENAME(__LINE__));
       }
 
       util::dtype dtype = reducer.return_dtype(dtype_);
@@ -3169,7 +3239,8 @@ namespace awkward {
       return localindex_axis0();
     }
     else if (shape_.size() <= 1) {
-      throw std::invalid_argument("'axis' out of range for localindex");
+      throw std::invalid_argument(
+        std::string("'axis' out of range for localindex") + FILENAME(__LINE__));
     }
     else {
       return toRegularArray().get()->localindex(posaxis, depth);
@@ -3184,7 +3255,8 @@ namespace awkward {
                            int64_t axis,
                            int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1") + FILENAME(__LINE__));
     }
 
     int64_t posaxis = axis_wrap_if_negative(axis);
@@ -3193,7 +3265,8 @@ namespace awkward {
     }
 
     else if (shape_.size() <= 1) {
-      throw std::invalid_argument("'axis' out of range for combinations");
+      throw std::invalid_argument(
+        std::string("'axis' out of range for combinations") + FILENAME(__LINE__));
     }
 
     else {
@@ -3215,7 +3288,8 @@ namespace awkward {
                         bool stable,
                         bool keepdims) const {
     if (shape_.empty()) {
-      throw std::runtime_error("attempting to sort a scalar");
+      throw std::runtime_error(
+        std::string("attempting to sort a scalar") + FILENAME(__LINE__));
     }
     else if (shape_.size() != 1  ||  !iscontiguous()) {
       return toRegularArray().get()->sort_next(negaxis,
@@ -3313,7 +3387,8 @@ namespace awkward {
                                    stable);
         break;
       case util::dtype::float16:
-        throw std::runtime_error("FIXME: sort for float16 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: sort for float16 not implemented") + FILENAME(__LINE__));
       case util::dtype::float32:
         ptr = array_sort<float>(reinterpret_cast<float*>(data()),
                                 length(),
@@ -3333,17 +3408,21 @@ namespace awkward {
                                  stable);
         break;
       case util::dtype::float128:
-        throw std::runtime_error("FIXME: sort for float128 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: sort for float128 not implemented") + FILENAME(__LINE__));
       case util::dtype::complex64:
-        throw std::runtime_error("FIXME: sort for complex64 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: sort for complex64 not implemented") + FILENAME(__LINE__));
       case util::dtype::complex128:
-        throw std::runtime_error("FIXME: sort for complex128 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: sort for complex128 not implemented") + FILENAME(__LINE__));
       case util::dtype::complex256:
-        throw std::runtime_error("FIXME: sort for complex256 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: sort for complex256 not implemented") + FILENAME(__LINE__));
       default:
         throw std::invalid_argument(
           std::string("cannot sort NumpyArray with format \"")
-          + format_ + std::string("\""));
+          + format_ + std::string("\"") + FILENAME(__LINE__));
       }
 
       out = std::make_shared<NumpyArray>(Identities::none(),
@@ -3377,7 +3456,8 @@ namespace awkward {
                            bool stable,
                            bool keepdims) const {
     if (shape_.empty()) {
-      throw std::runtime_error("attempting to argsort a scalar");
+      throw std::runtime_error(
+        std::string("attempting to argsort a scalar") + FILENAME(__LINE__));
     }
     else if (shape_.size() != 1  ||  !iscontiguous()) {
       return toRegularArray().get()->argsort_next(negaxis,
@@ -3475,7 +3555,9 @@ namespace awkward {
                                    stable);
         break;
       case util::dtype::float16:
-        throw std::runtime_error("FIXME: argsort for float16 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: argsort for float16 not implemented")
+          + FILENAME(__LINE__));
       case util::dtype::float32:
         ptr = index_sort<float>(reinterpret_cast<float*>(data()),
                                 length(),
@@ -3495,17 +3577,25 @@ namespace awkward {
                                  stable);
         break;
       case util::dtype::float128:
-        throw std::runtime_error("FIXME: argsort for float128 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: argsort for float128 not implemented")
+          + FILENAME(__LINE__));
       case util::dtype::complex64:
-        throw std::runtime_error("FIXME: argsort for complex64 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: argsort for complex64 not implemented")
+          + FILENAME(__LINE__));
       case util::dtype::complex128:
-        throw std::runtime_error("FIXME: argsort for complex128 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: argsort for complex128 not implemented")
+          + FILENAME(__LINE__));
       case util::dtype::complex256:
-        throw std::runtime_error("FIXME: argsort for complex256 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: argsort for complex256 not implemented")
+          + FILENAME(__LINE__));
       default:
         throw std::invalid_argument(
           std::string("cannot sort NumpyArray with format \"")
-          + format_ + std::string("\""));
+          + format_ + std::string("\"") + FILENAME(__LINE__));
       }
 
       ssize_t itemsize = 8;
@@ -3552,7 +3642,7 @@ namespace awkward {
     } else {
       throw std::invalid_argument(
         std::string("cannot sort NumpyArray as strings with format \"")
-        + format_ + std::string("\""));
+        + format_ + std::string("\"") + FILENAME(__LINE__));
     }
 
     out = std::make_shared<NumpyArray>(identities_,
@@ -3578,8 +3668,9 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: NumpyArray::getitem_next(at) "
-      "(without 'length', 'stride', and 'first')");
+      std::string("undefined operation: NumpyArray::getitem_next(at) "
+                  "(without 'length', 'stride', and 'first')")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -3587,8 +3678,9 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: NumpyArray::getitem_next(range) "
-      "(without 'length', 'stride', and 'first')");
+      std::string("undefined operation: NumpyArray::getitem_next(range) "
+                  "(without 'length', 'stride', and 'first')")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -3596,8 +3688,9 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: NumpyArray::getitem_next(array) "
-      "(without 'length','stride', and 'first')");
+      std::string("undefined operation: NumpyArray::getitem_next(array) "
+                  "(without 'length','stride', and 'first')")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -3605,8 +3698,9 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: NumpyArray::getitem_next(field) "
-      "(without 'length', 'stride', and 'first')");
+      std::string("undefined operation: NumpyArray::getitem_next(field) "
+                  "(without 'length', 'stride', and 'first')")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -3614,8 +3708,9 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: NumpyArray::getitem_next(fields) "
-      "(without 'length', 'stride', and 'first')");
+      std::string("undefined operation: NumpyArray::getitem_next(fields) "
+                  "(without 'length', 'stride', and 'first')")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -3623,18 +3718,20 @@ namespace awkward {
                            const Slice& tail, const Index64& advanced) const {
     if (shape_.size() != 1) {
       throw std::runtime_error(
-        "undefined operation: NumpyArray::getitem_next(jagged) with "
-        "ndim != 1");
+        std::string("undefined operation: NumpyArray::getitem_next(jagged) with "
+                    "ndim != 1") + FILENAME(__LINE__));
     }
 
     if (advanced.length() != 0) {
       throw std::invalid_argument(
-        "cannot mix jagged slice with NumPy-style advanced indexing");
+        std::string("cannot mix jagged slice with NumPy-style advanced indexing")
+        + FILENAME(__LINE__));
     }
 
     throw std::invalid_argument(
       std::string("cannot slice ") + classname()
-      + std::string(" by a jagged array because it is one-dimensional"));
+      + std::string(" by a jagged array because it is one-dimensional")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -3644,12 +3741,14 @@ namespace awkward {
                                   const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument(
-        "too many jagged slice dimensions for array");
+        std::string("too many jagged slice dimensions for array")
+        + FILENAME(__LINE__));
     }
     else {
       throw std::runtime_error(
         std::string("undefined operation: NumpyArray::getitem_next_jagged("
-                    "array) for ndim == ") + std::to_string(ndim()));
+                    "array) for ndim == ") + std::to_string(ndim())
+        + FILENAME(__LINE__));
     }
   }
 
@@ -3660,12 +3759,14 @@ namespace awkward {
                                   const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument(
-        "too many jagged slice dimensions for array");
+        std::string("too many jagged slice dimensions for array")
+        + FILENAME(__LINE__));
     }
     else {
       throw std::runtime_error(
         std::string("undefined operation: NumpyArray::getitem_next_jagged("
-                    "missing) for ndim == ") + std::to_string(ndim()));
+                    "missing) for ndim == ") + std::to_string(ndim())
+        + FILENAME(__LINE__));
     }
   }
 
@@ -3676,12 +3777,14 @@ namespace awkward {
                                   const Slice& tail) const {
     if (ndim() == 1) {
       throw std::invalid_argument(
-        "too many jagged slice dimensions for array");
+        std::string("too many jagged slice dimensions for array")
+        + FILENAME(__LINE__));
     }
     else {
       throw std::runtime_error(
         std::string("undefined operation: NumpyArray::getitem_next_jagged("
-                    "jagged) for ndim == ") + std::to_string(ndim()));
+                    "jagged) for ndim == ") + std::to_string(ndim())
+        + FILENAME(__LINE__));
     }
   }
 
@@ -3839,7 +3942,8 @@ namespace awkward {
     }
     else {
       throw std::runtime_error(
-        "unrecognized slice item type for NumpyArray::getitem_bystrides");
+        std::string("unrecognized slice item type for NumpyArray::getitem_bystrides")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -4096,26 +4200,31 @@ namespace awkward {
              dynamic_cast<SliceField*>(head.get())) {
       throw std::invalid_argument(
         std::string("cannot slice ") + classname()
-        + std::string(" by a field name because it has no fields"));
+        + std::string(" by a field name because it has no fields")
+        + FILENAME(__LINE__));
     }
     else if (SliceFields* fields =
              dynamic_cast<SliceFields*>(head.get())) {
       throw std::invalid_argument(
         std::string("cannot slice ") + classname()
-        + std::string(" by field names because it has no fields"));
+        + std::string(" by field names because it has no fields")
+        + FILENAME(__LINE__));
     }
     else if (SliceMissing64* missing =
              dynamic_cast<SliceMissing64*>(head.get())) {
       throw std::runtime_error(
-        "undefined operation: NumpyArray::getitem_next(missing) "
-        "(defer to Content::getitem_next(missing))");
+        std::string("undefined operation: NumpyArray::getitem_next(missing) "
+                    "(defer to Content::getitem_next(missing))")
+        + FILENAME(__LINE__));
     }
     else if (SliceJagged64* jagged =
              dynamic_cast<SliceJagged64*>(head.get())) {
-      throw std::runtime_error("FIXME: NumpyArray::getitem_next(jagged)");
+      throw std::runtime_error(
+        std::string("FIXME: NumpyArray::getitem_next(jagged)") + FILENAME(__LINE__));
     }
     else {
-      throw std::runtime_error("unrecognized slice item type");
+      throw std::runtime_error(
+        std::string("unrecognized slice item type") + FILENAME(__LINE__));
     }
   }
 
@@ -4772,7 +4881,9 @@ namespace awkward {
                                 dtype);
         break;
       case util::dtype::float16:
-        throw std::runtime_error("FIXME: numbers_to_type for float16 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: numbers_to_type for float16 not implemented")
+          + FILENAME(__LINE__));
       case util::dtype::float32:
         ptr = as_type<float>(reinterpret_cast<float*>(contiguous_self.ptr().get()),
                              contiguous_self.length(),
@@ -4784,17 +4895,25 @@ namespace awkward {
                               dtype);
         break;
       case util::dtype::float128:
-        throw std::runtime_error("FIXME: numbers_to_type for float128 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: numbers_to_type for float128 not implemented")
+          + FILENAME(__LINE__));
       case util::dtype::complex64:
-        throw std::runtime_error("FIXME: values_astype for complex64 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: values_astype for complex64 not implemented")
+          + FILENAME(__LINE__));
       case util::dtype::complex128:
-        throw std::runtime_error("FIXME: numbers_to_type for complex128 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: numbers_to_type for complex128 not implemented")
+          + FILENAME(__LINE__));
       case util::dtype::complex256:
-        throw std::runtime_error("FIXME: numbers_to_type for complex256 not implemented");
+        throw std::runtime_error(
+          std::string("FIXME: numbers_to_type for complex256 not implemented")
+          + FILENAME(__LINE__));
       default:
         throw std::invalid_argument(
           std::string("cannot recast NumpyArray with format \"")
-          + format_ + std::string("\""));
+          + format_ + std::string("\"") + FILENAME(__LINE__));
       }
 
       return std::make_shared<NumpyArray>(identities,
@@ -4968,7 +5087,9 @@ namespace awkward {
       ptr = cast_to_type<uint64_t>(data, length);
       break;
     case util::dtype::float16:
-      throw std::runtime_error("FIXME: as_type for float16 not implemented");
+      throw std::runtime_error(
+        std::string("FIXME: as_type for float16 not implemented")
+        + FILENAME(__LINE__));
     case util::dtype::float32:
       ptr = cast_to_type<float>(data, length);
       break;
@@ -4976,17 +5097,25 @@ namespace awkward {
       ptr = cast_to_type<double>(data, length);
       break;
     case util::dtype::float128:
-      throw std::runtime_error("FIXME: as_type for float128 not implemented");
+      throw std::runtime_error(
+        std::string("FIXME: as_type for float128 not implemented")
+        + FILENAME(__LINE__));
     case util::dtype::complex64:
-      throw std::runtime_error("FIXME: as_type for complex64 not implemented");
+      throw std::runtime_error(
+        std::string("FIXME: as_type for complex64 not implemented")
+        + FILENAME(__LINE__));
     case util::dtype::complex128:
-      throw std::runtime_error("FIXME: as_type for complex128 not implemented");
+      throw std::runtime_error(
+        std::string("FIXME: as_type for complex128 not implemented")
+        + FILENAME(__LINE__));
     case util::dtype::complex256:
-      throw std::runtime_error("FIXME: as_type for complex256 not implemented");
+      throw std::runtime_error(
+        std::string("FIXME: as_type for complex256 not implemented")
+        + FILENAME(__LINE__));
     default:
       throw std::invalid_argument(
         std::string("cannot recast NumpyArray with format \"")
-        + format_ + std::string("\""));
+        + format_ + std::string("\"") + FILENAME(__LINE__));
     }
 
     return ptr;

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/Record.cpp", line)
+
 #include <sstream>
 #include <memory>
 
@@ -18,7 +20,8 @@ namespace awkward {
     if (!(0 <= at  &&  at < array.get()->length())) {
       throw std::invalid_argument(
         std::string("at=") + std::to_string(at)
-        + std::string(" is out of range for recordarray"));
+        + std::string(" is out of range for recordarray")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -74,12 +77,16 @@ namespace awkward {
 
   void
   Record::setidentities() {
-    throw std::runtime_error("undefined operation: Record::setidentities");
+    throw std::runtime_error(
+      std::string("undefined operation: Record::setidentities")
+      + FILENAME(__LINE__));
   }
 
   void
   Record::setidentities(const IdentitiesPtr& identities) {
-    throw std::runtime_error("undefined operation: Record::setidentities");
+    throw std::runtime_error(
+      std::string("undefined operation: Record::setidentities")
+      + FILENAME(__LINE__));
   }
 
   const TypePtr
@@ -177,33 +184,39 @@ namespace awkward {
 
   const ContentPtr
   Record::getitem_nothing() const {
-    throw std::runtime_error("undefined operation: Record::getitem_nothing");
+    throw std::runtime_error(
+      std::string("undefined operation: Record::getitem_nothing")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   Record::getitem_at(int64_t at) const {
     throw std::invalid_argument(
       std::string("scalar Record can only be sliced by field name (string); "
-                  "try ") + util::quote(std::to_string(at), true));
+                  "try ") + util::quote(std::to_string(at), true)
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   Record::getitem_at_nowrap(int64_t at) const {
     throw std::invalid_argument(
       std::string("scalar Record can only be sliced by field name (string); "
-                  "try ") + util::quote(std::to_string(at), true));
+                  "try ") + util::quote(std::to_string(at), true)
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   Record::getitem_range(int64_t start, int64_t stop) const {
     throw std::invalid_argument(
-      "scalar Record can only be sliced by field name (string)");
+      std::string("scalar Record can only be sliced by field name (string)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   Record::getitem_range_nowrap(int64_t start, int64_t stop) const {
     throw std::invalid_argument(
-      "scalar Record can only be sliced by field name (string)");
+      std::string("scalar Record can only be sliced by field name (string)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -219,7 +232,8 @@ namespace awkward {
 
   const ContentPtr
   Record::carry(const Index64& carry, bool allow_lazy) const {
-    throw std::runtime_error("undefined operation: Record::carry");
+    throw std::runtime_error(
+      std::string("undefined operation: Record::carry") + FILENAME(__LINE__));
   }
 
   int64_t
@@ -279,7 +293,8 @@ namespace awkward {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
       throw std::invalid_argument(
-        "cannot call 'num' with an 'axis' of 0 on a Record");
+        std::string("cannot call 'num' with an 'axis' of 0 on a Record")
+        + FILENAME(__LINE__));
     }
     else {
       ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
@@ -290,24 +305,28 @@ namespace awkward {
   const std::pair<Index64, ContentPtr>
   Record::offsets_and_flattened(int64_t axis, int64_t depth) const {
     throw std::invalid_argument(
-      "Record cannot be flattened because it is not an array");
+      std::string("Record cannot be flattened because it is not an array")
+      + FILENAME(__LINE__));
   }
 
   bool
   Record::mergeable(const ContentPtr& other, bool mergebool) const {
     throw std::invalid_argument(
-      "Record cannot be merged because it is not an array");
+      std::string("Record cannot be merged because it is not an array")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   Record::merge(const ContentPtr& other) const {
     throw std::invalid_argument(
-      "Record cannot be merged because it is not an array");
+      std::string("Record cannot be merged because it is not an array")
+      + FILENAME(__LINE__));
   }
 
   const SliceItemPtr
   Record::asslice() const {
-    throw std::invalid_argument("cannot use a record as a slice");
+    throw std::invalid_argument(
+      std::string("cannot use a record as a slice") + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -321,13 +340,15 @@ namespace awkward {
   const ContentPtr
   Record::rpad(int64_t length, int64_t axis, int64_t depth) const {
     throw std::invalid_argument(
-      "Record cannot be padded because it is not an array");
+      std::string("Record cannot be padded because it is not an array")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
   Record::rpad_and_clip(int64_t length, int64_t axis, int64_t depth) const {
     throw std::invalid_argument(
-      "Record cannot be padded because it is not an array");
+      std::string("Record cannot be padded because it is not an array")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -353,7 +374,8 @@ namespace awkward {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
       throw std::invalid_argument(
-        "cannot call 'localindex' with an 'axis' of 0 on a Record");
+        std::string("cannot call 'localindex' with an 'axis' of 0 on a Record")
+        + FILENAME(__LINE__));
     }
     else {
       ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
@@ -371,12 +393,14 @@ namespace awkward {
                        int64_t axis,
                        int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1") + FILENAME(__LINE__));
     }
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
       throw std::invalid_argument(
-        "cannot call 'combinations' with an 'axis' of 0 on a Record");
+        std::string("cannot call 'combinations' with an 'axis' of 0 on a Record")
+        + FILENAME(__LINE__));
     }
     else {
       ContentPtr singleton = array_.get()->getitem_range_nowrap(at_, at_ + 1);
@@ -496,7 +520,9 @@ namespace awkward {
   Record::getitem_next(const SliceAt& at,
                        const Slice& tail,
                        const Index64& advanced) const {
-    throw std::runtime_error("undefined operation: Record::getitem_next(at)");
+    throw std::runtime_error(
+      std::string("undefined operation: Record::getitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -504,7 +530,8 @@ namespace awkward {
                        const Slice& tail,
                        const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: Record::getitem_next(range)");
+      std::string("undefined operation: Record::getitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -512,7 +539,8 @@ namespace awkward {
                        const Slice& tail,
                        const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: Record::getitem_next(array)");
+      std::string("undefined operation: Record::getitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -520,7 +548,8 @@ namespace awkward {
                        const Slice& tail,
                        const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: Record::getitem_next(field)");
+      std::string("undefined operation: Record::getitem_next(field)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -528,7 +557,8 @@ namespace awkward {
                        const Slice& tail,
                        const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: Record::getitem_next(fields)");
+      std::string("undefined operation: Record::getitem_next(fields)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -536,7 +566,8 @@ namespace awkward {
                        const Slice& tail,
                        const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: Record::getitem_next(jagged)");
+      std::string("undefined operation: Record::getitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -545,7 +576,8 @@ namespace awkward {
                               const SliceArray64& slicecontent,
                               const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: Record::getitem_next_jagged(array)");
+      std::string("undefined operation: Record::getitem_next_jagged(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -554,7 +586,8 @@ namespace awkward {
                               const SliceMissing64& slicecontent,
                               const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: Record::getitem_next_jagged(missing)");
+      std::string("undefined operation: Record::getitem_next_jagged(missing)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -563,7 +596,8 @@ namespace awkward {
                               const SliceJagged64& slicecontent,
                               const Slice& tail) const {
     throw std::runtime_error(
-      "undefined operation: Record::getitem_next_jagged(jagged)");
+      std::string("undefined operation: Record::getitem_next_jagged(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/RecordArray.cpp", line)
+
 #include <sstream>
 #include <algorithm>
 
@@ -34,7 +36,8 @@ namespace awkward {
     if (recordlookup.get() != nullptr  &&
         recordlookup.get()->size() != contents.size()) {
       throw std::invalid_argument(
-        "recordlookup (if provided) and contents must have the same length");
+        std::string("recordlookup (if provided) and contents must have the same length")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -59,7 +62,7 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("fieldindex ") + std::to_string(fieldindex)
         + std::string(" for record with only ") + std::to_string(numfields())
-        + std::string(" fields"));
+        + std::string(" fields") + FILENAME(__LINE__));
     }
     return contents_[(size_t)fieldindex];
   }
@@ -312,7 +315,8 @@ namespace awkward {
     if (recordlookup_.get() != nullptr  &&
         recordlookup_.get()->size() != contents_.size()) {
       throw std::invalid_argument(
-        "recordlookup and contents must have the same number of fields");
+        std::string("recordlookup and contents must have the same number of fields")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -360,13 +364,14 @@ namespace awkward {
   const ContentPtr
   RecordArray::setitem_field(int64_t where, const ContentPtr& what) const {
     if (where < 0) {
-      throw std::invalid_argument("where must be non-negative");
+      throw std::invalid_argument(
+        std::string("where must be non-negative") + FILENAME(__LINE__));
     }
     if (what.get()->length() != length()) {
       throw std::invalid_argument(
         std::string("array of length ") + std::to_string(what.get()->length())
         + std::string(" cannot be assigned to record array of length ")
-        + std::to_string(length()));
+        + std::to_string(length()) + FILENAME(__LINE__));
     }
     ContentPtrVec contents;
     for (size_t i = 0;  i < contents_.size();  i++) {
@@ -404,7 +409,7 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("array of length ") + std::to_string(what.get()->length())
         + std::string(" cannot be assigned to record array of length ")
-        + std::to_string(length()));
+        + std::to_string(length()) + FILENAME(__LINE__));
     }
     ContentPtrVec contents(contents_.begin(), contents_.end());
     contents.push_back(what);
@@ -864,12 +869,13 @@ namespace awkward {
   RecordArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
-      throw std::invalid_argument("axis=0 not allowed for flatten");
+      throw std::invalid_argument(
+        std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
     }
     else if (posaxis == depth + 1) {
       throw std::invalid_argument(
-        "arrays of records cannot be flattened (but their contents can be; "
-        "try a different 'axis')");
+        std::string("arrays of records cannot be flattened (but their contents can be; "
+                    "try a different 'axis')") + FILENAME(__LINE__));
     }
     else {
       ContentPtrVec contents;
@@ -879,8 +885,8 @@ namespace awkward {
           trimmed.get()->offsets_and_flattened(posaxis, depth);
         if (pair.first.length() != 0) {
           throw std::runtime_error(
-            "RecordArray content with axis > depth + 1 returned a non-empty "
-            "offsets from offsets_and_flattened");
+            std::string("RecordArray content with axis > depth + 1 returned a non-empty "
+                        "offsets from offsets_and_flattened") + FILENAME(__LINE__));
         }
         contents.push_back(pair.second);
       }
@@ -1084,18 +1090,20 @@ namespace awkward {
         }
       }
       throw std::invalid_argument(
-        "cannot merge records or tuples with different fields");
+        std::string("cannot merge records or tuples with different fields")
+        + FILENAME(__LINE__));
     }
     else {
       throw std::invalid_argument(
         std::string("cannot merge ") + classname() + std::string(" with ")
-        + other.get()->classname());
+        + other.get()->classname() + FILENAME(__LINE__));
     }
   }
 
   const SliceItemPtr
   RecordArray::asslice() const {
-    throw std::invalid_argument("cannot use records as a slice");
+    throw std::invalid_argument(
+      std::string("cannot use records as a slice") + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -1222,7 +1230,8 @@ namespace awkward {
                             int64_t axis,
                             int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1") + FILENAME(__LINE__));
     }
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
@@ -1252,7 +1261,7 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("fieldindex ") + std::to_string(fieldindex)
         + std::string(" for record with only " + std::to_string(numfields()))
-        + std::string(" fields"));
+        + std::string(" fields") + FILENAME(__LINE__));
     }
     return contents_[(size_t)fieldindex];
   }
@@ -1399,7 +1408,8 @@ namespace awkward {
                             const Slice& tail,
                             const Index64& advanced) const {
     throw std::invalid_argument(
-      std::string("undefined operation: RecordArray::getitem_next(at)"));
+      std::string("undefined operation: RecordArray::getitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -1407,7 +1417,8 @@ namespace awkward {
                             const Slice& tail,
                             const Index64& advanced) const {
     throw std::invalid_argument(
-      std::string("undefined operation: RecordArray::getitem_next(range)"));
+      std::string("undefined operation: RecordArray::getitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -1415,7 +1426,8 @@ namespace awkward {
                             const Slice& tail,
                             const Index64& advanced) const {
     throw std::invalid_argument(
-      std::string("undefined operation: RecordArray::getitem_next(array)"));
+      std::string("undefined operation: RecordArray::getitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -1445,7 +1457,8 @@ namespace awkward {
                             const Slice& tail,
                             const Index64& advanced) const {
     throw std::invalid_argument(
-      std::string("undefined operation: RecordArray::getitem_next(jagged)"));
+      std::string("undefined operation: RecordArray::getitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/RegularArray.cpp", line)
+
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
@@ -180,7 +182,9 @@ namespace awkward {
       , content_(content)
       , size_(size) {
     if (size < 0) {
-      throw std::invalid_argument("RegularArray size must be non-negative");
+      throw std::invalid_argument(
+        std::string("RegularArray size must be non-negative")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -211,7 +215,8 @@ namespace awkward {
   RegularArray::broadcast_tooffsets64(const Index64& offsets) const {
     if (offsets.length() == 0  ||  offsets.getitem_at_nowrap(0) != 0) {
       throw std::invalid_argument(
-        "broadcast_tooffsets64 can only be used with offsets that start at 0");
+        std::string("broadcast_tooffsets64 can only be used with offsets that start at 0")
+        + FILENAME(__LINE__));
     }
 
     int64_t len = length();
@@ -219,7 +224,7 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("cannot broadcast RegularArray of length ")
         + std::to_string(len) + (" to length ")
-        + std::to_string(offsets.length() - 1));
+        + std::to_string(offsets.length() - 1) + FILENAME(__LINE__));
     }
 
     IdentitiesPtr identities;
@@ -332,7 +337,9 @@ namespace awkward {
         content_.get()->setidentities(subidentities);
       }
       else {
-        throw std::runtime_error("unrecognized Identities specialization");
+        throw std::runtime_error(
+          std::string("unrecognized Identities specialization")
+          + FILENAME(__LINE__));
       }
     }
     identities_ = identities;
@@ -809,16 +816,16 @@ namespace awkward {
     else {
       throw std::invalid_argument(
         std::string("cannot merge ") + classname() + std::string(" with ")
-        + other.get()->classname());
+        + other.get()->classname() + FILENAME(__LINE__));
     }
   }
 
   const SliceItemPtr
   RegularArray::asslice() const {
     throw std::invalid_argument(
-      "slice items can have all fixed-size dimensions (to follow NumPy's "
-      "slice rules) or they can have all var-sized dimensions (for jagged "
-      "indexing), but not both in the same slice item");
+      std::string("slice items can have all fixed-size dimensions (to follow NumPy's "
+                  "slice rules) or they can have all var-sized dimensions (for jagged "
+                  "indexing), but not both in the same slice item") + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -943,7 +950,9 @@ namespace awkward {
                              int64_t axis,
                              int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1")
+        + FILENAME(__LINE__));
     }
 
     int64_t posaxis = axis_wrap_if_negative(axis);
@@ -1096,7 +1105,8 @@ namespace awkward {
                              const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::runtime_error(
-        "RegularArray::getitem_next(SliceAt): advanced.length() != 0");
+        std::string("RegularArray::getitem_next(SliceAt): advanced.length() != 0")
+        + FILENAME(__LINE__));
     }
     int64_t len = length();
     SliceItemPtr nexthead = tail.head();
@@ -1125,7 +1135,8 @@ namespace awkward {
 
     if (range.step() == 0) {
       throw std::runtime_error(
-        "RegularArray::getitem_next(SliceRange): range.step() == 0");
+        std::string("RegularArray::getitem_next(SliceRange): range.step() == 0")
+        + FILENAME(__LINE__));
     }
     int64_t regular_start = range.start();
     int64_t regular_stop = range.stop();
@@ -1258,14 +1269,16 @@ namespace awkward {
                              const Index64& advanced) const {
     if (advanced.length() != 0) {
       throw std::invalid_argument(
-        "cannot mix jagged slice with NumPy-style advanced indexing");
+        std::string("cannot mix jagged slice with NumPy-style advanced indexing")
+        + FILENAME(__LINE__));
     }
 
     if (jagged.length() != size_) {
       throw std::invalid_argument(
         std::string("cannot fit jagged slice with length ")
         + std::to_string(jagged.length()) + std::string(" into ")
-        + classname() + std::string(" of size ") + std::to_string(size_));
+        + classname() + std::string(" of size ") + std::to_string(size_)
+        + FILENAME(__LINE__));
     }
 
     int64_t regularlength = length();

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/UnionArray.cpp", line)
+
 #include <sstream>
 #include <type_traits>
 
@@ -204,15 +206,15 @@ namespace awkward {
   int64_t
   UnionForm::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
-      "UnionForm breaks the one-to-one relationship "
-      "between fieldindexes and keys");
+      std::string("UnionForm breaks the one-to-one relationship "
+                  "between fieldindexes and keys") + FILENAME(__LINE__));
   }
 
   const std::string
   UnionForm::key(int64_t fieldindex) const {
     throw std::invalid_argument(
-      "UnionForm breaks the one-to-one relationship "
-      "between fieldindexes and keys");
+      std::string("UnionForm breaks the one-to-one relationship "
+                  "between fieldindexes and keys") + FILENAME(__LINE__));
   }
 
   bool
@@ -369,7 +371,8 @@ namespace awkward {
     }
     if (index.length() < tags.length()) {
       throw std::invalid_argument(
-        "UnionArray index must not be shorter than its tags");
+        std::string("UnionArray index must not be shorter than its tags")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -405,7 +408,7 @@ namespace awkward {
         std::string("index ") + std::to_string(index)
         + std::string(" out of range for ") + classname()
         + std::string(" with ") + std::to_string(numcontents())
-        + std::string(" contents"));
+        + std::string(" contents") + FILENAME(__LINE__));
     }
     return contents_[(size_t)index];
   }
@@ -418,7 +421,7 @@ namespace awkward {
         std::string("index ") + std::to_string(index)
         + std::string(" out of range for ") + classname()
         + std::string(" with ") + std::to_string(numcontents())
-        + std::string(" contents"));
+        + std::string(" contents") + FILENAME(__LINE__));
     }
     int64_t lentags = tags_.length();
     if (index_.length() < lentags) {
@@ -637,7 +640,8 @@ namespace awkward {
 
     if (contents.size() > kMaxInt8) {
       throw std::runtime_error(
-        "FIXME: handle UnionArray with more than 127 contents");
+        std::string("FIXME: handle UnionArray with more than 127 contents")
+        + FILENAME(__LINE__));
     }
 
     if (contents.size() == 1) {
@@ -793,7 +797,9 @@ namespace awkward {
           }
         }
         else {
-          throw std::runtime_error("unrecognized Identities specialization");
+          throw std::runtime_error(
+            std::string("unrecognized Identities specialization")
+            + FILENAME(__LINE__));
         }
       }
     }
@@ -1109,7 +1115,8 @@ namespace awkward {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
-      throw std::runtime_error("unrecognized slice type");
+      throw std::runtime_error(
+        std::string("unrecognized slice type") + FILENAME(__LINE__));
     }
   }
 
@@ -1162,16 +1169,16 @@ namespace awkward {
   int64_t
   UnionArrayOf<T, I>::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
-      "UnionForm breaks the one-to-one relationship "
-      "between fieldindexes and keys");
+      std::string("UnionForm breaks the one-to-one relationship "
+                  "between fieldindexes and keys") + FILENAME(__LINE__));
   }
 
   template <typename T, typename I>
   const std::string
   UnionArrayOf<T, I>::key(int64_t fieldindex) const {
     throw std::invalid_argument(
-      "UnionForm breaks the one-to-one relationship "
-      "between fieldindexes and keys");
+      std::string("UnionForm breaks the one-to-one relationship "
+                  "between fieldindexes and keys") + FILENAME(__LINE__));
   }
 
   template <typename T, typename I>
@@ -1275,7 +1282,8 @@ namespace awkward {
                                             int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
-      throw std::invalid_argument("axis=0 not allowed for flatten");
+      throw std::invalid_argument(
+        std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
     }
     else {
       bool has_offsets = false;
@@ -1390,7 +1398,9 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
     }
     else {
-      throw std::runtime_error("unrecognized UnionArray specialization");
+      throw std::runtime_error(
+        std::string("unrecognized UnionArray specialization")
+        + FILENAME(__LINE__));
     }
 
     if (std::is_same<I, int32_t>::value) {
@@ -1421,12 +1431,15 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
     }
     else {
-      throw std::runtime_error("unrecognized UnionArray specialization");
+      throw std::runtime_error(
+        std::string("unrecognized UnionArray specialization")
+        + FILENAME(__LINE__));
     }
 
     if (contents.size() > kMaxInt8) {
       throw std::runtime_error(
-        "FIXME: handle UnionArray with more than 127 contents");
+        std::string("FIXME: handle UnionArray with more than 127 contents")
+        + FILENAME(__LINE__));
     }
 
     return std::make_shared<UnionArray8_64>(Identities::none(),
@@ -1467,7 +1480,9 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
     }
     else {
-      throw std::runtime_error("unrecognized UnionArray specialization");
+      throw std::runtime_error(
+        std::string("unrecognized UnionArray specialization")
+        + FILENAME(__LINE__));
     }
 
     if (std::is_same<I, int32_t>::value) {
@@ -1498,7 +1513,9 @@ namespace awkward {
       util::handle_error(err, classname(), identities_.get());
     }
     else {
-      throw std::runtime_error("unrecognized UnionArray specialization");
+      throw std::runtime_error(
+        std::string("unrecognized UnionArray specialization")
+        + FILENAME(__LINE__));
     }
 
     ContentPtrVec contents(contents_.begin(), contents_.end());
@@ -1605,7 +1622,8 @@ namespace awkward {
 
     if (contents.size() > kMaxInt8) {
       throw std::runtime_error(
-        "FIXME: handle UnionArray with more than 127 contents");
+        std::string("FIXME: handle UnionArray with more than 127 contents")
+        + FILENAME(__LINE__));
     }
 
     return std::make_shared<UnionArray8_64>(Identities::none(),
@@ -1626,7 +1644,8 @@ namespace awkward {
       }
       else {
         throw std::invalid_argument(
-          "cannot use a union of different types as a slice");
+          std::string("cannot use a union of different types as a slice")
+          + FILENAME(__LINE__));
       }
     }
     else if (UnionArray8_U32* raw =
@@ -1636,7 +1655,8 @@ namespace awkward {
       }
       else {
         throw std::invalid_argument(
-          "cannot use a union of different types as a slice");
+          std::string("cannot use a union of different types as a slice")
+          + FILENAME(__LINE__));
       }
     }
     else if (UnionArray8_64* raw =
@@ -1646,7 +1666,8 @@ namespace awkward {
       }
       else {
         throw std::invalid_argument(
-          "cannot use a union of different types as a slice");
+          std::string("cannot use a union of different types as a slice")
+          + FILENAME(__LINE__));
       }
     }
     else {
@@ -1725,7 +1746,8 @@ namespace awkward {
         dynamic_cast<UnionArray8_64*>(simplified.get())) {
       throw std::invalid_argument(
         std::string("cannot reduce (call '") + reducer.name()
-        + std::string("' on) an irreducible ") + classname());
+        + std::string("' on) an irreducible ") + classname()
+        + FILENAME(__LINE__));
     }
     return simplified.get()->reduce_next(reducer,
                                          negaxis,
@@ -1765,7 +1787,9 @@ namespace awkward {
                                    int64_t axis,
                                    int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1")
+        + FILENAME(__LINE__));
     }
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
@@ -1802,7 +1826,8 @@ namespace awkward {
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_64*>(simplified.get())) {
-      throw std::invalid_argument(std::string("cannot sort ") + classname());
+      throw std::invalid_argument(
+        std::string("cannot sort ") + classname() + FILENAME(__LINE__));
     }
     return simplified.get()->sort_next(negaxis,
                                        starts,
@@ -1826,7 +1851,8 @@ namespace awkward {
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_64*>(simplified.get())) {
-      throw std::invalid_argument(std::string("cannot sort ") + classname());
+      throw std::invalid_argument(
+        std::string("cannot sort ") + classname() + FILENAME(__LINE__));
     }
     return simplified.get()->argsort_next(negaxis,
                                           starts,
@@ -1843,7 +1869,8 @@ namespace awkward {
                                    const Slice& tail,
                                    const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: UnionArray::getitem_next(at)");
+      std::string("undefined operation: UnionArray::getitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   template <typename T, typename I>
@@ -1852,7 +1879,8 @@ namespace awkward {
                                    const Slice& tail,
                                    const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: UnionArray::getitem_next(range)");
+      std::string("undefined operation: UnionArray::getitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   template <typename T, typename I>
@@ -1861,7 +1889,8 @@ namespace awkward {
                                    const Slice& tail,
                                    const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: UnionArray::getitem_next(array)");
+      std::string("undefined operation: UnionArray::getitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   template <typename T, typename I>
@@ -1870,7 +1899,8 @@ namespace awkward {
                                    const Slice& tail,
                                    const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: UnionArray::getitem_next(jagged)");
+      std::string("undefined operation: UnionArray::getitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   template <typename T, typename I>
@@ -1962,7 +1992,8 @@ namespace awkward {
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_64*>(simplified.get())) {
       throw std::invalid_argument(
-        "cannot apply jagged slices to irreducible union arrays");
+        std::string("cannot apply jagged slices to irreducible union arrays")
+        + FILENAME(__LINE__));
     }
     return simplified.get()->getitem_next_jagged(slicestarts,
                                                  slicestops,

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/UnmaskedArray.cpp", line)
+
 #include <sstream>
 #include <type_traits>
 
@@ -277,7 +279,8 @@ namespace awkward {
         content_.get()->setidentities(subidentities);
       }
       else {
-        throw std::runtime_error("unrecognized Identities specialization");
+        throw std::runtime_error(
+          std::string("unrecognized Identities specialization") + FILENAME(__LINE__));
       }
     }
     identities_ = identities;
@@ -512,7 +515,8 @@ namespace awkward {
       return Content::getitem_next(*missing, tail, advanced);
     }
     else {
-      throw std::runtime_error("unrecognized slice type");
+      throw std::runtime_error(
+        std::string("unrecognized slice type") + FILENAME(__LINE__));
     }
   }
 
@@ -581,7 +585,8 @@ namespace awkward {
   UnmaskedArray::offsets_and_flattened(int64_t axis, int64_t depth) const {
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
-      throw std::invalid_argument("axis=0 not allowed for flatten");
+      throw std::invalid_argument(
+        std::string("axis=0 not allowed for flatten") + FILENAME(__LINE__));
     }
     else {
       std::pair<Index64, ContentPtr> offsets_flattened =
@@ -753,7 +758,9 @@ namespace awkward {
                               int64_t axis,
                               int64_t depth) const {
     if (n < 1) {
-      throw std::invalid_argument("in combinations, 'n' must be at least 1");
+      throw std::invalid_argument(
+        std::string("in combinations, 'n' must be at least 1")
+        + FILENAME(__LINE__));
     }
     int64_t posaxis = axis_wrap_if_negative(axis);
     if (posaxis == depth) {
@@ -839,7 +846,8 @@ namespace awkward {
                               const Slice& tail,
                               const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: UnmaskedArray::getitem_next(at)");
+      std::string("undefined operation: UnmaskedArray::getitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -847,7 +855,8 @@ namespace awkward {
                               const Slice& tail,
                               const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: UnmaskedArray::getitem_next(range)");
+      std::string("undefined operation: UnmaskedArray::getitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -855,7 +864,8 @@ namespace awkward {
                               const Slice& tail,
                               const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: UnmaskedArray::getitem_next(array)");
+      std::string("undefined operation: UnmaskedArray::getitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -863,7 +873,8 @@ namespace awkward {
                               const Slice& tail,
                               const Index64& advanced) const {
     throw std::runtime_error(
-      "undefined operation: UnmaskedArray::getitem_next(jagged)");
+      std::string("undefined operation: UnmaskedArray::getitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/array/VirtualArray.cpp", line)
+
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
@@ -39,7 +41,8 @@ namespace awkward {
   VirtualForm::type(const util::TypeStrs& typestrs) const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->type(typestrs);
@@ -84,7 +87,8 @@ namespace awkward {
   VirtualForm::purelist_isregular() const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->purelist_isregular();
@@ -95,7 +99,8 @@ namespace awkward {
   VirtualForm::purelist_depth() const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->purelist_depth();
@@ -106,7 +111,8 @@ namespace awkward {
   VirtualForm::minmax_depth() const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->minmax_depth();
@@ -117,7 +123,8 @@ namespace awkward {
   VirtualForm::branch_depth() const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->branch_depth();
@@ -128,7 +135,8 @@ namespace awkward {
   VirtualForm::numfields() const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->numfields();
@@ -139,7 +147,8 @@ namespace awkward {
   VirtualForm::fieldindex(const std::string& key) const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->fieldindex(key);
@@ -150,7 +159,8 @@ namespace awkward {
   VirtualForm::key(int64_t fieldindex) const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->key(fieldindex);
@@ -161,7 +171,8 @@ namespace awkward {
   VirtualForm::haskey(const std::string& key) const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->haskey(key);
@@ -172,7 +183,8 @@ namespace awkward {
   VirtualForm::keys() const {
     if (form_.get() == nullptr) {
       throw std::invalid_argument(
-          "VirtualForm cannot determine its type without an expected Form");
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
     }
     else {
       return form_.get()->keys();
@@ -338,12 +350,16 @@ namespace awkward {
 
   void
   VirtualArray::setidentities(const IdentitiesPtr& identities) {
-    throw std::runtime_error("FIXME: VirtualArray::setidentities(identities)");
+    throw std::runtime_error(
+      std::string("FIXME: VirtualArray::setidentities(identities)")
+      + FILENAME(__LINE__));
   }
 
   void
   VirtualArray::setidentities() {
-    throw std::runtime_error("FIXME: VirtualArray::setidentities");
+    throw std::runtime_error(
+      std::string("FIXME: VirtualArray::setidentities")
+      + FILENAME(__LINE__));
   }
 
   const TypePtr
@@ -738,7 +754,8 @@ namespace awkward {
       if (SliceRange* range =
           dynamic_cast<SliceRange*>(head.get())) {
         if (range->step() == 0) {
-            throw std::invalid_argument("slice step cannot be zero");
+            throw std::invalid_argument(
+              std::string("slice step cannot be zero") + FILENAME(__LINE__));
         }
         else if (generator_.get()->length() >= 0) {
           int64_t regular_start = range->start();
@@ -836,7 +853,8 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next(at)");
+      std::string("undefined operation: VirtualArray::getitem_next(at)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -844,7 +862,8 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next(range)");
+      std::string("undefined operation: VirtualArray::getitem_next(range)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -852,7 +871,8 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next(array)");
+      std::string("undefined operation: VirtualArray::getitem_next(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -860,7 +880,8 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next(field)");
+      std::string("undefined operation: VirtualArray::getitem_next(field)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -868,7 +889,8 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next(fields)");
+      std::string("undefined operation: VirtualArray::getitem_next(fields)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -876,7 +898,8 @@ namespace awkward {
                            const Slice& tail,
                            const Index64& advanced) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next(jagged)");
+      std::string("undefined operation: VirtualArray::getitem_next(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -885,7 +908,8 @@ namespace awkward {
                                   const SliceArray64& slicecontent,
                                   const Slice& tail) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next_jagged(array)");
+      std::string("undefined operation: VirtualArray::getitem_next_jagged(array)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -894,7 +918,8 @@ namespace awkward {
                                   const SliceMissing64& slicecontent,
                                   const Slice& tail) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next_jagged(missing)");
+      std::string("undefined operation: VirtualArray::getitem_next_jagged(missing)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -903,7 +928,8 @@ namespace awkward {
                                   const SliceJagged64& slicecontent,
                                   const Slice& tail) const {
     throw std::runtime_error(
-            "undefined operation: VirtualArray::getitem_next_jagged(jagged)");
+      std::string("undefined operation: VirtualArray::getitem_next_jagged(jagged)")
+      + FILENAME(__LINE__));
   }
 
   const ContentPtr

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ArrayBuilder.cpp", line)
+
 #include <sstream>
 
 #include "awkward/builder/ArrayBuilder.h"
@@ -124,7 +126,8 @@ namespace awkward {
     BuilderPtr tmp = builder_.get()->endlist();
     if (tmp.get() == nullptr) {
       throw std::invalid_argument(
-        "endlist doesn't match a corresponding beginlist");
+        std::string("endlist doesn't match a corresponding beginlist")
+        + FILENAME(__LINE__));
     }
     maybeupdate(tmp);
   }
@@ -192,9 +195,11 @@ namespace awkward {
       regular_at += length;
     }
     if (!(0 <= regular_at  &&  regular_at < length)) {
-      throw std::invalid_argument(std::string("'append' index (")
+      throw std::invalid_argument(
+        std::string("'append' index (")
         + std::to_string(at) + std::string(") out of bounds (")
-        + std::to_string(length) + std::string(")"));
+        + std::to_string(length) + std::string(")")
+        + FILENAME(__LINE__));
     }
     return append_nowrap(array, regular_at);
   }

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/BoolBuilder.cpp", line)
+
 #include "awkward/Identities.h"
 #include "awkward/array/NumpyArray.h"
 #include "awkward/type/PrimitiveType.h"
@@ -102,7 +104,8 @@ namespace awkward {
   const BuilderPtr
   BoolBuilder::endlist() {
     throw std::invalid_argument(
-      "called 'endlist' without 'beginlist' at the same level before it");
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -115,13 +118,15 @@ namespace awkward {
   const BuilderPtr
   BoolBuilder::index(int64_t index) {
     throw std::invalid_argument(
-      "called 'index' without 'begintuple' at the same level before it");
+      std::string("called 'index' without 'begintuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   BoolBuilder::endtuple() {
     throw std::invalid_argument(
-      "called 'endtuple' without 'begintuple' at the same level before it");
+      std::string("called 'endtuple' without 'begintuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -134,13 +139,15 @@ namespace awkward {
   const BuilderPtr
   BoolBuilder::field(const char* key, bool check) {
     throw std::invalid_argument(
-      "called 'field' without 'beginrecord' at the same level before it");
+      std::string("called 'field' without 'beginrecord' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   BoolBuilder::endrecord() {
     throw std::invalid_argument(
-      "called 'endrecord' without 'beginrecord' at the same level before it");
+      std::string("called 'endrecord' without 'beginrecord' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Float64Builder.cpp", line)
+
 #include "awkward/Identities.h"
 #include "awkward/array/NumpyArray.h"
 #include "awkward/type/PrimitiveType.h"
@@ -117,7 +119,8 @@ namespace awkward {
   const BuilderPtr
   Float64Builder::endlist() {
     throw std::invalid_argument(
-      "called 'endlist' without 'beginlist' at the same level before it");
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -130,13 +133,15 @@ namespace awkward {
   const BuilderPtr
   Float64Builder::index(int64_t index) {
     throw std::invalid_argument(
-      "called 'index' without 'begintuple' at the same level before it");
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   Float64Builder::endtuple() {
     throw std::invalid_argument(
-      "called 'endtuple' without 'begintuple' at the same level before it");
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -149,13 +154,15 @@ namespace awkward {
   const BuilderPtr
   Float64Builder::field(const char* key, bool check) {
     throw std::invalid_argument(
-      "called 'field' without 'beginrecord' at the same level before it");
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   Float64Builder::endrecord() {
     throw std::invalid_argument(
-      "called 'endrecord' without 'beginrecord' at the same level before it");
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr

--- a/src/libawkward/builder/IndexedBuilder.cpp
+++ b/src/libawkward/builder/IndexedBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/IndexedBuilder.cpp", line)
+
 #include <stdexcept>
 
 #include "awkward/Identities.h"
@@ -99,7 +101,8 @@ namespace awkward {
   const BuilderPtr
   IndexedBuilder<T>::endlist() {
     throw std::invalid_argument(
-      "called 'endlist' without 'beginlist' at the same level before it");
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   template <typename T>
@@ -114,14 +117,16 @@ namespace awkward {
   const BuilderPtr
   IndexedBuilder<T>::index(int64_t index) {
     throw std::invalid_argument(
-      "called 'index' without 'begintuple' at the same level before it");
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   template <typename T>
   const BuilderPtr
   IndexedBuilder<T>::endtuple() {
     throw std::invalid_argument(
-      "called 'endtuple' without 'begintuple' at the same level before it");
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   template <typename T>
@@ -136,14 +141,16 @@ namespace awkward {
   const BuilderPtr
   IndexedBuilder<T>::field(const char* key, bool check) {
     throw std::invalid_argument(
-      "called 'field' without 'beginrecord' at the same level before it");
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   template <typename T>
   const BuilderPtr
   IndexedBuilder<T>::endrecord() {
     throw std::invalid_argument(
-      "called 'endrecord' without 'beginrecord' at the same level before it");
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   ////////// IndexedGenericBuilder

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Int64Builder.cpp", line)
+
 #include "awkward/Identities.h"
 #include "awkward/array/NumpyArray.h"
 #include "awkward/type/PrimitiveType.h"
@@ -109,7 +111,8 @@ namespace awkward {
   const BuilderPtr
   Int64Builder::endlist() {
     throw std::invalid_argument(
-      "called 'endlist' without 'beginlist' at the same level before it");
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -122,13 +125,15 @@ namespace awkward {
   const BuilderPtr
   Int64Builder::index(int64_t index) {
     throw std::invalid_argument(
-      "called 'index' without 'begintuple' at the same level before it");
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   Int64Builder::endtuple() {
     throw std::invalid_argument(
-      "called 'endtuple' without 'begintuple' at the same level before it");
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -141,13 +146,15 @@ namespace awkward {
   const BuilderPtr
   Int64Builder::field(const char* key, bool check) {
     throw std::invalid_argument(
-      "called 'field' without 'beginrecord' at the same level before it");
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   Int64Builder::endrecord() {
     throw std::invalid_argument(
-      "called 'endrecord' without 'beginrecord' at the same level before it");
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ListBuilder.cpp", line)
+
 #include <stdexcept>
 
 #include "awkward/Identities.h"
@@ -145,7 +147,8 @@ namespace awkward {
   ListBuilder::endlist() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endlist' without 'beginlist' at the same level before it");
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (!content_.get()->active()) {
       offsets_.append(content_.get()->length());
@@ -174,7 +177,8 @@ namespace awkward {
   ListBuilder::index(int64_t index) {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'index' without 'begintuple' at the same level before it");
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       content_.get()->index(index);
@@ -186,7 +190,8 @@ namespace awkward {
   ListBuilder::endtuple() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endtuple' without 'begintuple' at the same level before it");
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       content_.get()->endtuple();
@@ -211,7 +216,8 @@ namespace awkward {
   ListBuilder::field(const char* key, bool check) {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'field' without 'beginrecord' at the same level before it");
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       content_.get()->field(key, check);
@@ -223,8 +229,8 @@ namespace awkward {
   ListBuilder::endrecord() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endrecord' without 'beginrecord' at the same level "
-        "before it");
+        std::string("called 'end_record' without 'begin_record' at the same level "
+                    "before it") + FILENAME(__LINE__));
     }
     else {
       content_.get()->endrecord();

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/OptionBuilder.cpp", line)
+
 #include <stdexcept>
 
 #include "awkward/Identities.h"
@@ -35,7 +37,7 @@ namespace awkward {
     out.get()->setthat(out);
     return out;
   }
- 
+
   OptionBuilder::OptionBuilder(const ArrayBuilderOptions& options,
                                const GrowableBuffer<int64_t>& index,
                                const BuilderPtr& content)
@@ -151,7 +153,8 @@ namespace awkward {
   OptionBuilder::endlist() {
     if (!content_.get()->active()) {
       throw std::invalid_argument(
-        "called 'endlist' without 'beginlist' at the same level before it");
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       int64_t length = content_.get()->length();
@@ -178,7 +181,8 @@ namespace awkward {
   OptionBuilder::index(int64_t index) {
     if (!content_.get()->active()) {
       throw std::invalid_argument(
-        "called 'index' without 'begintuple' at the same level before it");
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       content_.get()->index(index);
@@ -190,7 +194,8 @@ namespace awkward {
   OptionBuilder::endtuple() {
     if (!content_.get()->active()) {
       throw std::invalid_argument(
-        "called 'endtuple' without 'begintuple' at the same level before it");
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       int64_t length = content_.get()->length();
@@ -217,7 +222,8 @@ namespace awkward {
   OptionBuilder::field(const char* key, bool check) {
     if (!content_.get()->active()) {
       throw std::invalid_argument(
-        "called 'field' without 'beginrecord' at the same level before it");
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       content_.get()->field(key, check);
@@ -229,8 +235,8 @@ namespace awkward {
   OptionBuilder::endrecord() {
     if (!content_.get()->active()) {
       throw std::invalid_argument(
-        "called 'endrecord' without 'beginrecord' at the same level "
-        "before it");
+        std::string("called 'endrecord' without 'beginrecord' at the same level "
+                    "before it") + FILENAME(__LINE__));
     }
     else {
       int64_t length = content_.get()->length();

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/RecordBuilder.cpp", line)
+
 #include <stdexcept>
 
 #include "awkward/Identities.h"
@@ -128,8 +130,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'null' immediately after 'beginrecord'; "
-        "needs 'index' or 'endrecord'");
+        std::string("called 'null' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
@@ -149,8 +151,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'boolean' immediately after 'beginrecord'; "
-        "needs 'index' or 'endrecord'");
+        std::string("called 'boolean' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
@@ -170,8 +172,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'integer' immediately after 'beginrecord'; "
-        "needs 'index' or 'endrecord'");
+        std::string("called 'integer' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
@@ -191,8 +193,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'real' immediately after 'beginrecord'; "
-        "needs 'index' or 'endrecord'");
+        std::string("called 'real' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
@@ -212,8 +214,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'string' immediately after 'beginrecord'; "
-        "needs 'index' or 'endrecord'");
+        std::string("called 'string' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
@@ -236,8 +238,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'beginlist' immediately after 'beginrecord'; "
-        "needs 'index' or 'endrecord'");
+        std::string("called 'begin_list' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
@@ -253,12 +255,14 @@ namespace awkward {
   RecordBuilder::endlist() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endlist' without 'beginlist' at the same level before it");
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'endlist' immediately after 'beginrecord'; "
-        "needs 'index' or 'endrecord' and then 'beginlist'");
+        std::string("called 'end_list' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record' and then 'begin_list'")
+        + FILENAME(__LINE__));
     }
     else {
       contents_[(size_t)nextindex_].get()->endlist();
@@ -275,8 +279,9 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'begintuple' immediately after 'beginrecord'; "
-        "needs 'field_fast', 'field_check', or 'endrecord'");
+        std::string("called 'begin_tuple' immediately after 'begin_record'; "
+                    "needs 'field_fast', 'field_check', or 'end_record'")
+        + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
@@ -292,13 +297,14 @@ namespace awkward {
   RecordBuilder::index(int64_t index) {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'index' without 'begintuple' at the same level before it");
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'index' immediately after 'beginrecord'; "
-        "needs 'field_fast', 'field_check' or 'endrecord' "
-        "and then 'begintuple'");
+        std::string("called 'index' immediately after 'begin_record'; "
+                    "needs 'field_fast', 'field_check' or 'end_record' "
+                    "and then 'begin_tuple'") + FILENAME(__LINE__));
     }
     else {
       contents_[(size_t)nextindex_].get()->index(index);
@@ -310,13 +316,14 @@ namespace awkward {
   RecordBuilder::endtuple() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endtuple' without 'begintuple' at the same level before it");
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'endtuple' immediately after 'beginrecord'; "
-        "needs 'field_fast', 'field_check', or 'endrecord' "
-        "and then 'begintuple'");
+        std::string("called 'end_tuple' immediately after 'begin_record'; "
+                    "needs 'field_fast', 'field_check', or 'end_record' "
+                    "and then 'begin_tuple'") + FILENAME(__LINE__));
     }
     else {
       contents_[(size_t)nextindex_].get()->endtuple();
@@ -350,8 +357,9 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'beginrecord' immediately after 'beginrecord'; "
-        "needs 'field_fast', 'field_check', or 'endrecord'");
+        std::string("called 'begin_record' immediately after 'begin_record'; "
+                    "needs 'field_fast', 'field_check', or 'end_record'")
+        + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
@@ -378,7 +386,8 @@ namespace awkward {
   RecordBuilder::field_fast(const char* key) {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'field' without 'beginrecord' at the same level before it");
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1  ||
              !contents_[(size_t)nextindex_].get()->active()) {
@@ -423,7 +432,8 @@ namespace awkward {
   RecordBuilder::field_check(const char* key) {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'field' without 'beginrecord' at the same level before it");
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1  ||
              !contents_[(size_t)nextindex_].get()->active()) {
@@ -468,8 +478,8 @@ namespace awkward {
   RecordBuilder::endrecord() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endrecord' without 'beginrecord' at the same level "
-        "before it");
+        std::string("called 'end_record' without 'begin_record' at the same level "
+                    "before it") + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1  ||
              !contents_[(size_t)nextindex_].get()->active()) {
@@ -480,7 +490,7 @@ namespace awkward {
         if (contents_[i].get()->length() != length_ + 1) {
           throw std::invalid_argument(
             std::string("record field ") + util::quote(keys_[i], true)
-            + std::string(" filled more than once"));
+            + std::string(" filled more than once") + FILENAME(__LINE__));
         }
       }
       length_++;
@@ -501,8 +511,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'append' immediately after 'beginrecord'; "
-        "needs 'index' or 'endrecord'");
+        std::string("called 'append' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/StringBuilder.cpp", line)
+
 #include "awkward/Identities.h"
 #include "awkward/array/NumpyArray.h"
 #include "awkward/array/ListOffsetArray.h"
@@ -71,7 +73,8 @@ namespace awkward {
     }
     else {
       throw std::invalid_argument(
-        std::string("unsupported encoding: ") + util::quote(encoding_, false));
+        std::string("unsupported encoding: ") + util::quote(encoding_, false)
+        + FILENAME(__LINE__));
     }
 
     Index64 offsets(offsets_.ptr(), 0, offsets_.length());
@@ -152,7 +155,8 @@ namespace awkward {
   const BuilderPtr
   StringBuilder::endlist() {
     throw std::invalid_argument(
-      "called 'endlist' without 'beginlist' at the same level before it");
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -165,13 +169,15 @@ namespace awkward {
   const BuilderPtr
   StringBuilder::index(int64_t index) {
     throw std::invalid_argument(
-      "called 'index' without 'begintuple' at the same level before it");
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   StringBuilder::endtuple() {
     throw std::invalid_argument(
-      "called 'endtuple' without 'begintuple' at the same level before it");
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -184,13 +190,15 @@ namespace awkward {
   const BuilderPtr
   StringBuilder::field(const char* key, bool check) {
     throw std::invalid_argument(
-      "called 'field' without 'beginrecord' at the same level before it");
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   StringBuilder::endrecord() {
     throw std::invalid_argument(
-      "called 'endrecord' without 'beginrecord' at the same level before it");
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/TupleBuilder.cpp", line)
+
 #include <stdexcept>
 
 #include "awkward/Identities.h"
@@ -92,8 +94,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'null' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple'");
+        std::string("called 'null' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
@@ -113,8 +115,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'boolean' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple'");
+        std::string("called 'boolean' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
@@ -134,8 +136,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'integer' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple'");
+        std::string("called 'integer' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
@@ -155,8 +157,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'real' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple'");
+        std::string("called 'real' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
@@ -176,8 +178,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'string' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple'");
+        std::string("called 'string' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
@@ -200,8 +202,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'beginlist' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple'");
+        std::string("called 'begin_list' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
@@ -217,12 +219,14 @@ namespace awkward {
   TupleBuilder::endlist() {
     if (!begun_) {
       throw std::invalid_argument(
-        "called 'endlist' without 'beginlist' at the same level before it");
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'endlist' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple' and then 'beginlist'");
+        std::string("called 'end_list' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple' and then 'begin_list'")
+        + FILENAME(__LINE__));
     }
     else {
       contents_[(size_t)nextindex_].get()->endlist();
@@ -250,8 +254,9 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'begintuple' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple'");
+        std::string("called 'begin_tuple' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'")
+        + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
@@ -267,7 +272,8 @@ namespace awkward {
   TupleBuilder::index(int64_t index) {
     if (!begun_) {
       throw std::invalid_argument(
-      "called 'index' without 'begintuple' at the same level before it");
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1  ||
              !contents_[(size_t)nextindex_].get()->active()) {
@@ -283,7 +289,8 @@ namespace awkward {
   TupleBuilder::endtuple() {
     if (!begun_) {
       throw std::invalid_argument(
-      "called 'endtuple' without 'begintuple' at the same level before it");
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1  ||
              !contents_[(size_t)nextindex_].get()->active()) {
@@ -294,7 +301,7 @@ namespace awkward {
         if (contents_[i].get()->length() != length_ + 1) {
           throw std::invalid_argument(
             std::string("tuple index ") + std::to_string(i)
-            + std::string(" filled more than once"));
+            + std::string(" filled more than once") + FILENAME(__LINE__));
         }
       }
       length_++;
@@ -315,8 +322,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-      "called 'beginrecord' immediately after 'begintuple'; "
-      "needs 'index' or 'endtuple'");
+        std::string("called 'begin_record' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,
@@ -333,12 +340,14 @@ namespace awkward {
   TupleBuilder::field(const char* key, bool check) {
     if (!begun_) {
       throw std::invalid_argument(
-      "called 'field_fast' without 'beginrecord' at the same level before it");
+        std::string("called 'field_fast' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-      "called 'field_fast' immediately after 'begintuple'; "
-      "needs 'index' or 'endtuple' and then 'beginrecord'");
+        std::string("called 'field_fast' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple' and then 'begin_record'")
+        + FILENAME(__LINE__));
     }
     else {
       contents_[(size_t)nextindex_].get()->field(key, check);
@@ -350,12 +359,14 @@ namespace awkward {
   TupleBuilder::endrecord() {
     if (!begun_) {
       throw std::invalid_argument(
-      "called 'endrecord' without 'beginrecord' at the same level before it");
+        std::string("called 'end_record' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'endrecord' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple' and then 'beginrecord'");
+        std::string("called 'end_record' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple' and then 'begin_record'")
+        + FILENAME(__LINE__));
     }
     else {
       contents_[(size_t)nextindex_].get()->endrecord();
@@ -372,8 +383,8 @@ namespace awkward {
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
-        "called 'append' immediately after 'begintuple'; "
-        "needs 'index' or 'endtuple'");
+        std::string("called 'append' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
     }
     else if (!contents_[(size_t)nextindex_].get()->active()) {
       maybeupdate(nextindex_,

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnionBuilder.cpp", line)
+
 #include <stdexcept>
 
 #include "awkward/Identities.h"
@@ -252,7 +254,8 @@ namespace awkward {
   UnionBuilder::endlist() {
     if (current_ == -1) {
       throw std::invalid_argument(
-        "called 'endlist' without 'beginlist' at the same level before it");
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       int64_t length = contents_[(size_t)current_].get()->length();
@@ -297,7 +300,8 @@ namespace awkward {
   UnionBuilder::index(int64_t index) {
     if (current_ == -1) {
       throw std::invalid_argument(
-        "called 'index' without 'begintuple' at the same level before it");
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       contents_[(size_t)current_].get()->index(index);
@@ -309,7 +313,8 @@ namespace awkward {
   UnionBuilder::endtuple() {
     if (current_ == -1) {
       throw std::invalid_argument(
-        "called 'endtuple' without 'begintuple' at the same level before it");
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       int64_t length = contents_[(size_t)current_].get()->length();
@@ -356,7 +361,8 @@ namespace awkward {
   UnionBuilder::field(const char* key, bool check) {
     if (current_ == -1) {
       throw std::invalid_argument(
-        "called 'field' without 'beginrecord' at the same level before it");
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
     }
     else {
       contents_[(size_t)current_].get()->field(key, check);
@@ -368,8 +374,8 @@ namespace awkward {
   UnionBuilder::endrecord() {
     if (current_ == -1) {
       throw std::invalid_argument(
-        "called 'endrecord' without 'beginrecord' at the same level "
-        "before it");
+        std::string("called 'end_record' without 'begin_record' at the same level "
+                    "before it") + FILENAME(__LINE__));
     }
     else {
       int64_t length = contents_[(size_t)current_].get()->length();

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnknownBuilder.cpp", line)
+
 #include <stdexcept>
 
 #include "awkward/Identities.h"
@@ -133,7 +135,8 @@ namespace awkward {
   const BuilderPtr
   UnknownBuilder::endlist() {
     throw std::invalid_argument(
-      "called 'endlist' without 'beginlist' at the same level before it");
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -149,13 +152,15 @@ namespace awkward {
   const BuilderPtr
   UnknownBuilder::index(int64_t index) {
     throw std::invalid_argument(
-      "called 'index' without 'begintuple' at the same level before it");
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   UnknownBuilder::endtuple() {
     throw std::invalid_argument(
-      "called 'endtuple' without 'begintuple' at the same level before it");
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
@@ -171,13 +176,15 @@ namespace awkward {
   const BuilderPtr
   UnknownBuilder::field(const char* key, bool check) {
     throw std::invalid_argument(
-      "called 'field' without 'beginrecord' at the same level before it");
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr
   UnknownBuilder::endrecord() {
     throw std::invalid_argument(
-      "called 'endrecord' without 'beginrecord' at the same level before it");
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
   }
 
   const BuilderPtr

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/io/json.cpp", line)
+
 #include "rapidjson/document.h"
 #include "rapidjson/reader.h"
 #include "rapidjson/writer.h"
@@ -63,7 +65,8 @@ namespace awkward {
       writer.EndObject();
     }
     else {
-      throw std::runtime_error("unrecognized JSON element type");
+      throw std::runtime_error(
+        std::string("unrecognized JSON element type") + FILENAME(__LINE__));
     }
   }
 
@@ -549,7 +552,8 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("JSON error at char ")
         + std::to_string(reader.GetErrorOffset()) + std::string(": ")
-        + std::string(rj::GetParseError_En(reader.GetParseErrorCode())));
+        + std::string(rj::GetParseError_En(reader.GetParseErrorCode()))
+        + FILENAME(__LINE__));
     }
   }
 
@@ -571,7 +575,8 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("JSON error at char ")
         + std::to_string(reader.GetErrorOffset()) + std::string(": ")
-        + std::string(rj::GetParseError_En(reader.GetParseErrorCode())));
+        + std::string(rj::GetParseError_En(reader.GetParseErrorCode()))
+        + FILENAME(__LINE__));
     }
     return handler.snapshot();
   }

--- a/src/libawkward/io/root.cpp
+++ b/src/libawkward/io/root.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/io/root.cpp", line)
+
 #include <cstring>
 
 #include "awkward/Content.h"
@@ -56,10 +58,12 @@ namespace awkward {
                         std::string format,
                         const ArrayBuilderOptions& options) {
     if (depth <= 0) {
-      throw std::runtime_error("FromROOT_nestedvector: depth <= 0");
+      throw std::runtime_error(
+        std::string("FromROOT_nestedvector: depth <= 0") + FILENAME(__LINE__));
     }
     if (rawdata.ndim() != 1) {
-      throw std::runtime_error("FromROOT_nestedvector: rawdata.ndim() != 1");
+      throw std::runtime_error(
+        std::string("FromROOT_nestedvector: rawdata.ndim() != 1") + FILENAME(__LINE__));
     }
 
     Index64 level0(byteoffsets.length());

--- a/src/libawkward/kernel-dispatch.cpp
+++ b/src/libawkward/kernel-dispatch.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/kernel-dispatch.cpp", line)
+
 #include "awkward/common.h"
 #include "awkward/util.h"
 #include "awkward/kernels/operations.h"
@@ -56,19 +58,22 @@ namespace awkward {
       if (!handle) {
         if (ptr_lib == kernel::lib::cuda) {
           throw std::invalid_argument(
-            "array resides on a GPU, but 'awkward1-cuda-kernels' is not "
-            "installed; install it with:\n\n    "
-            "pip install awkward1[cuda] --upgrade");
+            std::string("array resides on a GPU, but 'awkward1-cuda-kernels' is not "
+                        "installed; install it with:\n\n    "
+                        "pip install awkward1[cuda] --upgrade")
+            + FILENAME(__LINE__));
         }
         else {
-          throw std::runtime_error("unrecognized ptr_lib in acquire_handle");
+          throw std::runtime_error(
+            std::string("unrecognized ptr_lib in acquire_handle")
+            + FILENAME(__LINE__));
         }
       }
       return handle;
 #else
       throw std::invalid_argument(
-          "array resides on a GPU, but 'awkward1-cuda-kernels' is not"
-          "supported on Windows");
+          std::string("array resides on a GPU, but 'awkward1-cuda-kernels' is not"
+                      "supported on Windows") + FILENAME(__LINE__));
 #endif
     }
 
@@ -77,8 +82,9 @@ namespace awkward {
 #ifndef _MSC_VER
       symbol_ptr = dlsym(handle, symbol_name.c_str());
       if (!symbol_ptr) {
-        throw std::runtime_error(symbol_name +
-                                 std::string(" not found in kernels library"));
+        throw std::runtime_error(
+          symbol_name + std::string(" not found in kernels library")
+          + FILENAME(__LINE__));
       }
 #endif
       return symbol_ptr;
@@ -115,7 +121,9 @@ namespace awkward {
       }
 
       else {
-        throw std::runtime_error("unrecognized ptr_lib in kernel::lib_tostring");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in kernel::lib_tostring")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -134,7 +142,9 @@ namespace awkward {
         return (*awkward_cuda_device_to_host_fcn)(to_ptr, from_ptr, bytelength);
       }
       else {
-        throw std::runtime_error("unrecognized combination of from_lib and to_lib");
+        throw std::runtime_error(
+          std::string("unrecognized combination of from_lib and to_lib")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -162,7 +172,9 @@ namespace awkward {
         return (*awkward_NumpyArraybool_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in bool NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in bool NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -178,7 +190,9 @@ namespace awkward {
         return (*awkward_NumpyArray8_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in int8_t NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in int8_t NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -194,7 +208,9 @@ namespace awkward {
         return (*awkward_NumpyArrayU8_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in uint8_t NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in uint8_t NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -210,7 +226,9 @@ namespace awkward {
         return (*awkward_NumpyArray16_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in int16_t NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in int16_t NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -226,7 +244,9 @@ namespace awkward {
         return (*awkward_NumpyArrayU16_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in uint16_t NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in uint16_t NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -242,7 +262,9 @@ namespace awkward {
         return (*awkward_NumpyArray32_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in int32_t NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in int32_t NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -258,7 +280,9 @@ namespace awkward {
         return (*awkward_NumpyArrayU32_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in uint32_t NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in uint32_t NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -274,7 +298,9 @@ namespace awkward {
         return (*awkward_NumpyArray64_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in int64_t NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in int64_t NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -290,7 +316,9 @@ namespace awkward {
         return (*awkward_NumpyArrayU64_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in uint64_t NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in uint64_t NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -306,7 +334,9 @@ namespace awkward {
         return (*awkward_NumpyArrayfloat32_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in float NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in float NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -322,7 +352,9 @@ namespace awkward {
         return (*awkward_NumpyArrayfloat64_getitem_at0_fcn)(ptr);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in double NumpyArray_getitem_at0");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in double NumpyArray_getitem_at0")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -356,11 +388,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for regularize_arrayslice_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for regularize_arrayslice_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for regularize_arrayslice_64");
+          std::string("unrecognized ptr_lib for regularize_arrayslice_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -378,11 +412,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_to_Index64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_to_Index64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_to_Index64");
+          std::string("unrecognized ptr_lib for Index_to_Index64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -400,11 +436,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_to_Index64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_to_Index64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_to_Index64");
+          std::string("unrecognized ptr_lib for Index_to_Index64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -422,11 +460,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_to_Index64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_to_Index64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_to_Index64");
+          std::string("unrecognized ptr_lib for Index_to_Index64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -444,11 +484,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_to_Index64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_to_Index64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_to_Index64");
+          std::string("unrecognized ptr_lib for Index_to_Index64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -470,11 +512,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_64");
+          std::string("unrecognized ptr_lib for Index_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -496,11 +540,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_64");
+          std::string("unrecognized ptr_lib for Index_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -522,11 +568,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_64");
+          std::string("unrecognized ptr_lib for Index_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -548,11 +596,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_64");
+          std::string("unrecognized ptr_lib for Index_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -574,11 +624,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_64");
+          std::string("unrecognized ptr_lib for Index_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -598,11 +650,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_nocheck_64");
+          std::string("unrecognized ptr_lib for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -622,11 +676,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_nocheck_64");
+          std::string("unrecognized ptr_lib for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -646,11 +702,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_nocheck_64");
+          std::string("unrecognized ptr_lib for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -670,11 +728,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_nocheck_64");
+          std::string("unrecognized ptr_lib for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -694,11 +754,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Index_carry_nocheck_64");
+          std::string("unrecognized ptr_lib for Index_carry_nocheck_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -719,11 +781,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for slicearray_ravel_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for slicearray_ravel_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for slicearray_ravel_64");
+          std::string("unrecognized ptr_lib for slicearray_ravel_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -742,11 +806,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for slicemissing_check_same");
+          std::string("not implemented: ptr_lib == cuda_kernels for slicemissing_check_same")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for slicemissing_check_same");
+          std::string("unrecognized ptr_lib for slicemissing_check_same")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -762,11 +828,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for carry_arange");
+          std::string("not implemented: ptr_lib == cuda_kernels for carry_arange")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for carry_arange");
+          std::string("unrecognized ptr_lib for carry_arange")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -782,11 +850,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for carry_arange");
+          std::string("not implemented: ptr_lib == cuda_kernels for carry_arange")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for carry_arange");
+          std::string("unrecognized ptr_lib for carry_arange")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -802,11 +872,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for carry_arange");
+          std::string("not implemented: ptr_lib == cuda_kernels for carry_arange")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for carry_arange");
+          std::string("unrecognized ptr_lib for carry_arange")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -830,11 +902,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_getitem_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_getitem_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_getitem_carry_64");
+          std::string("unrecognized ptr_lib for Identities_getitem_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -858,11 +932,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_getitem_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_getitem_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_getitem_carry_64");
+          std::string("unrecognized ptr_lib for Identities_getitem_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -879,11 +955,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_contiguous_init_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_contiguous_init_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_contiguous_init_64");
+          std::string("unrecognized ptr_lib for NumpyArray_contiguous_init_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -905,11 +983,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_contiguous_copy_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_contiguous_copy_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_contiguous_copy_64");
+          std::string("unrecognized ptr_lib for NumpyArray_contiguous_copy_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -930,11 +1010,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_contiguous_next_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_contiguous_next_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_contiguous_next_64");
+          std::string("unrecognized ptr_lib for NumpyArray_contiguous_next_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -955,11 +1037,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_null_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_null_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_getitem_next_null_64");
+          std::string("unrecognized ptr_lib for NumpyArray_getitem_next_null_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -980,11 +1064,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_at_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_at_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_getitem_next_at_64");
+          std::string("unrecognized ptr_lib for NumpyArray_getitem_next_at_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1009,11 +1095,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_range_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_range_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_getitem_next_range_64");
+          std::string("unrecognized ptr_lib for NumpyArray_getitem_next_range_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1042,11 +1130,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_range_advanced_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_range_advanced_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_getitem_next_range_advanced_64");
+          std::string("unrecognized ptr_lib for NumpyArray_getitem_next_range_advanced_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1071,11 +1161,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_array_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_array_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_getitem_next_array_64");
+          std::string("unrecognized ptr_lib for NumpyArray_getitem_next_array_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1098,11 +1190,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_array_advanced_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_next_array_advanced_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_getitem_next_array_advanced_64");
+          std::string("unrecognized ptr_lib for NumpyArray_getitem_next_array_advanced_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1121,11 +1215,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_boolean_numtrue");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_boolean_numtrue")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_getitem_boolean_numtrue");
+          std::string("unrecognized ptr_lib for NumpyArray_getitem_boolean_numtrue")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1144,11 +1240,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_boolean_nonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_getitem_boolean_nonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_getitem_boolean_nonzero_64");
+          std::string("unrecognized ptr_lib for NumpyArray_getitem_boolean_nonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1170,11 +1268,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_at_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_at_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_at_64");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_at_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1196,11 +1296,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_at_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_at_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_at_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_at_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1222,11 +1324,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_at_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_at_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_at_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_at_64<int64_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -1252,11 +1356,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_carrylength<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_carrylength<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_carrylength<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_carrylength<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1282,11 +1388,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_carrylength<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_carrylength<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_carrylength<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_carrylength<uint32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -1312,11 +1420,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_carrylength<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_carrylength<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_carrylength<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_carrylength<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1344,11 +1454,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_64<int32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -1376,11 +1488,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1408,11 +1522,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1430,11 +1546,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_counts_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_counts_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_counts_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_counts_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1452,11 +1570,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_counts_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_counts_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_counts_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_counts_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1474,11 +1594,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_counts_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_counts_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_counts_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_counts_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1498,11 +1620,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_spreadadvanced_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_spreadadvanced_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_spreadadvanced_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_spreadadvanced_64<int32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -1522,11 +1646,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_spreadadvanced_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_spreadadvanced_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_spreadadvanced_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_spreadadvanced_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1546,11 +1672,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_spreadadvanced_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_range_spreadadvanced_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_range_spreadadvanced_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_range_spreadadvanced_64<int64_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -1578,11 +1706,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_array_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_array_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1610,11 +1740,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_array_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_array_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1642,11 +1774,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_array_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_array_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1676,11 +1810,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_advanced_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_advanced_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_array_advanced_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_array_advanced_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1710,11 +1846,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_advanced_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_advanced_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_array_advanced_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_array_advanced_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1744,11 +1882,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_advanced_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_next_array_advanced_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_next_array_advanced_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_next_array_advanced_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1774,11 +1914,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_carry_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_carry_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_carry_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_carry_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1804,11 +1946,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_carry_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_carry_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_carry_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_carry_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -1834,11 +1978,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_carry_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_carry_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_carry_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_carry_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1857,11 +2003,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_at_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_at_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_getitem_next_at_64");
+          std::string("unrecognized ptr_lib for RegularArray_getitem_next_at_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1884,11 +2032,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_range_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_range_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_getitem_next_range_64");
+          std::string("unrecognized ptr_lib for RegularArray_getitem_next_range_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1907,11 +2057,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_range_spreadadvanced_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_range_spreadadvanced_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_getitem_next_range_spreadadvanced_64");
+          std::string("unrecognized ptr_lib for RegularArray_getitem_next_range_spreadadvanced_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1930,11 +2082,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_array_regularize_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_array_regularize_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_getitem_next_array_regularize_64");
+          std::string("unrecognized ptr_lib for RegularArray_getitem_next_array_regularize_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1957,11 +2111,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_array_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_array_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_getitem_next_array_64");
+          std::string("unrecognized ptr_lib for RegularArray_getitem_next_array_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -1986,11 +2142,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_array_advanced_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_next_array_advanced_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_getitem_next_array_advanced_64");
+          std::string("unrecognized ptr_lib for RegularArray_getitem_next_array_advanced_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2009,11 +2167,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_getitem_carry_64");
+          std::string("unrecognized ptr_lib for RegularArray_getitem_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2031,11 +2191,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_numnull<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_numnull<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_numnull<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_numnull<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2053,11 +2215,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_numnull<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_numnull<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_numnull<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_numnull<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2075,11 +2239,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_numnull<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_numnull<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_numnull<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_numnull<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2101,11 +2267,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_64<int32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2127,11 +2295,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2153,11 +2323,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_64<int64_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2179,11 +2351,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_mask_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_mask_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_mask_64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_mask_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2205,11 +2379,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_mask_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_mask_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_mask_64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_mask_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2231,11 +2407,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_mask_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_outindex_mask_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_mask_64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_outindex_mask_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2258,11 +2436,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_getitem_adjust_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_getitem_adjust_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_getitem_adjust_offsets_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_getitem_adjust_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2293,11 +2473,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_getitem_adjust_offsets_index_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_getitem_adjust_offsets_index_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_getitem_adjust_offsets_index_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_getitem_adjust_offsets_index_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2322,11 +2504,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_adjust_outindex_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_adjust_outindex_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_adjust_outindex_64");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_adjust_outindex_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2346,11 +2530,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_64");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2370,11 +2556,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_64");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2394,11 +2582,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_nextcarry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_nextcarry_64");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_nextcarry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2420,11 +2610,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_carry_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_carry_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_carry_64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_carry_64<int32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2446,11 +2638,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_carry_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_carry_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_carry_64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_carry_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2472,11 +2666,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_carry_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_getitem_carry_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_getitem_carry_64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_getitem_carry_64<int64_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2494,11 +2690,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_regular_index_getsize<int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_regular_index_getsize<int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_regular_index_getsize<int8_t>");
+          std::string("unrecognized ptr_lib for UnionArray_regular_index_getsize<int8_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2520,11 +2718,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_regular_index<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_regular_index<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_regular_index<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_regular_index<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2546,11 +2746,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_regular_index<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_regular_index<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_regular_index<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_regular_index<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2572,11 +2774,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_regular_index<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_regular_index<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_regular_index<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_regular_index<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2600,11 +2804,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_project_64<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_project_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_project_64<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_project_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2628,11 +2834,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_project_64<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_project_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_project_64<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_project_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2656,11 +2864,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_project_64<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_project_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_project_64<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_project_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2681,11 +2891,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for missing_repeat_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for missing_repeat_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for missing_repeat_64");
+          std::string("unrecognized ptr_lib for missing_repeat_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2706,11 +2918,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_jagged_expand_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_getitem_jagged_expand_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_getitem_jagged_expand_64");
+          std::string("unrecognized ptr_lib for RegularArray_getitem_jagged_expand_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2738,11 +2952,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_expand_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_expand_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_expand_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_expand_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2770,11 +2986,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_expand_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_expand_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_expand_64");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_expand_64")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2802,11 +3020,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_expand_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_expand_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_expand_64");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_expand_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2825,11 +3045,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_carrylen_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_carrylen_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_carrylen_64");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_carrylen_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2861,11 +3083,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_apply_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_apply_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_apply_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_apply_64<int32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2897,11 +3121,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_apply_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_apply_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_apply_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_apply_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2933,11 +3159,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_apply_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_apply_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_apply_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_apply_64<int64_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -2960,11 +3188,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_numvalid_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_numvalid_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_numvalid_64");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_numvalid_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -2989,11 +3219,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_shrink_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_shrink_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_shrink_64");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_shrink_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3017,11 +3249,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_descend_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_descend_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_descend_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_descend_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3045,11 +3279,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_descend_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_descend_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_descend_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_descend_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -3073,11 +3309,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_descend_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_getitem_jagged_descend_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_getitem_jagged_descend_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_getitem_jagged_descend_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3097,7 +3335,9 @@ namespace awkward {
           at);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in int8_t index_getitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in int8_t index_getitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3117,7 +3357,9 @@ namespace awkward {
           at);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in uint8_t index_getitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in uint8_t index_getitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3137,7 +3379,9 @@ namespace awkward {
           at);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in int32_t index_getitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in int32_t index_getitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3157,7 +3401,9 @@ namespace awkward {
           at);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in uint32_t index_getitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in uint32_t index_getitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3177,7 +3423,9 @@ namespace awkward {
           at);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in int64_t index_getitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in int64_t index_getitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3200,7 +3448,9 @@ namespace awkward {
           value);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in void index_setitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in void index_setitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3223,7 +3473,9 @@ namespace awkward {
           value);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in void index_setitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in void index_setitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3246,7 +3498,9 @@ namespace awkward {
           value);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in void index_setitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in void index_setitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3269,7 +3523,9 @@ namespace awkward {
           value);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in void index_setitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in void index_setitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3292,7 +3548,9 @@ namespace awkward {
           value);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in void index_setitem_at_nowrap");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in void index_setitem_at_nowrap")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3313,11 +3571,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_getitem_carry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_getitem_carry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ByteMaskedArray_getitem_carry_64");
+          std::string("unrecognized ptr_lib for ByteMaskedArray_getitem_carry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3336,11 +3596,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_numnull");
+          std::string("not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_numnull")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ByteMaskedArray_numnull");
+          std::string("unrecognized ptr_lib for ByteMaskedArray_numnull")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3359,11 +3621,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_getitem_nextcarry_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_getitem_nextcarry_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ByteMaskedArray_getitem_nextcarry_64");
+          std::string("unrecognized ptr_lib for ByteMaskedArray_getitem_nextcarry_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3384,11 +3648,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_getitem_nextcarry_outindex_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_getitem_nextcarry_outindex_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ByteMaskedArray_getitem_nextcarry_outindex_64");
+          std::string("unrecognized ptr_lib for ByteMaskedArray_getitem_nextcarry_outindex_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3407,11 +3673,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_toIndexedOptionArray64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_toIndexedOptionArray64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ByteMaskedArray_toIndexedOptionArray64");
+          std::string("unrecognized ptr_lib for ByteMaskedArray_toIndexedOptionArray64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3434,11 +3702,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Content_getitem_next_missing_jagged_getmaskstartstop");
+          std::string("not implemented: ptr_lib == cuda_kernels for Content_getitem_next_missing_jagged_getmaskstartstop")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Content_getitem_next_missing_jagged_getmaskstartstop");
+          std::string("unrecognized ptr_lib for Content_getitem_next_missing_jagged_getmaskstartstop")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3462,11 +3732,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for MaskedArray_getitem_next_jagged_project");
+          std::string("not implemented: ptr_lib == cuda_kernels for MaskedArray_getitem_next_jagged_project")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for MaskedArray_getitem_next_jagged_project");
+          std::string("unrecognized ptr_lib for MaskedArray_getitem_next_jagged_project")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -3489,11 +3761,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for MaskedArray_getitem_next_jagged_project");
+          std::string("not implemented: ptr_lib == cuda_kernels for MaskedArray_getitem_next_jagged_project")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for MaskedArray_getitem_next_jagged_project");
+          std::string("unrecognized ptr_lib for MaskedArray_getitem_next_jagged_project")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -3516,11 +3790,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for MaskedArray_getitem_next_jagged_project");
+          std::string("not implemented: ptr_lib == cuda_kernels for MaskedArray_getitem_next_jagged_project")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for MaskedArray_getitem_next_jagged_project");
+          std::string("unrecognized ptr_lib for MaskedArray_getitem_next_jagged_project")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3538,11 +3814,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for new_Identities");
+          std::string("not implemented: ptr_lib == cuda_kernels for new_Identities")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for new_Identities");
+          std::string("unrecognized ptr_lib for new_Identities")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3558,11 +3836,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for new_Identities");
+          std::string("not implemented: ptr_lib == cuda_kernels for new_Identities")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for new_Identities");
+          std::string("unrecognized ptr_lib for new_Identities")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3582,11 +3862,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_to_Identities64");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_to_Identities64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_to_Identities64");
+          std::string("unrecognized ptr_lib for Identities_to_Identities64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3610,11 +3892,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int32_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListOffsetArray<int32_t, int32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListOffsetArray<int32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3638,11 +3922,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int32_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListOffsetArray<int32_t, uint32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListOffsetArray<int32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3666,11 +3952,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int32_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListOffsetArray<int32_t, int64_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListOffsetArray<int32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3694,11 +3982,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int64_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListOffsetArray<int64_t, int32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListOffsetArray<int64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3722,11 +4012,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int64_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListOffsetArray<int64_t, uint32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListOffsetArray<int64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3750,11 +4042,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int64_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListOffsetArray<int64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListOffsetArray<int64_t, int64_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListOffsetArray<int64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3782,11 +4076,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int32_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListArray<int32_t, int32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListArray<int32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3814,11 +4110,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int32_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListArray<int32_t, uint32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListArray<int32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3846,11 +4144,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int32_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListArray<int32_t, int64_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListArray<int32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3878,11 +4178,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int64_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListArray<int64_t, int32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListArray<int64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3910,11 +4212,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int64_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListArray<int64_t, uint32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListArray<int64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3942,11 +4246,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int64_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_ListArray<int64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_ListArray<int64_t, int64_t>");
+          std::string("unrecognized ptr_lib for Identities_from_ListArray<int64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3970,11 +4276,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_RegularArray");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_RegularArray")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_RegularArray");
+          std::string("unrecognized ptr_lib for Identities_from_RegularArray")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -3998,11 +4306,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_RegularArray");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_RegularArray")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_RegularArray");
+          std::string("unrecognized ptr_lib for Identities_from_RegularArray")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4028,11 +4338,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int32_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_IndexedArray<int32_t, int32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_IndexedArray<int32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4058,11 +4370,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int32_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_IndexedArray<int32_t, uint32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_IndexedArray<int32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -4088,11 +4402,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int32_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_IndexedArray<int32_t, int64_t>");
+          std::string("unrecognized ptr_lib for Identities_from_IndexedArray<int32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4118,11 +4434,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int64_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_IndexedArray<int64_t, int32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_IndexedArray<int64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -4148,11 +4466,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int64_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_IndexedArray<int64_t, uint32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_IndexedArray<int64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4178,11 +4498,13 @@ namespace awkward {
      }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int64_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_IndexedArray<int64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_IndexedArray<int64_t, int64_t>");
+          std::string("unrecognized ptr_lib for Identities_from_IndexedArray<int64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
      }
 
@@ -4212,11 +4534,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int32_t, int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int32_t, int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_UnionArray<int32_t, int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_UnionArray<int32_t, int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4246,11 +4570,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int32_t, int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int32_t, int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_UnionArray<int32_t, int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_UnionArray<int32_t, int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4280,11 +4606,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int32_t, int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int32_t, int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_UnionArray<int32_t, int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for Identities_from_UnionArray<int32_t, int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4314,11 +4642,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int64_t, int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int64_t, int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_UnionArray<int64_t, int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_UnionArray<int64_t, int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4348,11 +4678,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int64_t, int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int64_t, int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_UnionArray<int64_t, int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for Identities_from_UnionArray<int64_t, int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4382,11 +4714,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int64_t, int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_from_UnionArray<int64_t, int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_from_UnionArray<int64_t, int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for Identities_from_UnionArray<int64_t, int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4406,11 +4740,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_extend");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_extend")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_extend");
+          std::string("unrecognized ptr_lib for Identities_extend")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4430,11 +4766,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for Identities_extend");
+          std::string("not implemented: ptr_lib == cuda_kernels for Identities_extend")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for Identities_extend");
+          std::string("unrecognized ptr_lib for Identities_extend")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4463,7 +4801,9 @@ namespace awkward {
           length);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in ListArray_num_64<int32_t>");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in ListArray_num_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4490,7 +4830,9 @@ namespace awkward {
           length);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in ListArray_num_64<uint32_t>");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in ListArray_num_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4517,7 +4859,9 @@ namespace awkward {
           length);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in ListArray_num_64<int64_t>");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in ListArray_num_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4540,7 +4884,9 @@ namespace awkward {
           length);
       }
       else {
-        throw std::runtime_error("unrecognized ptr_lib in RegularArray_num_64");
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib in RegularArray_num_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4562,11 +4908,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_flatten_offsets_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_flatten_offsets_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_flatten_offsets_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_flatten_offsets_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4588,11 +4936,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_flatten_offsets_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_flatten_offsets_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_flatten_offsets_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_flatten_offsets_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4614,11 +4964,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_flatten_offsets_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_flatten_offsets_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_flatten_offsets_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_flatten_offsets_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4640,11 +4992,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_none2empty_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_none2empty_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_flatten_none2empty_64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_flatten_none2empty_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4666,11 +5020,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_none2empty_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_none2empty_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_flatten_none2empty_64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_flatten_none2empty_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4692,11 +5048,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_none2empty_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_none2empty_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_flatten_none2empty_64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_flatten_none2empty_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4718,11 +5076,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_length_64<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_length_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_flatten_length_64<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_flatten_length_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4744,11 +5104,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_length_64<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_length_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_flatten_length_64<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_flatten_length_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4770,11 +5132,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_length_64<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_length_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_flatten_length_64<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_flatten_length_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4800,11 +5164,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_combine_64<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_combine_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_flatten_combine_64<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_flatten_combine_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4830,11 +5196,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_combine_64<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_combine_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_flatten_combine_64<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_flatten_combine_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4860,11 +5228,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_combine_64<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_flatten_combine_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_flatten_combine_64<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_flatten_combine_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4884,11 +5254,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_nextcarry_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_nextcarry_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_flatten_nextcarry_64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_flatten_nextcarry_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4908,11 +5280,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_nextcarry_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_nextcarry_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_flatten_nextcarry_64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_flatten_nextcarry_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4932,11 +5306,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_nextcarry_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_flatten_nextcarry_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_flatten_nextcarry_64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_flatten_nextcarry_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4956,11 +5332,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_overlay_mask8_to64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_overlay_mask8_to64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_overlay_mask8_to64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_overlay_mask8_to64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -4980,11 +5358,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_overlay_mask8_to64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_overlay_mask8_to64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_overlay_mask8_to64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_overlay_mask8_to64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5004,11 +5384,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_overlay_mask8_to64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_overlay_mask8_to64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_overlay_mask8_to64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_overlay_mask8_to64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5026,11 +5408,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_mask8<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_mask8<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_mask8<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_mask8<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5048,11 +5432,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_mask8<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_mask8<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_mask8<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_mask8<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5070,11 +5456,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_mask8<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_mask8<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_mask8<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_mask8<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5093,11 +5481,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_mask8");
+          std::string("not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_mask8")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ByteMaskedArray_mask8");
+          std::string("unrecognized ptr_lib for ByteMaskedArray_mask8")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5110,11 +5500,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for zero_mask8");
+          std::string("not implemented: ptr_lib == cuda_kernels for zero_mask8")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for zero_mask8");
+          std::string("unrecognized ptr_lib for zero_mask8")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5136,11 +5528,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify32_to64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify32_to64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplify32_to64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplify32_to64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5162,11 +5556,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify32_to64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify32_to64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplify32_to64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplify32_to64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5188,11 +5584,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify32_to64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify32_to64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplify32_to64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplify32_to64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5214,11 +5612,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplifyU32_to64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplifyU32_to64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplifyU32_to64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplifyU32_to64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5240,11 +5640,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplifyU32_to64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplifyU32_to64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplifyU32_to64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplifyU32_to64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5266,11 +5668,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplifyU32_to64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplifyU32_to64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplifyU32_to64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplifyU32_to64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5292,11 +5696,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify64_to64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify64_to64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplify64_to64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplify64_to64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5318,11 +5724,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify64_to64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify64_to64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplify64_to64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplify64_to64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5344,11 +5752,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify64_to64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_simplify64_to64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_simplify64_to64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_simplify64_to64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5368,11 +5778,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_compact_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_compact_offsets_64");
+          std::string("unrecognized ptr_lib for ListArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5392,11 +5804,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_compact_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_compact_offsets_64");
+          std::string("unrecognized ptr_lib for ListArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5416,11 +5830,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_compact_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_compact_offsets_64");
+          std::string("unrecognized ptr_lib for ListArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5437,11 +5853,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_compact_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_compact_offsets_64");
+          std::string("unrecognized ptr_lib for RegularArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5459,11 +5877,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_compact_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_compact_offsets_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5481,11 +5901,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_compact_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_compact_offsets_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5503,11 +5925,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_compact_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_compact_offsets_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_compact_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5531,11 +5955,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_broadcast_tooffsets_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_broadcast_tooffsets_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_broadcast_tooffsets_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_broadcast_tooffsets_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5559,11 +5985,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_broadcast_tooffsets_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_broadcast_tooffsets_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_broadcast_tooffsets_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_broadcast_tooffsets_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5587,11 +6015,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_broadcast_tooffsets_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_broadcast_tooffsets_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_broadcast_tooffsets_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_broadcast_tooffsets_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5608,11 +6038,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_broadcast_tooffsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_broadcast_tooffsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_broadcast_tooffsets_64");
+          std::string("unrecognized ptr_lib for RegularArray_broadcast_tooffsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5629,11 +6061,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_broadcast_tooffsets_size1_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_broadcast_tooffsets_size1_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_broadcast_tooffsets_size1_64");
+          std::string("unrecognized ptr_lib for RegularArray_broadcast_tooffsets_size1_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5651,11 +6085,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_toRegularArray<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_toRegularArray<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_toRegularArray<int32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_toRegularArray<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5673,11 +6109,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_toRegularArray<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_toRegularArray<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_toRegularArray<uint32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_toRegularArray<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5695,11 +6133,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_toRegularArray");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_toRegularArray")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_toRegularArray");
+          std::string("unrecognized ptr_lib for ListOffsetArray_toRegularArray")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5719,11 +6159,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<bool>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5743,11 +6185,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<int8_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5767,11 +6211,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<int16_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5791,11 +6237,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5815,11 +6263,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5839,11 +6289,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5863,11 +6315,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5887,11 +6341,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5911,11 +6367,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5935,11 +6393,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<float>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5959,11 +6419,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill_frombool<double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill_frombool<double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill_frombool<double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -5983,11 +6445,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6006,11 +6470,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6029,11 +6495,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6052,11 +6520,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6075,11 +6545,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6098,11 +6570,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6121,11 +6595,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6144,11 +6620,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6167,11 +6645,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6190,11 +6670,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6213,11 +6695,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<bool, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<bool, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<bool, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -6237,11 +6721,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6260,11 +6746,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6283,11 +6771,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6306,11 +6796,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6329,11 +6821,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6352,11 +6846,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6375,11 +6871,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6398,11 +6896,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6421,11 +6921,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6444,11 +6946,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6467,11 +6971,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int8_t, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int8_t, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int8_t, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -6491,11 +6997,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6514,11 +7022,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6537,11 +7047,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6560,11 +7072,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6583,11 +7097,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6606,11 +7122,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6629,11 +7147,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6652,11 +7172,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6675,11 +7197,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6698,11 +7222,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6721,11 +7247,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int16_t, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int16_t, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int16_t, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -6745,11 +7273,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6768,11 +7298,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6791,11 +7323,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6814,11 +7348,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6837,11 +7373,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6860,11 +7398,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6883,11 +7423,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6906,11 +7448,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6929,11 +7473,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6952,11 +7498,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -6975,11 +7523,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int32_t, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int32_t, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int32_t, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -6999,11 +7549,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7022,11 +7574,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7045,11 +7599,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7068,11 +7624,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7091,11 +7649,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7114,11 +7674,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7137,11 +7699,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7160,11 +7724,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7183,11 +7749,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7206,11 +7774,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7229,11 +7799,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<int64_t, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<int64_t, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<int64_t, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -7253,11 +7825,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7276,11 +7850,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7299,11 +7875,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7322,11 +7900,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7345,11 +7925,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7368,11 +7950,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7391,11 +7975,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7414,11 +8000,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7437,11 +8025,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7460,11 +8050,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7483,11 +8075,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint8_t, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint8_t, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint8_t, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -7507,11 +8101,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7530,11 +8126,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7553,11 +8151,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7576,11 +8176,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7599,11 +8201,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7622,11 +8226,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7645,11 +8251,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7668,11 +8276,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7691,11 +8301,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7714,11 +8326,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7737,11 +8351,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint16_t, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint16_t, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint16_t, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -7761,11 +8377,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7784,11 +8402,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7807,11 +8427,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7830,11 +8452,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7853,11 +8477,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7876,11 +8502,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7899,11 +8527,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7922,11 +8552,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7945,11 +8577,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7968,11 +8602,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -7991,11 +8627,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint32_t, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint32_t, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint32_t, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8015,11 +8653,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8038,11 +8678,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8061,11 +8703,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8084,11 +8728,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8107,11 +8753,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8130,11 +8778,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8153,11 +8803,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8176,11 +8828,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8199,11 +8853,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8222,11 +8878,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8245,11 +8903,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<uint64_t, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<uint64_t, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<uint64_t, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8269,11 +8929,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8292,11 +8954,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8315,11 +8979,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8338,11 +9004,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8361,11 +9029,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8384,11 +9054,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8407,11 +9079,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8430,11 +9104,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8453,11 +9129,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8476,11 +9154,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8499,11 +9179,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<float, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<float, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<float, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8523,11 +9205,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, bool>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8546,11 +9230,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, int8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8569,11 +9255,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, int16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8592,11 +9280,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8615,11 +9305,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8638,11 +9330,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8661,11 +9355,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8684,11 +9380,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8707,11 +9405,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8730,11 +9430,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, float>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, float>")
+          + FILENAME(__LINE__));
       }
     }
     template <>
@@ -8753,11 +9455,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_fill<double, double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_fill<double, double>");
+          std::string("unrecognized ptr_lib for NumpyArray_fill<double, double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8785,11 +9489,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_fill");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_fill")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_fill");
+          std::string("unrecognized ptr_lib for ListArray_fill")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8817,11 +9523,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_fill");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_fill")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_fill");
+          std::string("unrecognized ptr_lib for ListArray_fill")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8849,11 +9557,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_fill");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_fill")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_fill");
+          std::string("unrecognized ptr_lib for ListArray_fill")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8875,11 +9585,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_fill");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_fill")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_fill");
+          std::string("unrecognized ptr_lib for IndexedArray_fill")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8901,11 +9613,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_fill");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_fill")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_fill");
+          std::string("unrecognized ptr_lib for IndexedArray_fill")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8927,11 +9641,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_fill");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_fill")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_fill");
+          std::string("unrecognized ptr_lib for IndexedArray_fill")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8950,11 +9666,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_fill_to64_count");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_fill_to64_count")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_fill_to64_count");
+          std::string("unrecognized ptr_lib for IndexedArray_fill_to64_count")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8975,11 +9693,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_filltags_to8_from8");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_filltags_to8_from8")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_filltags_to8_from8");
+          std::string("unrecognized ptr_lib for UnionArray_filltags_to8_from8")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -8999,11 +9719,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_fillindex");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_fillindex")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_fillindex");
+          std::string("unrecognized ptr_lib for UnionArray_fillindex")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9023,11 +9745,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_fillindex");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_fillindex")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_fillindex");
+          std::string("unrecognized ptr_lib for UnionArray_fillindex")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9047,11 +9771,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_fillindex");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_fillindex")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_fillindex");
+          std::string("unrecognized ptr_lib for UnionArray_fillindex")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9070,11 +9796,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_filltags_to8_const");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_filltags_to8_const")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_filltags_to8_const");
+          std::string("unrecognized ptr_lib for UnionArray_filltags_to8_const")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9091,11 +9819,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_fillindex_count_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_fillindex_count_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_fillindex_count_64");
+          std::string("unrecognized ptr_lib for UnionArray_fillindex_count_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9129,11 +9859,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_32_to8_64<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_32_to8_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_32_to8_64<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_32_to8_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9167,11 +9899,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_32_to8_64<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_32_to8_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_32_to8_64<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_32_to8_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9205,11 +9939,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_32_to8_64<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_32_to8_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_32_to8_64<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_32_to8_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9243,11 +9979,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_U32_to8_64<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_U32_to8_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_U32_to8_64<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_U32_to8_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9281,11 +10019,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_U32_to8_64<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_U32_to8_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_U32_to8_64<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_U32_to8_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9319,11 +10059,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_U32_to8_64<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_U32_to8_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_U32_to8_64<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_U32_to8_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9357,11 +10099,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_64_to8_64<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_64_to8_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_64_to8_64<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_64_to8_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9395,11 +10139,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_64_to8_64<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_64_to8_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_64_to8_64<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_64_to8_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9433,11 +10179,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_64_to8_64<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify8_64_to8_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify8_64_to8_64<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify8_64_to8_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9465,11 +10213,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify_one_to8_64<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify_one_to8_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify_one_to8_64<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify_one_to8_64<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9497,11 +10247,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify_one_to8_64<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify_one_to8_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify_one_to8_64<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify_one_to8_64<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9529,11 +10281,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_simplify_one_to8_64<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_simplify_one_to8_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_simplify_one_to8_64<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_simplify_one_to8_64<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9553,11 +10307,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_validity<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_validity<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_validity<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_validity<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9577,11 +10333,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_validity<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_validity<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_validity<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_validity<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9601,11 +10359,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_validity<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_validity<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_validity<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_validity<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9625,11 +10385,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_validity<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_validity<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_validity<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_validity<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9649,11 +10411,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_validity<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_validity<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_validity<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_validity<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9673,11 +10437,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_validity<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_validity<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_validity<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_validity<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9699,11 +10465,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_validity<int8_t, int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_validity<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_validity<int8_t, int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_validity<int8_t, int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9725,11 +10493,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_validity<int8_t, uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_validity<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_validity<int8_t, uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_validity<int8_t, uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9751,11 +10521,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_validity<int8_t, int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_validity<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_validity<int8_t, int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_validity<int8_t, int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9773,11 +10545,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_fillna_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_fillna_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_fillna_64<int32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_fillna_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9795,11 +10569,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_fillna_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_fillna_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_fillna_64<uint32_t>");
+          std::string("unrecognized ptr_lib for UnionArray_fillna_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9817,11 +10593,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for UnionArray_fillna_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for UnionArray_fillna_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for UnionArray_fillna_64<int64_t>");
+          std::string("unrecognized ptr_lib for UnionArray_fillna_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9838,11 +10616,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedOptionArray_rpad_and_clip_mask_axis1_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedOptionArray_rpad_and_clip_mask_axis1_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedOptionArray_rpad_and_clip_mask_axis1_64");
+          std::string("unrecognized ptr_lib for IndexedOptionArray_rpad_and_clip_mask_axis1_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9859,11 +10639,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for index_rpad_and_clip_axis0_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for index_rpad_and_clip_axis0_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for index_rpad_and_clip_axis0_64");
+          std::string("unrecognized ptr_lib for index_rpad_and_clip_axis0_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9882,11 +10664,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for index_rpad_and_clip_axis1_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for index_rpad_and_clip_axis1_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for index_rpad_and_clip_axis1_64");
+          std::string("unrecognized ptr_lib for index_rpad_and_clip_axis1_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9905,11 +10689,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_rpad_and_clip_axis1_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_rpad_and_clip_axis1_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_rpad_and_clip_axis1_64");
+          std::string("unrecognized ptr_lib for RegularArray_rpad_and_clip_axis1_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9929,11 +10715,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_min_range<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_min_range<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_min_range<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_min_range<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9953,11 +10741,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_min_range<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_min_range<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_min_range<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_min_range<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -9977,11 +10767,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_min_range<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_min_range<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_min_range<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_min_range<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10003,11 +10795,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_rpad_and_clip_length_axis1<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_rpad_and_clip_length_axis1<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_rpad_and_clip_length_axis1<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_rpad_and_clip_length_axis1<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10029,11 +10823,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_rpad_and_clip_length_axis1<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_rpad_and_clip_length_axis1<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_rpad_and_clip_length_axis1<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_rpad_and_clip_length_axis1<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10055,11 +10851,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_rpad_and_clip_length_axis1<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_rpad_and_clip_length_axis1<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_rpad_and_clip_length_axis1<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_rpad_and_clip_length_axis1<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10085,11 +10883,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_rpad_axis1_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_rpad_axis1_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_rpad_axis1_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_rpad_axis1_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10115,11 +10915,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_rpad_axis1_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_rpad_axis1_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_rpad_axis1_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_rpad_axis1_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10145,11 +10947,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_rpad_axis1_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_rpad_axis1_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_rpad_axis1_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_rpad_axis1_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10169,11 +10973,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_and_clip_axis1_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_and_clip_axis1_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_and_clip_axis1_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_and_clip_axis1_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10193,11 +10999,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_and_clip_axis1_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_and_clip_axis1_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_and_clip_axis1_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_and_clip_axis1_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10217,11 +11025,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_and_clip_axis1_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_and_clip_axis1_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_and_clip_axis1_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_and_clip_axis1_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10243,11 +11053,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_length_axis1<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_length_axis1<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_length_axis1<int32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_length_axis1<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10269,11 +11081,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_length_axis1<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_length_axis1<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_length_axis1<uint32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_length_axis1<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10295,11 +11109,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_length_axis1<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_length_axis1<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_length_axis1<int64_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_length_axis1<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10319,11 +11135,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_axis1_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_axis1_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_axis1_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_axis1_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10343,11 +11161,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_axis1_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_axis1_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_axis1_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_axis1_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10367,11 +11187,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_axis1_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_rpad_axis1_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_rpad_axis1_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListOffsetArray_rpad_axis1_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10386,11 +11208,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for localindex_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for localindex_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for localindex_64");
+          std::string("unrecognized ptr_lib for localindex_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10408,11 +11232,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_localindex_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_localindex_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_localindex_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_localindex_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10430,11 +11256,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_localindex_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_localindex_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_localindex_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_localindex_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10452,11 +11280,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_localindex_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_localindex_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_localindex_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_localindex_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10473,11 +11303,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_localindex_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_localindex_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_localindex_64");
+          std::string("unrecognized ptr_lib for RegularArray_localindex_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10497,11 +11329,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for combinations");
+          std::string("not implemented: ptr_lib == cuda_kernels for combinations")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for combinations");
+          std::string("unrecognized ptr_lib for combinations")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10527,11 +11361,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_combinations_length_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_combinations_length_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_combinations_length_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_combinations_length_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10557,11 +11393,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_combinations_length_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_combinations_length_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_combinations_length_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_combinations_length_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10587,11 +11425,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_combinations_length_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_combinations_length_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_combinations_length_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_combinations_length_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10619,11 +11459,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_combinations_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_combinations_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_combinations_64<int32_t>");
+          std::string("unrecognized ptr_lib for ListArray_combinations_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10651,11 +11493,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_combinations_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_combinations_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_combinations_64<uint32_t>");
+          std::string("unrecognized ptr_lib for ListArray_combinations_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10683,11 +11527,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListArray_combinations_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListArray_combinations_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListArray_combinations_64<int64_t>");
+          std::string("unrecognized ptr_lib for ListArray_combinations_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10712,11 +11558,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for RegularArray_combinations_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for RegularArray_combinations_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for RegularArray_combinations_64");
+          std::string("unrecognized ptr_lib for RegularArray_combinations_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10737,11 +11585,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_overlay_mask8");
+          std::string("not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_overlay_mask8")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ByteMaskedArray_overlay_mask8");
+          std::string("unrecognized ptr_lib for ByteMaskedArray_overlay_mask8")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10762,11 +11612,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for BitMaskedArray_to_ByteMaskedArray");
+          std::string("not implemented: ptr_lib == cuda_kernels for BitMaskedArray_to_ByteMaskedArray")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for BitMaskedArray_to_ByteMaskedArray");
+          std::string("unrecognized ptr_lib for BitMaskedArray_to_ByteMaskedArray")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10787,11 +11639,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for BitMaskedArray_to_IndexedOptionArray64");
+          std::string("not implemented: ptr_lib == cuda_kernels for BitMaskedArray_to_IndexedOptionArray64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for BitMaskedArray_to_IndexedOptionArray64");
+          std::string("unrecognized ptr_lib for BitMaskedArray_to_IndexedOptionArray64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10812,11 +11666,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_count_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_count_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_count_64");
+          std::string("unrecognized ptr_lib for reduce_count_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10838,11 +11694,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10864,11 +11722,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10890,11 +11750,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10916,11 +11778,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10942,11 +11806,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10968,11 +11834,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -10994,11 +11862,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11020,11 +11890,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11046,11 +11918,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11072,11 +11946,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11098,11 +11974,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_countnonzero_64");
+          std::string("unrecognized ptr_lib for reduce_countnonzero_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11124,11 +12002,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11150,11 +12030,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11176,11 +12058,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11202,11 +12086,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11228,11 +12114,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11254,11 +12142,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11280,11 +12170,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11306,11 +12198,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11332,11 +12226,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11358,11 +12254,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11384,11 +12282,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11410,11 +12310,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11436,11 +12338,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11462,11 +12366,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11488,11 +12394,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11514,11 +12422,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11540,11 +12450,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11566,11 +12478,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_64");
+          std::string("unrecognized ptr_lib for reduce_sum_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11592,11 +12506,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11618,11 +12534,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11644,11 +12562,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11670,11 +12590,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11696,11 +12618,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11722,11 +12646,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11748,11 +12674,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11774,11 +12702,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11800,11 +12730,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11826,11 +12758,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11852,11 +12786,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_sum_bool_64");
+          std::string("unrecognized ptr_lib for reduce_sum_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11878,11 +12814,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11904,11 +12842,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11930,11 +12870,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11956,11 +12898,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -11982,11 +12926,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12008,11 +12954,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12034,11 +12982,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12060,11 +13010,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12086,11 +13038,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12112,11 +13066,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12138,11 +13094,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12164,11 +13122,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12190,11 +13150,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12216,11 +13178,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12242,11 +13206,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12268,11 +13234,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12294,11 +13262,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12320,11 +13290,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_64");
+          std::string("unrecognized ptr_lib for reduce_prod_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12346,11 +13318,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12372,11 +13346,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12398,11 +13374,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12424,11 +13402,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12450,11 +13430,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12476,11 +13458,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12502,11 +13486,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12528,11 +13514,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12554,11 +13542,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12580,11 +13570,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12606,11 +13598,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_prod_bool_64");
+          std::string("unrecognized ptr_lib for reduce_prod_bool_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12634,11 +13628,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12662,11 +13658,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12690,11 +13688,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12718,11 +13718,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12746,11 +13748,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12774,11 +13778,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12802,11 +13808,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12830,11 +13838,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12858,11 +13868,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12886,11 +13898,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_min_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_min_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_min_64");
+          std::string("unrecognized ptr_lib for reduce_min_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12914,11 +13928,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12942,11 +13958,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12970,11 +13988,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -12998,11 +14018,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13026,11 +14048,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13054,11 +14078,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13082,11 +14108,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13110,11 +14138,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13138,11 +14168,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13166,11 +14198,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_max_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_max_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_max_64");
+          std::string("unrecognized ptr_lib for reduce_max_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13194,11 +14228,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13222,11 +14258,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13250,11 +14288,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13278,11 +14318,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13306,11 +14348,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13334,11 +14378,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13362,11 +14408,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13390,11 +14438,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13418,11 +14468,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13446,11 +14498,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13474,11 +14528,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmin_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmin_64");
+          std::string("unrecognized ptr_lib for reduce_argmin_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13503,11 +14559,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13531,11 +14589,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13559,11 +14619,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13587,11 +14649,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13615,11 +14679,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13643,11 +14709,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13671,11 +14739,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13699,11 +14769,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13727,11 +14799,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13755,11 +14829,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13783,11 +14859,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for reduce_argmax_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for reduce_argmax_64");
+          std::string("unrecognized ptr_lib for reduce_argmax_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13802,11 +14880,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for content_reduce_zeroparents_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for content_reduce_zeroparents_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for content_reduce_zeroparents_64");
+          std::string("unrecognized ptr_lib for content_reduce_zeroparents_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13825,11 +14905,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_global_startstop_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_global_startstop_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_reduce_global_startstop_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_reduce_global_startstop_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13848,11 +14930,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13885,11 +14969,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_preparenext_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_preparenext_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_preparenext_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_preparenext_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13906,11 +14992,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_nextstarts_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_nextstarts_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_nextstarts_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_nextstarts_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13927,11 +15015,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_findgaps_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_findgaps_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_findgaps_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_findgaps_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13954,11 +15044,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_outstartsstops_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_nonlocal_outstartsstops_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_outstartsstops_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_reduce_nonlocal_outstartsstops_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13975,11 +15067,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_local_nextparents_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_local_nextparents_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_reduce_local_nextparents_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_reduce_local_nextparents_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -13998,11 +15092,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_local_outoffsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_reduce_local_outoffsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_reduce_local_outoffsets_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_reduce_local_outoffsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14026,11 +15122,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_reduce_next_64<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_reduce_next_64<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_reduce_next_64<int32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_reduce_next_64<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14054,11 +15152,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_reduce_next_64<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_reduce_next_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_reduce_next_64<uint32_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_reduce_next_64<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14082,11 +15182,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_reduce_next_64<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_reduce_next_64<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_reduce_next_64<int64_t>");
+          std::string("unrecognized ptr_lib for IndexedArray_reduce_next_64<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14105,11 +15207,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_reduce_next_fix_offsets_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_reduce_next_fix_offsets_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_reduce_next_fix_offsets_64");
+          std::string("unrecognized ptr_lib for IndexedArray_reduce_next_fix_offsets_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14128,11 +15232,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_reduce_mask_ByteMaskedArray_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_reduce_mask_ByteMaskedArray_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_reduce_mask_ByteMaskedArray_64");
+          std::string("unrecognized ptr_lib for NumpyArray_reduce_mask_ByteMaskedArray_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14157,11 +15263,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_reduce_next_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ByteMaskedArray_reduce_next_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ByteMaskedArray_reduce_next_64");
+          std::string("unrecognized ptr_lib for ByteMaskedArray_reduce_next_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14182,11 +15290,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for sorting_ranges");
+          std::string("not implemented: ptr_lib == cuda_kernels for sorting_ranges")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for sorting_ranges");
+          std::string("unrecognized ptr_lib for sorting_ranges")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14203,11 +15313,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for sorting_ranges_length");
+          std::string("not implemented: ptr_lib == cuda_kernels for sorting_ranges_length")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for sorting_ranges_length");
+          std::string("unrecognized ptr_lib for sorting_ranges_length")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14233,11 +15345,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<bool>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14263,11 +15377,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<int8_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14293,11 +15409,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14323,11 +15441,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<int16_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14353,11 +15473,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14383,11 +15505,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14413,11 +15537,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14443,11 +15569,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14473,11 +15601,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14503,11 +15633,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<float>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<float>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14533,11 +15665,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_argsort<double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_argsort<double>");
+          std::string("unrecognized ptr_lib for NumpyArray_argsort<double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14565,11 +15699,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<bool>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<bool>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<bool>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<bool>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14597,11 +15733,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14629,11 +15767,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<int8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<int8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<int8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<int8_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14661,11 +15801,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<uint16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<uint16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<uint16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<uint16_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14693,11 +15835,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<int16_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<int16_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<int16_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<int16_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14725,11 +15869,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<uint32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<uint32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<uint32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<uint32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14757,11 +15903,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<int32_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<int32_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<int32_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<int32_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14789,11 +15937,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<uint64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<uint64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<uint64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<uint64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14821,11 +15971,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<int64_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<int64_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<int64_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<int64_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14853,11 +16005,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<float>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<float>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<float>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<float>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14885,11 +16039,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<double>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort<double>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort<double>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort<double>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14915,11 +16071,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for NumpyArray_sort_asstrings<uint8_t>");
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_sort_asstrings<uint8_t>")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for NumpyArray_sort_asstrings<uint8_t>");
+          std::string("unrecognized ptr_lib for NumpyArray_sort_asstrings<uint8_t>")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14936,11 +16094,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for ListOffsetArray_local_preparenext_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for ListOffsetArray_local_preparenext_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for ListOffsetArray_local_preparenext_64");
+          std::string("unrecognized ptr_lib for ListOffsetArray_local_preparenext_64")
+          + FILENAME(__LINE__));
       }
     }
 
@@ -14961,11 +16121,13 @@ namespace awkward {
       }
       else if (ptr_lib == kernel::lib::cuda) {
         throw std::runtime_error(
-          "not implemented: ptr_lib == cuda_kernels for IndexedArray_local_preparenext_64");
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_local_preparenext_64")
+          + FILENAME(__LINE__));
       }
       else {
         throw std::runtime_error(
-          "unrecognized ptr_lib for IndexedArray_local_preparenext_64");
+          std::string("unrecognized ptr_lib for IndexedArray_local_preparenext_64")
+          + FILENAME(__LINE__));
       }
     }
 

--- a/src/libawkward/partition/IrregularlyPartitionedArray.cpp
+++ b/src/libawkward/partition/IrregularlyPartitionedArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/partition/IrregularlyPartitionedArray.cpp", line)
+
 #include <sstream>
 
 #include "awkward/array/UnionArray.h"
@@ -13,8 +15,8 @@ namespace awkward {
       , stops_(stops) {
     if (partitions.size() != stops.size()) {
       throw std::invalid_argument(
-        "IrregularlyPartitionedArray stops must have the same length "
-        "as its partitions");
+        std::string("IrregularlyPartitionedArray stops must have the same length "
+                    "as its partitions") + FILENAME(__LINE__));
     }
   }
 
@@ -70,7 +72,7 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("cannot repartition array of length ")
         + std::to_string(stops_.back()) + std::string(" to length ")
-        + std::to_string(stops.back()));
+        + std::to_string(stops.back()) + FILENAME(__LINE__));
     }
 
     int64_t partitionid = 0;

--- a/src/libawkward/partition/PartitionedArray.cpp
+++ b/src/libawkward/partition/PartitionedArray.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/partition/PartitionedArray.cpp", line)
+
 #include "awkward/partition/IrregularlyPartitionedArray.h"
 
 #include "awkward/partition/PartitionedArray.h"
@@ -9,7 +11,8 @@ namespace awkward {
       : partitions_(partitions) {
     if (partitions_.empty()) {
       throw std::invalid_argument(
-        "PartitionedArray must have at least one partition");
+        std::string("PartitionedArray must have at least one partition")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -28,7 +31,8 @@ namespace awkward {
   const ContentPtr
   PartitionedArray::partition(int64_t partitionindex) const {
     if (!(0 <= partitionindex  &&  partitionindex < numpartitions())) {
-      throw std::invalid_argument("partitionindex out of bounds");
+      throw std::invalid_argument(
+        std::string("partitionindex out of bounds") + FILENAME(__LINE__));
     }
     return partitions_[(size_t)partitionindex];
   }
@@ -241,7 +245,8 @@ namespace awkward {
     }
 
     else {
-      throw std::invalid_argument("slice step must not be zero");
+      throw std::invalid_argument(
+        std::string("slice step must not be zero") + FILENAME(__LINE__));
     }
 
     if (partitions.empty()) {

--- a/src/libawkward/type/ArrayType.cpp
+++ b/src/libawkward/type/ArrayType.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/type/ArrayType.cpp", line)
+
 #include <string>
 
 #include "awkward/type/ArrayType.h"
@@ -74,7 +76,7 @@ namespace awkward {
     if (length_ != 0) {
       throw std::invalid_argument(
         std::string("ArrayType with length ") + std::to_string(length_)
-        + std::string(" does not describe an empty array"));
+        + std::string(" does not describe an empty array") + FILENAME(__LINE__));
     }
     return type_.get()->empty();
   }

--- a/src/libawkward/type/PrimitiveType.cpp
+++ b/src/libawkward/type/PrimitiveType.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/type/PrimitiveType.cpp", line)
+
 #include <sstream>
 
 #include "awkward/array/NumpyArray.h"
@@ -60,22 +62,26 @@ namespace awkward {
 
   int64_t
   PrimitiveType::fieldindex(const std::string& key) const {
-    throw std::invalid_argument("type contains no Records");
+    throw std::invalid_argument(
+      std::string("type contains no Records") + FILENAME(__LINE__));
   }
 
   const std::string
   PrimitiveType::key(int64_t fieldindex) const {
-    throw std::invalid_argument("type contains no Records");
+    throw std::invalid_argument(
+      std::string("type contains no Records") + FILENAME(__LINE__));
   }
 
   bool
   PrimitiveType::haskey(const std::string& key) const {
-    throw std::invalid_argument("type contains no Records");
+    throw std::invalid_argument(
+      std::string("type contains no Records") + FILENAME(__LINE__));
   }
 
   const std::vector<std::string>
   PrimitiveType::keys() const {
-    throw std::invalid_argument("type contains no Records");
+    throw std::invalid_argument(
+      std::string("type contains no Records") + FILENAME(__LINE__));
   }
 
   const ContentPtr
@@ -86,7 +92,8 @@ namespace awkward {
     std::string format = util::dtype_to_format(dtype_);
     if (format.length() == 0) {
       throw std::invalid_argument(
-          "cannot create an empty array of unknown PrimitiveType");
+        std::string("cannot create an empty array of unknown PrimitiveType")
+        + FILENAME(__LINE__));
     }
     return std::make_shared<NumpyArray>(Identities::none(),
                                         parameters_,

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/type/RecordType.cpp", line)
+
 #include <string>
 #include <sstream>
 #include <algorithm>
@@ -22,7 +24,8 @@ namespace awkward {
     if (recordlookup_.get() != nullptr  &&
         recordlookup_.get()->size() != types_.size()) {
       throw std::runtime_error(
-        "recordlookup and types must have the same length");
+        std::string("recordlookup and types must have the same length")
+        + FILENAME(__LINE__));
     }
   }
 
@@ -234,7 +237,7 @@ namespace awkward {
       throw std::invalid_argument(
         std::string("fieldindex ") + std::to_string(fieldindex)
         + std::string(" for record with only ") + std::to_string(numfields())
-        + std::string(" fields"));
+        + std::string(" fields") + FILENAME(__LINE__));
     }
     return types_[(size_t)fieldindex];
   }

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/type/UnionType.cpp", line)
+
 #include <string>
 #include <sstream>
 
@@ -73,27 +75,32 @@ namespace awkward {
 
   int64_t
   UnionType::numfields() const {
-    throw std::runtime_error("FIXME: UnionType::numfields");
+    throw std::runtime_error(
+      std::string("FIXME: UnionType::numfields") + FILENAME(__LINE__));
   }
 
   int64_t
   UnionType::fieldindex(const std::string& key) const {
-    throw std::runtime_error("FIXME: UnionType::fieldindex(key)");
+    throw std::runtime_error(
+      std::string("FIXME: UnionType::fieldindex(key)") + FILENAME(__LINE__));
   }
 
   const std::string
   UnionType::key(int64_t fieldindex) const {
-    throw std::runtime_error("FIXME: UnionType::key(fieldindex)");
+    throw std::runtime_error(
+      std::string("FIXME: UnionType::key(fieldindex)") + FILENAME(__LINE__));
   }
 
   bool
   UnionType::haskey(const std::string& key) const {
-    throw std::runtime_error("FIXME: UnionType::haskey(key)");
+    throw std::runtime_error(
+      std::string("FIXME: UnionType::haskey(key)") + FILENAME(__LINE__));
   }
 
   const std::vector<std::string>
   UnionType::keys() const {
-    throw std::runtime_error("FIXME: UnionType::keys");
+    throw std::runtime_error(
+      std::string("FIXME: UnionType::keys") + FILENAME(__LINE__));
   }
 
   const std::vector<TypePtr>

--- a/src/libawkward/type/UnknownType.cpp
+++ b/src/libawkward/type/UnknownType.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/type/UnknownType.cpp", line)
+
 #include <string>
 #include <sstream>
 
@@ -55,22 +57,26 @@ namespace awkward {
 
   int64_t
   UnknownType::fieldindex(const std::string& key) const {
-    throw std::invalid_argument("type contains no Records");
+    throw std::invalid_argument(
+      std::string("type contains no Records") + FILENAME(__LINE__));
   }
 
   const std::string
   UnknownType::key(int64_t fieldindex) const {
-    throw std::invalid_argument("type contains no Records");
+    throw std::invalid_argument(
+      std::string("type contains no Records") + FILENAME(__LINE__));
   }
 
   bool
   UnknownType::haskey(const std::string& key) const {
-    throw std::invalid_argument("type contains no Records");
+    throw std::invalid_argument(
+      std::string("type contains no Records") + FILENAME(__LINE__));
   }
 
   const std::vector<std::string>
   UnknownType::keys() const {
-    throw std::invalid_argument("type contains no Records");
+    throw std::invalid_argument(
+      std::string("type contains no Records") + FILENAME(__LINE__));
   }
 
   const ContentPtr

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -399,8 +399,10 @@ namespace awkward {
     handle_error(const struct Error& err,
                  const std::string& classname,
                  const Identities* identities) {
+      std::string filename = (err.filename == nullptr ? "" : err.filename);
+
       if (err.pass_through == true) {
-        throw std::invalid_argument(err.str);
+        throw std::invalid_argument(std::string(err.str) + filename);
       }
       else {
         if (err.str != nullptr) {
@@ -417,7 +419,7 @@ namespace awkward {
           if (err.attempt != kSliceNone) {
             out << " attempting to get " << err.attempt;
           }
-          out << ", " << err.str;
+          out << ", " << err.str << filename;
           throw std::invalid_argument(out.str());
         }
       }

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/util.cpp", line)
+
 #include <sstream>
 #include <set>
 
@@ -488,13 +490,13 @@ namespace awkward {
         catch (std::invalid_argument err) {
           throw std::invalid_argument(
             std::string("key ") + quote(key, true)
-            + std::string(" does not exist (not in record)"));
+            + std::string(" does not exist (not in record)") + FILENAME(__LINE__));
         }
         if (!(0 <= out && out < numfields)) {
           throw std::invalid_argument(
             std::string("key interpreted as fieldindex ") + key
-            + std::string(" for records with only " + std::to_string(numfields)
-                          + std::string(" fields")));
+            + std::string(" for records with only ") + std::to_string(numfields)
+            + std::string(" fields") + FILENAME(__LINE__));
         }
       }
       return out;
@@ -507,8 +509,8 @@ namespace awkward {
       if (fieldindex >= numfields) {
         throw std::invalid_argument(
           std::string("fieldindex ") + std::to_string(fieldindex)
-          + std::string(" for records with only " + std::to_string(numfields)
-                        + std::string(" fields")));
+          + std::string(" for records with only ") + std::to_string(numfields)
+          + std::string(" fields") + FILENAME(__LINE__));
       }
       if (recordlookup.get() != nullptr) {
         return recordlookup.get()->at((size_t) fieldindex);
@@ -629,12 +631,14 @@ namespace awkward {
     parameter_asstring(const Parameters &parameters, const std::string &key) {
       auto item = parameters.find(key);
       if (item == parameters.end()) {
-        throw std::runtime_error("parameter is null");
+        throw std::runtime_error(
+          std::string("parameter is null") + FILENAME(__LINE__));
       }
       rj::Document mine;
       mine.Parse<rj::kParseNanAndInfFlag>(item->second.c_str());
       if (!mine.IsString()) {
-        throw std::runtime_error("parameter is not a string");
+        throw std::runtime_error(
+          std::string("parameter is not a string") + FILENAME(__LINE__));
       }
       return mine.GetString();
     }

--- a/src/libawkward/virtual/ArrayGenerator.cpp
+++ b/src/libawkward/virtual/ArrayGenerator.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/virtual/ArrayGenerator.cpp", line)
+
 #include "sstream"
 
 #include "awkward/array/VirtualArray.h"
@@ -31,14 +33,14 @@ namespace awkward {
           std::string(
               "generated array does not have sufficient length: expected") +
           std::to_string(length_) + std::string(" but generated ") +
-          std::to_string(out.get()->length()));
+          std::to_string(out.get()->length()) + FILENAME(__LINE__));
     }
     if (form_.get() != nullptr  &&
         !form_.get()->equal(out.get()->form(true), true, true, false, true)) {
       throw std::invalid_argument(
           std::string("generated array does not conform to expected form:\n\n")
           + form_.get()->tostring() + std::string("\n\nbut generated:\n\n")
-          + out.get()->form(true).get()->tostring());
+          + out.get()->form(true).get()->tostring() + FILENAME(__LINE__));
     }
     return out;
   }

--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/python/content.cpp", line)
+
 #include <pybind11/numpy.h>
 
 #include "awkward/python/identities.h"
@@ -125,7 +127,8 @@ box(const std::shared_ptr<ak::Content>& content) {
     return py::cast(*raw);
   }
   else {
-    throw std::runtime_error("missing boxer for Content subtype");
+    throw std::runtime_error(
+      std::string("missing boxer for Content subtype") + FILENAME(__LINE__));
   }
 }
 
@@ -143,7 +146,8 @@ box(const std::shared_ptr<ak::Identities>& identities) {
     return py::cast(*raw);
   }
   else {
-    throw std::runtime_error("missing boxer for Identities subtype");
+    throw std::runtime_error(
+      std::string("missing boxer for Identities subtype") + FILENAME(__LINE__));
   }
 }
 
@@ -152,7 +156,8 @@ unbox_content(const py::handle& obj) {
   try {
     obj.cast<ak::Record*>();
     throw std::invalid_argument(
-      "content argument must be a Content subtype (excluding Record)");
+      std::string("content argument must be a Content subtype (excluding Record)")
+      + FILENAME(__LINE__));
   }
   catch (py::cast_error err) { }
   try {
@@ -243,7 +248,9 @@ unbox_content(const py::handle& obj) {
     return obj.cast<ak::VirtualArray*>()->shallow_copy();
   }
   catch (py::cast_error err) { }
-  throw std::invalid_argument("content argument must be a Content subtype");
+  throw std::invalid_argument(
+    std::string("content argument must be a Content subtype")
+    + FILENAME(__LINE__));
 }
 
 std::shared_ptr<ak::Identities>
@@ -256,7 +263,9 @@ unbox_identities(const py::handle& obj) {
     return obj.cast<ak::Identities64*>()->shallow_copy();
   }
   catch (py::cast_error err) { }
-  throw std::invalid_argument("id argument must be an Identities subtype");
+  throw std::invalid_argument(
+    std::string("id argument must be an Identities subtype")
+    + FILENAME(__LINE__));
 }
 
 std::shared_ptr<ak::Identities>
@@ -362,7 +371,8 @@ toslice_part(ak::Slice& slice, py::object obj) {
       step = pystep.cast<int64_t>();
     }
     if (step == 0) {
-      throw std::invalid_argument("slice step must not be 0");
+      throw std::invalid_argument(
+        std::string("slice step must not be 0") + FILENAME(__LINE__));
     }
     slice.append(std::make_shared<ak::SliceRange>(start, stop, step));
   }
@@ -496,7 +506,8 @@ toslice_part(ak::Slice& slice, py::object obj) {
         py::array array = obj.cast<py::array>();
         if (array.ndim() == 0) {
           throw std::invalid_argument(
-            "arrays used as an index must have at least one dimension");
+            std::string("arrays used as an index must have at least one dimension")
+            + FILENAME(__LINE__));
         }
 
         py::buffer_info info = array.request();
@@ -541,7 +552,8 @@ toslice_part(ak::Slice& slice, py::object obj) {
                 ak::util::format_to_dtype(format, (int64_t)info.itemsize))  &&
               flatlen != 0) {
             throw std::invalid_argument(
-              "arrays used as an index must be a (native-endian) integer or boolean");
+              std::string("arrays used as an index must be a (native-endian) integer or boolean")
+              + FILENAME(__LINE__));
           }
 
           py::object intarray_object =
@@ -573,8 +585,9 @@ toslice_part(ak::Slice& slice, py::object obj) {
 
   else {
     throw std::invalid_argument(
-      "only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`), "
-      "and integer or boolean arrays (possibly jagged) are valid indices");
+      std::string("only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`), "
+                  "and integer or boolean arrays (possibly jagged) are valid indices")
+      + FILENAME(__LINE__));
   }
 }
 
@@ -602,7 +615,9 @@ check_maxdecimals(const py::object& maxdecimals) {
     return maxdecimals.cast<int64_t>();
   }
   catch (py::cast_error err) {
-    throw std::invalid_argument("maxdecimals must be None or an integer");
+    throw std::invalid_argument(
+      std::string("maxdecimals must be None or an integer")
+      + FILENAME(__LINE__));
   }
 }
 
@@ -631,7 +646,8 @@ tojson_file(const T& self,
 #endif
     throw std::invalid_argument(
       std::string("file \"") + destination
-      + std::string("\" could not be opened for writing"));
+      + std::string("\" could not be opened for writing")
+      + FILENAME(__LINE__));
   }
   try {
     self.tojson(file,
@@ -730,7 +746,8 @@ builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
     for (auto pair : dict) {
       if (!py::isinstance<py::str>(pair.first)) {
         throw std::invalid_argument(
-          "keys of dicts in 'fromiter' must all be strings");
+          std::string("keys of dicts in 'fromiter' must all be strings")
+          + FILENAME(__LINE__));
       }
       std::string key = pair.first.cast<std::string>();
       self.field_check(key.c_str());
@@ -768,7 +785,7 @@ builder_fromiter(ak::ArrayBuilder& self, const py::handle& obj) {
       std::string("cannot convert ")
       + obj.attr("__repr__")().cast<std::string>() + std::string(" (type ")
       + obj.attr("__class__").attr("__name__").cast<std::string>()
-      + std::string(") to an array element"));
+      + std::string(") to an array element") + FILENAME(__LINE__));
   }
 }
 
@@ -902,7 +919,8 @@ identity(const T& self) {
     throw std::invalid_argument(
       self.classname()
       + std::string(" instance has no associated identities (use "
-                    "'setidentities' to assign one to the array it is in)"));
+                    "'setidentities' to assign one to the array it is in)")
+      + FILENAME(__LINE__));
   }
   ak::Identities::FieldLoc fieldloc = self.identities().get()->fieldloc();
   if (self.isscalar()) {
@@ -961,7 +979,8 @@ dict2parameters(const py::object& in) {
     }
   }
   else {
-    throw std::invalid_argument("type parameters must be a dict (or None)");
+    throw std::invalid_argument(
+      std::string("type parameters must be a dict (or None)") + FILENAME(__LINE__));
   }
   return out;
 }
@@ -1261,7 +1280,8 @@ content_methods(py::class_<T, std::shared_ptr<T>, ak::Content>& x) {
               }
               if (n != recordlookup.get()->size()) {
                 throw std::invalid_argument(
-                  "if provided, the length of 'keys' must be 'n'");
+                  std::string("if provided, the length of 'keys' must be 'n'")
+                  + FILENAME(__LINE__));
               }
             }
             return box(self.combinations(n,
@@ -1303,7 +1323,8 @@ content_methods(py::class_<T, std::shared_ptr<T>, ak::Content>& x) {
                  return box(self.copy_to(ak::kernel::lib::cuda));
                }
                else {
-                 throw std::invalid_argument("specify 'cpu' or 'cuda'");
+                 throw std::invalid_argument(
+                   std::string("specify 'cpu' or 'cuda'") + FILENAME(__LINE__));
                }
           })
     ;
@@ -1674,12 +1695,14 @@ make_NumpyArray(const py::handle& m, const std::string& name) {
         py::buffer_info info = array.request();
         if (info.ndim == 0) {
           throw std::invalid_argument(
-            "NumpyArray must not be scalar; try array.reshape(1)");
+            std::string("NumpyArray must not be scalar; try array.reshape(1)")
+            + FILENAME(__LINE__));
         }
         if (info.shape.size() != info.ndim  ||
             info.strides.size() != info.ndim) {
           throw std::invalid_argument(
-            "NumpyArray len(shape) != ndim or len(strides) != ndim");
+            std::string("NumpyArray len(shape) != ndim or len(strides) != ndim")
+            + FILENAME(__LINE__));
         }
 
         return ak::NumpyArray(
@@ -1819,7 +1842,8 @@ iterable_to_RecordArray(const py::iterable& contents,
     }
     if (out.size() != recordlookup.get()->size()) {
       throw std::invalid_argument(
-        "if provided, 'keys' must have the same length as 'types'");
+        std::string("if provided, 'keys' must have the same length as 'types'")
+        + FILENAME(__LINE__));
     }
   }
   if (length.is(py::none())) {
@@ -1919,7 +1943,8 @@ make_RecordArray(const py::handle& m, const std::string& name) {
               return box(self.setitem_field(mywhere, mywhat));
             }
             catch (py::cast_error err) {
-              throw std::invalid_argument("where must be None, int, or str");
+              throw std::invalid_argument(
+                std::string("where must be None, int, or str") + FILENAME(__LINE__));
             }
           }
         }
@@ -2084,8 +2109,8 @@ make_VirtualArray(const py::handle& m, const std::string& name) {
           }
           catch (py::cast_error err) {
             throw std::invalid_argument(
-                "VirtualArray 'generator' must be an ArrayGenerator or a "
-                "SliceGenerator");
+              std::string("VirtualArray 'generator' must be an ArrayGenerator or a "
+                          "SliceGenerator") + FILENAME(__LINE__));
           }
         }
         std::shared_ptr<PyArrayCache> cppcache(nullptr);
@@ -2095,7 +2120,8 @@ make_VirtualArray(const py::handle& m, const std::string& name) {
           }
           catch (py::cast_error err) {
             throw std::invalid_argument(
-                "VirtualArray 'cache' must be an ArrayCache or None");
+              std::string("VirtualArray 'cache' must be an ArrayCache or None")
+              + FILENAME(__LINE__));
           }
         }
         if (!cache_key.is(py::none())) {
@@ -2105,7 +2131,8 @@ make_VirtualArray(const py::handle& m, const std::string& name) {
           }
           catch (py::cast_error err) {
             throw std::invalid_argument(
-                "VirtualArray 'cache_key' must be a string or None");
+              std::string("VirtualArray 'cache_key' must be a string or None")
+              + FILENAME(__LINE__));
           }
           return ak::VirtualArray(
             unbox_identities_none(identities),
@@ -2139,7 +2166,8 @@ make_VirtualArray(const py::handle& m, const std::string& name) {
         }
         else {
           throw std::invalid_argument(
-                  "VirtualArray's generator is not a Python function");
+            std::string("VirtualArray's generator is not a Python function")
+            + FILENAME(__LINE__));
         }
       })
       .def_property_readonly("cache", [](const ak::VirtualArray& self)
@@ -2154,7 +2182,8 @@ make_VirtualArray(const py::handle& m, const std::string& name) {
         }
         else {
           throw std::invalid_argument(
-                  "VirtualArray's cache is not a Python MutableMapping");
+            std::string("VirtualArray's cache is not a Python MutableMapping")
+            + FILENAME(__LINE__));
         }
       })
       .def_property_readonly("peek_array", [](const ak::VirtualArray& self)

--- a/src/python/forms.cpp
+++ b/src/python/forms.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/python/forms.cpp", line)
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -21,7 +23,9 @@ make_Form(const py::handle& m, const std::string& name) {
       .def_static("fromjson", &ak::Form::fromjson)
       .def_static("from_numpy", [](const py::object& dtype) {
         if (!py::isinstance(dtype, py::module::import("numpy").attr("dtype"))) {
-          throw std::invalid_argument("Form.from_numpy requires a numpy.dtype");
+          throw std::invalid_argument(
+            std::string("Form.from_numpy requires a numpy.dtype")
+            + FILENAME(__LINE__));
         }
         std::vector<int64_t> inner_shape;
         for (auto x : dtype.attr("shape")) {

--- a/src/python/identities.cpp
+++ b/src/python/identities.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/python/identities.cpp", line)
+
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
@@ -41,14 +43,16 @@ make_IdentitiesOf(const py::handle& m, const std::string& name) {
         py::buffer_info info = array.request();
         if (info.ndim != 2) {
           throw std::invalid_argument(
-            name + std::string(" must be built from a two-dimensional array"));
+            name + std::string(" must be built from a two-dimensional array")
+            + FILENAME(__LINE__));
         }
         if (info.strides[0] != sizeof(T)*info.shape[1]  ||
             info.strides[1] != sizeof(T)) {
           throw std::invalid_argument(
             name + std::string(" must be built from a contiguous array (array"
                                ".stries == (array.shape[1]*array.itemsize, "
-                               "array.itemsize)); try array.copy()"));
+                               "array.itemsize)); try array.copy()")
+            + FILENAME(__LINE__));
         }
         return ak::IdentitiesOf<T>(ref,
                                    fieldloc,

--- a/src/python/index.cpp
+++ b/src/python/index.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/python/index.cpp", line)
+
 #include <pybind11/numpy.h>
 
 #include "awkward/python/util.h"
@@ -26,13 +28,15 @@ make_IndexOf(const py::handle& m, const std::string& name) {
                            py::array::forcecast> array) -> ak::IndexOf<T> {
         py::buffer_info info = array.request();
         if (info.ndim != 1) {
-          throw std::invalid_argument(name + std::string(
-            " must be built from a one-dimensional array; try array.ravel()"));
+          throw std::invalid_argument(
+            name + std::string(" must be built from a one-dimensional array; "
+                               "try array.ravel()") + FILENAME(__LINE__));
         }
         if (info.strides[0] != sizeof(T)) {
-          throw std::invalid_argument(name + std::string(
-            " must be built from a contiguous array (array.strides == "
-            "(array.itemsize,)); try array.copy()"));
+          throw std::invalid_argument(
+            name + std::string(" must be built from a contiguous array "
+                               "(array.strides == (array.itemsize,)); "
+                               "try array.copy()") + FILENAME(__LINE__));
         }
         return ak::IndexOf<T>(
           std::shared_ptr<T>(reinterpret_cast<T*>(info.ptr),
@@ -66,12 +70,15 @@ make_IndexOf(const py::handle& m, const std::string& name) {
             return py::cast(out);
           }
           else {
-            throw std::invalid_argument("Index slices cannot contain step != 1");
+            throw std::invalid_argument(
+              std::string("Index slices cannot contain step != 1")
+              + FILENAME(__LINE__));
           }
         }
         else {
           throw std::invalid_argument(
-            "Index can only be sliced by an integer or start:stop slice");
+            std::string("Index can only be sliced by an integer or start:stop slice")
+            + FILENAME(__LINE__));
         }
       })
       .def("copy_to", [](const ak::IndexOf<T>& self, std::string& ptr_lib) {
@@ -82,7 +89,8 @@ make_IndexOf(const py::handle& m, const std::string& name) {
           return self.copy_to(ak::kernel::lib::cuda);
         }
         else {
-          throw std::invalid_argument("specify 'cpu' or 'cuda'");
+          throw std::invalid_argument(
+            std::string("specify 'cpu' or 'cuda'") + FILENAME(__LINE__));
         }
       })
   );

--- a/src/python/io.cpp
+++ b/src/python/io.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/python/io.cpp", line)
+
 #include <string>
 
 #include "awkward/Content.h"
@@ -54,7 +56,8 @@ make_fromjson(py::module& m, const std::string& name) {
 #endif
         throw std::invalid_argument(
           std::string("file \"") + source
-          + std::string("\" could not be opened for reading"));
+          + std::string("\" could not be opened for reading")
+          + FILENAME(__LINE__));
       }
       std::shared_ptr<ak::Content> out(nullptr);
       try {

--- a/src/python/partition.cpp
+++ b/src/python/partition.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/python/partition.cpp", line)
+
 #include "awkward/python/content.h"
 
 #include "awkward/python/partition.h"
@@ -35,7 +37,7 @@ tojson_file(const T& self,
 #endif
     throw std::invalid_argument(
       std::string("file \"") + destination
-      + std::string("\" could not be opened for writing"));
+      + std::string("\" could not be opened for writing") + FILENAME(__LINE__));
   }
   try {
     self.tojson(file,

--- a/src/python/types.cpp
+++ b/src/python/types.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/python/types.cpp", line)
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -44,7 +46,8 @@ box(const std::shared_ptr<ak::Type>& t) {
     return py::cast(*raw);
   }
   else {
-    throw std::runtime_error("missing boxer for Type subtype");
+    throw std::runtime_error(
+      std::string("missing boxer for Type subtype") + FILENAME(__LINE__));
   }
 }
 
@@ -82,7 +85,8 @@ unbox_type(const py::handle& obj) {
     return obj.cast<ak::UnknownType*>()->shallow_copy();
   }
   catch (py::cast_error err) { }
-  throw std::invalid_argument("argument must be a Type subtype");
+  throw std::invalid_argument(
+    std::string("argument must be a Type subtype") + FILENAME(__LINE__));
 }
 
 ////////// Type
@@ -289,7 +293,8 @@ make_PrimitiveType(const py::handle& m, const std::string& name) {
         ak::util::dtype dt = ak::util::name_to_dtype(dtype);
         if (dt == ak::util::dtype::NOT_PRIMITIVE) {
           throw std::invalid_argument(
-            std::string("unrecognized primitive type: ") + dtype);
+            std::string("unrecognized primitive type: ") + dtype
+            + FILENAME(__LINE__));
         }
         return ak::PrimitiveType(dict2parameters(parameters),
                                  typestr2str(typestr),
@@ -339,7 +344,8 @@ iterable_to_RecordType(const py::iterable& types,
     }
     if (out.size() != recordlookup.get()->size()) {
       throw std::invalid_argument(
-        "if provided, 'keys' must have the same length as 'types'");
+        std::string("if provided, 'keys' must have the same length as 'types'")
+        + FILENAME(__LINE__));
     }
     return ak::RecordType(dict2parameters(parameters),
                           typestr2str(typestr),

--- a/src/python/virtual.cpp
+++ b/src/python/virtual.cpp
@@ -1,5 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/python/virtual.cpp", line)
+
 #include <sstream>
 
 #include <pybind11/pybind11.h>
@@ -154,7 +156,8 @@ make_PyArrayGenerator(const py::handle& m, const std::string& name) {
           }
           catch (py::cast_error err) {
             throw std::invalid_argument(
-                "ArrayGenerator 'form' must be an ak.forms.Form or None");
+              std::string("ArrayGenerator 'form' must be an ak.forms.Form or None")
+              + FILENAME(__LINE__));
           }
         }
         int64_t cpplength = -1;
@@ -164,7 +167,8 @@ make_PyArrayGenerator(const py::handle& m, const std::string& name) {
           }
           catch (py::cast_error err) {
             throw std::invalid_argument(
-                "ArrayGenerator 'length' must be an int or None");
+              std::string("ArrayGenerator 'length' must be an int or None")
+              + FILENAME(__LINE__));
           }
         }
         return PyArrayGenerator(cppform, cpplength, callable, args, kwargs);
@@ -247,7 +251,8 @@ make_SliceGenerator(const py::handle& m, const std::string& name) {
           }
           catch (py::cast_error err) {
             throw std::invalid_argument(
-                "SliceGenerator 'form' must be an ak.forms.Form or None");
+              std::string("SliceGenerator 'form' must be an ak.forms.Form or None")
+              + FILENAME(__LINE__));
           }
         }
         int64_t cpplength = -1;
@@ -257,7 +262,8 @@ make_SliceGenerator(const py::handle& m, const std::string& name) {
           }
           catch (py::cast_error err) {
             throw std::invalid_argument(
-                "SliceGenerator 'length' must be an int or None");
+              std::string("SliceGenerator 'length' must be an int or None")
+              + FILENAME(__LINE__));
           }
         }
         ak::Slice cppslice = toslice(slice);

--- a/tests/test_0013-error-handling-struct.py
+++ b/tests/test_0013-error-handling-struct.py
@@ -16,69 +16,69 @@ def test_numpyarray():
 
     with pytest.raises(ValueError) as excinfo:
         array[20]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[-20]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     array[-20:20]
 
     with pytest.raises(ValueError) as excinfo:
         array[20,]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[-20,]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     array[-20:20,]
 
     with pytest.raises(ValueError) as excinfo:
         array[2, 3]
-    assert str(excinfo.value).endswith(", too many dimensions in slice")
+    assert ", too many dimensions in slice" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[[5, 3, 20, 8]]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[[5, 3, -20, 8]]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     array.setidentities()
 
     with pytest.raises(ValueError) as excinfo:
         array[20]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[-20]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     array[-20:20]
 
     with pytest.raises(ValueError) as excinfo:
         array[20,]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[-20,]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     array[-20:20,]
 
     with pytest.raises(ValueError) as excinfo:
         array[2, 3]
-    assert str(excinfo.value).endswith(", too many dimensions in slice")
+    assert ", too many dimensions in slice" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[[5, 3, 20, 8]]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[[5, 3, -20, 8]]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
 def test_listarray_numpyarray():
     starts  = awkward1.layout.Index64(numpy.array([0, 3, 3, 5, 6]))
@@ -94,35 +94,35 @@ def test_listarray_numpyarray():
 
     with pytest.raises(ValueError) as excinfo:
         array[20]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[-20]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     array[-20:20]
 
     with pytest.raises(ValueError) as excinfo:
         array[20,]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[-20,]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     array[-20:20,]
 
     with pytest.raises(ValueError) as excinfo:
         array[2, 1, 0]
-    assert str(excinfo.value).endswith(", too many dimensions in slice")
+    assert ", too many dimensions in slice" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[[2, 0, 0, 20, 3]]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[[2, 0, 0, -20, 3]]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     starts  = awkward1.layout.Index64(numpy.array([0, 3, 3, 5, 6]))
     stops   = awkward1.layout.Index64(numpy.array([3, 3, 5, 6, 10]))
@@ -133,35 +133,35 @@ def test_listarray_numpyarray():
 
     with pytest.raises(ValueError) as excinfo:
         array[2, 20]
-    assert str(excinfo.value).endswith(" with identity [2] attempting to get 20, index out of range")
+    assert " with identity [2] attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[2, -20]
-    assert str(excinfo.value).endswith(" with identity [2] attempting to get -20, index out of range")
+    assert " with identity [2] attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[1:][2, 20]
-    assert str(excinfo.value).endswith(" with identity [3] attempting to get 20, index out of range")
+    assert " with identity [3] attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[1:][2, -20]
-    assert str(excinfo.value).endswith(" with identity [3] attempting to get -20, index out of range")
+    assert " with identity [3] attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[2, [1, 0, 0, 20]]
-    assert str(excinfo.value).endswith(" with identity [2] attempting to get 20, index out of range")
+    assert " with identity [2] attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[2, [1, 0, 0, -20]]
-    assert str(excinfo.value).endswith(" with identity [2] attempting to get -20, index out of range")
+    assert " with identity [2] attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[1:][2, [0, 20]]
-    assert str(excinfo.value).endswith(" with identity [3] attempting to get 20, index out of range")
+    assert " with identity [3] attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array[1:][2, [0, -20]]
-    assert str(excinfo.value).endswith(" with identity [3] attempting to get -20, index out of range")
+    assert " with identity [3] attempting to get -20, index out of range" in str(excinfo.value)
 
 def test_listarray_listarray_numpyarray():
     content  = awkward1.layout.NumpyArray(numpy.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]))
@@ -177,74 +177,74 @@ def test_listarray_listarray_numpyarray():
 
     with pytest.raises(ValueError) as excinfo:
         array2[20]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[20,]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[2, 20]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[-20]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[-20,]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[2, -20]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[1, 0, 20]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     array2.setidentities()
 
     with pytest.raises(ValueError) as excinfo:
         array2[20]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[20,]
-    assert str(excinfo.value).endswith(" attempting to get 20, index out of range")
+    assert " attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[2, 20]
-    assert str(excinfo.value).endswith(" with identity [2] attempting to get 20, index out of range")
+    assert " with identity [2] attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[1:][2, 20]
-    assert str(excinfo.value).endswith(" with identity [3] attempting to get 20, index out of range")
+    assert " with identity [3] attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[-20]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[-20,]
-    assert str(excinfo.value).endswith(" attempting to get -20, index out of range")
+    assert " attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[2, -20]
-    assert str(excinfo.value).endswith(" with identity [2] attempting to get -20, index out of range")
+    assert " with identity [2] attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[1:][2, -20]
-    assert str(excinfo.value).endswith(" with identity [3] attempting to get -20, index out of range")
+    assert " with identity [3] attempting to get -20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[1, 0, 20]
-    assert str(excinfo.value).endswith(" with identity [1, 0] attempting to get 20, index out of range")
+    assert " with identity [1, 0] attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[1:][2, 0, 20]
-    assert str(excinfo.value).endswith(" with identity [3, 0] attempting to get 20, index out of range")
+    assert " with identity [3, 0] attempting to get 20, index out of range" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
         array2[:, 1:][3, 0, 20]
-    assert str(excinfo.value).endswith(" with identity [3, 1] attempting to get 20, index out of range")
+    assert " with identity [3, 1] attempting to get 20, index out of range" in str(excinfo.value)

--- a/tests/test_0021-emptyarray.py
+++ b/tests/test_0021-emptyarray.py
@@ -49,29 +49,29 @@ def test_getitem():
     assert awkward1.to_list(a[2, 1]) == []
     with pytest.raises(ValueError) as excinfo:
         a[2, 1, 0]
-    assert str(excinfo.value).endswith(" attempting to get 0, index out of range")
+    assert " attempting to get 0, index out of range" in str(excinfo.value)
     assert awkward1.to_list(a[2, 1][()]) == []
     with pytest.raises(ValueError) as excinfo:
         a[2, 1][0]
-    assert str(excinfo.value).endswith(" attempting to get 0, index out of range")
+    assert " attempting to get 0, index out of range" in str(excinfo.value)
     assert awkward1.to_list(a[2, 1][100:200]) == []
     assert awkward1.to_list(a[2, 1, 100:200]) == []
     assert awkward1.to_list(a[2, 1][numpy.array([], dtype=int)]) == []
     assert awkward1.to_list(a[2, 1, numpy.array([], dtype=int)]) == []
     with pytest.raises(ValueError) as excinfo:
         a[2, 1, numpy.array([0], dtype=int)]
-    assert str(excinfo.value).endswith(" attempting to get 0, index out of range")
+    assert " attempting to get 0, index out of range" in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
         a[2, 1][100:200, 0]
-    assert str(excinfo.value).endswith(", too many dimensions in slice")
+    assert ", too many dimensions in slice" in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
         a[2, 1][100:200, 200:300]
-    assert str(excinfo.value).endswith(", too many dimensions in slice")
+    assert ", too many dimensions in slice" in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
         a[2, 1][100:200, numpy.array([], dtype=int)]
-    assert str(excinfo.value).endswith(", too many dimensions in slice")
+    assert ", too many dimensions in slice" in str(excinfo.value)
 
     assert awkward1.to_list(a[1:, 1:]) == [[[]], [[], []]]
     with pytest.raises(ValueError) as excinfo:
         a[1:, 1:, 0]
-    assert str(excinfo.value).endswith(" attempting to get 0, index out of range")
+    assert " attempting to get 0, index out of range" in str(excinfo.value)

--- a/tests/test_0025-record-array.py
+++ b/tests/test_0025-record-array.py
@@ -226,7 +226,7 @@ def test_setidentities():
     assert recordarray2[2, "outer", "two", 1] == 5.5
     with pytest.raises(ValueError) as excinfo:
         recordarray2["outer", "two", 0, 99]
-    assert str(excinfo.value).endswith(' with identity [0, "outer", "two"] attempting to get 99, index out of range')
+    assert ' with identity [0, "outer", "two"] attempting to get 99, index out of range' in str(excinfo.value)
     assert recordarray2.identity == ()
     assert recordarray2[2].identity == (2,)
     assert recordarray2[2, "outer"].identity == (2, "outer")
@@ -250,7 +250,7 @@ def test_setidentities():
 
     with pytest.raises(ValueError) as excinfo:
         recordarray2["outer", 2, "two", 0, 99]
-    assert str(excinfo.value).endswith(' with identity [2, "outer", 0, "two"] attempting to get 99, index out of range')
+    assert ' with identity [2, "outer", 0, "two"] attempting to get 99, index out of range' in str(excinfo.value)
     assert recordarray2.identity == ()
     assert recordarray2[2].identity == (2,)
     assert recordarray2[2, "outer"].identity == (2, "outer")
@@ -296,10 +296,10 @@ def test_identities():
     assert b[2, "outer"].identity == (2, u'outer')
     with pytest.raises(ValueError) as err:
         b[2, "outer", 0].identity
-    assert str(err.value) == "in NumpyArray, too many dimensions in slice"
+    assert str(err.value).startswith("in NumpyArray, too many dimensions in slice")
     with pytest.raises(ValueError) as err:
         b[2, "outer", 0, "y"].identity
-    assert str(err.value) == "in NumpyArray, too many dimensions in slice"
+    assert str(err.value).startswith("in NumpyArray, too many dimensions in slice")
 
 def test_builder_tuple():
     typestrs = {}

--- a/tests/test_0042-stubs-for-flatten-operation.py
+++ b/tests/test_0042-stubs-for-flatten-operation.py
@@ -19,7 +19,7 @@ def test_flatten():
     assert awkward1.to_list(array.flatten(axis=-1)) == [0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]
     with pytest.raises(ValueError) as err:
         assert awkward1.to_list(array.flatten(axis=-2))
-    assert str(err.value) == "axis=0 not allowed for flatten"
+    assert str(err.value).startswith("axis=0 not allowed for flatten")
 
     array2 = array[2:-1]
     assert awkward1.to_list(array2.flatten(axis=1)) == [3.3, 4.4, 5.5]

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -47,7 +47,7 @@ def test_NumpyArray():
 
     with pytest.raises(ValueError) as err:
         array2.sort(2, True, False)
-    assert str(err.value) == "axis=2 exceeds the depth of the nested list structure (which is 2)"
+    assert str(err.value).startswith("axis=2 exceeds the depth of the nested list structure (which is 2)")
 
 def test_IndexedOffsetArray():
     array = awkward1.Array([[  2.2, 1.1,   3.3 ],
@@ -445,7 +445,7 @@ def test_UnionArray():
 
     with pytest.raises(ValueError) as err:
         array.sort(1, True, False)
-    assert str(err.value) == "cannot sort UnionArray8_32"
+    assert str(err.value).startswith("cannot sort UnionArray8_32")
 
 def test_sort_strings():
     content1 = awkward1.from_iter(["one", "two", "three", "four", "five"], highlevel=False)

--- a/tests/test_0082-indexedarray-setidentities.py
+++ b/tests/test_0082-indexedarray-setidentities.py
@@ -16,7 +16,7 @@ def test_error():
 
     with pytest.raises(ValueError) as err:
         indexedarray.setidentities()
-    assert str(err.value) == "in IndexedArray64 attempting to get 10, max(index) > len(content)"
+    assert str(err.value).startswith("in IndexedArray64 attempting to get 10, max(index) > len(content)")
 
 def test_passthrough_32():
     content = awkward1.layout.NumpyArray(numpy.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]))

--- a/tests/test_0084-start-unionarray.py
+++ b/tests/test_0084-start-unionarray.py
@@ -62,10 +62,10 @@ def test_getitem():
     assert awkward1.to_list(array2["y", :, 1:]) == ["ero", "ne", [], [], "wo", [2.2], "our", "hree"]
     with pytest.raises(ValueError) as err:
         array2[:, 1:, "y"]
-    assert str(err.value) == "in NumpyArray, too many dimensions in slice"
+    assert str(err.value).startswith("in NumpyArray, too many dimensions in slice")
     with pytest.raises(ValueError) as err:
         array2["z"]
-    assert str(err.value) == "key \"z\" does not exist (not in record)"
+    assert str(err.value).startswith("key \"z\" does not exist (not in record)")
 
     array3 = awkward1.layout.UnionArray8_32(tags, index, [content3, content2])
     array4 = awkward1.layout.UnionArray8_32(tags, index, [content0, content1, content2, content3])

--- a/tests/test_0089-numpy-functions.py
+++ b/tests/test_0089-numpy-functions.py
@@ -164,4 +164,4 @@ def test_size():
     assert numpy.size(numpy.arange(2*3*5).reshape(2, 3, 5), 2) == 5
     with pytest.raises(ValueError) as err:
         awkward1.size(awkward1.Array(numpy.arange(2*3*5).reshape(2, 3, 5).tolist(), check_valid=True))
-    assert str(err.value) == "ak.size is ambiguous due to variable-length arrays (try ak.flatten to remove structure or ak.to_numpy to force regularity, if possible)"
+    assert str(err.value).startswith("ak.size is ambiguous due to variable-length arrays (try ak.flatten to remove structure or ak.to_numpy to force regularity, if possible)")

--- a/tests/test_0117-finish-the-sizes-operation.py
+++ b/tests/test_0117-finish-the-sizes-operation.py
@@ -23,7 +23,7 @@ def test_numpyarray():
     assert awkward1.to_list(array.num(3)) == [[[7, 7, 7, 7, 7], [7, 7, 7, 7, 7], [7, 7, 7, 7, 7]], [[7, 7, 7, 7, 7], [7, 7, 7, 7, 7], [7, 7, 7, 7, 7]]]
     with pytest.raises(ValueError) as err:
         array.num(4)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
 def test_regulararray():
     array = awkward1.layout.NumpyArray(numpy.arange(2*3*5*7).reshape(2, 3, 5, 7)).toRegularArray()
@@ -33,7 +33,7 @@ def test_regulararray():
     assert awkward1.to_list(array.num(3)) == [[[7, 7, 7, 7, 7], [7, 7, 7, 7, 7], [7, 7, 7, 7, 7]], [[7, 7, 7, 7, 7], [7, 7, 7, 7, 7], [7, 7, 7, 7, 7]]]
     with pytest.raises(ValueError) as err:
         array.num(4)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
 def test_listarray():
     content = awkward1.layout.NumpyArray(numpy.arange(2*3*5).reshape(5, 3, 2))
@@ -54,7 +54,7 @@ def test_listarray():
     assert awkward1.to_list(array.num(3)) == [[[2, 2, 2], [2, 2, 2], [2, 2, 2]], [], [[2, 2, 2], [2, 2, 2]]]
     with pytest.raises(ValueError) as err:
         array.num(4)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
 def test_listoffsetarray():
     content = awkward1.layout.NumpyArray(numpy.arange(2*3*5).reshape(5, 3, 2))
@@ -74,7 +74,7 @@ def test_listoffsetarray():
     assert awkward1.to_list(array.num(3)) == [[[2, 2, 2], [2, 2, 2], [2, 2, 2]], [], [[2, 2, 2], [2, 2, 2]]]
     with pytest.raises(ValueError) as err:
         array.num(4)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
 def test_indexedarray():
     content = awkward1.layout.NumpyArray(numpy.arange(2*3*5).reshape(5, 3, 2))
@@ -99,7 +99,7 @@ def test_indexedarray():
 
     with pytest.raises(ValueError) as err:
         array.num(4)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
 def test_indexedoptionarray():
     content = awkward1.layout.NumpyArray(numpy.arange(2*3*5).reshape(5, 3, 2))
@@ -126,7 +126,7 @@ def test_indexedoptionarray():
 
     with pytest.raises(ValueError) as err:
         array.num(4)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
 def test_recordarray():
     array = awkward1.from_iter([{"x": 0.0, "y": []}, {"x": 1.1, "y": [1]}, {"x": 2.2, "y": [2, 2]}, {"x": 3.3, "y": [3, 3, 3]}], highlevel=False)

--- a/tests/test_0163_negative-axis-wrap.py
+++ b/tests/test_0163_negative-axis-wrap.py
@@ -19,7 +19,7 @@ def test_array_3d():
                                                              [2, 2, 2, 2, 2]]
     with pytest.raises(ValueError) as err:
         assert awkward1.num(array, axis=3)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
     assert awkward1.to_list(awkward1.num(array, axis=-1)) == [[2, 2, 2, 2, 2],
                                                               [2, 2, 2, 2, 2],
@@ -29,7 +29,7 @@ def test_array_3d():
 
     with pytest.raises(ValueError) as err:
         assert awkward1.num(array, axis=-4)
-    assert str(err.value) == "axis == -4 exceeds the depth == 3 of this array"
+    assert str(err.value).startswith("axis == -4 exceeds the depth == 3 of this array")
 
 def test_list_array():
     array = awkward1.Array(numpy.arange(3*5*2).reshape(3, 5, 2).tolist())
@@ -41,7 +41,7 @@ def test_list_array():
 
     with pytest.raises(ValueError) as err:
         assert awkward1.num(array, axis=3)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
     assert awkward1.num(array, axis=-1) == [5, 5, 5]
     assert awkward1.num(array, axis=-2) == [[2, 2, 2, 2, 2],
@@ -50,7 +50,7 @@ def test_list_array():
     assert awkward1.num(array, axis=-3) == 3
     with pytest.raises(ValueError) as err:
         assert awkward1.num(array, axis=-4)
-    assert str(err.value) == "axis == -4 exceeds the depth == 3 of this array"
+    assert str(err.value).startswith("axis == -4 exceeds the depth == 3 of this array")
 
 def test_record_array():
     array = awkward1.Array([
@@ -64,7 +64,7 @@ def test_record_array():
                                                     {'x': 3, 'y': 4}]
     with pytest.raises(ValueError) as err:
         assert awkward1.num(array, axis=2)
-    assert str(err.value) == "'axis' out of range for 'num'"
+    assert str(err.value).startswith("'axis' out of range for 'num'")
 
     assert awkward1.num(array, axis=-1).tolist() == [{'x': 1, 'y': [0, 1]},
                                                      {'x': 2, 'y': [0, 1, 2]},
@@ -78,8 +78,8 @@ def test_record_array_axis_out_of_range():
 
     with pytest.raises(ValueError) as err:
         assert awkward1.num(array, axis=-2)
-    assert str(err.value) == "axis == -2 exceeds the min depth == 2 of this array"
+    assert str(err.value).startswith("axis == -2 exceeds the min depth == 2 of this array")
 
     with pytest.raises(ValueError) as err:
         assert awkward1.num(array, axis=-3)
-    assert str(err.value) == "axis == -3 exceeds the depth == 2 of this array"
+    assert str(err.value).startswith("axis == -3 exceeds the depth == 2 of this array")


### PR DESCRIPTION
   - [X] Add macros to all the C++ exceptions.
   - [x] Add `filename` as an `Error` struct field and have all the kernels report their line numbers as well.
   - [x] Make sure that the kernel-specification/documentation still works.
   - [x] Use [this trick](https://stackoverflow.com/a/45973535/1623645) to do the same for all Python exceptions. Be careful to only say `sys._getframe()` if `hasattr(sys, "_getframe")`.