### PR TITLE
Fix nesting structure of arrays passed to ArrayBuilder.append.

### DIFF
--- a/src/awkward1/highlevel.py
+++ b/src/awkward1/highlevel.py
@@ -2576,7 +2576,9 @@ class ArrayBuilder(Iterable, Sized):
             if isinstance(obj, Record):
                 self._layout.append(obj.layout.array, obj.layout.at)
             elif isinstance(obj, Array):
+                self._layout.beginlist()
                 self._layout.extend(obj.layout)
+                self._layout.endlist()
             else:
                 self._layout.fromiter(obj)
 

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -214,8 +214,8 @@ namespace awkward {
     BuilderPtr tmp = builder_;
     for (int64_t i = 0;  i < array.get()->length();  i++) {
       tmp = builder_.get()->append(array, i);
+      maybeupdate(tmp);
     }
-    maybeupdate(tmp);
   }
 
   void

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -64,10 +64,10 @@ namespace awkward {
   const ContentPtr
   OptionBuilder::snapshot() const {
     Index64 index(index_.ptr(), 0, index_.length(), kernel::lib::cpu);
-    return std::make_shared<IndexedOptionArray64>(Identities::none(),
-                                                  util::Parameters(),
-                                                  index,
-                                                  content_.get()->snapshot());
+    return IndexedOptionArray64(Identities::none(),
+                                util::Parameters(),
+                                index,
+                                content_.get()->snapshot()).simplify_optiontype();
   }
 
   bool

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -74,11 +74,11 @@ namespace awkward {
     for (auto content : contents_) {
       contents.push_back(content.get()->snapshot());
     }
-    return std::make_shared<UnionArray8_64>(Identities::none(),
-                                            util::Parameters(),
-                                            tags,
-                                            index,
-                                            contents);
+    return UnionArray8_64(Identities::none(),
+                          util::Parameters(),
+                          tags,
+                          index,
+                          contents).simplify_uniontype(false);
   }
 
   bool

--- a/tests/test_0118-numba-cpointers.py
+++ b/tests/test_0118-numba-cpointers.py
@@ -124,7 +124,7 @@ def test_ArrayBuilder_append():
     assert isinstance(tmp.layout, awkward1.layout.IndexedArray64)
     assert isinstance(tmp.layout.content, awkward1.layout.RecordArray)
 
-    builder.append(array)
+    builder.extend(array)
     tmp = builder.snapshot()
     assert awkward1.to_list(tmp) == [{"x": 2.2, "y": [2, 2]}, {"x": 2.2, "y": [2, 2]}, {"x": 1.1, "y": [1]}, {"x": 3.3, "y": [3, 3, 3]}, {"x": 0.0, "y": []}, {"x": 1.1, "y": [1]}, {"x": 2.2, "y": [2, 2]}, {"x": 3.3, "y": [3, 3, 3]}]
     assert isinstance(tmp.layout, awkward1.layout.IndexedArray64)
@@ -162,6 +162,56 @@ def test_ArrayBuilder_append():
     builder.append(array3, 0)
     array4 = builder.snapshot()
     assert isinstance(array4.layout.content, awkward1.layout.ListOffsetArray64)
+
+def test_ArrayBuilder_append_2():
+    # issue 415
+    A = awkward1.from_numpy(numpy.array([0, 1, 2], dtype=numpy.float32))
+    B = awkward1.from_numpy(numpy.array([0, 1], dtype=numpy.float32))
+
+    builder = awkward1.ArrayBuilder()
+    with builder.list():
+        builder.append(A.tolist())
+    with builder.list():
+        builder.append(A.tolist())
+    with builder.list():
+        pass
+    with builder.list():
+        builder.append(B.tolist())
+
+    assert builder.snapshot().tolist() == [[[0, 1, 2]], [[0, 1, 2]], [], [[0, 1]]]
+
+    builder = awkward1.ArrayBuilder()
+    with builder.list():
+        builder.append(A)
+    with builder.list():
+        builder.append(A)
+    with builder.list():
+        pass
+    with builder.list():
+        builder.append(B)
+
+    assert builder.snapshot().tolist() == [[[0, 1, 2]], [[0, 1, 2]], [], [[0, 1]]]
+
+    @numba.njit
+    def f1(builder, A, B):
+        builder.begin_list()
+        builder.append(A)
+        builder.end_list()
+
+        builder.begin_list()
+        builder.append(A)
+        builder.end_list()
+
+        builder.begin_list()
+        builder.end_list()
+
+        builder.begin_list()
+        builder.append(B)
+        builder.end_list()
+
+        return builder
+
+    assert f1(awkward1.ArrayBuilder(), A, B).snapshot().tolist() == [[[0, 1, 2]], [[0, 1, 2]], [], [[0, 1]]]
 
 def test_views():
     assert awkward1.to_list(awkward1_numba_arrayview.ArrayView.fromarray(awkward1.Array([1.1, 2.2, 3.3, 4.4, 5.5], check_valid=True)).toarray()) == [1.1, 2.2, 3.3, 4.4, 5.5]

--- a/tests/test_0118-numba-cpointers.py
+++ b/tests/test_0118-numba-cpointers.py
@@ -164,7 +164,7 @@ def test_ArrayBuilder_append():
     assert isinstance(array4.layout.content, awkward1.layout.ListOffsetArray64)
 
 def test_ArrayBuilder_append_2():
-    # issue 415
+    # issue #415
     A = awkward1.from_numpy(numpy.array([0, 1, 2], dtype=numpy.float32))
     B = awkward1.from_numpy(numpy.array([0, 1], dtype=numpy.float32))
 
@@ -179,6 +179,7 @@ def test_ArrayBuilder_append_2():
         builder.append(B.tolist())
 
     assert builder.snapshot().tolist() == [[[0, 1, 2]], [[0, 1, 2]], [], [[0, 1]]]
+    assert str(awkward1.type(builder.snapshot())) == "4 * var * var * float64"
 
     builder = awkward1.ArrayBuilder()
     with builder.list():
@@ -191,6 +192,7 @@ def test_ArrayBuilder_append_2():
         builder.append(B)
 
     assert builder.snapshot().tolist() == [[[0, 1, 2]], [[0, 1, 2]], [], [[0, 1]]]
+    assert str(awkward1.type(builder.snapshot())) == "4 * var * var * float32"
 
     @numba.njit
     def f1(builder, A, B):


### PR DESCRIPTION
At least fix the bug in #415; maybe also address the original complaint about unions of T and T. (What's the best way to proceed? Make it automatic, slowing down some `snapshot` operations, or make `ak.simplify` a user-visible operation?)