### PR TITLE
Deprecate 'keys' -> 'fields' and add properties to ak.Array and ak.Record

### DIFF
--- a/src/awkward1/operations/convert.py
+++ b/src/awkward1/operations/convert.py
@@ -2412,7 +2412,7 @@ def to_parquet(array, where, explode_records=False, **options):
         array: Data to write to a Parquet file.
         where (str, Path, file-like object): Where to write the Parquet file.
         explode_records (bool): If True, lists of records are written as
-            records of lists, so that nested keys become top-level fields
+            records of lists, so that nested fields become top-level fields
             (which can be zipped when read back).
         options: All other options are passed to pyarrow.parquet.ParquetWriter.
             In particular, if no `schema` is given, a schema is derived from

--- a/src/awkward1/operations/describe.py
+++ b/src/awkward1/operations/describe.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import numbers
+import warnings
 
 import awkward1.layout
 import awkward1.nplike
@@ -247,12 +248,20 @@ def parameters(array):
 
 
 def keys(array):
+    warnings.warn(
+        "ak.keys is deprecated, will be removed in 0.4.0. Use ak.fields instead.",
+        DeprecationWarning,
+    )
+    return fields(array)
+
+
+def fields(array):
     """
-    Extracts record or tuple keys from `array` (many types supported,
-    including all Awkward Arrays and Records).
+    Extracts record fields or tuple slot numbers from `array` (many types
+    supported, including all Awkward Arrays and Records).
 
     If the array contains nested records, only the outermost record is
-    queried. If it contains tuples instead of records, the keys are
+    queried. If it contains tuples instead of records, this function outputs
     string representations of integers, such as `"0"`, `"1"`, `"2"`, etc.
     The records or tuples may be within multiple layers of nested lists.
 

--- a/tests/test_0079-argchoose-and-choose.py
+++ b/tests/test_0079-argchoose-and-choose.py
@@ -13,7 +13,7 @@ def test_ListOffsetArray():
     array = awkward1.Array([[0.0, 1.1, 2.2, 3.3], [], [4.4, 5.5, 6.6], [7.7], [8.8, 9.9, 10.0, 11.1, 12.2]])
 
     assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False)) == [[(0.0, 1.1), (0.0, 2.2), (0.0, 3.3), (1.1, 2.2), (1.1, 3.3), (2.2, 3.3)], [], [(4.4, 5.5), (4.4, 6.6), (5.5, 6.6)], [], [(8.8, 9.9), (8.8, 10.0), (8.8, 11.1), (8.8, 12.2), (9.9, 10.0), (9.9, 11.1), (9.9, 12.2), (10.0, 11.1), (10.0, 12.2), (11.1, 12.2)]]
-    assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False, keys=["x", "y"])) == [[{"x": 0.0, "y": 1.1}, {"x": 0.0, "y": 2.2}, {"x": 0.0, "y": 3.3}, {"x": 1.1, "y": 2.2}, {"x": 1.1, "y": 3.3}, {"x": 2.2, "y": 3.3}], [], [{"x": 4.4, "y": 5.5}, {"x": 4.4, "y": 6.6}, {"x": 5.5, "y": 6.6}], [], [{"x": 8.8, "y": 9.9}, {"x": 8.8, "y": 10.0}, {"x": 8.8, "y": 11.1}, {"x": 8.8, "y": 12.2}, {"x": 9.9, "y": 10.0}, {"x": 9.9, "y": 11.1}, {"x": 9.9, "y": 12.2}, {"x": 10.0, "y": 11.1}, {"x": 10.0, "y": 12.2}, {"x": 11.1, "y": 12.2}]]
+    assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False, fields=["x", "y"])) == [[{"x": 0.0, "y": 1.1}, {"x": 0.0, "y": 2.2}, {"x": 0.0, "y": 3.3}, {"x": 1.1, "y": 2.2}, {"x": 1.1, "y": 3.3}, {"x": 2.2, "y": 3.3}], [], [{"x": 4.4, "y": 5.5}, {"x": 4.4, "y": 6.6}, {"x": 5.5, "y": 6.6}], [], [{"x": 8.8, "y": 9.9}, {"x": 8.8, "y": 10.0}, {"x": 8.8, "y": 11.1}, {"x": 8.8, "y": 12.2}, {"x": 9.9, "y": 10.0}, {"x": 9.9, "y": 11.1}, {"x": 9.9, "y": 12.2}, {"x": 10.0, "y": 11.1}, {"x": 10.0, "y": 12.2}, {"x": 11.1, "y": 12.2}]]
     tmp = awkward1.combinations(array, 2, replacement=False, parameters={"some": "param"}).layout
     if isinstance(tmp, awkward1.partition.PartitionedArray):
         assert awkward1.partition.first(tmp).content.parameters["some"] == "param"
@@ -30,7 +30,7 @@ def test_RegularArray():
     array = awkward1.Array(numpy.array([[0.0, 1.1, 2.2, 3.3], [4.4, 5.5, 6.6, 7.7]]))
 
     assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False)) == [[(0.0, 1.1), (0.0, 2.2), (0.0, 3.3), (1.1, 2.2), (1.1, 3.3), (2.2, 3.3)], [(4.4, 5.5), (4.4, 6.6), (4.4, 7.7), (5.5, 6.6), (5.5, 7.7), (6.6, 7.7)]]
-    assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False, keys=["x", "y"])) == [[{"x": 0.0, "y": 1.1}, {"x": 0.0, "y": 2.2}, {"x": 0.0, "y": 3.3}, {"x": 1.1, "y": 2.2}, {"x": 1.1, "y": 3.3}, {"x": 2.2, "y": 3.3}], [{"x": 4.4, "y": 5.5}, {"x": 4.4, "y": 6.6}, {"x": 4.4, "y": 7.7}, {"x": 5.5, "y": 6.6}, {"x": 5.5, "y": 7.7}, {"x": 6.6, "y": 7.7}]]
+    assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False, fields=["x", "y"])) == [[{"x": 0.0, "y": 1.1}, {"x": 0.0, "y": 2.2}, {"x": 0.0, "y": 3.3}, {"x": 1.1, "y": 2.2}, {"x": 1.1, "y": 3.3}, {"x": 2.2, "y": 3.3}], [{"x": 4.4, "y": 5.5}, {"x": 4.4, "y": 6.6}, {"x": 4.4, "y": 7.7}, {"x": 5.5, "y": 6.6}, {"x": 5.5, "y": 7.7}, {"x": 6.6, "y": 7.7}]]
 
     tmp = awkward1.combinations(array, 2, replacement=False, parameters={"some": "param"}).layout
     if isinstance(tmp, awkward1.partition.PartitionedArray):
@@ -49,7 +49,7 @@ def test_axis0():
 
     assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False, axis=0)) == [(0.0, 1.1), (0.0, 2.2), (0.0, 3.3), (1.1, 2.2), (1.1, 3.3), (2.2, 3.3)]
 
-    assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False, axis=0, keys=["x", "y"])) == [{"x": 0.0, "y": 1.1}, {"x": 0.0, "y": 2.2}, {"x": 0.0, "y": 3.3}, {"x": 1.1, "y": 2.2}, {"x": 1.1, "y": 3.3}, {"x": 2.2, "y": 3.3}]
+    assert awkward1.to_list(awkward1.combinations(array, 2, replacement=False, axis=0, fields=["x", "y"])) == [{"x": 0.0, "y": 1.1}, {"x": 0.0, "y": 2.2}, {"x": 0.0, "y": 3.3}, {"x": 1.1, "y": 2.2}, {"x": 1.1, "y": 3.3}, {"x": 2.2, "y": 3.3}]
 
     assert awkward1.combinations(array, 2, replacement=False, axis=0, parameters={"some": "param"}).layout.parameters["some"] == "param"
 


### PR DESCRIPTION
New properties:

   * `ndim` to mean `self.layout.purelist_depth` (Pandas forced me to make `ndim` always 1, which is terrible)
   * `fields` to mean `ak.fields`, and rename `ak.keys` to `ak.fields`
   * `type` to mean `ak.type`

with a formal deprecation process (to 0.4.0) of `ak.keys` → `ak.fields` and the `keys` arguments of `ak.combinations`, and `ak.argcombinations` to `fields` (also a deprecation process, to 0.4.0).

(@nsmith-)