### PR TITLE
Introduce a 'categorical' type (behavioral, just as 'string' is) that is the only thing that passes to Arrow as DictionaryArray.

### DIFF
--- a/docs-sphinx/prepare_docstrings.py
+++ b/docs-sphinx/prepare_docstrings.py
@@ -242,14 +242,15 @@ def dofunction(link, shortname, name, astfcn):
 
 done_extra = False
 for filename in sorted(glob.glob("../src/awkward1/**/*.py", recursive=True),
-                       key=lambda x: x.replace("/__init__.py",  "!")
-                                      .replace("/highlevel",    "#")
-                                      .replace("/operations",   "$")
+                       key=lambda x: x.replace("/__init__.py",    "!")
+                                      .replace("/highlevel",      "#")
+                                      .replace("/operations",     "$")
 
-                                      .replace("/describe.py",  "#")
-                                      .replace("/convert.py",   "$")
-                                      .replace("/structure.py", "%")
-                                      .replace("/reducers.py",  "&")
+                                      .replace("/describe.py",    "#")
+                                      .replace("/convert.py",     "$")
+                                      .replace("/structure.py",   "%")
+                                      .replace("/reducers.py",    "&")
+                                      .replace("/categorical.py", "'")
 
                                       .replace("/_", "/~")):
 
@@ -263,7 +264,11 @@ for filename in sorted(glob.glob("../src/awkward1/**/*.py", recursive=True),
                            .replace(".operations.convert", "")
                            .replace(".operations.describe", "")
                            .replace(".operations.structure", "")
-                           .replace(".operations.reducers", ""))
+                           .replace(".operations.reducers", "")
+                           .replace(".operations.transfers", "")
+                           .replace(".behaviors.mixins", "")
+                           .replace(".behaviors.categorical", "")
+                           .replace(".behaviors.string", ""))
 
     if modulename == "awkward1.operations.describe":
         toctree.append("ak.behavior.rst")

