### PR TITLE
Libraries and includes should only go into the Python directory, not multiple places.

### DIFF
--- a/.ci/azure-buildtest-awkward.yml
+++ b/.ci/azure-buildtest-awkward.yml
@@ -308,6 +308,8 @@ jobs:
           cmake --build build
           export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
           echo $LD_LIBRARY_PATH
+          ls build/dependent*
+          ldd build/dependent*
           pytest -vv test-python.py
         workingDirectory: dependent-project
         displayName: "Test dependent project 3"

--- a/.ci/azure-buildtest-awkward.yml
+++ b/.ci/azure-buildtest-awkward.yml
@@ -27,155 +27,150 @@ pr:
       - "*"
 
 jobs:
-  - job: Windows
+  # - job: Windows
 
-    pool:
-      vmImage: "vs2017-win2016"
+  #   pool:
+  #     vmImage: "vs2017-win2016"
 
-    variables:
-      PIP_ONLY_BINARY: cmake
+  #   variables:
+  #     PIP_ONLY_BINARY: cmake
 
-    strategy:
-      matrix:
-        "py27-32bit":
-          python.version: "2.7"
-          python.architecture: "x86"
-          numpy.version: "1.16.5"
-        "py27-64bit":
-          python.version: "2.7"
-          python.architecture: "x64"
-          numpy.version: "1.16.5"
-        "py35-64bit":
-          python.version: "3.5"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py36-64bit":
-          python.version: "3.6"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py37-32bit":
-          python.version: "3.7"
-          python.architecture: "x86"
-          numpy.version: "latest"
-        "py37-64bit":
-          python.version: "3.7"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py38-32bit":
-          python.version: "3.8"
-          python.architecture: "x86"
-          numpy.version: "latest"
-        "py38-64bit":
-          python.version: "3.8"
-          python.architecture: "x64"
-          numpy.version: "latest"
+  #   strategy:
+  #     matrix:
+  #       "py27-32bit":
+  #         python.version: "2.7"
+  #         python.architecture: "x86"
+  #         numpy.version: "1.16.5"
+  #       "py27-64bit":
+  #         python.version: "2.7"
+  #         python.architecture: "x64"
+  #         numpy.version: "1.16.5"
+  #       "py35-64bit":
+  #         python.version: "3.5"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py36-64bit":
+  #         python.version: "3.6"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py37-32bit":
+  #         python.version: "3.7"
+  #         python.architecture: "x86"
+  #         numpy.version: "latest"
+  #       "py37-64bit":
+  #         python.version: "3.7"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py38-32bit":
+  #         python.version: "3.8"
+  #         python.architecture: "x86"
+  #         numpy.version: "latest"
+  #       "py38-64bit":
+  #         python.version: "3.8"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
 
-    steps:
-      - checkout: self
-        submodules: recursive
+  #   steps:
+  #     - checkout: self
+  #       submodules: recursive
 
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '$(python.version)'
-          architecture: '$(python.architecture)'
-        displayName: 'Python $(python.version)'
+  #     - task: UsePythonVersion@0
+  #       inputs:
+  #         versionSpec: '$(python.version)'
+  #         architecture: '$(python.architecture)'
+  #       displayName: 'Python $(python.version)'
 
-      - script: |
-          python -m pip install --upgrade pip
-        displayName: "Install Pip"
-      - script: |
-          python -m pip list
-        displayName: "Show versions"
-      - script: |
-          python -m pip install -v .[test,dev]
-        displayName: "Build"
-      - script: |
-          python dev/generate-kernelspec.py
-        displayName: "Generate Kernel specification"
-      - script: |
-          python dev/generate-tests.py
-        displayName: "Generate Kernel tests"
-      - script: |
-          python -m pytest -vv -rs tests-spec
-        displayName: "Test specification"
-      - script: |
-          python -m pytest -vv -rs tests-cpu-kernels
-        displayName: "Test CPU kernels"
-      - script: |
-          python -m pytest -vv -rs tests
-        displayName: "Test"
+  #     - script: |
+  #         python -m pip install --upgrade pip
+  #       displayName: "Install Pip"
+  #     - script: |
+  #         python -m pip list
+  #       displayName: "Show versions"
+  #     - script: |
+  #         python -m pip install -v .[test,dev]
+  #       displayName: "Build"
+  #     - script: |
+  #         python dev/generate-kernelspec.py
+  #       displayName: "Generate Kernel specification"
+  #     - script: |
+  #         python dev/generate-tests.py
+  #       displayName: "Generate Kernel tests"
+  #     - script: |
+  #         python -m pytest -vv -rs tests-spec
+  #       displayName: "Test specification"
+  #     - script: |
+  #         python -m pytest -vv -rs tests-cpu-kernels
+  #       displayName: "Test CPU kernels"
+  #     - script: |
+  #         python -m pytest -vv -rs tests
+  #       displayName: "Test"
 
-  - job: MacOS
+  # - job: MacOS
 
-    pool:
-      vmImage: "macOS-10.14"
+  #   pool:
+  #     vmImage: "macOS-10.14"
 
-    variables:
-      PIP_ONLY_BINARY: cmake
+  #   variables:
+  #     PIP_ONLY_BINARY: cmake
 
-    strategy:
-      matrix:
-        "py27":
-          python.version: "2.7"
-          python.architecture: "x64"
-          numpy.version: "1.16.5"
-        "py35":
-          python.version: "3.5"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py36":
-          python.version: "3.6"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py37":
-          python.version: "3.7"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py38":
-          python.version: "3.8"
-          python.architecture: "x64"
-          numpy.version: "latest"
+  #   strategy:
+  #     matrix:
+  #       "py27":
+  #         python.version: "2.7"
+  #         python.architecture: "x64"
+  #         numpy.version: "1.16.5"
+  #       "py35":
+  #         python.version: "3.5"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py36":
+  #         python.version: "3.6"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py37":
+  #         python.version: "3.7"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py38":
+  #         python.version: "3.8"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
 
-    steps:
-      - checkout: self
-        submodules: recursive
+  #   steps:
+  #     - checkout: self
+  #       submodules: recursive
 
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '$(python.version)'
-          architecture: '$(python.architecture)'
-        displayName: 'Python $(python.version)'
+  #     - task: UsePythonVersion@0
+  #       inputs:
+  #         versionSpec: '$(python.version)'
+  #         architecture: '$(python.architecture)'
+  #       displayName: 'Python $(python.version)'
 
-      - script: |
-          python -m pip install --upgrade pip
-        displayName: "Install Pip"
-      - script: |
-          python -m pip list
-        displayName: "Print versions"
+  #     - script: |
+  #         python -m pip install --upgrade pip
+  #       displayName: "Install Pip"
+  #     - script: |
+  #         python -m pip list
+  #       displayName: "Print versions"
 
-      - script: |
-          python -m pip install -v .[test,dev]
-        displayName: "Build"
-      - script: |
-          python dev/generate-kernelspec.py
-        displayName: "Generate Kernel specification"
-      - script: |
-          python dev/generate-tests.py
-        displayName: "Generate Kernel tests"
-      - script: |
-          python -m pytest -vv -rs tests-spec
-        displayName: "Test specification"
-      - script: |
-          python -m pytest -vv -rs tests-cpu-kernels
-        displayName: "Test CPU kernels"
-      - script: |
-          python -m pytest -vv -rs tests
-        displayName: "Test"
-
-      # - script: |
-      #     cmake -S . -B build  &&  cmake --build build  &&  python -m pytest -vv tests.py
-      #   workingDirectory: dependent-project
-      #   displayName: "Test dependent project"
+  #     - script: |
+  #         python -m pip install -v .[test,dev]
+  #       displayName: "Build"
+  #     - script: |
+  #         python dev/generate-kernelspec.py
+  #       displayName: "Generate Kernel specification"
+  #     - script: |
+  #         python dev/generate-tests.py
+  #       displayName: "Generate Kernel tests"
+  #     - script: |
+  #         python -m pytest -vv -rs tests-spec
+  #       displayName: "Test specification"
+  #     - script: |
+  #         python -m pytest -vv -rs tests-cpu-kernels
+  #       displayName: "Test CPU kernels"
+  #     - script: |
+  #         python -m pytest -vv -rs tests
+  #       displayName: "Test"
 
   - job: Linux
 
@@ -263,8 +258,13 @@ jobs:
           bash cuda-build.sh
         displayName: "Test-build the cuda-kernels"
         condition: "ne(variables['python.version'], '2.7')"
-
-      # - script: |
-      #     cmake -S . -B build  &&  cmake --build build  &&  python -m pytest -vv tests.py
-      #   workingDirectory: dependent-project
-      #   displayName: "Test dependent project"
+      - script: |
+          python -m awkward1.config --cflags --libs
+          g++ `python -m awkward1.config --cflags --libs` minimal.cpp -o minimal
+          export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
+          ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
+          cmake -S . -B build
+          cmake --build build
+          pytest -vv test-python.py
+        workingDirectory: dependent-project
+        displayName: "Test dependent project"

--- a/.ci/azure-buildtest-awkward.yml
+++ b/.ci/azure-buildtest-awkward.yml
@@ -304,12 +304,14 @@ jobs:
         displayName: "Test dependent project 2"
 
       - script: |
-          cmake -S . -B build
+          which python
+          python -c 'import sys; print(sys.version)'
+          cmake -S . -B build -DPYTHON_EXECUTABLE:FILEPATH=`which python`
           cmake --build build
           export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
           echo $LD_LIBRARY_PATH
           ls build/dependent*
           ldd build/dependent*
-          pytest -vv test-python.py
+          python -m pytest -vv test-python.py
         workingDirectory: dependent-project
         displayName: "Test dependent project 3"

--- a/.ci/azure-buildtest-awkward.yml
+++ b/.ci/azure-buildtest-awkward.yml
@@ -282,23 +282,32 @@ jobs:
       #   condition: "ne(variables['python.version'], '2.7')"
 
       - script: |
-          ls `python -m awkward1.config --incdir`
+          echo '===== include directory ============================='
+          ls -R `python -m awkward1.config --incdir`
+          echo '===== library directory ============================='
           ls `python -m awkward1.config --libdir`
-          g++ `python -m awkward1.config --cflags --libs` minimal.cpp -o minimal
-          export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
-          echo $LD_LIBRARY_PATH
+          echo '===== compilation ==================================='
+          g++ minimal.cpp `python -m awkward1.config --cflags --static-libs` -o minimal
           ldd minimal
           ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
         workingDirectory: dependent-project
         displayName: "Test dependent project 1"
 
       - script: |
-          ls `python -m awkward1.config --incdir`
-          ls `python -m awkward1.config --libdir`
+          rm -f minimal
+          g++ minimal.cpp `python -m awkward1.config --cflags --libs` -o minimal
+          export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
+          echo $LD_LIBRARY_PATH
+          ldd minimal
+          ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
+        workingDirectory: dependent-project
+        displayName: "Test dependent project 2"
+
+      - script: |
           cmake -S . -B build
           cmake --build build
           export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
           echo $LD_LIBRARY_PATH
           pytest -vv test-python.py
         workingDirectory: dependent-project
-        displayName: "Test dependent project 2"
+        displayName: "Test dependent project 3"

--- a/.ci/azure-buildtest-awkward.yml
+++ b/.ci/azure-buildtest-awkward.yml
@@ -83,24 +83,31 @@ jobs:
   #     - script: |
   #         python -m pip install --upgrade pip
   #       displayName: "Install Pip"
+
   #     - script: |
   #         python -m pip list
   #       displayName: "Show versions"
+
   #     - script: |
   #         python -m pip install -v .[test,dev]
   #       displayName: "Build"
+
   #     - script: |
   #         python dev/generate-kernelspec.py
   #       displayName: "Generate Kernel specification"
+
   #     - script: |
   #         python dev/generate-tests.py
   #       displayName: "Generate Kernel tests"
+
   #     - script: |
   #         python -m pytest -vv -rs tests-spec
   #       displayName: "Test specification"
+
   #     - script: |
   #         python -m pytest -vv -rs tests-cpu-kernels
   #       displayName: "Test CPU kernels"
+
   #     - script: |
   #         python -m pytest -vv -rs tests
   #       displayName: "Test"
@@ -149,6 +156,7 @@ jobs:
   #     - script: |
   #         python -m pip install --upgrade pip
   #       displayName: "Install Pip"
+
   #     - script: |
   #         python -m pip list
   #       displayName: "Print versions"
@@ -156,18 +164,23 @@ jobs:
   #     - script: |
   #         python -m pip install -v .[test,dev]
   #       displayName: "Build"
+
   #     - script: |
   #         python dev/generate-kernelspec.py
   #       displayName: "Generate Kernel specification"
+
   #     - script: |
   #         python dev/generate-tests.py
   #       displayName: "Generate Kernel tests"
+
   #     - script: |
   #         python -m pytest -vv -rs tests-spec
   #       displayName: "Test specification"
+
   #     - script: |
   #         python -m pytest -vv -rs tests-cpu-kernels
   #       displayName: "Test CPU kernels"
