### PR TITLE
Fixes #186; proper string-escape sequences in util::quote.

### DIFF
--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -105,7 +105,7 @@ namespace awkward {
 
     int64_t
       fieldindex(const std::string& key) const override {
-      throw std::invalid_argument(std::string("key ") + util::quote(key, true)
+      throw std::invalid_argument(std::string("key ") + util::quote(key)
         + std::string(" does not exist (data are not records)") + FILENAME(__LINE__));
     }
 
@@ -138,7 +138,7 @@ namespace awkward {
 
     const FormPtr
       getitem_field(const std::string& key) const override {
-      throw std::invalid_argument(std::string("key ") + util::quote(key, true)
+      throw std::invalid_argument(std::string("key ") + util::quote(key)
         + std::string(" does not exist (data are not records)"));
     }
 
@@ -756,7 +756,7 @@ namespace awkward {
     int64_t
       fieldindex(const std::string& key) const override {
       throw std::invalid_argument(
-        std::string("key ") + util::quote(key, true)
+        std::string("key ") + util::quote(key)
         + std::string(" does not exist (data are not records)")
         + FILENAME(__LINE__));
     }

--- a/include/awkward/util.h
+++ b/include/awkward/util.h
@@ -110,7 +110,7 @@ namespace awkward {
     /// strings. See issue
     /// [scikit-hep/awkward-1.0#186](https://github.com/scikit-hep/awkward-1.0/issues/186).
     std::string
-      quote(const std::string& x, bool doublequote);
+      quote(const std::string& x);
 
     /// @brief Converts an `offsets` index (from
     /// {@link ListOffsetArrayOf ListOffsetArray}, for instance) into a

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -1606,7 +1606,7 @@ namespace awkward {
       std::stringstream out;
       out << indent << pre << "<parameters>\n";
       for (auto pair : parameters_) {
-        out << indent << "    <param key=" << util::quote(pair.first, true)
+        out << indent << "    <param key=" << util::quote(pair.first)
             << ">" << pair.second << "</param>\n";
       }
       out << indent << "</parameters>" << post;

--- a/src/libawkward/Identities.cpp
+++ b/src/libawkward/Identities.cpp
@@ -131,7 +131,7 @@ namespace awkward {
       out << ptr_.get()[offset_ + at*width_ + i];
       for (auto pair : fieldloc_) {
         if (pair.first == i) {
-          out << ", " << util::quote(pair.second, true);
+          out << ", " << util::quote(pair.second);
         }
       }
     }
@@ -174,15 +174,14 @@ namespace awkward {
       name = "Identities64";
     }
     out << indent << pre << "<" << name << " ref=\"" << ref_
-        << "\" fieldloc=\"[";
+        << "\" fieldloc=\"";
     for (size_t i = 0;  i < fieldloc_.size();  i++) {
       if (i != 0) {
         out << " ";
       }
-      out << "(" << fieldloc_[i].first << ", "
-          << util::quote(fieldloc_[i].second, false) << ")";
+      out << fieldloc_[i].first << ": " << fieldloc_[i].second;
     }
-    out << "]\" width=\"" << width_ << "\" offset=\"" << offset_
+    out << "\" width=\"" << width_ << "\" offset=\"" << offset_
         << "\" length=\"" << length_ << "\" at=\"0x";
     out << std::hex << std::setw(12) << std::setfill('0')
         << reinterpret_cast<ssize_t>(ptr_.get()) << "\"/>" << post;

--- a/src/libawkward/Reducer.cpp
+++ b/src/libawkward/Reducer.cpp
@@ -48,7 +48,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -172,7 +172,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -190,7 +190,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -207,7 +207,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -224,7 +224,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -241,7 +241,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -258,7 +258,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -275,7 +275,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -292,7 +292,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -309,7 +309,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -326,7 +326,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -343,7 +343,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -409,7 +409,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -438,7 +438,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -467,7 +467,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -496,7 +496,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -525,7 +525,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -554,7 +554,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -583,7 +583,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -600,7 +600,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -617,7 +617,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -634,7 +634,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -651,7 +651,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -717,7 +717,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -746,7 +746,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -775,7 +775,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -804,7 +804,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -833,7 +833,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -862,7 +862,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -891,7 +891,7 @@ namespace awkward {
       parents.length(),
       outlength);
 #endif
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -908,7 +908,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -925,7 +925,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -942,7 +942,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -959,7 +959,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -993,7 +993,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1010,7 +1010,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1027,7 +1027,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1044,7 +1044,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1061,7 +1061,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1078,7 +1078,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1095,7 +1095,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1112,7 +1112,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1129,7 +1129,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1146,7 +1146,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1163,7 +1163,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1197,7 +1197,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1214,7 +1214,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1231,7 +1231,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1248,7 +1248,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1265,7 +1265,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1282,7 +1282,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1299,7 +1299,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1316,7 +1316,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1333,7 +1333,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1350,7 +1350,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1367,7 +1367,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1396,7 +1396,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1414,7 +1414,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<int8_t>::max());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1432,7 +1432,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<uint8_t>::max());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1450,7 +1450,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<int16_t>::max());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1468,7 +1468,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<uint16_t>::max());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1486,7 +1486,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<int32_t>::max());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1504,7 +1504,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<uint32_t>::max());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1522,7 +1522,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<int64_t>::max());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1540,7 +1540,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<uint64_t>::max());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1558,7 +1558,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<float>::infinity());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1576,7 +1576,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<double>::infinity());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1605,7 +1605,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1623,7 +1623,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<int8_t>::min());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1641,7 +1641,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<uint8_t>::min());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1659,7 +1659,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<int16_t>::min());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1677,7 +1677,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<uint16_t>::min());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1695,7 +1695,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<int32_t>::min());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1713,7 +1713,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<uint32_t>::min());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1731,7 +1731,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<int64_t>::min());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1749,7 +1749,7 @@ namespace awkward {
       parents.length(),
       outlength,
       std::numeric_limits<uint64_t>::min());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1767,7 +1767,7 @@ namespace awkward {
       parents.length(),
       outlength,
       -std::numeric_limits<float>::infinity());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1785,7 +1785,7 @@ namespace awkward {
       parents.length(),
       outlength,
       -std::numeric_limits<double>::infinity());
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1824,7 +1824,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1841,7 +1841,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1858,7 +1858,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1875,7 +1875,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1892,7 +1892,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1909,7 +1909,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1926,7 +1926,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1943,7 +1943,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1960,7 +1960,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1977,7 +1977,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -1994,7 +1994,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2033,7 +2033,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2050,7 +2050,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2067,7 +2067,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2084,7 +2084,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2101,7 +2101,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2118,7 +2118,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2135,7 +2135,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2152,7 +2152,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2169,7 +2169,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2186,7 +2186,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 
@@ -2203,7 +2203,7 @@ namespace awkward {
       parents.data(),
       parents.length(),
       outlength);
