### PR TITLE
Explicitly cast list to CuPy array in cumsum test

### DIFF
--- a/tests-cuda/test_0388-abstract-all-uses-of-numpy.py
+++ b/tests-cuda/test_0388-abstract-all-uses-of-numpy.py
@@ -152,7 +152,7 @@ def test_cumsum():
     assert np_prefixsum.tolist() == [3, 8, 13, 13, 15]
 
     cp_prefixsum = cupy.empty(5)
-    assert cupy.cumsum([3, 5, 5, 0, 2], out=cp_prefixsum).tolist() == [3, 8, 13, 13, 15]
+    assert cupy.cumsum(cupy.array([3, 5, 5, 0, 2]), out=cp_prefixsum).tolist() == [3, 8, 13, 13, 15]
     assert cp_prefixsum.tolist() == [3, 8, 13, 13, 15]
 
 


### PR DESCRIPTION
cupy.cumsum does not cast Python list and NumPy array to CuPy array from 8.0.0rc1.
https://github.com/cupy/cupy/issues/3984