+
   #     - script: |
   #         python -m pytest -vv -rs tests
   #       displayName: "Test"
@@ -220,6 +233,7 @@ jobs:
       - script: |
           python -m pip install --upgrade pip
         displayName: "Install Pip"
+
       - script: |
           if [ $(numpy.version) = "latest" ]; then
             python -m pip install numpy;
@@ -227,6 +241,7 @@ jobs:
             python -m pip install numpy==$(numpy.version);
           fi
         displayName: "Install NumPy"
+
       - script: |
           python -m pip list
         displayName: "Print versions"
@@ -234,37 +249,56 @@ jobs:
       - script: |
           python -m pip install -v .[test,dev]
         displayName: "Build"
+
+      # - script: |
+      #     python dev/generate-kernelspec.py
+      #   displayName: "Generate Kernel specification"
+
+      # - script: |
+      #     python dev/generate-tests.py
+      #   displayName: "Generate Kernel tests"
+
+      # - script: |
+      #     python -m pytest -vv -rs tests-spec
+      #   displayName: "Test specification"
+
+      # - script: |
+      #     python -m pytest -vv -rs tests-cpu-kernels
+      #   displayName: "Test CPU kernels"
+
+      # - script: |
+      #     python -m pytest -vv -rs tests
+      #   displayName: "Test"
+
+      # - script: |
+      #     python dev/generate-cuda.py
+      #   displayName: "Generate CUDA kernels"
+      #   condition: "ne(variables['python.version'], '3.8')"
+
+      # - script: |
+      #     python -m pip install wheel
+      #     bash cuda-build.sh
+      #   displayName: "Build the cuda-kernels"
+      #   condition: "ne(variables['python.version'], '2.7')"
+
       - script: |
-          python dev/generate-kernelspec.py
-        displayName: "Generate Kernel specification"
-      - script: |
-          python dev/generate-tests.py
-        displayName: "Generate Kernel tests"
-      - script: |
-          python -m pytest -vv -rs tests-spec
-        displayName: "Test specification"
-      - script: |
-          python -m pytest -vv -rs tests-cpu-kernels
-        displayName: "Test CPU kernels"
-      - script: |
-          python -m pytest -vv -rs tests
-        displayName: "Test"
-      - script: |
-          python dev/generate-cuda.py
-        displayName: "Generate CUDA kernels"
-        condition: "ne(variables['python.version'], '3.8')"
-      - script: |
-          python -m pip install wheel
-          bash cuda-build.sh
-        displayName: "Test-build the cuda-kernels"
-        condition: "ne(variables['python.version'], '2.7')"
-      - script: |
-          python -m awkward1.config --cflags --libs
+          ls `python -m awkward1.config --incdir`
+          ls `python -m awkward1.config --libdir`
           g++ `python -m awkward1.config --cflags --libs` minimal.cpp -o minimal
           export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
+          echo $LD_LIBRARY_PATH
+          ldd minimal
           ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
+        workingDirectory: dependent-project
+        displayName: "Test dependent project 1"
+
+      - script: |
+          ls `python -m awkward1.config --incdir`
+          ls `python -m awkward1.config --libdir`
           cmake -S . -B build
           cmake --build build
+          export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
+          echo $LD_LIBRARY_PATH
           pytest -vv test-python.py
         workingDirectory: dependent-project
-        displayName: "Test dependent project"
+        displayName: "Test dependent project 2"

--- a/.ci/azure-buildtest-awkward.yml
+++ b/.ci/azure-buildtest-awkward.yml
@@ -27,90 +27,90 @@ pr:
       - "*"
 
 jobs:
-  # - job: Windows
+  - job: Windows
 
-  #   pool:
-  #     vmImage: "vs2017-win2016"
+    pool:
+      vmImage: "vs2017-win2016"
 
-  #   variables:
-  #     PIP_ONLY_BINARY: cmake
+    variables:
+      PIP_ONLY_BINARY: cmake
 
-  #   strategy:
-  #     matrix:
-  #       "py27-32bit":
-  #         python.version: "2.7"
-  #         python.architecture: "x86"
-  #         numpy.version: "1.16.5"
-  #       "py27-64bit":
-  #         python.version: "2.7"
-  #         python.architecture: "x64"
-  #         numpy.version: "1.16.5"
-  #       "py35-64bit":
-  #         python.version: "3.5"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py36-64bit":
-  #         python.version: "3.6"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py37-32bit":
-  #         python.version: "3.7"
-  #         python.architecture: "x86"
-  #         numpy.version: "latest"
-  #       "py37-64bit":
-  #         python.version: "3.7"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py38-32bit":
-  #         python.version: "3.8"
-  #         python.architecture: "x86"
-  #         numpy.version: "latest"
-  #       "py38-64bit":
-  #         python.version: "3.8"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
+    strategy:
+      matrix:
+        "py27-32bit":
+          python.version: "2.7"
+          python.architecture: "x86"
+          numpy.version: "1.16.5"
+        "py27-64bit":
+          python.version: "2.7"
+          python.architecture: "x64"
+          numpy.version: "1.16.5"
+        "py35-64bit":
+          python.version: "3.5"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py36-64bit":
+          python.version: "3.6"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py37-32bit":
+          python.version: "3.7"
+          python.architecture: "x86"
+          numpy.version: "latest"
+        "py37-64bit":
+          python.version: "3.7"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py38-32bit":
+          python.version: "3.8"
+          python.architecture: "x86"
+          numpy.version: "latest"
+        "py38-64bit":
+          python.version: "3.8"
+          python.architecture: "x64"
+          numpy.version: "latest"
 
-  #   steps:
-  #     - checkout: self
-  #       submodules: recursive
+    steps:
+      - checkout: self
+        submodules: recursive
 
-  #     - task: UsePythonVersion@0
-  #       inputs:
-  #         versionSpec: '$(python.version)'
-  #         architecture: '$(python.architecture)'
-  #       displayName: 'Python $(python.version)'
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '$(python.version)'
+          architecture: '$(python.architecture)'
+        displayName: 'Python $(python.version)'
 
-  #     - script: |
-  #         python -m pip install --upgrade pip
-  #       displayName: "Install Pip"
+      - script: |
+          python -m pip install --upgrade pip
+        displayName: "Install Pip"
 
-  #     - script: |
-  #         python -m pip list
-  #       displayName: "Show versions"
+      - script: |
+          python -m pip list
+        displayName: "Show versions"
 
-  #     - script: |
-  #         python -m pip install -v .[test,dev]
-  #       displayName: "Build"
+      - script: |
+          python -m pip install -v .[test,dev]
+        displayName: "Build"
 
-  #     - script: |
-  #         python dev/generate-kernelspec.py
-  #       displayName: "Generate Kernel specification"
+      - script: |
+          python dev/generate-kernelspec.py
+        displayName: "Generate Kernel specification"
 
-  #     - script: |
-  #         python dev/generate-tests.py
-  #       displayName: "Generate Kernel tests"
+      - script: |
+          python dev/generate-tests.py
+        displayName: "Generate Kernel tests"
 
-  #     - script: |
-  #         python -m pytest -vv -rs tests-spec
-  #       displayName: "Test specification"
+      - script: |
+          python -m pytest -vv -rs tests-spec
+        displayName: "Test specification"
 
-  #     - script: |
-  #         python -m pytest -vv -rs tests-cpu-kernels
-  #       displayName: "Test CPU kernels"
+      - script: |
+          python -m pytest -vv -rs tests-cpu-kernels
+        displayName: "Test CPU kernels"
 
-  #     - script: |
-  #         python -m pytest -vv -rs tests
-  #       displayName: "Test"
+      - script: |
+          python -m pytest -vv -rs tests
+        displayName: "Test"
 
   - job: MacOS
 
@@ -165,25 +165,25 @@ jobs:
           python -m pip install -v .[test,dev]
         displayName: "Build"
 
-      # - script: |
-      #     python dev/generate-kernelspec.py
-      #   displayName: "Generate Kernel specification"
+      - script: |
+          python dev/generate-kernelspec.py
+        displayName: "Generate Kernel specification"
 
-      # - script: |
-      #     python dev/generate-tests.py
-      #   displayName: "Generate Kernel tests"
+      - script: |
+          python dev/generate-tests.py
+        displayName: "Generate Kernel tests"
 
-      # - script: |
-      #     python -m pytest -vv -rs tests-spec
-      #   displayName: "Test specification"
+      - script: |
+          python -m pytest -vv -rs tests-spec
+        displayName: "Test specification"
 
-      # - script: |
-      #     python -m pytest -vv -rs tests-cpu-kernels
-      #   displayName: "Test CPU kernels"
+      - script: |
+          python -m pytest -vv -rs tests-cpu-kernels
+        displayName: "Test CPU kernels"
 
-      # - script: |
-      #     python -m pytest -vv -rs tests
-      #   displayName: "Test"
+      - script: |
+          python -m pytest -vv -rs tests
+        displayName: "Test"
 
       - script: |
           echo '===== include directory ============================='
@@ -193,7 +193,7 @@ jobs:
           echo '===== compilation ==================================='
           which g++
           g++ minimal.cpp `python -m awkward1.config --cflags --static-libs` -o minimal
-          ldd minimal
+          otool -L minimal
           ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
         workingDirectory: dependent-project
         displayName: "Test dependent project 1"
@@ -203,7 +203,7 @@ jobs:
           g++ minimal.cpp `python -m awkward1.config --cflags --libs` -o minimal
           export DYLD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$DYLD_LIBRARY_PATH
           echo $DYLD_LIBRARY_PATH
-          ldd minimal
+          otool -L minimal
           ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
         workingDirectory: dependent-project
         displayName: "Test dependent project 2"
@@ -216,7 +216,7 @@ jobs:
           export DYLD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$DYLD_LIBRARY_PATH
           echo $DYLD_LIBRARY_PATH
           ls build/dependent*
-          ldd build/dependent*
+          otool -L build/dependent*
           touch build/__init__.py
           python -m pytest -vv test-python.py
         workingDirectory: dependent-project
@@ -287,36 +287,36 @@ jobs:
           python -m pip install -v .[test,dev]
         displayName: "Build"
 
-      # - script: |
-      #     python dev/generate-kernelspec.py
-      #   displayName: "Generate Kernel specification"
+      - script: |
+          python dev/generate-kernelspec.py
+        displayName: "Generate Kernel specification"
 
-      # - script: |
-      #     python dev/generate-tests.py
-      #   displayName: "Generate Kernel tests"
+      - script: |
+          python dev/generate-tests.py
+        displayName: "Generate Kernel tests"
 
-      # - script: |
-      #     python -m pytest -vv -rs tests-spec
-      #   displayName: "Test specification"
+      - script: |
+          python -m pytest -vv -rs tests-spec
+        displayName: "Test specification"
 
-      # - script: |
-      #     python -m pytest -vv -rs tests-cpu-kernels
-      #   displayName: "Test CPU kernels"
+      - script: |
+          python -m pytest -vv -rs tests-cpu-kernels
+        displayName: "Test CPU kernels"
 
-      # - script: |
-      #     python -m pytest -vv -rs tests
-      #   displayName: "Test"
+      - script: |
+          python -m pytest -vv -rs tests
+        displayName: "Test"
 
-      # - script: |
-      #     python dev/generate-cuda.py
-      #   displayName: "Generate CUDA kernels"
-      #   condition: "ne(variables['python.version'], '3.8')"
+      - script: |
+          python dev/generate-cuda.py
+        displayName: "Generate CUDA kernels"
+        condition: "ne(variables['python.version'], '3.8')"
 
-      # - script: |
-      #     python -m pip install wheel
-      #     bash cuda-build.sh
-      #   displayName: "Build the cuda-kernels"
-      #   condition: "ne(variables['python.version'], '2.7')"
+      - script: |
+          python -m pip install wheel
+          bash cuda-build.sh
+        displayName: "Build the cuda-kernels"
+        condition: "ne(variables['python.version'], '2.7')"
 
       - script: |
           echo '===== include directory ============================='

--- a/.ci/azure-buildtest-awkward.yml
+++ b/.ci/azure-buildtest-awkward.yml
@@ -112,78 +112,115 @@ jobs:
   #         python -m pytest -vv -rs tests
   #       displayName: "Test"
 
-  # - job: MacOS
+  - job: MacOS
 
-  #   pool:
-  #     vmImage: "macOS-10.14"
+    pool:
+      vmImage: "macOS-10.14"
 
-  #   variables:
-  #     PIP_ONLY_BINARY: cmake
+    variables:
+      PIP_ONLY_BINARY: cmake
 
-  #   strategy:
-  #     matrix:
-  #       "py27":
-  #         python.version: "2.7"
-  #         python.architecture: "x64"
-  #         numpy.version: "1.16.5"
-  #       "py35":
-  #         python.version: "3.5"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py36":
-  #         python.version: "3.6"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py37":
-  #         python.version: "3.7"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py38":
-  #         python.version: "3.8"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
+    strategy:
+      matrix:
+        "py27":
+          python.version: "2.7"
+          python.architecture: "x64"
+          numpy.version: "1.16.5"
+        "py35":
+          python.version: "3.5"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py36":
+          python.version: "3.6"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py37":
+          python.version: "3.7"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py38":
+          python.version: "3.8"
+          python.architecture: "x64"
+          numpy.version: "latest"
 