-    util::handle_error(err, util::quote(name(), true), nullptr);
+    util::handle_error(err, util::quote(name()), nullptr);
     return ptr;
   }
 

--- a/src/libawkward/Slice.cpp
+++ b/src/libawkward/Slice.cpp
@@ -345,7 +345,7 @@ namespace awkward {
 
   const std::string
   SliceField::tostring() const {
-    return util::quote(key_, true);
+    return util::quote(key_);
   }
 
   bool
@@ -376,7 +376,7 @@ namespace awkward {
       if (i != 0) {
         out << ", ";
       }
-      out << util::quote(keys_[i], true);
+      out << util::quote(keys_[i]);
     }
     out << "]";
     return out.str();

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -82,7 +82,7 @@ namespace awkward {
   int64_t
   EmptyForm::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
-      std::string("key ") + util::quote(key, true)
+      std::string("key ") + util::quote(key)
       + std::string(" does not exist (data might not be records)")
       + FILENAME(__LINE__));
   }
@@ -134,7 +134,7 @@ namespace awkward {
   const FormPtr
   EmptyForm::getitem_field(const std::string& key) const {
     throw std::invalid_argument(
-      std::string("key ") + util::quote(key, true)
+      std::string("key ") + util::quote(key)
       + std::string(" does not exist (data might not be records)"));
   }
 
@@ -336,7 +336,7 @@ namespace awkward {
   int64_t
   EmptyArray::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
-      std::string("key ") + util::quote(key, true)
+      std::string("key ") + util::quote(key)
       + std::string(" does not exist (data might not be records)")
       + FILENAME(__LINE__));
   }

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -210,7 +210,7 @@ namespace awkward {
   int64_t
   NumpyForm::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
-      std::string("key ") + util::quote(key, true)
+      std::string("key ") + util::quote(key)
       + std::string(" does not exist (data are not records)")
       + FILENAME(__LINE__));
   }