--- a/include/awkward/type/Type.h
+++ b/include/awkward/type/Type.h
@@ -200,6 +200,16 @@ namespace awkward {
     bool
       get_typestr(std::string& output) const;
 
+    /// @brief Internal function to determine if there are no parameters
+    /// *except* `__categorical__`.
+    bool
+      parameters_empty() const;
+
+    /// @brief Internal function that wraps `output` with `categorical[type=`
+    /// and `]` if `__categorical__` is `true`; passes through otherwise.
+    std::string
+      wrap_categorical(const std::string& output) const;
+
     /// @brief Internal function to format parameters as part of the #tostring
     /// string.
     const std::string

--- a/src/awkward1/__init__.py
+++ b/src/awkward1/__init__.py
@@ -54,9 +54,9 @@ from awkward1.highlevel import Record
 from awkward1.highlevel import ArrayBuilder
 
 # behaviors
-from awkward1.behaviors.mixins import mixin_class, mixin_class_method
-import awkward1.behaviors.string
-import awkward1.behaviors.categorical
+from awkward1.behaviors.mixins import *
+from awkward1.behaviors.string import *
+from awkward1.behaviors.categorical import *
 
 # operations
 from awkward1.operations.convert import *

--- a/src/awkward1/__init__.py
+++ b/src/awkward1/__init__.py
@@ -56,6 +56,7 @@ from awkward1.highlevel import ArrayBuilder
 # behaviors
 from awkward1.behaviors.mixins import mixin_class, mixin_class_method
 import awkward1.behaviors.string
+import awkward1.behaviors.categorical
 
 # operations
 from awkward1.operations.convert import *

--- a/src/awkward1/_util.py
+++ b/src/awkward1/_util.py
@@ -61,6 +61,11 @@ uniontypes = (
     awkward1.layout.UnionArray8_64,
 )
 
+indexedoptiontypes = (
+    awkward1.layout.IndexedOptionArray32,
+    awkward1.layout.IndexedOptionArray64,
+)
+
 optiontypes = (
     awkward1.layout.IndexedOptionArray32,
     awkward1.layout.IndexedOptionArray64,

--- a/src/awkward1/behaviors/categorical.py
+++ b/src/awkward1/behaviors/categorical.py
@@ -62,25 +62,22 @@ def _hashable(obj):
         return obj
 
 
-_all_indexedtypes = (
-    awkward1.layout.IndexedOptionArray32,
-    awkward1.layout.IndexedOptionArray64,
-) + awkward1._util.indexedtypes
-
-
 def _categorical_equal(one, two):
-    nplike = awkward1.nplike.of(one, two)
     behavior = awkward1._util.behaviorof(one, two)
 
     one, two = one.layout, two.layout
 
-    assert isinstance(one, _all_indexedtypes)
-    assert isinstance(two, _all_indexedtypes)
+    assert isinstance(
+        one, awkward1._util.indexedtypes + awkward1._util.indexedoptiontypes
+    )
+    assert isinstance(
+        two, awkward1._util.indexedtypes + awkward1._util.indexedoptiontypes
+    )
     assert one.parameter("__array__") == "categorical"
     assert two.parameter("__array__") == "categorical"
 
-    one_index = nplike.asarray(one.index)
-    two_index = nplike.asarray(two.index)
+    one_index = awkward1.nplike.numpy.asarray(one.index)
+    two_index = awkward1.nplike.numpy.asarray(two.index)
     one_content = awkward1._util.wrap(one.content, behavior)
     two_content = awkward1._util.wrap(two.content, behavior)
 
@@ -97,7 +94,7 @@ def _categorical_equal(one, two):
         two_hashable = [_hashable(x) for x in two_list]
         two_lookup = {x: i for i, x in enumerate(two_hashable)}
 
-        one_to_two = nplike.empty(len(one_hashable) + 1, dtype=np.int64)
+        one_to_two = awkward1.nplike.numpy.empty(len(one_hashable) + 1, dtype=np.int64)
         for i, x in enumerate(one_hashable):
             one_to_two[i] = two_lookup.get(x, len(two_hashable))
         one_to_two[-1] = -1
@@ -105,7 +102,95 @@ def _categorical_equal(one, two):
         one_mapped = one_to_two[one_index]
 
     out = one_mapped == two_index
-    return awkward1.highlevel.Array(awkward1.layout.NumpyArray(out))
+    return awkward1._util.wrap(
+        awkward1.layout.NumpyArray(out), awkward1._util.behaviorof(one, two)
+    )
 
 
 awkward1.behavior[awkward1.nplike.numpy.equal, "categorical", "categorical"] = _categorical_equal
+
+
+def to_categorical(array, highlevel=True):
+    def getfunction(layout, depth):
+        p = layout.purelist_parameter("__array__")
+        print("depth", depth, "layout", type(layout), "p", p)
+
+        if (layout.purelist_depth == 1 or (
+            layout.purelist_depth == 2 and (p == "string" or p == "bytestring")
+        )):
+            if isinstance(layout, awkward1._util.optiontypes):
+                layout = layout.simplify()
+            if isinstance(
+                layout,
+                awkward1._util.indexedoptiontypes + awkward1._util.indexedtypes
+            ):
+                content = layout.content
+                cls = awkward1.layout.IndexedOptionArray64
+            elif isinstance(layout, awkward1._util.optiontypes):
+                content = layout.content
+                cls = awkward1.layout.IndexedOptionArray64
+            else:
+                content = layout
+                cls = awkward1.layout.IndexedArray64
+
+            content_list = awkward1.operations.convert.to_list(content)
+            hashable = [_hashable(x) for x in content_list]
+
+            lookup = {}
+            is_first = awkward1.nplike.numpy.empty(len(hashable), dtype=np.bool_)
+            mapping = awkward1.nplike.numpy.empty(len(hashable), dtype=np.int64)
+            for i, x in enumerate(hashable):
+                if x in lookup:
+                    is_first[i] = False
+                    mapping[i] = lookup[x]
+                else:
+                    is_first[i] = True
+                    lookup[x] = i
+                    mapping[i] = i
+
+            if isinstance(layout, awkward1._util.indexedoptiontypes):
+                original_index = awkward1.nplike.numpy.asarray(layout.index)
+                index = mapping[original_index]
+                index[original_index < 0] = -1
+                index = awkward1.layout.Index64(index)
+
+            elif isinstance(layout, awkward1._util.indexedtypes):
+                original_index = awkward1.nplike.numpy.asarray(layout.index)
+                index = awkward1.layout.Index64(mapping[original_index])
+
+            elif isinstance(layout, awkward1._util.optiontypes):
+                mask = awkward1.nplike.numpy.asarray(layout.bytemask())
+                mapping[mask.view(np.bool_)] = -1
+                index = awkward1.layout.Index64(mapping)
+
+            else:
+                index = awkward1.layout.Index64(mapping)
+
+            out = cls(index, content[is_first], parameters={"__array__": "categorical"})
+            return lambda: out
+
+        else:
+            return None
+
+    out = awkward1._util.recursively_apply(
+        awkward1.operations.convert.to_layout(
+            array, allow_record=False, allow_other=False
+        ),
+        getfunction,
+    )
+    if highlevel:
+        return awkward1._util.wrap(out, awkward1._util.behaviorof(array))
+    else:
+        return out
+
+
+__all__ = [
+    x
+    for x in list(globals())
+    if not x.startswith("_")
+    and x not in (
+        "absolute_import",
+        "np",
+        "awkward1",
+    )
+]

--- a/src/awkward1/behaviors/categorical.py
+++ b/src/awkward1/behaviors/categorical.py
@@ -1,0 +1,111 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import awkward1.highlevel
+import awkward1.nplike
+import awkward1.operations.convert
+import awkward1.operations.reducers
+import awkward1._util
+
+
+np = awkward1.nplike.NumpyMetadata.instance()
+
+
+class CategoricalBehavior(awkward1.highlevel.Array):
+    __name__ = "Array"
+
+
+awkward1.behavior["categorical"] = CategoricalBehavior
+
+
+class _HashableDict(object):
+    def __init__(self, obj):
+        self.keys = tuple(sorted(obj))
+        self.values = tuple(_hashable(obj[k]) for k in self.keys)
+        self.hash = hash((_HashableDict,) + self.keys, self.values)
+
+    def __hash__(self):
+        return self.hash
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, _HashableDict)
+            and self.keys == other.keys
+            and self.values == other.values
+        )
+
+
+class _HashableList(object):
+    def __init__(self, obj):
+        self.values = tuple(obj)
+        self.hash = hash((_HashableList,) + self.values)
+
+    def __hash__(self):
+        return self.hash
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, _HashableList)
+            and self.values == other.values
+        )
+
+
+def _hashable(obj):
+    if isinstance(obj, dict):
+        return _HashableDict(obj)
+    elif isinstance(obj, tuple):
+        return tuple(_hashable(x) for x in obj)
+    elif isinstance(obj, list):
+        return _HashableList(obj)
+    else:
+        return obj
+
+
+_all_indexedtypes = (
+    awkward1.layout.IndexedOptionArray32,
+    awkward1.layout.IndexedOptionArray64,
+) + awkward1._util.indexedtypes
+
+
+def _categorical_equal(one, two):
+    nplike = awkward1.nplike.of(one, two)
+    behavior = awkward1._util.behaviorof(one, two)
+
+    one, two = one.layout, two.layout
+
+    assert isinstance(one, _all_indexedtypes)
+    assert isinstance(two, _all_indexedtypes)
+    assert one.parameter("__array__") == "categorical"
+    assert two.parameter("__array__") == "categorical"
+
+    one_index = nplike.asarray(one.index)
+    two_index = nplike.asarray(two.index)
+    one_content = awkward1._util.wrap(one.content, behavior)
+    two_content = awkward1._util.wrap(two.content, behavior)
+
+    if (
+        len(one_content) == len(two_content) and
+        awkward1.operations.reducers.all(one_content == two_content, axis=None)
+    ):
+        one_mapped = one_index
+
+    else:
+        one_list = awkward1.operations.convert.to_list(one_content)
+        two_list = awkward1.operations.convert.to_list(two_content)
+        one_hashable = [_hashable(x) for x in one_list]
+        two_hashable = [_hashable(x) for x in two_list]
+        two_lookup = {x: i for i, x in enumerate(two_hashable)}
+
+        one_to_two = nplike.empty(len(one_hashable) + 1, dtype=np.int64)
+        for i, x in enumerate(one_hashable):
+            one_to_two[i] = two_lookup.get(x, len(two_hashable))
+        one_to_two[-1] = -1
+
+        one_mapped = one_to_two[one_index]
+
+    out = one_mapped == two_index
+    return awkward1.highlevel.Array(awkward1.layout.NumpyArray(out))
+
+
+awkward1.behavior[awkward1.nplike.numpy.equal, "categorical", "categorical"] = _categorical_equal

--- a/src/awkward1/behaviors/categorical.py
+++ b/src/awkward1/behaviors/categorical.py
@@ -241,12 +241,13 @@ def to_categorical(array, highlevel=True):
         )):
             if isinstance(layout, awkward1._util.optiontypes):
                 layout = layout.simplify()
-            if isinstance(
-                layout,
-                awkward1._util.indexedoptiontypes + awkward1._util.indexedtypes
-            ):
+
+            if isinstance(layout, awkward1._util.indexedoptiontypes):
                 content = layout.content
                 cls = awkward1.layout.IndexedOptionArray64
+            elif isinstance(layout, awkward1._util.indexedtypes):
+                content = layout.content
+                cls = awkward1.layout.IndexedArray64
             elif isinstance(layout, awkward1._util.optiontypes):
                 content = layout.content
                 cls = awkward1.layout.IndexedOptionArray64

--- a/src/awkward1/behaviors/categorical.py
+++ b/src/awkward1/behaviors/categorical.py
@@ -243,8 +243,8 @@ def to_categorical(array, highlevel=True):
                     mapping[i] = lookup[x]
                 else:
                     is_first[i] = True
-                    lookup[x] = i
-                    mapping[i] = i
+                    lookup[x] = j = len(lookup)
+                    mapping[i] = j
 
             if isinstance(layout, awkward1._util.indexedoptiontypes):
                 original_index = awkward1.nplike.numpy.asarray(layout.index)