-  #   steps:
-  #     - checkout: self
-  #       submodules: recursive
+    steps:
+      - checkout: self
+        submodules: recursive
 
-  #     - task: UsePythonVersion@0
-  #       inputs:
-  #         versionSpec: '$(python.version)'
-  #         architecture: '$(python.architecture)'
-  #       displayName: 'Python $(python.version)'
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '$(python.version)'
+          architecture: '$(python.architecture)'
+        displayName: 'Python $(python.version)'
 
-  #     - script: |
-  #         python -m pip install --upgrade pip
-  #       displayName: "Install Pip"
+      - script: |
+          python -m pip install --upgrade pip
+        displayName: "Install Pip"
 
-  #     - script: |
-  #         python -m pip list
-  #       displayName: "Print versions"
+      - script: |
+          python -m pip list
+        displayName: "Print versions"
 
-  #     - script: |
-  #         python -m pip install -v .[test,dev]
-  #       displayName: "Build"
+      - script: |
+          python -m pip install -v .[test,dev]
+        displayName: "Build"
 
-  #     - script: |
-  #         python dev/generate-kernelspec.py
-  #       displayName: "Generate Kernel specification"
+      # - script: |
+      #     python dev/generate-kernelspec.py
+      #   displayName: "Generate Kernel specification"
 
-  #     - script: |
-  #         python dev/generate-tests.py
-  #       displayName: "Generate Kernel tests"
+      # - script: |
+      #     python dev/generate-tests.py
+      #   displayName: "Generate Kernel tests"
 
-  #     - script: |
-  #         python -m pytest -vv -rs tests-spec
-  #       displayName: "Test specification"
+      # - script: |
+      #     python -m pytest -vv -rs tests-spec
+      #   displayName: "Test specification"
 
-  #     - script: |
-  #         python -m pytest -vv -rs tests-cpu-kernels
-  #       displayName: "Test CPU kernels"
+      # - script: |
+      #     python -m pytest -vv -rs tests-cpu-kernels
+      #   displayName: "Test CPU kernels"
 
-  #     - script: |
-  #         python -m pytest -vv -rs tests
-  #       displayName: "Test"
+      # - script: |
+      #     python -m pytest -vv -rs tests
+      #   displayName: "Test"
+
+      - script: |
+          echo '===== include directory ============================='
+          ls -R `python -m awkward1.config --incdir`
+          echo '===== library directory ============================='
+          ls `python -m awkward1.config --libdir`
+          echo '===== compilation ==================================='
+          which g++
+          g++ minimal.cpp `python -m awkward1.config --cflags --static-libs` -o minimal
+          ldd minimal
+          ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
+        workingDirectory: dependent-project
+        displayName: "Test dependent project 1"
+
+      - script: |
+          rm -f minimal
+          g++ minimal.cpp `python -m awkward1.config --cflags --libs` -o minimal
+          export DYLD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$DYLD_LIBRARY_PATH
+          echo $DYLD_LIBRARY_PATH
+          ldd minimal
+          ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
+        workingDirectory: dependent-project
+        displayName: "Test dependent project 2"
+
+      - script: |
+          which python
+          python -c 'import sys; print(sys.version)'
+          cmake -S . -B build -DPYTHON_EXECUTABLE:FILEPATH=`which python`
+          cmake --build build
+          export DYLD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$DYLD_LIBRARY_PATH
+          echo $DYLD_LIBRARY_PATH
+          ls build/dependent*
+          ldd build/dependent*
+          touch build/__init__.py
+          python -m pytest -vv test-python.py
+        workingDirectory: dependent-project
+        displayName: "Test dependent project 3"
 
   - job: Linux
 
@@ -312,6 +349,7 @@ jobs:
           echo $LD_LIBRARY_PATH
           ls build/dependent*
           ldd build/dependent*
+          touch build/__init__.py
           python -m pytest -vv test-python.py
         workingDirectory: dependent-project
         displayName: "Test dependent project 3"

--- a/.ci/azure-deploy-awkward.yml
+++ b/.ci/azure-deploy-awkward.yml
@@ -49,13 +49,13 @@ jobs:
           bash cuda-build.sh
         displayName: "Build"
 
-      # - script: |
-      #     ls dist
-      #     rm -rf dist/awkward1_cuda_kernels-*-py3-none-any.whl dist/awkward1_cuda_kernels dist/awkward1_cuda_kernels-*.dist-info dist/tmp_WHEEL
-      #     ls dist
-      #     python -m twine upload dist/awkward1_cuda_kernels-*-py3-none-manylinux2014_x86_64.whl --config-file $(pypirc.secureFilePath) --verbose
-      #   displayName: "Deploy"
-      #   condition: contains(variables['Build.SourceBranch'], 'tags')
+      - script: |
+          ls dist
+          rm -rf dist/awkward1_cuda_kernels-*-py3-none-any.whl dist/awkward1_cuda_kernels dist/awkward1_cuda_kernels-*.dist-info dist/tmp_WHEEL
+          ls dist
+          python -m twine upload dist/awkward1_cuda_kernels-*-py3-none-manylinux2014_x86_64.whl --config-file $(pypirc.secureFilePath) --verbose
+        displayName: "Deploy"
+        condition: contains(variables['Build.SourceBranch'], 'tags')
 
       - task: PublishPipelineArtifact@0
         inputs:
@@ -121,198 +121,198 @@ jobs:
           cp wheelhouse/awkward1*manylinux*.whl dist/.
         displayName: "Copy wheels to dist"
 
-      # - script: |
-      #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
-      #   displayName: "Deploy"
-      #   condition: contains(variables['Build.SourceBranch'], 'tags')
+      - script: |
+          python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
+        displayName: "Deploy"
+        condition: contains(variables['Build.SourceBranch'], 'tags')
 
       - task: PublishPipelineArtifact@0
         inputs:
           artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
           targetPath: 'dist'
 
-  # - job: Windows
+  - job: Windows
 
-  #   pool:
-  #     vmImage: "vs2017-win2016"
+    pool:
+      vmImage: "vs2017-win2016"
 
-  #   variables:
-  #     PIP_ONLY_BINARY: cmake
+    variables:
+      PIP_ONLY_BINARY: cmake
 
-  #   strategy:
-  #     matrix:
-  #       "py27-32bit":
-  #         python.version: "2.7"
-  #         python.architecture: "x86"
-  #         numpy.version: "1.16.5"
-  #       "py27-64bit":
-  #         python.version: "2.7"
-  #         python.architecture: "x64"
-  #         numpy.version: "1.16.5"
-  #       "py35-32bit":
-  #         python.version: "3.5"
-  #         python.architecture: "x86"
-  #         numpy.version: "latest"
-  #       "py35-64bit":
-  #         python.version: "3.5"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py36-32bit":
-  #         python.version: "3.6"
-  #         python.architecture: "x86"
-  #         numpy.version: "latest"
-  #       "py36-64bit":
-  #         python.version: "3.6"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py37-32bit":
-  #         python.version: "3.7"
-  #         python.architecture: "x86"
-  #         numpy.version: "latest"
-  #       "py37-64bit":
-  #         python.version: "3.7"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py38-32bit":
-  #         python.version: "3.8"
-  #         python.architecture: "x86"
-  #         numpy.version: "latest"
-  #       "py38-64bit":
-  #         python.version: "3.8"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
+    strategy:
+      matrix:
+        "py27-32bit":
+          python.version: "2.7"
+          python.architecture: "x86"
+          numpy.version: "1.16.5"
+        "py27-64bit":
+          python.version: "2.7"
+          python.architecture: "x64"
+          numpy.version: "1.16.5"
+        "py35-32bit":
+          python.version: "3.5"
+          python.architecture: "x86"
+          numpy.version: "latest"
+        "py35-64bit":
+          python.version: "3.5"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py36-32bit":
+          python.version: "3.6"
+          python.architecture: "x86"
+          numpy.version: "latest"
+        "py36-64bit":
+          python.version: "3.6"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py37-32bit":
+          python.version: "3.7"
+          python.architecture: "x86"
+          numpy.version: "latest"
+        "py37-64bit":
+          python.version: "3.7"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py38-32bit":
+          python.version: "3.8"
+          python.architecture: "x86"
+          numpy.version: "latest"
+        "py38-64bit":
+          python.version: "3.8"
+          python.architecture: "x64"
+          numpy.version: "latest"
 
-  #   steps:
-  #     - checkout: self
-  #       submodules: recursive
+    steps:
+      - checkout: self
+        submodules: recursive
 
-  #     - task: DownloadSecureFile@1
-  #       name: pypirc
-  #       inputs:
-  #         secureFile: pivarski-pypirc
-  #       displayName: "Credentials"
+      - task: DownloadSecureFile@1
+        name: pypirc
+        inputs:
+          secureFile: pivarski-pypirc
+        displayName: "Credentials"
 
-  #     - task: UsePythonVersion@0
-  #       inputs:
-  #         versionSpec: '$(python.version)'
-  #         architecture: '$(python.architecture)'
-  #       displayName: 'Python $(python.version)'
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '$(python.version)'
+          architecture: '$(python.architecture)'
+        displayName: 'Python $(python.version)'
 
-  #     - script: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install twine wheel
-  #       displayName: "Install"
+      - script: |
+          python -m pip install --upgrade pip
+          python -m pip install twine wheel
+        displayName: "Install"
 
-  #     - script: |
-  #         python -m pip wheel . -v -w wheelhouse/
-  #       displayName: "Build"
+      - script: |
+          python -m pip wheel . -v -w wheelhouse/
+        displayName: "Build"
 
-  #     - script: |
-  #         if not exist "dist" mkdir dist
-  #         cp wheelhouse/awkward1*.whl dist/.
-  #       displayName: "Copy wheels to dist"
+      - script: |
+          if not exist "dist" mkdir dist
+          cp wheelhouse/awkward1*.whl dist/.
+        displayName: "Copy wheels to dist"
 
-  #     # - script: |
-  #     #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
-  #     #   displayName: "Deploy"
-  #     #   condition: contains(variables['Build.SourceBranch'], 'tags')
+      - script: |
+          python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
+        displayName: "Deploy"
+        condition: contains(variables['Build.SourceBranch'], 'tags')
 
-  #     - task: PublishPipelineArtifact@0
-  #       inputs:
-  #         artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
-  #         targetPath: 'dist'
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
+          targetPath: 'dist'
 
-  # - job: MacOS
+  - job: MacOS
 
-  #   pool:
-  #     vmImage: "macOS-10.14"
+    pool:
+      vmImage: "macOS-10.14"
 
-  #   variables:
-  #     PIP_ONLY_BINARY: cmake
+    variables:
+      PIP_ONLY_BINARY: cmake
 
-  #   strategy:
-  #     matrix:
-  #       "py27":
-  #         python.version: "2.7"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py36":
-  #         python.version: "3.6"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py37":
-  #         python.version: "3.7"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
-  #       "py38":
-  #         python.version: "3.8"
-  #         python.architecture: "x64"
-  #         numpy.version: "latest"
+    strategy:
+      matrix:
+        "py27":
+          python.version: "2.7"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py36":
+          python.version: "3.6"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py37":
+          python.version: "3.7"
+          python.architecture: "x64"
+          numpy.version: "latest"
+        "py38":
+          python.version: "3.8"
+          python.architecture: "x64"
+          numpy.version: "latest"
 
-  #   steps:
-  #     - checkout: self
-  #       submodules: recursive
+    steps:
+      - checkout: self
+        submodules: recursive
 
-  #     - task: DownloadSecureFile@1
-  #       name: pypirc
-  #       inputs:
-  #         secureFile: pivarski-pypirc
-  #       displayName: "Credentials"
+      - task: DownloadSecureFile@1
+        name: pypirc
+        inputs:
+          secureFile: pivarski-pypirc
+        displayName: "Credentials"
 
-  #     - script: |
-  #         case $(python.version) in
-  #         2.7)
-  #           FULL_VERSION=2.7.17
-  #           ;;
-  #         3.6)
-  #           FULL_VERSION=3.6.8
-  #           ;;
-  #         3.7)
-  #           FULL_VERSION=3.7.5
-  #           ;;
-  #         3.8)
-  #           FULL_VERSION=3.8.0
-  #           ;;
-  #         esac
+      - script: |
+          case $(python.version) in
+          2.7)
+            FULL_VERSION=2.7.17
+            ;;
+          3.6)
+            FULL_VERSION=3.6.8
+            ;;
+          3.7)
+            FULL_VERSION=3.7.5
+            ;;
+          3.8)
+            FULL_VERSION=3.8.0
+            ;;
+          esac
 
-  #         INSTALLER_NAME=python-$FULL_VERSION-macosx10.9.pkg
-  #         URL=https://www.python.org/ftp/python/$FULL_VERSION/$INSTALLER_NAME
+          INSTALLER_NAME=python-$FULL_VERSION-macosx10.9.pkg
+          URL=https://www.python.org/ftp/python/$FULL_VERSION/$INSTALLER_NAME
 
