### PR TITLE
Attempt to make check for -A x64 flag more robust

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,8 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
                 "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{0}={1}".format(cfg.upper(), extdir),
                 "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE",
             ]
-            excluded_gens = ["NMake Makefiles", "Visual Studio 15 2017 Win64"]
-            if sys.maxsize > 2**32 and os.environ.get("CMAKE_GENERATOR") not in excluded_gens:
+            cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
+            if sys.maxsize > 2**32 and cmake_generator != "NMake Makefiles" and "Win64" not in cmake_generator:
                 cmake_args += ["-A", "x64"]
         else:
             cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]


### PR DESCRIPTION
As the version of the compilers used will change from time to time I think this might be a slightly more robust check to use.