### PR TITLE
Allow ArrayCache(None) construction

### DIFF
--- a/src/python/virtual.cpp
+++ b/src/python/virtual.cpp
@@ -358,7 +358,7 @@ PyArrayCache::set(const std::string& key, const ak::ContentPtr& value) {
                                      "surrogateescape"));
   const py::object mapping = mutablemapping();
   if ( ! mapping.is(py::none()) ) {
-    mutablemapping().attr("__setitem__")(pykey, box(value));
+    mapping.attr("__setitem__")(pykey, box(value));
   }
 }
 

--- a/tests/test_0057-virtual-array.py
+++ b/tests/test_0057-virtual-array.py
@@ -270,6 +270,14 @@ def test_basic():
     assert awkward1.to_list(virtualarray.array) == [1.1, 2.2, 3.3, 4.4, 5.5]
     assert awkward1.to_list(d[virtualarray.cache_key]) == [1.1, 2.2, 3.3, 4.4, 5.5]
 
+    cache = awkward1.layout.ArrayCache(None)
+
+    virtualarray = awkward1.layout.VirtualArray(generator, cache)
+    assert virtualarray.peek_array is None
+    assert virtualarray.array is not None
+    assert virtualarray.peek_array is None
+    assert awkward1.to_list(virtualarray.array) == [1.1, 2.2, 3.3, 4.4, 5.5]
+
 def test_slice():
     generator = awkward1.layout.ArrayGenerator(
         lambda: awkward1.Array([[1.1, 2.2, 3.3, 4.4, 5.5], [6.6, 7.7, 8.8], [100, 200, 300, 400]]),


### PR DESCRIPTION
An omission from the previous implementation of weakrefs.
Apparently I had no cases of creating arrays that didn't have some sort of cache.