-  #         PY_PREFIX=/Library/Frameworks/Python.framework/Versions
+          PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 
-  #         set -e -x
+          set -e -x
 
-  #         curl $URL > $INSTALLER_NAME
+          curl $URL > $INSTALLER_NAME
 
-  #         sudo installer -pkg $INSTALLER_NAME -target /
+          sudo installer -pkg $INSTALLER_NAME -target /
 
-  #         sudo rm /usr/local/bin/python
-  #         sudo ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
+          sudo rm /usr/local/bin/python
+          sudo ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
 
-  #       displayName: 'Python $(python.version)'
+        displayName: 'Python $(python.version)'
 
-  #     - script: |
-  #         python -m ensurepip
-  #         python -m pip install --upgrade pip
-  #         python -m pip install setuptools twine wheel
-  #       displayName: "Install"
+      - script: |
+          python -m ensurepip
+          python -m pip install --upgrade pip
+          python -m pip install setuptools twine wheel
+        displayName: "Install"
 
-  #     - script: |
-  #         python --version
-  #         python -m pip wheel . -v -w wheelhouse/
-  #       displayName: "Build"
+      - script: |
+          python --version
+          python -m pip wheel . -v -w wheelhouse/
+        displayName: "Build"
 
-  #     - script: |
-  #         mkdir -p dist
-  #         cp wheelhouse/awkward1*.whl dist/.
-  #       displayName: "Copy wheels to dist"
+      - script: |
+          mkdir -p dist
+          cp wheelhouse/awkward1*.whl dist/.
+        displayName: "Copy wheels to dist"
 
-  #     # - script: |
-  #     #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
-  #     #   displayName: "Deploy"
-  #     #   condition: contains(variables['Build.SourceBranch'], 'tags')
+      - script: |
+          python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
+        displayName: "Deploy"
+        condition: contains(variables['Build.SourceBranch'], 'tags')
 
-  #     - task: PublishPipelineArtifact@0
-  #       inputs:
-  #         artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
-  #         targetPath: 'dist'
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
+          targetPath: 'dist'

--- a/.ci/azure-deploy-awkward.yml
+++ b/.ci/azure-deploy-awkward.yml
@@ -131,188 +131,188 @@ jobs:
           artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
           targetPath: 'dist'
 
-  - job: Windows
+  # - job: Windows
 
-    pool:
-      vmImage: "vs2017-win2016"
+  #   pool:
+  #     vmImage: "vs2017-win2016"
 
-    variables:
-      PIP_ONLY_BINARY: cmake
+  #   variables:
+  #     PIP_ONLY_BINARY: cmake
 
-    strategy:
-      matrix:
-        "py27-32bit":
-          python.version: "2.7"
-          python.architecture: "x86"
-          numpy.version: "1.16.5"
-        "py27-64bit":
-          python.version: "2.7"
-          python.architecture: "x64"
-          numpy.version: "1.16.5"
-        "py35-32bit":
-          python.version: "3.5"
-          python.architecture: "x86"
-          numpy.version: "latest"
-        "py35-64bit":
-          python.version: "3.5"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py36-32bit":
-          python.version: "3.6"
-          python.architecture: "x86"
-          numpy.version: "latest"
-        "py36-64bit":
-          python.version: "3.6"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py37-32bit":
-          python.version: "3.7"
-          python.architecture: "x86"
-          numpy.version: "latest"
-        "py37-64bit":
-          python.version: "3.7"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py38-32bit":
-          python.version: "3.8"
-          python.architecture: "x86"
-          numpy.version: "latest"
-        "py38-64bit":
-          python.version: "3.8"
-          python.architecture: "x64"
-          numpy.version: "latest"
+  #   strategy:
+  #     matrix:
+  #       "py27-32bit":
+  #         python.version: "2.7"
+  #         python.architecture: "x86"
+  #         numpy.version: "1.16.5"
+  #       "py27-64bit":
+  #         python.version: "2.7"
+  #         python.architecture: "x64"
+  #         numpy.version: "1.16.5"
+  #       "py35-32bit":
+  #         python.version: "3.5"
+  #         python.architecture: "x86"
+  #         numpy.version: "latest"
+  #       "py35-64bit":
+  #         python.version: "3.5"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py36-32bit":
+  #         python.version: "3.6"
+  #         python.architecture: "x86"
+  #         numpy.version: "latest"
+  #       "py36-64bit":
+  #         python.version: "3.6"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py37-32bit":
+  #         python.version: "3.7"
+  #         python.architecture: "x86"
+  #         numpy.version: "latest"
+  #       "py37-64bit":
+  #         python.version: "3.7"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py38-32bit":
+  #         python.version: "3.8"
+  #         python.architecture: "x86"
+  #         numpy.version: "latest"
+  #       "py38-64bit":
+  #         python.version: "3.8"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
 
-    steps:
-      - checkout: self
-        submodules: recursive
+  #   steps:
+  #     - checkout: self
+  #       submodules: recursive
 
-      - task: DownloadSecureFile@1
-        name: pypirc
-        inputs:
-          secureFile: pivarski-pypirc
-        displayName: "Credentials"
+  #     - task: DownloadSecureFile@1
+  #       name: pypirc
+  #       inputs:
+  #         secureFile: pivarski-pypirc
+  #       displayName: "Credentials"
 
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '$(python.version)'
-          architecture: '$(python.architecture)'
-        displayName: 'Python $(python.version)'
+  #     - task: UsePythonVersion@0
+  #       inputs:
+  #         versionSpec: '$(python.version)'
+  #         architecture: '$(python.architecture)'
+  #       displayName: 'Python $(python.version)'
 
-      - script: |
-          python -m pip install --upgrade pip
-          python -m pip install twine wheel
-        displayName: "Install"
+  #     - script: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install twine wheel
+  #       displayName: "Install"
 
-      - script: |
-          python -m pip wheel . -v -w wheelhouse/
-        displayName: "Build"
+  #     - script: |
+  #         python -m pip wheel . -v -w wheelhouse/
+  #       displayName: "Build"
 
-      - script: |
-          if not exist "dist" mkdir dist
-          cp wheelhouse/awkward1*.whl dist/.
-        displayName: "Copy wheels to dist"
+  #     - script: |
+  #         if not exist "dist" mkdir dist
+  #         cp wheelhouse/awkward1*.whl dist/.
+  #       displayName: "Copy wheels to dist"
 
-      # - script: |
-      #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
-      #   displayName: "Deploy"
-      #   condition: contains(variables['Build.SourceBranch'], 'tags')
+  #     # - script: |
+  #     #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
+  #     #   displayName: "Deploy"
+  #     #   condition: contains(variables['Build.SourceBranch'], 'tags')
 
-      - task: PublishPipelineArtifact@0
-        inputs:
-          artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
-          targetPath: 'dist'
+  #     - task: PublishPipelineArtifact@0
+  #       inputs:
+  #         artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
+  #         targetPath: 'dist'
 
-  - job: MacOS
+  # - job: MacOS
 
-    pool:
-      vmImage: "macOS-10.14"
+  #   pool:
+  #     vmImage: "macOS-10.14"
 
-    variables:
-      PIP_ONLY_BINARY: cmake
+  #   variables:
+  #     PIP_ONLY_BINARY: cmake
 
-    strategy:
-      matrix:
-        "py27":
-          python.version: "2.7"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py36":
-          python.version: "3.6"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py37":
-          python.version: "3.7"
-          python.architecture: "x64"
-          numpy.version: "latest"
-        "py38":
-          python.version: "3.8"
-          python.architecture: "x64"
-          numpy.version: "latest"
+  #   strategy:
+  #     matrix:
+  #       "py27":
+  #         python.version: "2.7"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py36":
+  #         python.version: "3.6"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py37":
+  #         python.version: "3.7"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
+  #       "py38":
+  #         python.version: "3.8"
+  #         python.architecture: "x64"
+  #         numpy.version: "latest"
 
-    steps:
-      - checkout: self
-        submodules: recursive
+  #   steps:
+  #     - checkout: self
+  #       submodules: recursive
 
-      - task: DownloadSecureFile@1
-        name: pypirc
-        inputs:
-          secureFile: pivarski-pypirc
-        displayName: "Credentials"
+  #     - task: DownloadSecureFile@1
+  #       name: pypirc
+  #       inputs:
+  #         secureFile: pivarski-pypirc
+  #       displayName: "Credentials"
 
-      - script: |
-          case $(python.version) in
-          2.7)
-            FULL_VERSION=2.7.17
-            ;;
-          3.6)
-            FULL_VERSION=3.6.8
-            ;;
-          3.7)
-            FULL_VERSION=3.7.5
-            ;;
-          3.8)
-            FULL_VERSION=3.8.0
-            ;;
-          esac
+  #     - script: |
+  #         case $(python.version) in
+  #         2.7)
+  #           FULL_VERSION=2.7.17
+  #           ;;
+  #         3.6)
+  #           FULL_VERSION=3.6.8
+  #           ;;
+  #         3.7)
+  #           FULL_VERSION=3.7.5
+  #           ;;
+  #         3.8)
+  #           FULL_VERSION=3.8.0
+  #           ;;
+  #         esac
 
-          INSTALLER_NAME=python-$FULL_VERSION-macosx10.9.pkg
-          URL=https://www.python.org/ftp/python/$FULL_VERSION/$INSTALLER_NAME
+  #         INSTALLER_NAME=python-$FULL_VERSION-macosx10.9.pkg
+  #         URL=https://www.python.org/ftp/python/$FULL_VERSION/$INSTALLER_NAME
 
-          PY_PREFIX=/Library/Frameworks/Python.framework/Versions
+  #         PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 
-          set -e -x
+  #         set -e -x
 
-          curl $URL > $INSTALLER_NAME
+  #         curl $URL > $INSTALLER_NAME
 
-          sudo installer -pkg $INSTALLER_NAME -target /
+  #         sudo installer -pkg $INSTALLER_NAME -target /
 
-          sudo rm /usr/local/bin/python
-          sudo ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
+  #         sudo rm /usr/local/bin/python
+  #         sudo ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
 
-        displayName: 'Python $(python.version)'
+  #       displayName: 'Python $(python.version)'
 
-      - script: |
-          python -m ensurepip
-          python -m pip install --upgrade pip
-          python -m pip install setuptools twine wheel
-        displayName: "Install"
+  #     - script: |
+  #         python -m ensurepip
+  #         python -m pip install --upgrade pip
+  #         python -m pip install setuptools twine wheel
+  #       displayName: "Install"
 
-      - script: |
-          python --version
-          python -m pip wheel . -v -w wheelhouse/
-        displayName: "Build"
+  #     - script: |
+  #         python --version
+  #         python -m pip wheel . -v -w wheelhouse/
+  #       displayName: "Build"
 
-      - script: |
-          mkdir -p dist
-          cp wheelhouse/awkward1*.whl dist/.
-        displayName: "Copy wheels to dist"
+  #     - script: |
+  #         mkdir -p dist
+  #         cp wheelhouse/awkward1*.whl dist/.
+  #       displayName: "Copy wheels to dist"
 
-      # - script: |
-      #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
-      #   displayName: "Deploy"
-      #   condition: contains(variables['Build.SourceBranch'], 'tags')
+  #     # - script: |
+  #     #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
+  #     #   displayName: "Deploy"
+  #     #   condition: contains(variables['Build.SourceBranch'], 'tags')
 
-      - task: PublishPipelineArtifact@0
-        inputs:
-          artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
-          targetPath: 'dist'
+  #     - task: PublishPipelineArtifact@0
+  #       inputs:
+  #         artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
+  #         targetPath: 'dist'

--- a/.ci/azure-deploy-awkward.yml
+++ b/.ci/azure-deploy-awkward.yml
@@ -36,9 +36,11 @@ jobs:
       - script: |
           python -m pip install --upgrade pip
         displayName: "Install Pip"
+
       - script: |
           python -m pip install twine wheel
         displayName: "Install Twine & Wheel"
+
       - script: |
           python -m pip list
         displayName: "Print versions"
@@ -46,13 +48,14 @@ jobs:
       - script: |
           bash cuda-build.sh
         displayName: "Build"
-      - script: |
-          ls dist
-          rm -rf dist/awkward1_cuda_kernels-*-py3-none-any.whl dist/awkward1_cuda_kernels dist/awkward1_cuda_kernels-*.dist-info dist/tmp_WHEEL
-          ls dist
-          python -m twine upload dist/awkward1_cuda_kernels-*-py3-none-manylinux2014_x86_64.whl --config-file $(pypirc.secureFilePath) --verbose
-        displayName: "Deploy"
-        condition: contains(variables['Build.SourceBranch'], 'tags')
+
+      # - script: |
+      #     ls dist
+      #     rm -rf dist/awkward1_cuda_kernels-*-py3-none-any.whl dist/awkward1_cuda_kernels dist/awkward1_cuda_kernels-*.dist-info dist/tmp_WHEEL
+      #     ls dist
+      #     python -m twine upload dist/awkward1_cuda_kernels-*-py3-none-manylinux2014_x86_64.whl --config-file $(pypirc.secureFilePath) --verbose
+      #   displayName: "Deploy"
+      #   condition: contains(variables['Build.SourceBranch'], 'tags')
 
       - task: PublishPipelineArtifact@0
         inputs:
