### PR TITLE
NumpyArray::bytelength and NumpyArray::carry were wrong for non-contiguous; fixed.

### DIFF
--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -422,7 +422,11 @@ namespace awkward {
       return itemsize_;
     }
     else {
-      return shape_[0]*strides_[0];
+      ssize_t out = itemsize_;
+      for (size_t i = 0;  i < shape_.size();  i++) {
+        out += (shape_[i] - 1)*strides_[i];
+      }
+      return out;
     }
   }
 
@@ -638,7 +642,7 @@ namespace awkward {
       out << "strides=\"";
       for (std::size_t i = 0;  i < shape_.size();  i++) {
         if (i != 0) {
-          out << ", ";
+          out << " ";
         }
         out << strides_[i];
       }
@@ -1210,6 +1214,10 @@ namespace awkward {
 
   const ContentPtr
   NumpyArray::carry(const Index64& carry, bool allow_lazy) const {
+    if (!iscontiguous()) {
+      return contiguous().carry(carry, allow_lazy);
+    }
+
     std::shared_ptr<void> ptr(
       kernel::malloc<void>(ptr_lib_, carry.length()*((int64_t)strides_[0])));
     struct Error err = kernel::NumpyArray_getitem_next_null_64(

--- a/tests/test_0420-fix-numpyarray-carry-for-noncontiguous.py
+++ b/tests/test_0420-fix-numpyarray-carry-for-noncontiguous.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+
+import pytest
+
+import numpy
+import awkward1
+
+
+def test():
+    np_content = numpy.asfortranarray(numpy.arange(15).reshape(3, 5))
+    ak_content = awkward1.layout.NumpyArray(np_content)
+    offsets = awkward1.layout.Index64(numpy.array([0, 0, 1, 1, 2, 2, 3, 3]))
+    listoffsetarray = awkward1.layout.ListOffsetArray64(offsets, ak_content)
+    assert awkward1.to_list(listoffsetarray[1, 0]) == [0, 1, 2, 3, 4]
+    assert awkward1.to_list(listoffsetarray[3, 0]) == [5, 6, 7, 8, 9]


### PR DESCRIPTION
Fixes #418.