--- a/src/awkward1/behaviors/categorical.py
+++ b/src/awkward1/behaviors/categorical.py
@@ -188,6 +188,21 @@ def to_categorical(array, highlevel=True):
     Arrays by the guarantee of no duplicate categories and the `"categorical"`
     parameter.
 
+        >>> array = ak.Array([["one", "two", "three"], [], ["three", "two"]])
+        >>> categorical = ak.to_categorical(array)
+        >>> categorical
+        <Array [['one', 'two', ... 'three', 'two']] type='3 * var * categorical[type=str...'>
+        >>> ak.type(categorical)
+        3 * var * categorical[type=string]
+        >>> ak.to_list(categorical) == ak.to_list(array)
+        True
+        >>> ak.categories(categorical)
+        <Array ['one', 'two', 'three'] type='3 * string'>
+        >>> ak.is_categorical(categorical)
+        True
+        >>> ak.from_categorical(categorical)
+        <Array [['one', 'two', ... 'three', 'two']] type='3 * var * string'>
+
     This function descends through nested lists, but not into the fields of
     records, so records can be categories. To make categorical record
     fields, split up the record, apply this function to each desired field,
@@ -200,10 +215,18 @@ def to_categorical(array, highlevel=True):
         ...     {"x": 2.2, "y": "two"},
         ...     {"x": 1.1, "y": "one"}
         ... ])
+        >>> records
+        <Array [{x: 1.1, y: 'one'}, ... y: 'one'}] type='5 * {"x": float64, "y": string}'>
         >>> categorical_records = ak.zip({
         ...     "x": ak.to_categorical(records["x"]),
         ...     "y": ak.to_categorical(records["y"]),
         ... })
+        >>> categorical_records
+        <Array [{x: 1.1, y: 'one'}, ... y: 'one'}] type='5 * {"x": categorical[type=floa...'>
+        >>> ak.type(categorical_records)
+        5 * {"x": categorical[type=float64], "y": categorical[type=string]}
+        >>> ak.to_list(categorical_records) == ak.to_list(records)
+        True
 
     The check for uniqueness is currently implemented in a Python loop, so
     conversion to categorical should be regarded as expensive. (This can

--- a/src/awkward1/behaviors/mixins.py
+++ b/src/awkward1/behaviors/mixins.py
@@ -77,3 +77,14 @@ def mixin_class_method(ufunc, rhs=None, transpose=True):
         return method
 
     return register
+
+
+__all__ = [
+    x
+    for x in list(globals())
+    if not x.startswith("_")
+    and x not in (
+        "absolute_import",
+        "awkward1",
+    )
+]

--- a/src/awkward1/behaviors/string.py
+++ b/src/awkward1/behaviors/string.py
@@ -99,6 +99,7 @@ awkward1.behavior["__typestr__", "string"] = "string"
 
 def _string_equal(one, two):
     nplike = awkward1.nplike.of(one, two)
+    behavior = awkward1._util.behaviorof(one, two)
 
     one, two = one.layout, two.layout
 
@@ -121,7 +122,7 @@ def _string_equal(one, two):
         # update same-length strings with a verdict about their characters
         out[possible] = reduced
 
-    return awkward1.highlevel.Array(awkward1.layout.NumpyArray(out))
+    return awkward1._util.wrap(awkward1.layout.NumpyArray(out), behavior)
 
 
 awkward1.behavior[awkward1.nplike.numpy.equal, "bytestring", "bytestring"] = _string_equal
@@ -235,3 +236,15 @@ awkward1.behavior["__numba_typer__", "bytestring"] = _string_numba_typer
 awkward1.behavior["__numba_lower__", "bytestring"] = _string_numba_lower
 awkward1.behavior["__numba_typer__", "string"] = _string_numba_typer
 awkward1.behavior["__numba_lower__", "string"] = _string_numba_lower
+
+
+__all__ = [
+    x
+    for x in list(globals())
+    if not x.startswith("_")
+    and x not in (
+        "absolute_import",
+        "np",
+        "awkward1",
+    )
+]

--- a/src/awkward1/highlevel.py
+++ b/src/awkward1/highlevel.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import re
 import keyword
+import warnings
 
 try:
     from collections.abc import Iterable
@@ -481,6 +482,11 @@ class Array(
 
         See also #ak.to_json and #ak.from_json.
         """
+        warnings.warn(
+            ".tojson is deprecated, will be removed in 0.3.0. Use\n\n"
+            "    ak.to_json(array)\n\ninstead.",
+            DeprecationWarning,
+        )
         return awkward1.operations.convert.to_json(
             self, destination, pretty, maxdecimals, buffersize
         )
@@ -1625,6 +1631,11 @@ class Record(awkward1._connect._numpy.NDArrayOperatorsMixin):
 
         See also #ak.to_json and #ak.from_json.
         """
+        warnings.warn(
+            ".tojson is deprecated, will be removed in 0.3.0. Use\n\n"
+            "    ak.to_json(array)\n\ninstead.",
+            DeprecationWarning,
+        )
         return awkward1.operations.convert.to_json(
             self, destination, pretty, maxdecimals, buffersize
         )

--- a/src/awkward1/operations/convert.py
+++ b/src/awkward1/operations/convert.py
@@ -3671,5 +3671,16 @@ __all__ = [
     x
     for x in list(globals())
     if not x.startswith("_")
-    and x not in ("numbers", "json", "Iterable", "numpy", "np", "awkward1")
+    and x not in (
+        "absolute_import",
+        "numbers",
+        "json",
+        "collections",
+        "math",
+        "threading",
+        "Iterable",
+        "numpy",
+        "np",
+        "awkward1",
+    )
 ]

--- a/src/awkward1/operations/convert.py
+++ b/src/awkward1/operations/convert.py
@@ -1716,6 +1716,8 @@ def from_arrow(array, highlevel=True, behavior=None):
                 )
 
             if isinstance(index, awkward1.layout.BitMaskedArray):
+                if isinstance(content, awkward1.layout.UnmaskedArray):
+                    content = content.content
                 return awkward1.layout.BitMaskedArray(
                     index.mask,
                     awkward1.layout.IndexedArray32(
@@ -1753,7 +1755,7 @@ def from_arrow(array, highlevel=True, behavior=None):
                 )
                 return awkward1.layout.BitMaskedArray(mask, out, True, length, True)
             else:
-                return out
+                return awkward1.layout.UnmaskedArray(out)
 
         elif isinstance(tpe, pyarrow.lib.ListType):
             assert tpe.num_buffers == 2
@@ -1775,7 +1777,7 @@ def from_arrow(array, highlevel=True, behavior=None):
                 )
                 return awkward1.layout.BitMaskedArray(mask, out, True, length, True)
             else:
-                return out
+                return awkward1.layout.UnmaskedArray(out)
 
         elif isinstance(tpe, pyarrow.lib.LargeListType):
             assert tpe.num_buffers == 2
@@ -1797,7 +1799,7 @@ def from_arrow(array, highlevel=True, behavior=None):
                 )
                 return awkward1.layout.BitMaskedArray(mask, out, True, length, True)
             else:
-                return out
+                return awkward1.layout.UnmaskedArray(out)
 
         elif isinstance(tpe, pyarrow.lib.UnionType) and tpe.mode == "sparse":
             assert tpe.num_buffers == 2
@@ -1829,7 +1831,7 @@ def from_arrow(array, highlevel=True, behavior=None):
                 )
                 return awkward1.layout.BitMaskedArray(mask, out, True, length, True)
             else:
-                return out
+                return awkward1.layout.UnmaskedArray(out)
 
         elif isinstance(tpe, pyarrow.lib.UnionType) and tpe.mode == "dense":
             assert tpe.num_buffers == 3
@@ -1860,7 +1862,7 @@ def from_arrow(array, highlevel=True, behavior=None):
                 )
                 return awkward1.layout.BitMaskedArray(mask, out, True, length, True)
             else:
-                return out
+                return awkward1.layout.UnmaskedArray(out)
 
         elif tpe == pyarrow.string():
             assert tpe.num_buffers == 3
@@ -1878,7 +1880,7 @@ def from_arrow(array, highlevel=True, behavior=None):
             awk_arr.setparameter("__array__", "string")
 
             if mask is None:
-                return awk_arr
+                return awkward1.layout.UnmaskedArray(awk_arr)
             else:
                 awk_mask = awkward1.layout.IndexU8(
                     numpy.frombuffer(mask, dtype=np.uint8)
@@ -1903,7 +1905,7 @@ def from_arrow(array, highlevel=True, behavior=None):
             awk_arr.setparameter("__array__", "string")
 
             if mask is None:
-                return awk_arr
+                return awkward1.layout.UnmaskedArray(awk_arr)
             else:
                 awk_mask = awkward1.layout.IndexU8(
                     numpy.frombuffer(mask, dtype=np.uint8)
@@ -1928,7 +1930,7 @@ def from_arrow(array, highlevel=True, behavior=None):
             awk_arr.setparameter("__array__", "bytestring")
 
             if mask is None:
-                return awk_arr
+                return awkward1.layout.UnmaskedArray(awk_arr)
             else:
                 awk_mask = awkward1.layout.IndexU8(
                     numpy.frombuffer(mask, dtype=np.uint8)
@@ -1953,7 +1955,7 @@ def from_arrow(array, highlevel=True, behavior=None):
             awk_arr.setparameter("__array__", "bytestring")
 
             if mask is None:
-                return awk_arr
+                return awkward1.layout.UnmaskedArray(awk_arr)
             else:
                 awk_mask = awkward1.layout.IndexU8(
                     numpy.frombuffer(mask, dtype=np.uint8)
@@ -1976,7 +1978,7 @@ def from_arrow(array, highlevel=True, behavior=None):
                 mask = numpy.frombuffer(mask, dtype=np.uint8)
                 return awkward1.layout.BitMaskedArray(awk_mask, out, True, length, True)
             else:
-                return out
+                return awkward1.layout.UnmaskedArray(out)
 
         elif isinstance(tpe, pyarrow.lib.DataType):
             assert tpe.num_buffers == 2
@@ -1990,7 +1992,7 @@ def from_arrow(array, highlevel=True, behavior=None):
                 )
                 return awkward1.layout.BitMaskedArray(mask, out, True, length, True)
             else:
-                return out
+                return awkward1.layout.UnmaskedArray(out)
 
         else:
             raise TypeError(

--- a/src/awkward1/operations/describe.py
+++ b/src/awkward1/operations/describe.py
@@ -262,5 +262,11 @@ def keys(array):
 __all__ = [
     x
     for x in list(globals())
-    if not x.startswith("_") and x not in ("numbers", "numpy", "np", "awkward1")
+    if not x.startswith("_") and x not in (
+        "absolute_import",
+        "numbers",
+        "numpy",
+        "np",
+        "awkward1",
+    )
 ]

--- a/src/awkward1/operations/reducers.py
+++ b/src/awkward1/operations/reducers.py
@@ -1433,5 +1433,9 @@ def softmax(x, axis=None, keepdims=False, mask_identity=False):
 __all__ = [
     x
     for x in list(globals())
-    if not x.startswith("_") and x not in ("collections", "numpy", "np", "awkward1")
+    if not x.startswith("_") and x not in (
+        "absolute_import",
+        "np",
+        "awkward1",
+    )
 ]

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -2790,5 +2790,13 @@ def values_astype(array, to, highlevel=True):
 __all__ = [
     x
     for x in list(globals())
-    if not x.startswith("_") and x not in ("numpy", "np", "awkward1")
+    if not x.startswith("_") and x not in (
+        "absolute_import",
+        "numbers",
+        "json",
+        "Iterable",
+        "MutableMapping",
+        "np",
+        "awkward1",
+    )
 ]

--- a/src/awkward1/operations/structure.py
+++ b/src/awkward1/operations/structure.py
@@ -328,8 +328,12 @@ def zip(arrays, depth_limit=None, parameters=None, with_name=None, highlevel=Tru
         parameters["__record__"] = with_name
 
     def getfunction(inputs, depth):
-        if (depth_limit is None and all(x.purelist_depth == 1 for x in inputs)) or (
-            depth_limit == depth
+        if depth_limit == depth or (
+            depth_limit is None and
+            all(x.purelist_depth == 1 or (
+                x.purelist_depth == 2 and
+                x.purelist_parameter("__array__") in ("string", "bytestring", "categorical")
+            ) for x in inputs)
         ):
             return lambda: (
                 awkward1.layout.RecordArray(

--- a/src/awkward1/operations/transfers.py
+++ b/src/awkward1/operations/transfers.py
@@ -20,4 +20,12 @@ def copy_to(array, ptr_lib, highlevel=True, behavior=None):
     else:
         return arr.copy_to(ptr_lib)
 
-__all__ = [x for x in list(globals()) if not x.startswith("_") and x not in ("awkward1")]
+
+__all__ = [
+    x
+    for x in list(globals())
+    if not x.startswith("_") and x not in (
+        "absolute_import",
+        "awkward1",
+    )
+]

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -56,7 +56,23 @@ namespace awkward {
   const TypePtr
   IndexedForm::type(const util::TypeStrs& typestrs) const {
     TypePtr out = content_.get()->type(typestrs);
-    out.get()->setparameters(parameters_);
+    if (out.get()->parameters().empty()  &&  !parameters_.empty()) {
+      out.get()->setparameters(parameters_);
+      if (parameter_equals("__array__", "\"categorical\"")) {
+        out.get()->setparameter("__array__", "null");
+        out.get()->setparameter("__categorical__", "true");
+      }
+    }
+    else if (!out.get()->parameters().empty()  &&  !parameters_.empty()) {
+      for (auto p : parameters_) {
+        if (p.first != std::string("__array__")) {
+          out.get()->setparameter(p.first, p.second);
+        }
+      }
+      if (parameter_equals("__array__", "\"categorical\"")) {
+        out.get()->setparameter("__categorical__", "true");
+      }
+    }
     return out;
   }
 
@@ -210,10 +226,15 @@ namespace awkward {
 
   const TypePtr
   IndexedOptionForm::type(const util::TypeStrs& typestrs) const {
-    return std::make_shared<OptionType>(
-               parameters_,
-               util::gettypestr(parameters_, typestrs),
-               content_.get()->type(typestrs));
+    TypePtr out = std::make_shared<OptionType>(
+                    parameters_,
+                    util::gettypestr(parameters_, typestrs),
+                    content_.get()->type(typestrs));
+    if (out.get()->parameter_equals("__array__", "\"categorical\"")) {
+      out.get()->setparameter("__array__", "null");
+      out.get()->setparameter("__categorical__", "true");
+    }
+    return out;
   }
 
   void

--- a/src/libawkward/type/ListType.cpp
+++ b/src/libawkward/type/ListType.cpp
@@ -22,11 +22,11 @@ namespace awkward {
                           const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
-      return typestr;
+      return wrap_categorical(typestr);
     }
 
     std::stringstream out;
-    if (parameters_.empty()) {
+    if (parameters_empty()) {
       out << indent << pre << "var * "
           << type_.get()->tostring_part(indent, "", "") << post;
     }
@@ -35,7 +35,7 @@ namespace awkward {
           << type_.get()->tostring_part(indent, "", "") << ", "
           << string_parameters() << "]" << post;
     }
-    return out.str();
+    return wrap_categorical(out.str());
   }
 
   const TypePtr

--- a/src/libawkward/type/OptionType.cpp
+++ b/src/libawkward/type/OptionType.cpp
@@ -24,11 +24,11 @@ namespace awkward {
                             const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
-      return typestr;
+      return wrap_categorical(typestr);
     }
 
     std::stringstream out;
-    if (parameters_.empty()) {
+    if (parameters_empty()) {
       if (dynamic_cast<ListType*>(type_.get()) != nullptr  ||
           dynamic_cast<RegularType*>(type_.get()) != nullptr) {
         out << indent << pre << "option["
@@ -44,7 +44,7 @@ namespace awkward {
           << type_.get()->tostring_part(indent, "", "") << ", "
           << string_parameters() << "]" << post;
     }
-    return out.str();
+    return wrap_categorical(out.str());
   }
 
   const TypePtr

--- a/src/libawkward/type/PrimitiveType.cpp
+++ b/src/libawkward/type/PrimitiveType.cpp
@@ -23,18 +23,18 @@ namespace awkward {
                                const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
-      return typestr;
+      return wrap_categorical(typestr);
     }
 
     std::stringstream out;
     std::string s = util::dtype_to_name(dtype_);
-    if (parameters_.empty()) {
+    if (parameters_empty()) {
       out << indent << pre << s << post;
     }
     else {
       out << indent << pre << s << "[" << string_parameters() << "]" << post;
     }
-    return out.str();
+    return wrap_categorical(out.str());
   }
 
   const TypePtr

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -67,7 +67,7 @@ namespace awkward {
                             const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
-      return typestr;
+      return wrap_categorical(typestr);
     }
 
     std::stringstream out;
@@ -88,11 +88,11 @@ namespace awkward {
           out << types_[j].get()->tostring_part("", "", "");
         }
         out << "]";
-        return out.str();
+        return wrap_categorical(out.str());
       }
     }
 
-    if (parameters_.empty()) {
+    if (parameters_empty()) {
       if (recordlookup_.get() != nullptr) {
         out << "{";
         for (size_t j = 0;  j < types_.size();  j++) {
@@ -143,7 +143,7 @@ namespace awkward {
       }
       out << "], " << string_parameters() << "]";
     }
-    return out.str();
+    return wrap_categorical(out.str());
   }
 
   const TypePtr

--- a/src/libawkward/type/RegularType.cpp
+++ b/src/libawkward/type/RegularType.cpp
@@ -24,11 +24,11 @@ namespace awkward {
                              const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
-      return typestr;
+      return wrap_categorical(typestr);
     }
 
     std::stringstream out;
-    if (parameters_.empty()) {
+    if (parameters_empty()) {
       out << indent << pre << size_ << " * "
           << type_.get()->tostring_part(indent, "", "") << post;
     }
@@ -37,7 +37,7 @@ namespace awkward {
           << type_.get()->tostring_part(indent, "", "") << ", "
           << string_parameters() << "]" << post;
     }
-    return out.str();
+    return wrap_categorical(out.str());
   }
 
   const TypePtr

--- a/src/libawkward/type/Type.cpp
+++ b/src/libawkward/type/Type.cpp
@@ -44,7 +44,12 @@ namespace awkward {
 
   void
   Type::setparameter(const std::string& key, const std::string& value) {
-    parameters_[key] = value;
+    if (value == std::string("null")) {
+      parameters_.erase(key);
+    }
+    else {
+      parameters_[key] = value;
+    }
   }
 
   bool
@@ -95,17 +100,42 @@ namespace awkward {
     }
   }
 
+  bool
+  Type::parameters_empty() const {
+    if (parameters_.empty()) {
+      return true;
+    }
+    else if (parameters_.size() == 1  &&  parameter_equals("__categorical__", "true")) {
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+
+  std::string
+  Type::wrap_categorical(const std::string& output) const {
+    if (parameter_equals("__categorical__", "true")) {
+      return std::string("categorical[type=") + output + std::string("]");
+    }
+    else {
+      return output;
+    }
+  }
+
   const std::string
   Type::string_parameters() const {
     std::stringstream out;
     out << "parameters={";
     bool first = true;
     for (auto pair : parameters_) {
-      if (!first) {
-        out << ", ";
+      if (pair.first != std::string("__categorical__")) {
+        if (!first) {
+          out << ", ";
+        }
+        out << util::quote(pair.first, true) << ": " << pair.second;
+        first = false;
       }
-      out << util::quote(pair.first, true) << ": " << pair.second;
-      first = false;
     }
     out << "}";
     return out.str();

--- a/src/libawkward/type/UnionType.cpp
+++ b/src/libawkward/type/UnionType.cpp
@@ -24,7 +24,7 @@ namespace awkward {
                            const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
-      return typestr;
+      return wrap_categorical(typestr);
     }
 
     std::stringstream out;
@@ -35,11 +35,11 @@ namespace awkward {
       }
       out << type(i).get()->tostring_part(indent, "", "");
     }
-    if (!parameters_.empty()) {
+    if (!parameters_empty()) {
       out << ", " << string_parameters();
     }
     out << "]" << post;
-    return out.str();
+    return wrap_categorical(out.str());
   }
 
   const TypePtr

--- a/src/libawkward/type/UnknownType.cpp
+++ b/src/libawkward/type/UnknownType.cpp
@@ -19,17 +19,17 @@ namespace awkward {
                              const std::string& post) const {
     std::string typestr;
     if (get_typestr(typestr)) {
-      return typestr;
+      return wrap_categorical(typestr);
     }
 
     std::stringstream out;
-    if (parameters_.empty()) {
+    if (parameters_empty()) {
       out << indent << pre << "unknown" << post;
     }
     else {
       out << indent << pre << "unknown[" << string_parameters() << "]" << post;
     }
-    return out.str();
+    return wrap_categorical(out.str());
   }
 
   const TypePtr

--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -1467,6 +1467,8 @@ make_ByteMaskedArray(const py::handle& m, const std::string& name) {
       .def("simplify", [](const ak::ByteMaskedArray& self) {
         return box(self.simplify_optiontype());
       })
+      .def("toIndexedOptionArray64",
+           &ak::ByteMaskedArray::toIndexedOptionArray64)
   );
 }
 

--- a/tests/test_0224-arrow-to-awkward.py
+++ b/tests/test_0224-arrow-to-awkward.py
@@ -128,11 +128,28 @@ def test_toarrow_IndexedArray():
     index = awkward1.layout.Index32(
         numpy.array([0, 2, 4, 6, 8, 9, 7, 5], dtype=numpy.int64))
     indexedarray = awkward1.layout.IndexedArray32(index, content)
+    do_this_instead = awkward1.to_categorical(indexedarray, highlevel=False)
 
-    assert isinstance(awkward1.to_arrow(indexedarray),
-                      (pyarrow.DictionaryArray))
+    assert isinstance(awkward1.to_arrow(indexedarray), pyarrow.lib.DoubleArray)
     assert awkward1.to_arrow(indexedarray).to_pylist() == [
         0.0, 2.2, 4.4, 6.6, 8.8, 9.9, 7.7, 5.5]
+
+    assert isinstance(awkward1.to_arrow(do_this_instead), pyarrow.DictionaryArray)
+    assert awkward1.to_arrow(do_this_instead).to_pylist() == [
+        0.0, 2.2, 4.4, 6.6, 8.8, 9.9, 7.7, 5.5]
+
+def test_toarrow_IndexedOptionArray_2():
+    array = awkward1.Array([1.1, 2.2, 3.3, 4.4, 5.5, None])
+
+    assert awkward1.to_arrow(array).to_pylist() == [1.1, 2.2, 3.3, 4.4, 5.5, None]
+    assert awkward1.to_arrow(array[:-1]).to_pylist() == [1.1, 2.2, 3.3, 4.4, 5.5]
+    assert awkward1.to_arrow(array[:1]).to_pylist() == [1.1]
+    assert awkward1.to_arrow(array[:0]).to_pylist() == []
+
+    content = awkward1.layout.NumpyArray(numpy.array([], dtype=numpy.float64))
+    index = awkward1.layout.Index32(numpy.array([-1, -1, -1, -1], dtype=numpy.int32))
+    indexedoptionarray = awkward1.layout.IndexedOptionArray32(index, content)
+    assert awkward1.to_arrow(indexedoptionarray).to_pylist() == [None, None, None, None]
 
 def test_toarrow_ByteMaskedArray_2():
     content = awkward1.layout.NumpyArray(

--- a/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -1,0 +1,104 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+
+import pytest
+
+import numpy
+import awkward1
+
+
+def test_same_categories():
+    categories = awkward1.Array(["one", "two", "three"])
+    index1 = awkward1.layout.Index64(numpy.array([0, 2, 2, 1, 2, 0, 1, 0], dtype=numpy.int64))
+    index2 = awkward1.layout.Index64(numpy.array([1, 1, 2, 1, 0, 0, 0, 1], dtype=numpy.int64))
+    categorical1 = awkward1.layout.IndexedArray64(index1, categories.layout, parameters={"__array__": "categorical"})
+    categorical2 = awkward1.layout.IndexedArray64(index2, categories.layout, parameters={"__array__": "categorical"})
+    array1 = awkward1.Array(categorical1)
+    array2 = awkward1.Array(categorical2)
+    assert (array1 == array2).tolist() == [False, False, True, True, False, True, False, False]
+
+
+def test_different_categories():
+    categories1 = awkward1.Array(["one", "two", "three"])
+    categories2 = awkward1.Array(["three", "two", "one"])
+    index1 = awkward1.layout.Index64(numpy.array([0, 2, 2, 1, 2, 0, 1, 0], dtype=numpy.int64))
+    index2 = awkward1.layout.Index64(numpy.array([1, 1, 2, 1, 0, 0, 0, 1], dtype=numpy.int64))
+    categorical1 = awkward1.layout.IndexedArray64(index1, categories1.layout, parameters={"__array__": "categorical"})
+    categorical2 = awkward1.layout.IndexedArray64(index2, categories2.layout, parameters={"__array__": "categorical"})
+    array1 = awkward1.Array(categorical1)
+    array2 = awkward1.Array(categorical2)
+    assert (array1 == array2).tolist() == [False, False, False, True, True, False, False, False]
+
+
+def test_one_extra():
+    categories1 = awkward1.Array(["one", "two", "three", "four"])
+    categories2 = awkward1.Array(["three", "two", "one"])
+    index1 = awkward1.layout.Index64(numpy.array([0, 3, 0, 1, 2, 3, 1, 0], dtype=numpy.int64))
+    index2 = awkward1.layout.Index64(numpy.array([1, 1, 2, 1, 0, 0, 0, 1], dtype=numpy.int64))
+    categorical1 = awkward1.layout.IndexedArray64(index1, categories1.layout, parameters={"__array__": "categorical"})
+    categorical2 = awkward1.layout.IndexedArray64(index2, categories2.layout, parameters={"__array__": "categorical"})
+    array1 = awkward1.Array(categorical1)
+    array2 = awkward1.Array(categorical2)
+    assert (array1 == array2).tolist() == [False, False, True, True, True, False, False, False]
+
+
+def test_two_extra():
+    categories1 = awkward1.Array(["one", "two", "three"])
+    categories2 = awkward1.Array(["four", "three", "two", "one"])
+    index1 = awkward1.layout.Index64(numpy.array([0, 2, 2, 1, 2, 0, 1, 0], dtype=numpy.int64))
+    index2 = awkward1.layout.Index64(numpy.array([1, 3, 1, 1, 3, 3, 2, 1], dtype=numpy.int64))
+    categorical1 = awkward1.layout.IndexedArray64(index1, categories1.layout, parameters={"__array__": "categorical"})
+    categorical2 = awkward1.layout.IndexedArray64(index2, categories2.layout, parameters={"__array__": "categorical"})
+    array1 = awkward1.Array(categorical1)
+    array2 = awkward1.Array(categorical2)
+    assert (array1 == array2).tolist() == [False, False, True, False, False, True, True, False]
+
+
+def test_option_same_categories():
+    categories = awkward1.Array(["one", "two", "three"])
+    index1 = awkward1.layout.Index64(numpy.array([0, 2, 2, 1, -1,  0, 1, 0], dtype=numpy.int64))
+    index2 = awkward1.layout.Index64(numpy.array([1, 1, 2, 1, -1, -1, 0, 1], dtype=numpy.int64))
+    categorical1 = awkward1.layout.IndexedOptionArray64(index1, categories.layout, parameters={"__array__": "categorical"})
+    categorical2 = awkward1.layout.IndexedOptionArray64(index2, categories.layout, parameters={"__array__": "categorical"})
+    array1 = awkward1.Array(categorical1)
+    array2 = awkward1.Array(categorical2)
+    assert (array1 == array2).tolist() == [False, False, True, True, True, False, False, False]
+
+
+def test_option_different_categories():
+    categories1 = awkward1.Array(["one", "two", "three"])
+    categories2 = awkward1.Array(["three", "two", "one"])
+    index1 = awkward1.layout.Index64(numpy.array([0, 2, 2, 1, -1, -1, 1, 0], dtype=numpy.int64))
+    index2 = awkward1.layout.Index64(numpy.array([1, 1, 2, 1,  0, -1, 0, 1], dtype=numpy.int64))
+    categorical1 = awkward1.layout.IndexedOptionArray64(index1, categories1.layout, parameters={"__array__": "categorical"})
+    categorical2 = awkward1.layout.IndexedOptionArray64(index2, categories2.layout, parameters={"__array__": "categorical"})
+    array1 = awkward1.Array(categorical1)
+    array2 = awkward1.Array(categorical2)
+    assert (array1 == array2).tolist() == [False, False, False, True, False, True, False, False]
+
+
+def test_option_one_extra():
+    categories1 = awkward1.Array(["one", "two", "three", "four"])
+    categories2 = awkward1.Array(["three", "two", "one"])
+    index1 = awkward1.layout.Index64(numpy.array([0, -1,  0, 1, 2, 3, 1, 0], dtype=numpy.int64))
+    index2 = awkward1.layout.Index64(numpy.array([1, -1, -1, 1, 0, 0, 0, 1], dtype=numpy.int64))
+    categorical1 = awkward1.layout.IndexedOptionArray64(index1, categories1.layout, parameters={"__array__": "categorical"})
+    categorical2 = awkward1.layout.IndexedOptionArray64(index2, categories2.layout, parameters={"__array__": "categorical"})
+    array1 = awkward1.Array(categorical1)
+    array2 = awkward1.Array(categorical2)
+    assert (array1 == array2).tolist() == [False, True, False, True, True, False, False, False]
+
+
+def test_option_two_extra():
+    categories1 = awkward1.Array(["one", "two", "three"])
+    categories2 = awkward1.Array(["four", "three", "two", "one"])
+    index1 = awkward1.layout.Index64(numpy.array([0, -1, -1, 1, 2, 0, 1, 0], dtype=numpy.int64))
+    index2 = awkward1.layout.Index64(numpy.array([1, -1,  1, 1, 3, 3, 2, 1], dtype=numpy.int64))
+    categorical1 = awkward1.layout.IndexedOptionArray64(index1, categories1.layout, parameters={"__array__": "categorical"})
+    categorical2 = awkward1.layout.IndexedOptionArray64(index2, categories2.layout, parameters={"__array__": "categorical"})
+    array1 = awkward1.Array(categorical1)
+    array2 = awkward1.Array(categorical2)
+    assert (array1 == array2).tolist() == [False, True, False, False, False, True, True, False]

--- a/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -182,7 +182,16 @@ def test_to_categorical_masked():
 
 
 def test_typestr():
-    assert str(awkward1.type(awkward1.to_categorical(awkward1.Array([1.1, 2.2, 2.2, 3.3])))) == "4 * categorical[type=float64]"
-    assert str(awkward1.type(awkward1.to_categorical(awkward1.Array([1.1, 2.2, None, 2.2, 3.3])))) == "5 * categorical[type=?float64]"
-    assert str(awkward1.type(awkward1.to_categorical(awkward1.Array(["one", "two", "two", "three"])))) == "4 * categorical[type=string]"
-    assert str(awkward1.type(awkward1.to_categorical(awkward1.Array(["one", "two", None, "two", "three"])))) == "5 * categorical[type=option[string]]"
+    if not awkward1._util.py27:
+        assert str(awkward1.type(awkward1.to_categorical(awkward1.Array([1.1, 2.2, 2.2, 3.3])))) == "4 * categorical[type=float64]"
+        assert str(awkward1.type(awkward1.to_categorical(awkward1.Array([1.1, 2.2, None, 2.2, 3.3])))) == "5 * categorical[type=?float64]"
+        assert str(awkward1.type(awkward1.to_categorical(awkward1.Array(["one", "two", "two", "three"])))) == "4 * categorical[type=string]"
+        assert str(awkward1.type(awkward1.to_categorical(awkward1.Array(["one", "two", None, "two", "three"])))) == "5 * categorical[type=option[string]]"
+
+
+def test_zip():
+    x = awkward1.Array([1.1, 2.2, 3.3])
+    y = awkward1.Array(["one", "two", "three"])
+    assert awkward1.zip({"x": x, "y": y}).tolist() == [{"x": 1.1, "y": "one"}, {"x": 2.2, "y": "two"}, {"x": 3.3, "y": "three"}]
+    y = awkward1.to_categorical(y)
+    assert awkward1.zip({"x": x, "y": y}).tolist() == [{"x": 1.1, "y": "one"}, {"x": 2.2, "y": "two"}, {"x": 3.3, "y": "three"}]

--- a/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -102,3 +102,35 @@ def test_option_two_extra():
     array1 = awkward1.Array(categorical1)
     array2 = awkward1.Array(categorical2)
     assert (array1 == array2).tolist() == [False, True, False, False, False, True, True, False]
+
+
+def test_to_categorical():
+    array = awkward1.Array(["one", "two", "three", "one", "two", "three", "one", "two", "three"])
+    categorical = awkward1.to_categorical(array)
+    assert awkward1.to_list(array) == categorical.tolist()
+    assert awkward1.to_list(categorical.layout.content) == ["one", "two", "three"]
+
+
+def test_to_categorical_none():
+    array = awkward1.Array(["one", "two", "three", None, "one", "two", "three", None, "one", "two", "three", None])
+    categorical = awkward1.to_categorical(array)
+    assert awkward1.to_list(array) == categorical.tolist()
+    assert awkward1.to_list(categorical.layout.content) == ["one", "two", "three"]
+
+def test_to_categorical_masked():
+    content = awkward1.Array(["one", "two", "three", "one", "one", "two", "three", "two", "one", "two", "three", "three"]).layout
+    mask = awkward1.layout.Index8(numpy.array([False, False, False, True, False, False, False, True, False, False, False, True]))
+    array = awkward1.Array(awkward1.layout.ByteMaskedArray(mask, content, valid_when=False))
+    categorical = awkward1.to_categorical(array)
+    assert awkward1.to_list(array) == categorical.tolist()
+    assert awkward1.to_list(categorical.layout.content) == ["one", "two", "three"]
+
+def test_to_categorical_masked():
+    content = awkward1.Array(["one", "two", "three", "one", "one", "two", "three", "two"]).layout
+    index = awkward1.layout.Index64(numpy.array([0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3], dtype=numpy.int64))
+    indexedarray = awkward1.layout.IndexedArray64(index, content)
+    mask = awkward1.layout.Index8(numpy.array([False, False, False, True, False, False, False, True, False, False, False, True]))
+    array = awkward1.Array(awkward1.layout.ByteMaskedArray(mask, indexedarray, valid_when=False))
+    categorical = awkward1.to_categorical(array)
+    assert awkward1.to_list(array) == categorical.tolist()
+    assert awkward1.to_list(categorical.layout.content) == ["one", "two", "three"]

--- a/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -195,3 +195,12 @@ def test_zip():
     assert awkward1.zip({"x": x, "y": y}).tolist() == [{"x": 1.1, "y": "one"}, {"x": 2.2, "y": "two"}, {"x": 3.3, "y": "three"}]
     y = awkward1.to_categorical(y)
     assert awkward1.zip({"x": x, "y": y}).tolist() == [{"x": 1.1, "y": "one"}, {"x": 2.2, "y": "two"}, {"x": 3.3, "y": "three"}]
+
+
+pyarrow = pytest.importorskip("pyarrow")
+
+
+def test_arrow_nomask():
+    array = awkward1.Array([1.1, 2.2, 3.3, 4.4, None])
+    assert str(awkward1.type(awkward1.from_arrow(awkward1.to_arrow(array)))) == "5 * ?float64"
+    assert str(awkward1.type(awkward1.from_arrow(awkward1.to_arrow(array[:-1])))) == "4 * ?float64"

--- a/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -179,3 +179,10 @@ def test_to_categorical_masked():
     not_categorical = awkward1.from_categorical(categorical)
     assert not awkward1.is_categorical(not_categorical)
     assert awkward1.categories(categorical).tolist() == ["one", "two", "three"]
+
+
+def test_typestr():
+    assert str(awkward1.type(awkward1.to_categorical(awkward1.Array([1.1, 2.2, 2.2, 3.3])))) == "4 * categorical[type=float64]"
+    assert str(awkward1.type(awkward1.to_categorical(awkward1.Array([1.1, 2.2, None, 2.2, 3.3])))) == "5 * categorical[type=?float64]"
+    assert str(awkward1.type(awkward1.to_categorical(awkward1.Array(["one", "two", "two", "three"])))) == "4 * categorical[type=string]"
+    assert str(awkward1.type(awkward1.to_categorical(awkward1.Array(["one", "two", None, "two", "three"])))) == "5 * categorical[type=option[string]]"

--- a/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -104,26 +104,66 @@ def test_option_two_extra():
     assert (array1 == array2).tolist() == [False, True, False, False, False, True, True, False]
 
 
+def test_to_categorical_numbers():
+    array = awkward1.Array([1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3])
+    assert not awkward1.is_categorical(array)
+    categorical = awkward1.to_categorical(array)
+    assert awkward1.is_categorical(categorical)
+    assert awkward1.to_list(array) == categorical.tolist()
+    assert awkward1.to_list(categorical.layout.content) == [1.1, 2.2, 3.3]
+    not_categorical = awkward1.from_categorical(categorical)
+    assert not awkward1.is_categorical(not_categorical)
+    assert awkward1.categories(categorical).tolist() == [1.1, 2.2, 3.3]
+
+
+def test_to_categorical_nested():
+    array = awkward1.Array([["one", "two", "three"], [], ["one", "two"], ["three"]])
+    assert not awkward1.is_categorical(array)
+    categorical = awkward1.to_categorical(array)
+    assert awkward1.is_categorical(categorical)
+    assert awkward1.to_list(array) == categorical.tolist()
+    not_categorical = awkward1.from_categorical(categorical)
+    assert not awkward1.is_categorical(not_categorical)
+    assert awkward1.categories(categorical).tolist() == ["one", "two", "three"]
+
+
 def test_to_categorical():
     array = awkward1.Array(["one", "two", "three", "one", "two", "three", "one", "two", "three"])
+    assert not awkward1.is_categorical(array)
     categorical = awkward1.to_categorical(array)
+    assert awkward1.is_categorical(categorical)
     assert awkward1.to_list(array) == categorical.tolist()
     assert awkward1.to_list(categorical.layout.content) == ["one", "two", "three"]
+    not_categorical = awkward1.from_categorical(categorical)
+    assert not awkward1.is_categorical(not_categorical)
+    assert awkward1.categories(categorical).tolist() == ["one", "two", "three"]
 
 
 def test_to_categorical_none():
     array = awkward1.Array(["one", "two", "three", None, "one", "two", "three", None, "one", "two", "three", None])
+    assert not awkward1.is_categorical(array)
     categorical = awkward1.to_categorical(array)
+    assert awkward1.is_categorical(categorical)
     assert awkward1.to_list(array) == categorical.tolist()
     assert awkward1.to_list(categorical.layout.content) == ["one", "two", "three"]
+    not_categorical = awkward1.from_categorical(categorical)
+    assert not awkward1.is_categorical(not_categorical)
+    assert awkward1.categories(categorical).tolist() == ["one", "two", "three"]
+
 
 def test_to_categorical_masked():
     content = awkward1.Array(["one", "two", "three", "one", "one", "two", "three", "two", "one", "two", "three", "three"]).layout
     mask = awkward1.layout.Index8(numpy.array([False, False, False, True, False, False, False, True, False, False, False, True]))
     array = awkward1.Array(awkward1.layout.ByteMaskedArray(mask, content, valid_when=False))
+    assert not awkward1.is_categorical(array)
     categorical = awkward1.to_categorical(array)
+    assert awkward1.is_categorical(categorical)
     assert awkward1.to_list(array) == categorical.tolist()
     assert awkward1.to_list(categorical.layout.content) == ["one", "two", "three"]
+    not_categorical = awkward1.from_categorical(categorical)
+    assert not awkward1.is_categorical(not_categorical)
+    assert awkward1.categories(categorical).tolist() == ["one", "two", "three"]
+
 
 def test_to_categorical_masked():
     content = awkward1.Array(["one", "two", "three", "one", "one", "two", "three", "two"]).layout
@@ -131,6 +171,11 @@ def test_to_categorical_masked():
     indexedarray = awkward1.layout.IndexedArray64(index, content)
     mask = awkward1.layout.Index8(numpy.array([False, False, False, True, False, False, False, True, False, False, False, True]))
     array = awkward1.Array(awkward1.layout.ByteMaskedArray(mask, indexedarray, valid_when=False))
+    assert not awkward1.is_categorical(array)
     categorical = awkward1.to_categorical(array)
+    assert awkward1.is_categorical(categorical)
     assert awkward1.to_list(array) == categorical.tolist()
     assert awkward1.to_list(categorical.layout.content) == ["one", "two", "three"]
+    not_categorical = awkward1.from_categorical(categorical)
+    assert not awkward1.is_categorical(not_categorical)
+    assert awkward1.categories(categorical).tolist() == ["one", "two", "three"]


### PR DESCRIPTION
As discussed in #400.

Don't forget:

  - [x] Better string representation of categorical types.
  - [x] Zip without an explicit `depth_limit` should not break up strings.
  - [x] Arrays from Arrow without a bitmask must be mapped to `UnmaskedArray` to maintain type.
  - [x] Apply this to Arrow conversion.