@@ -118,10 +121,10 @@ jobs:
           cp wheelhouse/awkward1*manylinux*.whl dist/.
         displayName: "Copy wheels to dist"
 
-      - script: |
-          python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
-        displayName: "Deploy"
-        condition: contains(variables['Build.SourceBranch'], 'tags')
+      # - script: |
+      #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
+      #   displayName: "Deploy"
+      #   condition: contains(variables['Build.SourceBranch'], 'tags')
 
       - task: PublishPipelineArtifact@0
         inputs:
@@ -209,10 +212,10 @@ jobs:
           cp wheelhouse/awkward1*.whl dist/.
         displayName: "Copy wheels to dist"
 
-      - script: |
-          python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
-        displayName: "Deploy"
-        condition: contains(variables['Build.SourceBranch'], 'tags')
+      # - script: |
+      #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
+      #   displayName: "Deploy"
+      #   condition: contains(variables['Build.SourceBranch'], 'tags')
 
       - task: PublishPipelineArtifact@0
         inputs:
@@ -304,10 +307,10 @@ jobs:
           cp wheelhouse/awkward1*.whl dist/.
         displayName: "Copy wheels to dist"
 
-      - script: |
-          python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
-        displayName: "Deploy"
-        condition: contains(variables['Build.SourceBranch'], 'tags')
+      # - script: |
+      #     python -m twine upload dist/* --config-file $(pypirc.secureFilePath) --verbose
+      #   displayName: "Deploy"
+      #   condition: contains(variables['Build.SourceBranch'], 'tags')
 
       - task: PublishPipelineArtifact@0
         inputs:

--- a/.ci/linux-build.sh
+++ b/.ci/linux-build.sh
@@ -12,7 +12,7 @@ export PATH=`ls -d /opt/_internal/cpython-3.7.*/lib/python3.7/site-packages/cmak
 echo "PATH:" $PATH
 echo "which cmake:" `which cmake`
 
-for PYBIN in /opt/python/cp37-cp37m/bin; do # /opt/python/*/bin; do
+for PYBIN in /opt/python/*/bin; do
     echo "========================================================="
     echo $PYBIN
     echo "========================================================="

--- a/.ci/linux-build.sh
+++ b/.ci/linux-build.sh
@@ -12,7 +12,7 @@ export PATH=`ls -d /opt/_internal/cpython-3.7.*/lib/python3.7/site-packages/cmak
 echo "PATH:" $PATH
 echo "which cmake:" `which cmake`
 
-for PYBIN in /opt/python/*/bin; do
+for PYBIN in /opt/python/cp37-cp37m/bin; do # /opt/python/*/bin; do
     echo "========================================================="
     echo $PYBIN
     echo "========================================================="
@@ -25,4 +25,3 @@ for whl in wheelhouse/awkward*.whl; do
     auditwheel show "$whl"
     auditwheel repair --plat $PLAT "$whl" -w /io/wheelhouse/
 done
-

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dependent-project/CMakeCache.txt
 dependent-project/Makefile
 dependent-project/cmake_install.cmake
 dependent-project/cmake_pybind11
+dependent-project/minimal
 
 # to use all-contributors-cli without adding it to the project
 node_modules

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,5 @@ include *.dll
 
 recursive-include pybind11/include/pybind11 *
 recursive-include pybind11/tools *
+recursive-include rapidjson/include *
 include pybind11/CMakeLists.txt pybind11/LICENSE pybind11/README.md pybind11/CONTRIBUTING.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include requirements.txt requirements-test.txt VERSION_INFO CMakeLists.txt LICENSE README.md
