### PR TITLE
fix: avoid hardcoded threads and macOS target

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
             "-DCMAKE_INSTALL_PREFIX={0}".format(extdir),
             "-DPYTHON_EXECUTABLE={0}".format(sys.executable),
             "-DPYBUILD=ON",
-            "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9",
             "-DPYBUILD=ON",
             "-DBUILD_TESTING=OFF",
         ]
@@ -71,8 +70,12 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
             cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
             if sys.maxsize > 2**32 and cmake_generator != "NMake Makefiles" and "Win64" not in cmake_generator:
                 cmake_args += ["-A", "x64"]
-        else:
+                
+        elif "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ::
             build_args += ["-j", str(multiprocessing.cpu_count())]
+            
+        if platform.system() == "Darwin" and "MACOSX_DEPLOYMENT_TARGET" not in os.environ:
+            cmake_args += ["-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"]
 
         if not os.path.exists(self.build_temp):
              os.makedirs(self.build_temp)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
             if sys.maxsize > 2**32 and cmake_generator != "NMake Makefiles" and "Win64" not in cmake_generator:
                 cmake_args += ["-A", "x64"]
                 
-        elif "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ::
+        elif "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
             build_args += ["-j", str(multiprocessing.cpu_count())]
             
         if platform.system() == "Darwin" and "MACOSX_DEPLOYMENT_TARGET" not in os.environ:


### PR DESCRIPTION
This is broken on conda-forge because it's running out of memory on Travis - you should always be able to build single threaded if you need to!

And I've also avoided overriding the macOS deployment target - most build systems (cibuildwheel, conda-forge, etc) set this and you should avoid overriding that.

See https://github.com/pybind/cmake_example/blob/master/setup.py - this should be similar to that.

This is stopping this PR: https://github.com/conda-forge/awkward-feedstock/pull/58 (though the broken build is not the one that was being added in that PR). I'll add it as a patch as soon as it's merged. _Please be sure to Squash and Merge, not "regular merge", to make the patch clean and easy to apply._