### PR TITLE
Fix ak.flatten for arrays that have been sliced.

### DIFF
--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -857,7 +857,9 @@ namespace awkward {
       ContentPtr listoffsetarray = toListOffsetArray64(true);
       ListOffsetArray64* raw =
         dynamic_cast<ListOffsetArray64*>(listoffsetarray.get());
-      return std::pair<Index64, ContentPtr>(raw->offsets(), raw->content());
+      int64_t stop = raw->offsets().getitem_at(-1);
+      ContentPtr content = raw->content().get()->getitem_range_nowrap(0, stop);
+      return std::pair<Index64, ContentPtr>(raw->offsets(), content);
     }
     else {
       std::pair<Index64, ContentPtr> pair =

--- a/tests/test_0446-fix-flatten-of-sliced-array.py
+++ b/tests/test_0446-fix-flatten-of-sliced-array.py
@@ -1,0 +1,18 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import sys
+
+import pytest
+
+import numpy
+import awkward1
+
+
+def test():
+    array = awkward1.Array([[1, 2, 3], [], [4, 5], [6, 7, 8, 9]])
+    assert awkward1.flatten(array[:-1], axis=1).tolist() == [1, 2, 3, 4, 5]
+    assert awkward1.flatten(array[:-2], axis=1).tolist() == [1, 2, 3]
+    assert awkward1.flatten(array[:-1], axis=None).tolist() == [1, 2, 3, 4, 5]
+    assert awkward1.flatten(array[:-2], axis=None).tolist() == [1, 2, 3]


### PR DESCRIPTION
I noticed this while handling those performance issues.