+include requirements*.txt VERSION_INFO CMakeLists.txt LICENSE README*.md CONTRIBUTING.md
 recursive-include include *.h
 recursive-include src *.cpp
 recursive-include src/awkward1 *.py

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -1,0 +1,105 @@
+<a href="https://github.com/scikit-hep/awkward-1.0#readme"><img src="https://github.com/scikit-hep/awkward-1.0/raw/master/docs-img/logo/logo-300px.png"></a>
+
+Awkward Array is a library for **nested, variable-sized data**, including arbitrary-length lists, records, mixed types, and missing data, using **NumPy-like idioms**.
+
+Arrays are **dynamically typed**, but operations on them are **compiled and fast**. Their behavior coincides with NumPy when array dimensions are regular and generalizes when they're not.
+
+<table>
+  <tr>
+    <td width="66%" valign="top">
+      <a href="https://awkward-array.org">
+        <img src="https://github.com/scikit-hep/awkward-1.0/raw/master/docs-img/panel-tutorials.png" width="570">
+      </a>
+      <p align="center"><b>
+        <a href="https://awkward-array.org">
+        How-to tutorials
+        </a>
+      </b></p>
+    </td>
+    <td width="33%" valign="top">
+      <a href="https://awkward-array.readthedocs.io/en/latest/index.html">
+        <img src="https://github.com/scikit-hep/awkward-1.0/raw/master/docs-img/panel-sphinx.png" width="268">
+      </a>
+      <p align="center"><b>
+        <a href="https://awkward-array.readthedocs.io/en/latest/index.html">
+        Python API reference
+        </a>
+      </b></p>
+      <a href="https://awkward-array.readthedocs.io/en/latest/_static/index.html">
+        <img src="https://github.com/scikit-hep/awkward-1.0/raw/master/docs-img/panel-doxygen.png" width="268">
+      </a>
+      <p align="center"><b>
+        <a href="https://awkward-array.readthedocs.io/en/latest/_static/index.html">
+        C++ API reference
+        </a>
+      </b></p>
+    </td>
+  </tr>
+</table>
+
+# Motivating example
+
+Given an array of objects with `x`, `y` fields and variable-length nested lists like
+
+```python
+array = ak.Array([
+    [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}],
+    [],
+    [{"x": 4.4, "y": {1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}]
+])
+```
+
+the following slices out the `y` values, drops the first element from each inner list, and runs NumPy's `np.square` function on everything that is left:
+
+```python
+output = np.square(array["y", ..., 1:])
+```
+
+The result is
+
+```python
+[
+    [[], [4], [4, 9]],
+    [],
+    [[4, 9, 16], [4, 9, 16, 25]]
+]
+```
+
+The equivalent using only Python is
+
+```python
+output = []
+for sublist in array:
+    tmp1 = []
+    for record in sublist:
+        tmp2 = []
+        for number in record["y"][1:]:
+            tmp2.append(np.square(number))
+        tmp1.append(tmp2)
+    output.append(tmp1)
+```
+
+Not only is the expression using Awkward Arrays more concise, using idioms familiar from NumPy, but it's much faster and uses less memory.
+
+For a similar problem 10 million times larger than the one above (on a single-threaded 2.2 GHz processor),
+
+   * the Awkward Array one-liner takes **4.6 seconds** to run and uses **2.1 GB** of memory,
+   * the equivalent using Python lists and dicts takes **138 seconds** to run and uses **22 GB** of memory.
+
+Speed and memory factors in the double digits are common because we're replacing Python's dynamically typed, pointer-chasing virtual machine with type-specialized, precompiled routines on contiguous data. (In other words, for the same reasons as NumPy.) Even higher speedups are possible when Awkward Array is paired with [Numba](https://numba.pydata.org/).
+
+Our [presentation at SciPy 2020](https://youtu.be/WlnUF3LRBj4) provides a good introduction, showing how to use these arrays in a real analysis.
+
+# Installation
+
+Awkward Array can be installed [from PyPI](https://pypi.org/project/awkward1/) using pip:
+
+```bash
+pip install awkward1
+```
+
+Most users will get a precompiled binary (wheel) for your operating system and Python version. If not, the above attempts to compile from source.
+
+   * Report bugs, request features, and ask for additional documentation on [GitHub Issues](https://github.com/scikit-hep/awkward-1.0/issues). If you have a general "How do I…?" question, we'll answer it as a new [example in the tutorial](https://awkward-array.org/how-to.html).
+   * If you have a problem that's too specific to be new documentation or it isn't exclusively related to Awkward Array, it might be more appropriate to ask on [StackOverflow with the [awkward-array] tag](https://stackoverflow.com/questions/tagged/awkward-array). Be sure to include tags for any other libraries that you use, such as Pandas or PyTorch.
+   * The [Gitter Scikit-HEP/community](https://gitter.im/Scikit-HEP/community) is a way to get in touch with all Scikit-HEP developers and users.

--- a/dependent-project/CMakeLists.txt
+++ b/dependent-project/CMakeLists.txt
@@ -3,18 +3,15 @@
 cmake_minimum_required(VERSION 3.1...3.16)
 project(dependent LANGUAGES CXX)
 
-execute_process(COMMAND python -m awkward1.config --incdir OUTPUT_VARIABLE AWKWARD_INCLUDE)
-execute_process(COMMAND python -m awkward1.config --libdir OUTPUT_VARIABLE AWKWARD_LIBRARIES)
+execute_process(COMMAND python -m awkward1.config --incdir OUTPUT_VARIABLE AWKWARD_INCLUDE OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND python -m awkward1.config --libdir OUTPUT_VARIABLE AWKWARD_LIBRARIES OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-message("AWKWARD_INCLUDE ${AWKWARD_INCLUDE}")
-message("AWKWARD_LIBRARIES ${AWKWARD_LIBRARIES}")
-
-include_directories(${AWKWARD_INCLUDE})
+include_directories(BEFORE "${AWKWARD_INCLUDE}")
 
 add_subdirectory(../pybind11 cmake_pybind11)
 
-find_library(CPU-KERNELS awkward-cpu-kernels PATHS ${AWKWARD_LIBRARIES} REQUIRED)
-find_library(LIBAWKWARD awkward PATHS ${AWKWARD_LIBRARIES} REQUIRED)
+find_library(CPU-KERNELS awkward-cpu-kernels REQUIRED HINTS ${AWKWARD_LIBRARIES})
+find_library(LIBAWKWARD awkward REQUIRED HINTS ${AWKWARD_LIBRARIES})
 message(STATUS "Libraries: ${LIBAWKWARD} ${CPU-KERNELS}")
 
 pybind11_add_module(dependent dependent.cpp)

--- a/dependent-project/CMakeLists.txt
+++ b/dependent-project/CMakeLists.txt
@@ -3,12 +3,18 @@
 cmake_minimum_required(VERSION 3.1...3.16)
 project(dependent LANGUAGES CXX)
 
-include_directories(${CMAKE_PREFIX_PATH}/include)
+execute_process(COMMAND python -m awkward1.config --incdir OUTPUT_VARIABLE AWKWARD_INCLUDE)
+execute_process(COMMAND python -m awkward1.config --libdir OUTPUT_VARIABLE AWKWARD_LIBRARIES)
+
+message("AWKWARD_INCLUDE ${AWKWARD_INCLUDE}")
+message("AWKWARD_LIBRARIES ${AWKWARD_LIBRARIES}")
+
+include_directories(${AWKWARD_INCLUDE})
 
 add_subdirectory(../pybind11 cmake_pybind11)
 
-find_library(CPU-KERNELS awkward-cpu-kernels HINTS ${CMAKE_PREFIX_PATH}/lib)
-find_library(LIBAWKWARD awkward HINTS ${CMAKE_PREFIX_PATH}/lib)
+find_library(CPU-KERNELS awkward-cpu-kernels PATHS ${AWKWARD_LIBRARIES} REQUIRED)
+find_library(LIBAWKWARD awkward PATHS ${AWKWARD_LIBRARIES} REQUIRED)
 message(STATUS "Libraries: ${LIBAWKWARD} ${CPU-KERNELS}")
 
 pybind11_add_module(dependent dependent.cpp)

--- a/dependent-project/CMakeLists.txt
+++ b/dependent-project/CMakeLists.txt
@@ -12,8 +12,9 @@ add_subdirectory(../pybind11 cmake_pybind11)
 
 find_library(CPU-KERNELS awkward-cpu-kernels REQUIRED HINTS ${AWKWARD_LIBRARIES})
 find_library(LIBAWKWARD awkward REQUIRED HINTS ${AWKWARD_LIBRARIES})
-message(STATUS "Libraries: ${LIBAWKWARD} ${CPU-KERNELS}")
+find_library(LIBDL dl REQUIRED)
+message(STATUS "Libraries: ${CPU-KERNELS} ${LIBAWKWARD} ${LIBDL}")
 
 pybind11_add_module(dependent dependent.cpp)
 set_target_properties(dependent PROPERTIES CXX_VISIBILITY_PRESET hidden)
-target_link_libraries(dependent PRIVATE ${CPU-KERNELS} ${LIBAWKWARD})
+target_link_libraries(dependent PRIVATE ${CPU-KERNELS} ${LIBAWKWARD} ${LIBDL})

--- a/dependent-project/README.md
+++ b/dependent-project/README.md
@@ -9,7 +9,7 @@ $ python -m awkward1.config --cflags --libs
 -std=c++11 -I/path/to/awkward1/include -L/path/to/awkward1 -lawkward -lawkward-cpu-kernels
 ```
 
-The Python package includes both static (.a) and shared (.so or .dylib) libraries.
+The Python package includes both shared (.so or .dylib) and static (.a) libraries (see `python -m awkward1.config --help`).
 
 A C++ program that depends on Awkward Array, like [minimal.cpp](./minimal.cpp), can be compiled like this:
 
@@ -17,10 +17,12 @@ A C++ program that depends on Awkward Array, like [minimal.cpp](./minimal.cpp), 
 $ g++ `python -m awkward1.config --cflags --libs` minimal.cpp -o minimal
 ```
 
-The new executable, `./minimal`, depends on Awkward Array's shared libraries, we they need to be on your system's library search path. The way to do that is system-dependent, but a quick and dirty way to do it on Linux is
+The new executable, `./minimal`, depends on Awkward Array's shared libraries, we they need to be on your system's library search path (if you didn't use `--static-libs`).
+
+The way to set up your search path is system-dependent, but a quick and dirty way to do it on Linux is
 
 ```bash
-export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
+$ export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
 ```
 
 Then you can run this executable. (It takes two arguments, an array as JSON and an item to select and print as JSON.)

--- a/dependent-project/README.md
+++ b/dependent-project/README.md
@@ -11,21 +11,19 @@ $ python -m awkward1.config --cflags --libs
 
 The Python package includes both shared (.so or .dylib) and static (.a) libraries (see `python -m awkward1.config --help`).
 
-A C++ program that depends on Awkward Array, like [minimal.cpp](./minimal.cpp), can be compiled like this:
+A C++ program that depends on Awkward Array, like [minimal.cpp](./minimal.cpp), can be compiled like the following (be sure to configure Awkward libraries *after* your own project's files! argument order matters!):
 
 ```bash
-$ g++ `python -m awkward1.config --cflags --libs` minimal.cpp -o minimal
+$ g++ minimal.cpp `python -m awkward1.config --cflags --libs` -o minimal
 ```
 
-The new executable, `./minimal`, depends on Awkward Array's shared libraries, we they need to be on your system's library search path (if you didn't use `--static-libs`).
-
-The way to set up your search path is system-dependent, but a quick and dirty way to do it on Linux is
+If you want the new executable to include Awkward Array libraries within it, use `--static-libs` to link them statically. Otherwise, you will either need to copy the shared libraries into a directory on your system's library search path or point your system's library search path to the Awkward package. A quick and dirty way to do the latter is
 
 ```bash
 $ export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
 ```
 
-Then you can run this executable. (It takes two arguments, an array as JSON and an item to select and print as JSON.)
+Now you can run this executable. (It takes two arguments, an array as JSON and an item to select and print as JSON.)
 
 ```bash
 $ ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2

--- a/dependent-project/README.md
+++ b/dependent-project/README.md
@@ -9,7 +9,7 @@ $ python -m awkward1.config --cflags --libs
 -std=c++11 -I/path/to/awkward1/include -L/path/to/awkward1 -lawkward -lawkward-cpu-kernels
 ```
 
-The Python package includes both shared (.so or .dylib) and static (.a) libraries (see `python -m awkward1.config --help`).
+The Python package includes both shared (.so/.dylib/.dll) and static (.a/.lib) libraries (see `python -m awkward1.config --help`).
 
 A C++ program that depends on Awkward Array, such as [minimal.cpp](./minimal.cpp), can be compiled with the following (be sure to configure Awkward libraries *after* your own project's files! argument order matters!):
 
@@ -17,7 +17,7 @@ A C++ program that depends on Awkward Array, such as [minimal.cpp](./minimal.cpp
 $ g++ minimal.cpp `python -m awkward1.config --cflags --libs` -o minimal
 ```
 
-If you want Awkward Array to be statically linked into the executable, use `--static-libs`. Otherwise, you will either need to copy the shared libraries into a directory on your system's library search path or point your system's library search path to the Awkward package. A quick and dirty way to do the latter on Linux is
+If you want Awkward Array to be statically linked into the executable, use `--static-libs` instead of `--libs`. Otherwise, you will either need to copy the shared libraries into a directory on your system's library search path or point your system's library search path to the Awkward package. A quick and dirty way to do the latter on Linux is
 
 ```bash
 $ export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH

--- a/dependent-project/README.md
+++ b/dependent-project/README.md
@@ -17,7 +17,13 @@ A C++ program that depends on Awkward Array, like [minimal.cpp](./minimal.cpp), 
 $ g++ `python -m awkward1.config --cflags --libs` minimal.cpp -o minimal
 ```
 
-and used like this (it picks one item from an Awkward Array):
+The new executable, `./minimal`, depends on Awkward Array's shared libraries, we they need to be on your system's library search path. The way to do that is system-dependent, but a quick and dirty way to do it on Linux is
+
+```bash
+export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
+```
+
+Then you can run this executable. (It takes two arguments, an array as JSON and an item to select and print as JSON.)
 
 ```bash
 $ ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2

--- a/dependent-project/README.md
+++ b/dependent-project/README.md
@@ -2,7 +2,7 @@
 
 Python code that depends on Awkward requires no configuration; just `pip install awkward1` and import it like any other Python library.
 
-C++ compilers, on the other hand, don't know where to find Awkward Array's header files and shared libraries without help. These files are distributed along with the Python library, and it can be used as a "pkg-config" substitute to locate these libraries:
+C++ compilers, on the other hand, don't know where to find Awkward Array's header files and libraries without help. These files are distributed inside of the Python library. To find the right search paths, `python -m awkward1.config` can be used like "pkg-config":
 
 ```bash
 $ python -m awkward1.config --cflags --libs
@@ -11,13 +11,13 @@ $ python -m awkward1.config --cflags --libs
 
 The Python package includes both shared (.so or .dylib) and static (.a) libraries (see `python -m awkward1.config --help`).
 
-A C++ program that depends on Awkward Array, like [minimal.cpp](./minimal.cpp), can be compiled like the following (be sure to configure Awkward libraries *after* your own project's files! argument order matters!):
+A C++ program that depends on Awkward Array, such as [minimal.cpp](./minimal.cpp), can be compiled with the following (be sure to configure Awkward libraries *after* your own project's files! argument order matters!):
 
 ```bash
 $ g++ minimal.cpp `python -m awkward1.config --cflags --libs` -o minimal
 ```
 
-If you want the new executable to include Awkward Array libraries within it, use `--static-libs` to link them statically. Otherwise, you will either need to copy the shared libraries into a directory on your system's library search path or point your system's library search path to the Awkward package. A quick and dirty way to do the latter is
+If you want Awkward Array to be statically linked into the executable, use `--static-libs`. Otherwise, you will either need to copy the shared libraries into a directory on your system's library search path or point your system's library search path to the Awkward package. A quick and dirty way to do the latter is
 
 ```bash
 $ export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH

--- a/dependent-project/README.md
+++ b/dependent-project/README.md
@@ -17,7 +17,7 @@ A C++ program that depends on Awkward Array, such as [minimal.cpp](./minimal.cpp
 $ g++ minimal.cpp `python -m awkward1.config --cflags --libs` -o minimal
 ```
 
-If you want Awkward Array to be statically linked into the executable, use `--static-libs`. Otherwise, you will either need to copy the shared libraries into a directory on your system's library search path or point your system's library search path to the Awkward package. A quick and dirty way to do the latter is
+If you want Awkward Array to be statically linked into the executable, use `--static-libs`. Otherwise, you will either need to copy the shared libraries into a directory on your system's library search path or point your system's library search path to the Awkward package. A quick and dirty way to do the latter on Linux is
 
 ```bash
 $ export LD_LIBRARY_PATH=`python -m awkward1.config --libdir`:$LD_LIBRARY_PATH
@@ -30,7 +30,7 @@ $ ./minimal "[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]]" -2
 [4.4,5.5]
 ```
 
-If you want your C++ code to have a Python interface, compile it with the same version of pybind11 as Awkward (see release notes) as shown in [CMakeLists.txt](CMakeLists.txt) and [dependent.cpp](dependent.cpp), which can be compiled like this:
+If you want your C++ code to have a Python interface, compile it with the same version of pybind11 as Awkward (see release notes) as shown in [CMakeLists.txt](CMakeLists.txt) and [dependent.cpp](dependent.cpp), which can be compiled like the following (you may need to [tell pybind11 which Python to use](https://pybind11.readthedocs.io/en/stable/faq.html#cmake-doesn-t-detect-the-right-python-version)):
 
 ```bash
 $ cmake -S . -B build

--- a/dependent-project/dependent.cpp
+++ b/dependent-project/dependent.cpp
@@ -6,7 +6,7 @@
 
 #include "awkward/builder/ArrayBuilder.h"
 #include "awkward/builder/ArrayBuilderOptions.h"
-#include "awkward/cpu-kernels/getitem.h"
+#include "awkward/kernels/getitem.h"
 
 namespace py = pybind11;
 namespace ak = awkward;
@@ -38,7 +38,7 @@ std::shared_ptr<ak::Content> producer() {
   builder.field_fast("y");
   builder.string("wow");
   builder.endrecord();
-  
+
   return builder.snapshot();
 }
 

--- a/dependent-project/minimal.cpp
+++ b/dependent-project/minimal.cpp
@@ -20,6 +20,6 @@ int main(int argc, char** argv) {
   std::shared_ptr<ak::Content> selection = input.get()->getitem_at(at);
 
   std::cout << selection.get()->tojson(false, 1) << std::endl;
-  
+
   return 0;
 }

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -1,7 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("include/awkward/array/RawArray.h", line)
-#define FILENAME_C(line) FILENAME_FOR_EXCEPTIONS_C("include/awkward/array/RawArray.h", line)
+#define FILENAME(line) std::string("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/master/include/awkward/array/RawArray.h#L" #line ")")
+#define FILENAME_C(line) FILENAME(line)
 
 #ifndef AWKWARD_RAWARRAY_H_
 #define AWKWARD_RAWARRAY_H_

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -1,7 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
 #define FILENAME(line) std::string("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/master/include/awkward/array/RawArray.h#L" #line ")")
-#define FILENAME_C(line) FILENAME(line)
+#define FILENAME_C(line) ("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/master/include/awkward/array/RawArray.h#L" #line ")")
 
 #ifndef AWKWARD_RAWARRAY_H_
 #define AWKWARD_RAWARRAY_H_

--- a/include/awkward/kernel-dispatch.h
+++ b/include/awkward/kernel-dispatch.h
@@ -182,8 +182,7 @@ namespace awkward {
       }
       else {
         throw std::runtime_error(
-          std::string("unrecognized ptr_lib in ptr_alloc<bool>")
-          + FILENAME_FOR_EXCEPTIONS("include/awkward/kernel-dispatch.h", __LINE__));
+          std::string("unrecognized ptr_lib in ptr_alloc<bool>"));
       }
     }
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+numba>=0.50.0;python_version>="3.6"
+pandas>=0.24.0;python_version>="3.6"
+numexpr;python_version>="3.6"
+autograd;python_version>="3.6"
+pyarrow>=1.0;python_version>="3.6" and sys_platform != "win32"

--- a/setup.py
+++ b/setup.py
@@ -100,21 +100,29 @@ def tree(x):
 if platform.system() == "Windows":
     class Install(setuptools.command.install.install):
         def run(self):
+            outerdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])))
+
+            print("--- this directory --------------------------------------------")
+            for x in sorted(os.listdir(".")):
+                print(x)
+
             print("--- build directory -------------------------------------------")
             tree("build")
 
-            print("--- specifically, the dlldir ----------------------------------")
-            dlldir = os.path.join(os.path.join("build", "temp.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])), "Release", "Release")
-            tree(dlldir)
+            print("--- copying includes ------------------------------------------")
+            shutil.copytree(os.path.join("include"), os.path.join(outerdir, "awkward1", "include"))
 
-            print("--- copying ---------------------------------------------------")
+            print("--- outerdir after copy ---------------------------------------")
+            tree(outerdir)
+
+            print("--- copying libraries -----------------------------------------")
+            dlldir = os.path.join(os.path.join("build", "temp.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])), "Release", "Release")
             for x in os.listdir(dlldir):
                 if x.startswith("awkward"):
                     print("copying", os.path.join(dlldir, x), "-->", os.path.join(self.build_lib, "awkward1", x))
                     shutil.copyfile(os.path.join(dlldir, x), os.path.join(self.build_lib, "awkward1", x))
 
-            print("--- deleting --------------------------------------------------")
-            outerdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])))
+            print("--- deleting libraries ----------------------------------------")
             for x in os.listdir(outerdir):
                 if x.endswith(".pyd"):
                     print("deleting", os.path.join(outerdir, x))
@@ -126,12 +134,16 @@ if platform.system() == "Windows":
 else:
     class Install(setuptools.command.install.install):
         def run(self):
+            outerdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])))
+
+            print("--- this directory --------------------------------------------")
+            for x in sorted(os.listdir(".")):
+                print(x)
+
             print("--- build directory -------------------------------------------")
             tree("build")
 
-            outerdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])))
-
-            print("--- copying ---------------------------------------------------")
+            print("--- copying includes ------------------------------------------")
             shutil.copytree(os.path.join("include"), os.path.join(outerdir, "awkward1", "include"))
 
             print("--- outerdir after copy ---------------------------------------")

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ def tree(x):
             tree(os.path.join(x, y))
 
 