@@ -262,7 +262,7 @@ namespace awkward {
   const FormPtr
   NumpyForm::getitem_field(const std::string& key) const {
     throw std::invalid_argument(
-      std::string("key ") + util::quote(key, true)
+      std::string("key ") + util::quote(key)
       + std::string(" does not exist (data are not records)"));
   }
 
@@ -630,7 +630,7 @@ namespace awkward {
                             const std::string& post) const {
     std::stringstream out;
     out << indent << pre << "<" << classname() << " format="
-        << util::quote(format_, true) << " shape=\"";
+        << util::quote(format_) << " shape=\"";
     for (std::size_t i = 0;  i < shape_.size();  i++) {
       if (i != 0) {
         out << " ";
@@ -1256,7 +1256,7 @@ namespace awkward {
   int64_t
   NumpyArray::fieldindex(const std::string& key) const {
     throw std::invalid_argument(
-      std::string("key ") + util::quote(key, true)
+      std::string("key ") + util::quote(key)
       + std::string(" does not exist (data are not records)")
       + FILENAME(__LINE__));
   }

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -195,7 +195,7 @@ namespace awkward {
   Record::getitem_at(int64_t at) const {
     throw std::invalid_argument(
       std::string("scalar Record can only be sliced by field name (string); "
-                  "try ") + util::quote(std::to_string(at), true)
+                  "try ") + util::quote(std::to_string(at))
       + FILENAME(__LINE__));
   }
 
@@ -203,7 +203,7 @@ namespace awkward {
   Record::getitem_at_nowrap(int64_t at) const {
     throw std::invalid_argument(
       std::string("scalar Record can only be sliced by field name (string); "
-                  "try ") + util::quote(std::to_string(at), true)
+                  "try ") + util::quote(std::to_string(at))
       + FILENAME(__LINE__));
   }
 

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -100,7 +100,7 @@ namespace awkward {
     }
     util::Parameters parameters;
     if (nameptr_ != nullptr) {
-      parameters["__record__"] = util::quote(name_, true);
+      parameters["__record__"] = util::quote(name_);
     }
     ContentPtrVec contents;
     util::RecordLookupPtr recordlookup =
@@ -489,7 +489,7 @@ namespace awkward {
         }
         if (contents_[i].get()->length() != length_ + 1) {
           throw std::invalid_argument(
-            std::string("record field ") + util::quote(keys_[i], true)
+            std::string("record field ") + util::quote(keys_[i])
             + std::string(" filled more than once") + FILENAME(__LINE__));
         }
       }

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -73,7 +73,7 @@ namespace awkward {
     }
     else {
       throw std::invalid_argument(
-        std::string("unsupported encoding: ") + util::quote(encoding_, false)
+        std::string("unsupported encoding: ") + util::quote(encoding_)
         + FILENAME(__LINE__));
     }
 

--- a/src/libawkward/type/RecordType.cpp
+++ b/src/libawkward/type/RecordType.cpp
@@ -83,7 +83,7 @@ namespace awkward {
             out << ", ";
           }
           if (recordlookup_.get() != nullptr) {
-            out << util::quote(recordlookup_.get()->at(j), true) << ": ";
+            out << util::quote(recordlookup_.get()->at(j)) << ": ";
           }
           out << types_[j].get()->tostring_part("", "", "");
         }
@@ -99,7 +99,7 @@ namespace awkward {
           if (j != 0) {
             out << ", ";
           }
-          out << util::quote(recordlookup_.get()->at(j), true) << ": ";
+          out << util::quote(recordlookup_.get()->at(j)) << ": ";
           out << types_[j].get()->tostring_part("", "", "");
         }
         out << "}";
@@ -122,7 +122,7 @@ namespace awkward {
           if (j != 0) {
             out << ", ";
           }
-          out << util::quote(recordlookup_.get()->at(j), true);
+          out << util::quote(recordlookup_.get()->at(j));
         }
         out << "], [";
         for (size_t j = 0;  j < types_.size();  j++) {

--- a/src/libawkward/type/Type.cpp
+++ b/src/libawkward/type/Type.cpp
@@ -133,7 +133,7 @@ namespace awkward {
         if (!first) {
           out << ", ";
         }
-        out << util::quote(pair.first, true) << ": " << pair.second;
+        out << util::quote(pair.first) << ": " << pair.second;
         first = false;
       }
     }

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -6,6 +6,8 @@
 #include <set>
 
 #include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 
 #include "awkward/kernels/identities.h"
 #include "awkward/kernels/getitem.h"
@@ -454,13 +456,11 @@ namespace awkward {
     template IndexOf<int64_t> make_stops(const IndexOf<int64_t> &offsets);
 
     std::string
-    quote(const std::string &x, bool doublequote) {
-      // TODO: escape characters, possibly using RapidJSON.
-      if (doublequote) {
-        return std::string("\"") + x + std::string("\"");
-      } else {
-        return std::string("'") + x + std::string("'");
-      }
+    quote(const std::string &x) {
+      rj::StringBuffer buffer;
+      rj::Writer<rj::StringBuffer> writer(buffer);
+      writer.String(x.c_str(), x.length());
+      return std::string(buffer.GetString());
     }
 
     RecordLookupPtr
@@ -491,7 +491,7 @@ namespace awkward {
         }
         catch (std::invalid_argument err) {
           throw std::invalid_argument(
-            std::string("key ") + quote(key, true)
+            std::string("key ") + quote(key)
             + std::string(" does not exist (not in record)") + FILENAME(__LINE__));
         }
         if (!(0 <= out && out < numfields)) {

--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -77,7 +77,7 @@ box(const std::shared_ptr<ak::Content>& content) {
           if (raw->ptr_lib() == ak::kernel::lib::cuda) {
             throw std::runtime_error(
               std::string("not implemented: format ")
-              + ak::util::quote(raw->format(), true)
+              + ak::util::quote(raw->format())
               + std::string(" in CUDA")
               + FILENAME(__LINE__));
           }


### PR DESCRIPTION
I got tired of looking at that as a "bug" when it's easily fixable.