### PR TITLE
Add setuptools to requirements for pkg_resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+setuptools
 numpy>=1.13.1


### PR DESCRIPTION
I just saw a failure when using uproot with the traceback:
```
+ python -c 'import uproot; assert len(uproot.open("root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root")["Events"]["PV_x"].array()) == 29308627'
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/extras.py", line 21, in awkward
    import awkward
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/awkward/__init__.py", line 29, in <module>
    import awkward._cpu_kernels
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/awkward/_cpu_kernels.py", line 7, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/behaviors/TBranch.py", line 2059, in array
    _ranges_or_baskets_to_arrays(
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/behaviors/TBranch.py", line 3430, in _ranges_or_baskets_to_arrays
    uproot.source.futures.delayed_raise(*obj)
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/source/futures.py", line 46, in delayed_raise
    raise exception_value.with_traceback(traceback)
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/behaviors/TBranch.py", line 3401, in basket_to_array
    arrays[branch.cache_key] = interpretation.final_array(
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/interpretation/numerical.py", line 115, in final_array
    output = library.finalize(output, branch, self, entry_start, entry_stop)
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/interpretation/library.py", line 481, in finalize
    awkward = self.imported
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/interpretation/library.py", line 478, in imported
    return uproot.extras.awkward()
  File "/home/conda/feedstock_root/build_artifacts/uproot_1608368458292/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/uproot/extras.py", line 23, in awkward
    raise ImportError(
ImportError: install the 'awkward' package with:

    pip install awkward

Alternatively, you can use ``library="np"`` or globally set ``uproot.default_library``
to output as NumPy arrays, rather than Awkward arrays.

Tests failed for uproot-4.0.0-pyhd8ed1ab_0.tar.bz2 - moving package to /home/conda/feedstock_root/build_artifacts/broken
```

The issue is that `pkg_resources` is part of `setuptools` and this isn't declared in the awkward `install_requires`. As it's a dependency of pip it's rare to be running on a system without it installed so it's often missed as a dependency.