-data_files = []
 if platform.system() == "Windows":
     class Install(setuptools.command.install.install):
         def run(self):
@@ -125,16 +124,6 @@ if platform.system() == "Windows":
             setuptools.command.install.install.run(self)
 
 else:
-    # Libraries do not exist yet, so they cannot be determined with a glob pattern.
-    libdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])), "awkward1")
-
-    # Install shared libraries system-wide only on Linux.
-    if platform.system() != "Darwin":
-        data_files = [("lib", [
-            os.path.join(libdir, "libawkward-cpu-kernels.so"),
-            os.path.join(libdir, "libawkward.so"),
-        ])]
-
     class Install(setuptools.command.install.install):
         def run(self):
             print("--- build directory -------------------------------------------")
@@ -155,7 +144,6 @@ else:
 setup(name = "awkward1",
       packages = [x for x in setuptools.find_packages(where="src") if x != "awkward1_cuda_kernels"],
       package_dir = {"awkward1": "src/awkward1"},
-      data_files = data_files,
       version = open("VERSION_INFO").read().strip(),
       author = "Jim Pivarski",
       author_email = "pivarski@princeton.edu",

--- a/setup.py
+++ b/setup.py
@@ -16,17 +16,14 @@ import setuptools.command.install
 from setuptools import setup, Extension
 
 
-install_requires = open("requirements.txt").read().strip().split()
-
-extras = {"cuda": ["awkward1-cuda-kernels"],
-          "test": open("requirements-test.txt").read().strip().split(),
-          "dev":  ['numba>=0.50.0;python_version>="3.6"',
-                   'pandas>=0.24.0;python_version>="3.6"',
-                   'numexpr;python_version>="3.6"',
-                   'autograd;python_version>="3.6"',
-                   'pyarrow>=1.0;python_version>="3.6" and sys_platform != "win32"']}
+extras = {
+    "cuda": ["awkward1-cuda-kernels"],
+    "test": open("requirements-test.txt").read().strip().split("\n"),
+    "dev":  open("requirements-dev.txt").read().strip().split("\n"),
+}
 extras["all"] = sum(extras.values(), [])
 
+install_requires = open("requirements.txt").read().strip().split("\n")
 tests_require = extras["test"]
 
 
@@ -34,6 +31,7 @@ class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
+
 
 class CMakeBuild(setuptools.command.build_ext.build_ext):
     def build_extensions(self):
@@ -46,14 +44,15 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
             self.build_extension(x)
 
     def build_extension(self, ext):
-
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ["-DCMAKE_INSTALL_PREFIX={0}".format(extdir),
-                      "-DPYTHON_EXECUTABLE={0}".format(sys.executable),
-                      "-DPYBUILD=ON",
-                      "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9",
-                      "-DPYBUILD=ON",
-                      "-DBUILD_TESTING=OFF"]
+        cmake_args = [
+            "-DCMAKE_INSTALL_PREFIX={0}".format(extdir),
+            "-DPYTHON_EXECUTABLE={0}".format(sys.executable),
+            "-DPYBUILD=ON",
+            "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9",
+            "-DPYBUILD=ON",
+            "-DBUILD_TESTING=OFF",
+        ]
         try:
            compiler_path = self.compiler.compiler_cxx[0]
            cmake_args.append("-DCMAKE_CXX_COMPILER={0}".format(compiler_path))
@@ -64,8 +63,10 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
         build_args = ["--config", cfg]
 
         if platform.system() == "Windows":
-            cmake_args += ["-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{0}={1}".format(cfg.upper(), extdir),
-                           "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE"]
+            cmake_args += [
+                "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{0}={1}".format(cfg.upper(), extdir),
+                "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE",
+            ]
             if sys.maxsize > 2**32:
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
@@ -88,16 +89,15 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
         subprocess.check_call(["cmake", "--build", build_dir] + build_args)
         subprocess.check_call(["cmake", "--build", build_dir, "--target", "install"])
 
+
+def tree(x):
+    print(x + (" (dir)" if os.path.isdir(x) else ""))
+    if os.path.isdir(x):
+        for y in os.listdir(x):
+            tree(os.path.join(x, y))
+
+
 if platform.system() == "Windows":
-    # Libraries are not installed system-wide on Windows, but they do have to be in the awkward1 directory.
-    libraries = []
-
-    def tree(x):
-        print(x + (" (dir)" if os.path.isdir(x) else ""))
-        if os.path.isdir(x):
-            for y in os.listdir(x):
-                tree(os.path.join(x, y))
-
     class Install(setuptools.command.install.install):
         def run(self):
             print("--- build directory -------------------------------------------")
@@ -112,8 +112,8 @@ if platform.system() == "Windows":
                 if x.startswith("awkward"):
                     print("copying", os.path.join(dlldir, x), "-->", os.path.join(self.build_lib, "awkward1", x))
                     shutil.copyfile(os.path.join(dlldir, x), os.path.join(self.build_lib, "awkward1", x))
-            print("--- deleting --------------------------------------------------")
 
+            print("--- deleting --------------------------------------------------")
             outerdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])))
             for x in os.listdir(outerdir):
                 if x.endswith(".pyd"):
@@ -124,146 +124,31 @@ if platform.system() == "Windows":
             setuptools.command.install.install.run(self)
 
 else:
-    # Libraries do not exist yet, so they cannot be determined with a glob pattern.
-    libdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])), "awkward1")
-    static = ".a"
-    if platform.system() == "Darwin":
-        shared = ".dylib"
-    else:
-        shared = ".so"
-    libraries = [("lib", [os.path.join(libdir, "libawkward-cpu-kernels-static" + static),
-                          os.path.join(libdir, "libawkward-cpu-kernels" + shared),
-                          os.path.join(libdir, "libawkward-static" + static),
-                          os.path.join(libdir, "libawkward" + shared)])]
+    class Install(setuptools.command.install.install):
+        def run(self):
+            print("--- build directory -------------------------------------------")
+            tree("build")
 
-    Install = setuptools.command.install.install
+            print("--- copying ---------------------------------------------------")
+            shutil.copytree(os.path.join("include"), os.path.join(outerdir, "awkward1", "include"))
+
+            print("--- outerdir after copy ---------------------------------------")
+            tree(outerdir)
+
+            print("--- begin normal install --------------------------------------")
+            setuptools.command.install.install.run(self)
+
 
 setup(name = "awkward1",
-      packages = setuptools.find_packages(where="src"),
-      package_dir = {"": "src"},
-      include_package_data = True,
-      package_data = {"": ["*.dll"]},
-      data_files = libraries + [
-          ("include/awkward",              glob.glob("include/awkward/*.h")),
-          ("include/awkward/cpu-kernels",  glob.glob("include/awkward/cpu-kernels/*.h")),
-          ("include/awkward/python",       glob.glob("include/awkward/python/*.h")),
-          ("include/awkward/array",        glob.glob("include/awkward/array/*.h")),
-          ("include/awkward/builder",      glob.glob("include/awkward/builder/*.h")),
-          ("include/awkward/partition",    glob.glob("include/awkward/partition/*.h")),
-          ("include/awkward/io",           glob.glob("include/awkward/io/*.h")),
-          ("include/awkward/type",         glob.glob("include/awkward/type/*.h"))],
+      packages = [x for x in setuptools.find_packages(where="src") if x != "awkward1_cuda_kernels"],
+      package_dir = {"awkward1": "src/awkward1"},
       version = open("VERSION_INFO").read().strip(),
       author = "Jim Pivarski",
       author_email = "pivarski@princeton.edu",
       maintainer = "Jim Pivarski",
       maintainer_email = "pivarski@princeton.edu",
       description = "Manipulate JSON-like data with NumPy-like idioms.",
-      long_description = """<a href="https://github.com/scikit-hep/awkward-1.0#readme"><img src="https://github.com/scikit-hep/awkward-1.0/raw/master/docs-img/logo/logo-300px.png"></a>
-
-Awkward Array is a library for **nested, variable-sized data**, including arbitrary-length lists, records, mixed types, and missing data, using **NumPy-like idioms**.
-
-Arrays are **dynamically typed**, but operations on them are **compiled and fast**. Their behavior coincides with NumPy when array dimensions are regular and generalizes when they're not.
-
-<table>
-  <tr>
-    <td width="66%" valign="top">
-      <a href="https://awkward-array.org">
-        <img src="https://github.com/scikit-hep/awkward-1.0/raw/master/docs-img/panel-tutorials.png" width="570">
-      </a>
-      <p align="center"><b>
-        <a href="https://awkward-array.org">
-        How-to tutorials
-        </a>
-      </b></p>
-    </td>
-    <td width="33%" valign="top">
-      <a href="https://awkward-array.readthedocs.io/en/latest/index.html">
-        <img src="https://github.com/scikit-hep/awkward-1.0/raw/master/docs-img/panel-sphinx.png" width="268">
-      </a>
-      <p align="center"><b>
-        <a href="https://awkward-array.readthedocs.io/en/latest/index.html">
-        Python API reference
-        </a>
-      </b></p>
-      <a href="https://awkward-array.readthedocs.io/en/latest/_static/index.html">
-        <img src="https://github.com/scikit-hep/awkward-1.0/raw/master/docs-img/panel-doxygen.png" width="268">
-      </a>
-      <p align="center"><b>
-        <a href="https://awkward-array.readthedocs.io/en/latest/_static/index.html">
-        C++ API reference
-        </a>
-      </b></p>
-    </td>
-  </tr>
-</table>
-
-# Motivating example
-
-Given an array of objects with `x`, `y` fields and variable-length nested lists like
-
-```python
-array = ak.Array([
-    [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}],
-    [],
-    [{"x": 4.4, "y": {1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}]
-])
-```
-
-the following slices out the `y` values, drops the first element from each inner list, and runs NumPy's `np.square` function on everything that is left:
-
-```python
-output = np.square(array["y", ..., 1:])
-```
-
-The result is
-
-```python
-[
-    [[], [4], [4, 9]],
-    [],
-    [[4, 9, 16], [4, 9, 16, 25]]
-]
-```
-
-The equivalent using only Python is
-
-```python
-output = []
-for sublist in array:
-    tmp1 = []
-    for record in sublist:
-        tmp2 = []
-        for number in record["y"][1:]:
-            tmp2.append(np.square(number))
-        tmp1.append(tmp2)
-    output.append(tmp1)
-```
-
-Not only is the expression using Awkward Arrays more concise, using idioms familiar from NumPy, but it's much faster and uses less memory.
-
-For a similar problem 10 million times larger than the one above (on a single-threaded 2.2 GHz processor),
-
-   * the Awkward Array one-liner takes **4.6 seconds** to run and uses **2.1 GB** of memory,
-   * the equivalent using Python lists and dicts takes **138 seconds** to run and uses **22 GB** of memory.
-
-Speed and memory factors in the double digits are common because we're replacing Python's dynamically typed, pointer-chasing virtual machine with type-specialized, precompiled routines on contiguous data. (In other words, for the same reasons as NumPy.) Even higher speedups are possible when Awkward Array is paired with [Numba](https://numba.pydata.org/).
-
-Our [presentation at SciPy 2020](https://youtu.be/WlnUF3LRBj4) provides a good introduction, showing how to use these arrays in a real analysis.
-
-# Installation
-
-Awkward Array can be installed [from PyPI](https://pypi.org/project/awkward1/) using pip:
-
-```bash
-pip install awkward1
-```
-
-Most users will get a precompiled binary (wheel) for your operating system and Python version. If not, the above attempts to compile from source.
-
-   * Report bugs, request features, and ask for additional documentation on [GitHub Issues](https://github.com/scikit-hep/awkward-1.0/issues). If you have a general "How do I…?" question, we'll answer it as a new [example in the tutorial](https://awkward-array.org/how-to.html).
-   * If you have a problem that's too specific to be new documentation or it isn't exclusively related to Awkward Array, it might be more appropriate to ask on [StackOverflow with the [awkward-array] tag](https://stackoverflow.com/questions/tagged/awkward-array). Be sure to include tags for any other libraries that you use, such as Pandas or PyTorch.
-   * The [Gitter Scikit-HEP/community](https://gitter.im/Scikit-HEP/community) is a way to get in touch with all Scikit-HEP developers and users.
-""",
+      long_description = open("README-pypi.md").read(),
       long_description_content_type = "text/markdown",
       url = "https://github.com/scikit-hep/awkward-1.0",
       download_url = "https://github.com/scikit-hep/awkward-1.0/releases",
@@ -278,9 +163,13 @@ Most users will get a precompiled binary (wheel) for your operating system and P
       extras_require = extras,
 
       # cmake_args=['-DBUILD_TESTING=OFF'],      # for scikit-build
-      ext_modules = [CMakeExtension("awkward")], # NOT scikit-build
-      cmdclass = {"build_ext": CMakeBuild,       # NOT scikit-build
-                  "install": Install},
+      ext_modules = [
+          CMakeExtension("awkward"),             # NOT scikit-build
+      ],
+      cmdclass = {
+          "build_ext": CMakeBuild,               # NOT scikit-build
+          "install": Install,
+      },
 
       classifiers = [
 #         "Development Status :: 1 - Planning",

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,8 @@ else:
             print("--- build directory -------------------------------------------")
             tree("build")
 
+            outerdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])))
+
             print("--- copying ---------------------------------------------------")
             shutil.copytree(os.path.join("include"), os.path.join(outerdir, "awkward1", "include"))
 

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ def tree(x):
             tree(os.path.join(x, y))
 
 
