### PR TITLE
Implement unflatten function

### DIFF
--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -1588,6 +1588,11 @@ def to_layout(
             )
         return from_numpy(array, regulararray=True, recordarray=True, highlevel=False)
 
+    elif (
+        type(array).__module__.startswith("cupy.") and type(array).__name__ == "ndarray"
+    ):
+        return from_cupy(array, regulararray=True, highlevel=False)
+
     elif isinstance(array, (str, bytes)) or (
         ak._util.py27 and isinstance(array, ak._util.unicode)
     ):

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -1513,13 +1513,13 @@ def unflatten(array, counts, highlevel=True):
         else:
             mask = False
         nplike = ak.nplike.of(counts_layout)
-        if nplike.asarray(counts_layout).dtype != "int":
+        if counts.dtype != "int":
             raise ValueError(
                 "non-integer counts" + ak._util.exception_suffix(__file__)
             )
-        offsets = nplike.empty(len(counts_layout) + 1, np.int64)
+        offsets = nplike.empty(len(counts) + 1, np.int64)
         offsets[0] = 0
-        nplike.cumsum(counts_layout, out=offsets[1:])
+        nplike.cumsum(counts, out=offsets[1:])
         offsets = ak.layout.Index64(offsets)
         out = ak.layout.ListOffsetArray64(offsets, layout)
         if mask is not False:

--- a/tests/test_0583-implement-unflatten-function.py
+++ b/tests/test_0583-implement-unflatten-function.py
@@ -1,0 +1,39 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    assert ak.unflatten(array, 5).tolist() == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+    assert ak.unflatten(array, [3, 0, 2, 1, 4]).tolist() == [
+        [0, 1, 2],
+        [],
+        [3, 4],
+        [5],
+        [6, 7, 8, 9],
+    ]
+    assert ak.unflatten(array, [3, None, 2, 1, 4]).tolist() == [
+        [0, 1, 2],
+        None,
+        [3, 4],
+        [5],
+        [6, 7, 8, 9],
+    ]
+
+    original = ak.Array([[0, 1, 2], [], [3, 4], [5], [6, 7, 8, 9]])
+    counts = ak.num(original)
+    array = ak.flatten(original)
+    assert counts.tolist() == [3, 0, 2, 1, 4]
+    assert array.tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert ak.unflatten(array, counts).tolist() == [
+        [0, 1, 2],
+        [],
+        [3, 4],
+        [5],
+        [6, 7, 8, 9],
+    ]


### PR DESCRIPTION
This implements an `unflatten` function for awkward as described in #555.
As I really needed this function and the issue was marked as "good first issue" I thought I would give it a try.
Would you like to have a unit test for the function? I'm not sure as this is my first pull request, but if needed I can write one.

I noticed one problem with `cumsum` while writing this. However, this might need to go into a separate issue. Consider
```
arr = ak.Array(cupy.array([1,2,3]))
ak.nplike.of(arr.layout).cumsum(arr.layout)
```
will raise a `TypeError`. However it will work fine if you change `cupy` to `numpy`.