+data_files = []
 if platform.system() == "Windows":
     class Install(setuptools.command.install.install):
         def run(self):
@@ -124,6 +125,16 @@ if platform.system() == "Windows":
             setuptools.command.install.install.run(self)
 
 else:
+    # Libraries do not exist yet, so they cannot be determined with a glob pattern.
+    libdir = os.path.join(os.path.join("build", "lib.%s-%d.%d" % (distutils.util.get_platform(), sys.version_info[0], sys.version_info[1])), "awkward1")
+
+    # Install shared libraries system-wide only on Linux.
+    if platform.system() != "Darwin":
+        data_files = [("lib", [
+            os.path.join(libdir, "libawkward-cpu-kernels.so"),
+            os.path.join(libdir, "libawkward.so"),
+        ])]
+
     class Install(setuptools.command.install.install):
         def run(self):
             print("--- build directory -------------------------------------------")
@@ -144,6 +155,7 @@ else:
 setup(name = "awkward1",
       packages = [x for x in setuptools.find_packages(where="src") if x != "awkward1_cuda_kernels"],
       package_dir = {"awkward1": "src/awkward1"},
+      data_files = data_files,
       version = open("VERSION_INFO").read().strip(),
       author = "Jim Pivarski",
       author_email = "pivarski@princeton.edu",

--- a/src/awkward1/_cpu_kernels.py
+++ b/src/awkward1/_cpu_kernels.py
@@ -3,12 +3,9 @@
 from __future__ import absolute_import
 
 import ctypes
-import ctypes.util
 import platform
 import pkg_resources
 
-# libpath = ctypes.util.find_library("awkward")
-# if libpath is None:
 if platform.system() == "Windows":
     name = "awkward-cpu-kernels.dll"
 elif platform.system() == "Darwin":

--- a/src/awkward1/_libawkward.py
+++ b/src/awkward1/_libawkward.py
@@ -3,12 +3,9 @@
 from __future__ import absolute_import
 
 import ctypes
-import ctypes.util
 import platform
 import pkg_resources
 
-# libpath = ctypes.util.find_library("awkward")
-# if libpath is None:
 if platform.system() == "Windows":
     name = "awkward.dll"
 elif platform.system() == "Darwin":

--- a/src/awkward1/config.py
+++ b/src/awkward1/config.py
@@ -4,21 +4,12 @@ from __future__ import absolute_import
 
 import sys
 import argparse
-import platform
 import pkg_resources
 
 if __name__ == "__main__":
-    if platform.system() == "Windows":
-        libawkward_cpu_kernels_name = "awkward-cpu-kernels.dll"
-        libawkward_name = "awkward.dll"
-    elif platform.system() == "Darwin":
-        libawkward_cpu_kernels_name = "libawkward-cpu-kernels.dylib"
-        libawkward_name = "libawkward.dylib"
-    else:
-        libawkward_cpu_kernels_name = "libawkward-cpu-kernels.so"
-        libawkward_name = "libawkward.so"
-
     awkward_path = pkg_resources.resource_filename("awkward1", "")
+    libawkward_cpu_kernels_name = "libawkward-cpu-kernels.so"
+    libawkward_name = "libawkward.so"
 
     argparser = argparse.ArgumentParser(description="Print out compilation arguments to use Awkward Array as a C++ dependency")
     argparser.add_argument("--cflags", action="store_true", help="output compiler flags and Awkward include path")

--- a/src/awkward1/config.py
+++ b/src/awkward1/config.py
@@ -1,0 +1,65 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+import argparse
+import platform
+import pkg_resources
+
+if __name__ == "__main__":
+    if platform.system() == "Windows":
+        libawkward_cpu_kernels_name = "awkward-cpu-kernels.dll"
+        libawkward_name = "awkward.dll"
+    elif platform.system() == "Darwin":
+        libawkward_cpu_kernels_name = "libawkward-cpu-kernels.dylib"
+        libawkward_name = "libawkward.dylib"
+    else:
+        libawkward_cpu_kernels_name = "libawkward-cpu-kernels.so"
+        libawkward_name = "libawkward.so"
+
+    awkward_path = pkg_resources.resource_filename("awkward1", "")
+
+    argparser = argparse.ArgumentParser(description="Print out compilation arguments to use Awkward Array as a C++ dependency")
+    argparser.add_argument("--cflags", action="store_true", help="output compiler flags and Awkward include path")
+    argparser.add_argument("--libs", action="store_true", help="output Awkward libraries with path")
+    argparser.add_argument("--libs-only-L", action="store_true", help="output Awkward library path")
+    argparser.add_argument("--libs-only-l", action="store_true", help="output Awkward libraries without path")
+    argparser.add_argument("--cflags-only-I", action="store_true", help="output Awkward include path")
+
+    # only used in validating the arguments
+    args = argparser.parse_args()
+
+    output = []
+
+    # loop over original sys.argv to get optional arguments in order
+    for arg in sys.argv:
+        if arg == "--cflags":
+            output.append("-std=c++11 -I{0}".format(
+                pkg_resources.resource_filename("awkward1", "include")
+            ))
+
+        if arg == "--libs":
+            output.append("-L{0} -l{1} -l{2}".format(
+                pkg_resources.resource_filename("awkward1", ""),
+                libawkward_name,
+                libawkward_cpu_kernels_name,
+            ))
+
+        if arg == "--libs-only-L":
+            output.append("-L{0}".format(
+                pkg_resources.resource_filename("awkward1", ""),
+            ))
+
+        if arg == "--libs-only-l":
+            output.append("-l{0} -l{1}".format(
+                libawkward_name,
+                libawkward_cpu_kernels_name,
+            ))
+
+        if arg == "--cflags-only-I":
+            output.append("-I{0}".format(
+                pkg_resources.resource_filename("awkward1", "include")
+            ))
+
+    print(" ".join(output))

--- a/src/awkward1/config.py
+++ b/src/awkward1/config.py
@@ -7,50 +7,57 @@ import argparse
 import pkg_resources
 
 if __name__ == "__main__":
-    awkward_path = pkg_resources.resource_filename("awkward1", "")
-    libawkward_cpu_kernels_name = "libawkward-cpu-kernels.so"
-    libawkward_name = "libawkward.so"
-
     argparser = argparse.ArgumentParser(description="Print out compilation arguments to use Awkward Array as a C++ dependency")
     argparser.add_argument("--cflags", action="store_true", help="output compiler flags and Awkward include path")
     argparser.add_argument("--libs", action="store_true", help="output Awkward libraries with path")
     argparser.add_argument("--libs-only-L", action="store_true", help="output Awkward library path")
     argparser.add_argument("--libs-only-l", action="store_true", help="output Awkward libraries without path")
+    argparser.add_argument("--static-libs", action="store_true", help="output Awkward static libraries with path")
+    argparser.add_argument("--static-libs-only-L", action="store_true", help="output Awkward static library path")
+    argparser.add_argument("--static-libs-only-l", action="store_true", help="output Awkward static libraries without path")
     argparser.add_argument("--cflags-only-I", action="store_true", help="output Awkward include path")
+    argparser.add_argument("--incdir", action="store_true", help="output Awkward include directory name")
+    argparser.add_argument("--libdir", action="store_true", help="output Awkward library directory name")
 
     # only used in validating the arguments
     args = argparser.parse_args()
 
     output = []
+    incdir = pkg_resources.resource_filename("awkward1", "include")
+    libdir = pkg_resources.resource_filename("awkward1", "")
+    cpu_kernels = "awkward-cpu-kernels"
+    libawkward = "awkward"
 
     # loop over original sys.argv to get optional arguments in order
     for arg in sys.argv:
         if arg == "--cflags":
-            output.append("-std=c++11 -I{0}".format(
-                pkg_resources.resource_filename("awkward1", "include")
-            ))
+            output.append("-std=c++11 -I{0}".format(incdir))
 
         if arg == "--libs":
-            output.append("-L{0} -l{1} -l{2}".format(
-                pkg_resources.resource_filename("awkward1", ""),
-                libawkward_name,
-                libawkward_cpu_kernels_name,
-            ))
+            output.append("-L{0} -l{1} -l{2}".format(libdir, libawkward, cpu_kernels))
 
         if arg == "--libs-only-L":
-            output.append("-L{0}".format(
-                pkg_resources.resource_filename("awkward1", ""),
-            ))
+            output.append("-L{0}".format(libdir))
 
         if arg == "--libs-only-l":
-            output.append("-l{0} -l{1}".format(
-                libawkward_name,
-                libawkward_cpu_kernels_name,
-            ))
+            output.append("-l{0} -l{1}".format(libawkward, cpu_kernels))
+
+        if arg == "--static-libs":
+            output.append("-L{0} -l{1}-static -l{2}-static".format(libdir, libawkward, cpu_kernels))
+
+        if arg == "--static-libs-only-L":
+            output.append("-L{0}".format(libdir))
+
+        if arg == "--static-libs-only-l":
+            output.append("-l{0}-static -l{1}-static".format(libawkward, cpu_kernels))
 
         if arg == "--cflags-only-I":
-            output.append("-I{0}".format(
-                pkg_resources.resource_filename("awkward1", "include")
-            ))
+            output.append("-I{0}".format(incdir))
+
+        if arg == "--incdir":
+            output.append(incdir)
+
+        if arg == "--libdir":
+            output.append(libdir)
 
     print(" ".join(output))

--- a/src/awkward1/config.py
+++ b/src/awkward1/config.py
@@ -34,22 +34,22 @@ if __name__ == "__main__":
             output.append("-std=c++11 -I{0}".format(incdir))
 
         if arg == "--libs":
-            output.append("-L{0} -l{1} -l{2}".format(libdir, libawkward, cpu_kernels))
+            output.append("-L{0} -l{1} -l{2} -ldl".format(libdir, libawkward, cpu_kernels))
 
         if arg == "--libs-only-L":
             output.append("-L{0}".format(libdir))
 
         if arg == "--libs-only-l":
-            output.append("-l{0} -l{1}".format(libawkward, cpu_kernels))
+            output.append("-l{0} -l{1} -ldl".format(libawkward, cpu_kernels))
 
         if arg == "--static-libs":
-            output.append("-L{0} -l{1}-static -l{2}-static".format(libdir, libawkward, cpu_kernels))
+            output.append("-L{0} -l{1}-static -l{2}-static -ldl".format(libdir, libawkward, cpu_kernels))
 
         if arg == "--static-libs-only-L":
             output.append("-L{0}".format(libdir))
 
         if arg == "--static-libs-only-l":
-            output.append("-l{0}-static -l{1}-static".format(libawkward, cpu_kernels))
+            output.append("-l{0}-static -l{1}-static -ldl".format(libawkward, cpu_kernels))
 
         if arg == "--cflags-only-I":
             output.append("-I{0}".format(incdir))

--- a/src/awkward1_cuda_kernels/__init__.py
+++ b/src/awkward1_cuda_kernels/__init__.py
@@ -2,17 +2,20 @@
 
 from __future__ import absolute_import
 
-import os.path
-import glob
+import platform
+import pkg_resources
 
-directory, filename = os.path.split(__file__)
+# awkward1-cuda-kernels is only supported on Linux, but let's leave the placeholder.
+if platform.system() == "Windows":
+    shared_library_name = "awkward-cuda-kernels.dll"
+elif platform.system() == "Darwin":
+    shared_library_name = "libawkward-cuda-kernels.dylib"
+else:
+    shared_library_name = "libawkward-cuda-kernels.so"
 
-shared_library_path = None
-for filename in glob.glob(os.path.join(directory, "*awkward-cuda-kernels.*")):
-    shared_library_path = filename
+shared_library_path = pkg_resources.resource_filename(
+    "awkward1_cuda_kernels", shared_library_name
+)
 
-del os
-del glob
-del directory
-del filename
-
+del platform
+del pkg_resources


### PR DESCRIPTION
Also, we're going to get the `dependent-project` into the tests again by making

```bash
python -m awkward1.config --cflags --libs
```

return

```
-std=c++11 -I/path/to/include -L/path/to/lib -lawkward -lawkward-cpu-kernels
```

and using that to get the location of the currently installed Awkward library.