### PR TITLE
run static analyser on Forth machine

### DIFF
--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -174,7 +174,7 @@ namespace awkward {
                const std::vector<ssize_t>& strides,
                ssize_t byteoffset,
                ssize_t itemsize,
-               const std::string format,
+               const std::string& format,
                util::dtype dtype,
                const kernel::lib ptr_lib);
 

--- a/include/awkward/forth/ForthMachine.h
+++ b/include/awkward/forth/ForthMachine.h
@@ -56,7 +56,7 @@ namespace awkward {
       decompiled_at(int64_t bytecode_position, const std::string& indent="") const;
 
     /// @brief HERE
-    const std::vector<std::string>
+    const std::vector<std::string>&
       dictionary() const;
 
     /// @brief HERE
@@ -122,7 +122,7 @@ namespace awkward {
       variables() const;
 
     /// @brief HERE
-    const std::vector<std::string>
+    const std::vector<std::string>&
       variable_index() const;
 
     /// @brief HERE
@@ -146,7 +146,7 @@ namespace awkward {
       outputs() const;
 
     /// @brief HERE
-    const std::vector<std::string>
+    const std::vector<std::string>&
       output_index() const noexcept;
 
     /// @brief HERE

--- a/include/awkward/forth/ForthMachine.h
+++ b/include/awkward/forth/ForthMachine.h
@@ -56,7 +56,7 @@ namespace awkward {
       decompiled_at(int64_t bytecode_position, const std::string& indent="") const;
 
     /// @brief HERE
-    const std::vector<std::string>&
+    const std::vector<std::string>
       dictionary() const;
 
     /// @brief HERE
@@ -122,7 +122,7 @@ namespace awkward {
       variables() const;
 
     /// @brief HERE
-    const std::vector<std::string>&
+    const std::vector<std::string>
       variable_index() const;
 
     /// @brief HERE
@@ -146,7 +146,7 @@ namespace awkward {
       outputs() const;
 
     /// @brief HERE
-    const std::vector<std::string>&
+    const std::vector<std::string>
       output_index() const noexcept;
 
     /// @brief HERE

--- a/include/awkward/forth/ForthOutputBuffer.h
+++ b/include/awkward/forth/ForthOutputBuffer.h
@@ -296,7 +296,7 @@ namespace awkward {
     inline void write_one(IN value) noexcept {
       length_++;
       maybe_resize(length_);
-      ptr_.get()[length_ - 1] = value;
+      ptr_.get()[length_ - 1] = (OUT)value;
     }
 
     /// @brief HERE
@@ -305,7 +305,7 @@ namespace awkward {
       int64_t next = length_ + num_items;
       maybe_resize(next);
       for (int64_t i = 0;  i < num_items;  i++) {
-        ptr_.get()[length_ + i] = values[i];
+        ptr_.get()[length_ + i] = (OUT)values[i];
       }
       length_ = next;
     }

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -296,7 +296,7 @@ namespace awkward {
                          const std::vector<ssize_t>& strides,
                          ssize_t byteoffset,
                          ssize_t itemsize,
-                         const std::string format,
+                         const std::string& format,
                          util::dtype dtype,
                          const kernel::lib ptr_lib)
       : Content(identities, parameters)

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -646,7 +646,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::vector<std::string>&
+  const std::vector<std::string>
   ForthMachineOf<T, I>::dictionary() const {
     return dictionary_names_;
   }
@@ -714,7 +714,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::vector<std::string>&
+  const std::vector<std::string>
   ForthMachineOf<T, I>::variable_index() const {
     return variable_names_;
   }
@@ -783,7 +783,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::vector<std::string>&
+  const std::vector<std::string>
   ForthMachineOf<T, I>::output_index() const noexcept {
     return output_names_;
   }
@@ -1505,8 +1505,9 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  void ForthMachineOf<T, I>::tokenize(std::vector<std::string>& tokenized,
-                                      std::vector<std::pair<int64_t, int64_t>>& linecol) {
+  void
+  ForthMachineOf<T, I>::tokenize(std::vector<std::string>& tokenized,
+                                 std::vector<std::pair<int64_t, int64_t>>& linecol) {
     IndexTypeOf<int64_t> start = 0;
     IndexTypeOf<int64_t> stop = 0;
     bool full = false;
@@ -1560,8 +1561,9 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  void ForthMachineOf<T, I>::compile(const std::vector<std::string>& tokenized,
-                                     const std::vector<std::pair<int64_t, int64_t>>& linecol) {
+  void
+  ForthMachineOf<T, I>::compile(const std::vector<std::string>& tokenized,
+                                const std::vector<std::pair<int64_t, int64_t>>& linecol) {
     std::vector<std::vector<I>> dictionary;
 
     // Start recursive parsing.

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -1282,8 +1282,8 @@ namespace awkward {
     else {
       int64_t which = current_which_[recursion_current_depth_ - 1];
       int64_t where = current_where_[recursion_current_depth_ - 1];
-      if (where < bytecodes_offsets_[which + 1] - bytecodes_offsets_[which]) {
-        return bytecodes_offsets_[which] + where;
+      if (where < bytecodes_offsets_[(IndexTypeOf<int64_t>)which + 1] - bytecodes_offsets_[(IndexTypeOf<int64_t>)which]) {
+        return bytecodes_offsets_[(IndexTypeOf<int64_t>)which] + where;
       }
       else {
         return -1;

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -302,7 +302,7 @@ namespace awkward {
       out << std::endl;
     }
     out << decompiled_segment(0);
-    return out.str();
+    return std::move(out.str());
   }
 
   template <typename T, typename I>
@@ -325,7 +325,7 @@ namespace awkward {
       out << decompiled_at(bytecode_position, indent) << std::endl;
       bytecode_position += bytecodes_per_instruction(bytecode_position);
     }
-    return out.str();
+    return std::move(out.str());
   }
 
   template <typename T, typename I>
@@ -404,30 +404,30 @@ namespace awkward {
 
     else if (next_bytecode == CODE_AGAIN) {
       int64_t body = bytecode - BOUND_DICTIONARY;
-      return std::string("begin\n")
+      return std::move(std::string("begin\n")
              + (segment_nonempty(body) ? indent + "  " : "")
              + decompiled_segment(body, indent + "  ")
-             + indent + "again";
+             + indent + "again");
     }
 
     else if (next_bytecode == CODE_UNTIL) {
       int64_t body = bytecode - BOUND_DICTIONARY;
-      return std::string("begin\n")
+      return std::move(std::string("begin\n")
              + (segment_nonempty(body) ? indent + "  " : "")
              + decompiled_segment(body, indent + "  ")
-             + indent + "until";
+             + indent + "until");
     }
 
     else if (next_bytecode == CODE_WHILE) {
       int64_t precondition = bytecode - BOUND_DICTIONARY;
       int64_t postcondition = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 2] - BOUND_DICTIONARY;
-      return std::string("begin\n")
+      return std::move(std::string("begin\n")
              + (segment_nonempty(precondition) ? indent + "  " : "")
              + decompiled_segment(precondition, indent + "  ")
              + indent + "while\n"
              + (segment_nonempty(postcondition) ? indent + "  " : "")
              + decompiled_segment(postcondition, indent + "  ")
-             + indent + "repeat";
+             + indent + "repeat");
     }
 
     else if (bytecode >= BOUND_DICTIONARY) {
@@ -452,38 +452,38 @@ namespace awkward {
         }
         case CODE_IF: {
           int64_t consequent = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 1] - BOUND_DICTIONARY;
-          return std::string("if\n")
+          return std::move(std::string("if\n")
                  + (segment_nonempty(consequent) ? indent + "  " : "")
                  + decompiled_segment(consequent, indent + "  ")
-                 + indent + "then";
+                 + indent + "then");
         }
         case CODE_IF_ELSE: {
           int64_t consequent = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 1] - BOUND_DICTIONARY;
           int64_t alternate = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 2] - BOUND_DICTIONARY;
-          return std::string("if\n")
+          return std::move(std::string("if\n")
                  + (segment_nonempty(consequent) ? indent + "  " : "")
                  + decompiled_segment(consequent, indent + "  ")
                  + indent + "else\n"
                  + (segment_nonempty(alternate) ? indent + "  " : "")
                  + decompiled_segment(alternate, indent + "  ")
-                 + indent + "then";
+                 + indent + "then");
         }
         case CODE_DO: {
           int64_t body = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 1] - BOUND_DICTIONARY;
-          return std::string("do\n")
+          return std::move(std::string("do\n")
                  + (segment_nonempty(body) ? indent + "  " : "")
                  + decompiled_segment(body, indent + "  ")
-                 + indent + "loop";
+                 + indent + "loop");
         }
         case CODE_DO_STEP: {
           int64_t body = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 1] - BOUND_DICTIONARY;
-          return std::string("do\n")
+          return std::move(std::string("do\n")
                  + (segment_nonempty(body) ? indent + "  " : "")
                  + decompiled_segment(body, indent + "  ")
-                 + indent + "+loop";
+                 + indent + "+loop");
         }
         case CODE_EXIT: {
-          return std::string("exit");
+          return std::move(std::string("exit"));
         }
         case CODE_PUT: {
           int64_t var_num = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 1];
@@ -641,12 +641,12 @@ namespace awkward {
           return "true";
         }
       }
-      return std::string("(unrecognized bytecode ") + std::to_string(bytecode) + ")";
+      return std::move(std::string("(unrecognized bytecode ") + std::to_string(bytecode) + ")");
     }
   }
 
   template <typename T, typename I>
-  const std::vector<std::string>
+  const std::vector<std::string>&
   ForthMachineOf<T, I>::dictionary() const {
     return dictionary_names_;
   }
@@ -680,7 +680,7 @@ namespace awkward {
   ForthMachineOf<T, I>::stack() const {
     std::vector<T> out;
     for (int64_t i = 0;  i < stack_depth_;  i++) {
-      out.push_back(stack_buffer_[i]);
+      out.emplace_back(stack_buffer_[i]);
     }
     return out;
   }
@@ -714,7 +714,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::vector<std::string>
+  const std::vector<std::string>&
   ForthMachineOf<T, I>::variable_index() const {
     return variable_names_;
   }
@@ -783,7 +783,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  const std::vector<std::string>
+  const std::vector<std::string>&
   ForthMachineOf<T, I>::output_index() const noexcept {
     return output_names_;
   }
@@ -986,7 +986,7 @@ namespace awkward {
       bool found = false;
       for (auto pair : inputs) {
         if (pair.first == name) {
-          current_inputs_.push_back(pair.second);
+          current_inputs_.emplace_back(pair.second);
           found = true;
           break;
         }
@@ -1054,7 +1054,7 @@ namespace awkward {
                                    + FILENAME(__LINE__));
         }
       }
-      current_outputs_.push_back(out);
+      current_outputs_.emplace_back(out);
     }
 
     recursion_target_depth_.push(0);
@@ -1358,7 +1358,7 @@ namespace awkward {
       try {
         value = (int64_t)std::stoul(word.substr(2, word.size() - 2), nullptr, 16);
       }
-      catch (std::invalid_argument err) {
+      catch (std::invalid_argument& err) {
         return false;
       }
       return true;
@@ -1367,7 +1367,7 @@ namespace awkward {
       try {
         value = (int64_t)std::stoul(word, nullptr, 10);
       }
-      catch (std::invalid_argument err) {
+      catch (std::invalid_argument& err) {
         return false;
       }
       return true;
@@ -1501,7 +1501,7 @@ namespace awkward {
       stop++;
     }
     out << source_.substr(start, stop - start);
-    return out.str();
+    return std::move(out.str());
   }
 
   template <typename T, typename I>
@@ -1519,8 +1519,8 @@ namespace awkward {
       if (current == ' '  ||  current == '\r'  ||  current == '\t'  ||
           current == '\v'  ||  current == '\f') {
         if (full) {
-          tokenized.push_back(source_.substr(start, stop - start));
-          linecol.push_back(std::pair<int64_t, int64_t>(line, colstart));
+          tokenized.emplace_back(source_.substr(start, stop - start));
+          linecol.emplace_back(std::pair<int64_t, int64_t>(line, colstart));
         }
         start = stop;
         full = false;
@@ -1530,11 +1530,11 @@ namespace awkward {
       // It has no semantic meaning after the parsing stage.
       else if (current == '\n') {
         if (full) {
-          tokenized.push_back(source_.substr(start, stop - start));
-          linecol.push_back(std::pair<int64_t, int64_t>(line, colstart));
+          tokenized.emplace_back(source_.substr(start, stop - start));
+          linecol.emplace_back(std::pair<int64_t, int64_t>(line, colstart));
         }
-        tokenized.push_back(source_.substr(stop, 1));
-        linecol.push_back(std::pair<int64_t, int64_t>(line, colstart));
+        tokenized.emplace_back(source_.substr(stop, 1));
+        linecol.emplace_back(std::pair<int64_t, int64_t>(line, colstart));
         start = stop;
         full = false;
         line++;
@@ -1554,8 +1554,8 @@ namespace awkward {
     }
     // The source code might end on non-whitespace.
     if (full) {
-      tokenized.push_back(source_.substr(start, stop - start));
-      linecol.push_back(std::pair<int64_t, int64_t>(line, colstart));
+      tokenized.emplace_back(source_.substr(start, stop - start));
+      linecol.emplace_back(std::pair<int64_t, int64_t>(line, colstart));
     }
   }
 
@@ -1566,7 +1566,7 @@ namespace awkward {
 
     // Start recursive parsing.
     std::vector<I> bytecodes;
-    dictionary.push_back(bytecodes);
+    dictionary.emplace_back(bytecodes);
     parse("",
           tokenized,
           linecol,
@@ -1579,12 +1579,12 @@ namespace awkward {
     dictionary[0] = bytecodes;
 
     // Copy std::vector<std::vector<I>> to flattened contents and offsets.
-    bytecodes_offsets_.push_back(0);
+    bytecodes_offsets_.emplace_back(0);
     for (auto segment : dictionary) {
       for (auto bytecode : segment) {
-        bytecodes_.push_back(bytecode);
+        bytecodes_.emplace_back(bytecode);
       }
-      bytecodes_offsets_.push_back((int64_t)bytecodes_.size());
+      bytecodes_offsets_.emplace_back((int64_t)bytecodes_.size());
     }
   }
 
@@ -1690,12 +1690,12 @@ namespace awkward {
         // Add the new word to the dictionary before parsing it so that recursive
         // functions can be defined.
         I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
-        dictionary_names_.push_back(name);
-        dictionary_bytecodes_.push_back(bytecode);
+        dictionary_names_.emplace_back(name);
+        dictionary_bytecodes_.emplace_back(bytecode);
 
         // Now parse the subroutine and add it to the dictionary.
         std::vector<I> body;
-        dictionary.push_back(body);
+        dictionary.emplace_back(body);
         parse(name,
               tokenized,
               linecol,
@@ -1720,7 +1720,7 @@ namespace awkward {
         }
         for (IndexTypeOf<I> i = 0;  i < dictionary_names_.size();  i++) {
           if (dictionary_names_[i] == defn) {
-            bytecodes.push_back(dictionary_bytecodes_[i]);
+            bytecodes.emplace_back(dictionary_bytecodes_[i]);
           }
         }
 
@@ -1748,8 +1748,8 @@ namespace awkward {
           );
         }
 
-        variable_names_.push_back(name);
-        variables_.push_back(0);
+        variable_names_.emplace_back(name);
+        variables_.emplace_back(0);
 
         pos += 2;
       }
@@ -1774,7 +1774,7 @@ namespace awkward {
           );
         }
 
-        input_names_.push_back(name);
+        input_names_.emplace_back(name);
 
         pos += 2;
       }
@@ -1804,8 +1804,8 @@ namespace awkward {
         bool found_dtype = false;
         for (auto pair : output_dtype_words_) {
           if (pair.first == dtype_string) {
-            output_names_.push_back(name);
-            output_dtypes_.push_back(pair.second);
+            output_names_.emplace_back(name);
+            output_dtypes_.emplace_back(pair.second);
             found_dtype = true;
             break;
           }
@@ -1821,13 +1821,13 @@ namespace awkward {
       }
 
       else if (word == "halt") {
-        bytecodes.push_back(CODE_HALT);
+        bytecodes.emplace_back(CODE_HALT);
 
         pos++;
       }
 
       else if (word == "pause") {
-        bytecodes.push_back(CODE_PAUSE);
+        bytecodes.emplace_back(CODE_PAUSE);
 
         pos++;
       }
@@ -1861,7 +1861,7 @@ namespace awkward {
           // without special instruction pointer manipulation at runtime.
           I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> consequent;
-          dictionary.push_back(consequent);
+          dictionary.emplace_back(consequent);
           parse(defn,
                 tokenized,
                 linecol,
@@ -1873,8 +1873,8 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode - BOUND_DICTIONARY] = consequent;
 
-          bytecodes.push_back(CODE_IF);
-          bytecodes.push_back(bytecode);
+          bytecodes.emplace_back(CODE_IF);
+          bytecodes.emplace_back(bytecode);
 
           pos = substop + 1;
         }
@@ -1882,7 +1882,7 @@ namespace awkward {
           // Same as above, except that two new definitions must be made.
           I bytecode1 = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> consequent;
-          dictionary.push_back(consequent);
+          dictionary.emplace_back(consequent);
           parse(defn,
                 tokenized,
                 linecol,
@@ -1896,7 +1896,7 @@ namespace awkward {
 
           I bytecode2 = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> alternate;
-          dictionary.push_back(alternate);
+          dictionary.emplace_back(alternate);
           parse(defn,
                 tokenized,
                 linecol,
@@ -1908,9 +1908,9 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode2 - BOUND_DICTIONARY] = alternate;
 
-          bytecodes.push_back(CODE_IF_ELSE);
-          bytecodes.push_back(bytecode1);
-          bytecodes.push_back(bytecode2);
+          bytecodes.emplace_back(CODE_IF_ELSE);
+          bytecodes.emplace_back(bytecode1);
+          bytecodes.emplace_back(bytecode2);
 
           pos = substop + 1;
         }
@@ -1948,7 +1948,7 @@ namespace awkward {
         // without special instruction pointer manipulation at runtime.
         I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
         std::vector<I> body;
-        dictionary.push_back(body);
+        dictionary.emplace_back(body);
         parse(defn,
               tokenized,
               linecol,
@@ -1961,12 +1961,12 @@ namespace awkward {
         dictionary[(IndexTypeOf<int64_t>)bytecode - BOUND_DICTIONARY] = body;
 
         if (is_step) {
-          bytecodes.push_back(CODE_DO_STEP);
-          bytecodes.push_back(bytecode);
+          bytecodes.emplace_back(CODE_DO_STEP);
+          bytecodes.emplace_back(bytecode);
         }
         else {
-          bytecodes.push_back(CODE_DO);
-          bytecodes.push_back(bytecode);
+          bytecodes.emplace_back(CODE_DO);
+          bytecodes.emplace_back(bytecode);
         }
 
         pos = substop + 1;
@@ -2029,7 +2029,7 @@ namespace awkward {
           // used without special instruction pointer manipulation at runtime.
           I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> body;
-          dictionary.push_back(body);
+          dictionary.emplace_back(body);
           parse(defn,
                 tokenized,
                 linecol,
@@ -2041,8 +2041,8 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode - BOUND_DICTIONARY] = body;
 
-          bytecodes.push_back(bytecode);
-          bytecodes.push_back(CODE_AGAIN);
+          bytecodes.emplace_back(bytecode);
+          bytecodes.emplace_back(CODE_AGAIN);
 
           pos = substop + 1;
         }
@@ -2050,7 +2050,7 @@ namespace awkward {
           // Same for the 'begin .. until' body.
           I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> body;
-          dictionary.push_back(body);
+          dictionary.emplace_back(body);
           parse(defn,
                 tokenized,
                 linecol,
@@ -2062,8 +2062,8 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode - BOUND_DICTIONARY] = body;
 
-          bytecodes.push_back(bytecode);
-          bytecodes.push_back(CODE_UNTIL);
+          bytecodes.emplace_back(bytecode);
+          bytecodes.emplace_back(CODE_UNTIL);
 
           pos = substop + 1;
         }
@@ -2071,7 +2071,7 @@ namespace awkward {
           // Same for the 'begin .. repeat' statements.
           I bytecode1 = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> precondition;
-          dictionary.push_back(precondition);
+          dictionary.emplace_back(precondition);
           parse(defn,
                 tokenized,
                 linecol,
@@ -2086,7 +2086,7 @@ namespace awkward {
           // Same for the 'repeat .. until' statements.
           I bytecode2 = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> postcondition;
-          dictionary.push_back(postcondition);
+          dictionary.emplace_back(postcondition);
           parse(defn,
                 tokenized,
                 linecol,
@@ -2098,17 +2098,17 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode2 - BOUND_DICTIONARY] = postcondition;
 
-          bytecodes.push_back(bytecode1);
-          bytecodes.push_back(CODE_WHILE);
-          bytecodes.push_back(bytecode2);
+          bytecodes.emplace_back(bytecode1);
+          bytecodes.emplace_back(CODE_WHILE);
+          bytecodes.emplace_back(bytecode2);
 
           pos = substop + 1;
         }
       }
 
       else if (word == "exit") {
-        bytecodes.push_back(CODE_EXIT);
-        bytecodes.push_back((int32_t)exitdepth);
+        bytecodes.emplace_back(CODE_EXIT);
+        bytecodes.emplace_back((int32_t)exitdepth);
 
         pos++;
       }
@@ -2121,20 +2121,20 @@ namespace awkward {
           }
         }
         if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "!") {
-          bytecodes.push_back(CODE_PUT);
-          bytecodes.push_back((int32_t)variable_index);
+          bytecodes.emplace_back(CODE_PUT);
+          bytecodes.emplace_back((int32_t)variable_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "+!") {
-          bytecodes.push_back(CODE_INC);
-          bytecodes.push_back((int32_t)variable_index);
+          bytecodes.emplace_back(CODE_INC);
+          bytecodes.emplace_back((int32_t)variable_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "@") {
-          bytecodes.push_back(CODE_GET);
-          bytecodes.push_back((int32_t)variable_index);
+          bytecodes.emplace_back(CODE_GET);
+          bytecodes.emplace_back((int32_t)variable_index);
 
           pos += 2;
         }
@@ -2155,32 +2155,32 @@ namespace awkward {
         }
 
         if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "len") {
-          bytecodes.push_back(CODE_LEN_INPUT);
-          bytecodes.push_back((int32_t)input_index);
+          bytecodes.emplace_back(CODE_LEN_INPUT);
+          bytecodes.emplace_back((int32_t)input_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "pos") {
-          bytecodes.push_back(CODE_POS);
-          bytecodes.push_back((int32_t)input_index);
+          bytecodes.emplace_back(CODE_POS);
+          bytecodes.emplace_back((int32_t)input_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "end") {
-          bytecodes.push_back(CODE_END);
-          bytecodes.push_back((int32_t)input_index);
+          bytecodes.emplace_back(CODE_END);
+          bytecodes.emplace_back((int32_t)input_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "seek") {
-          bytecodes.push_back(CODE_SEEK);
-          bytecodes.push_back((int32_t)input_index);
+          bytecodes.emplace_back(CODE_SEEK);
+          bytecodes.emplace_back((int32_t)input_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "skip") {
-          bytecodes.push_back(CODE_SKIP);
-          bytecodes.push_back((int32_t)input_index);
+          bytecodes.emplace_back(CODE_SKIP);
+          bytecodes.emplace_back((int32_t)input_index);
 
           pos += 2;
         }
@@ -2295,10 +2295,10 @@ namespace awkward {
           }
 
           // Parser instructions are bit-flipped to detect them by the sign bit.
-          bytecodes.push_back(~bytecode);
-          bytecodes.push_back((int32_t)input_index);
+          bytecodes.emplace_back(~bytecode);
+          bytecodes.emplace_back((int32_t)input_index);
           if (found_output) {
-            bytecodes.push_back((int32_t)output_index);
+            bytecodes.emplace_back((int32_t)output_index);
           }
 
           pos += 3;
@@ -2322,8 +2322,8 @@ namespace awkward {
         }
         if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "<-") {
           if (pos + 2 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 2] == "stack") {
-            bytecodes.push_back(CODE_WRITE);
-            bytecodes.push_back((int32_t)output_index);
+            bytecodes.emplace_back(CODE_WRITE);
+            bytecodes.emplace_back((int32_t)output_index);
 
             pos += 3;
           }
@@ -2335,14 +2335,14 @@ namespace awkward {
           }
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "len") {
-          bytecodes.push_back(CODE_LEN_OUTPUT);
-          bytecodes.push_back((int32_t)output_index);
+          bytecodes.emplace_back(CODE_LEN_OUTPUT);
+          bytecodes.emplace_back((int32_t)output_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "rewind") {
-          bytecodes.push_back(CODE_REWIND);
-          bytecodes.push_back((int32_t)output_index);
+          bytecodes.emplace_back(CODE_REWIND);
+          bytecodes.emplace_back((int32_t)output_index);
 
           pos += 2;
         }
@@ -2378,7 +2378,7 @@ namespace awkward {
                 + FILENAME(__LINE__)
               );
             }
-            bytecodes.push_back((int32_t)pair.second);
+            bytecodes.emplace_back((int32_t)pair.second);
 
             pos++;
           }
@@ -2389,7 +2389,7 @@ namespace awkward {
           for (IndexTypeOf<std::string> i = 0;  i < dictionary_names_.size();  i++) {
             if (dictionary_names_[i] == word) {
               found_in_dictionary = true;
-              bytecodes.push_back((int32_t)dictionary_bytecodes_[i]);
+              bytecodes.emplace_back((int32_t)dictionary_bytecodes_[i]);
 
               pos++;
             }
@@ -2398,8 +2398,8 @@ namespace awkward {
           if (!found_in_dictionary) {
             int64_t num;
             if (is_integer(word, num)) {
-              bytecodes.push_back(CODE_LITERAL);
-              bytecodes.push_back((int32_t)num);
+              bytecodes.emplace_back(CODE_LITERAL);
+              bytecodes.emplace_back((int32_t)num);
 
               pos++;
             }

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -680,7 +680,7 @@ namespace awkward {
   ForthMachineOf<T, I>::stack() const {
     std::vector<T> out;
     for (int64_t i = 0;  i < stack_depth_;  i++) {
-      out.emplace_back(stack_buffer_[i]);
+      out.push_back(stack_buffer_[i]);
     }
     return out;
   }
@@ -986,7 +986,7 @@ namespace awkward {
       bool found = false;
       for (auto pair : inputs) {
         if (pair.first == name) {
-          current_inputs_.emplace_back(pair.second);
+          current_inputs_.push_back(pair.second);
           found = true;
           break;
         }
@@ -1054,7 +1054,7 @@ namespace awkward {
                                    + FILENAME(__LINE__));
         }
       }
-      current_outputs_.emplace_back(out);
+      current_outputs_.push_back(out);
     }
 
     recursion_target_depth_.push(0);
@@ -1519,8 +1519,8 @@ namespace awkward {
       if (current == ' '  ||  current == '\r'  ||  current == '\t'  ||
           current == '\v'  ||  current == '\f') {
         if (full) {
-          tokenized.emplace_back(source_.substr(start, stop - start));
-          linecol.emplace_back(std::pair<int64_t, int64_t>(line, colstart));
+          tokenized.push_back(source_.substr(start, stop - start));
+          linecol.push_back(std::pair<int64_t, int64_t>(line, colstart));
         }
         start = stop;
         full = false;
@@ -1530,11 +1530,11 @@ namespace awkward {
       // It has no semantic meaning after the parsing stage.
       else if (current == '\n') {
         if (full) {
-          tokenized.emplace_back(source_.substr(start, stop - start));
-          linecol.emplace_back(std::pair<int64_t, int64_t>(line, colstart));
+          tokenized.push_back(source_.substr(start, stop - start));
+          linecol.push_back(std::pair<int64_t, int64_t>(line, colstart));
         }
-        tokenized.emplace_back(source_.substr(stop, 1));
-        linecol.emplace_back(std::pair<int64_t, int64_t>(line, colstart));
+        tokenized.push_back(source_.substr(stop, 1));
+        linecol.push_back(std::pair<int64_t, int64_t>(line, colstart));
         start = stop;
         full = false;
         line++;
@@ -1554,8 +1554,8 @@ namespace awkward {
     }
     // The source code might end on non-whitespace.
     if (full) {
-      tokenized.emplace_back(source_.substr(start, stop - start));
-      linecol.emplace_back(std::pair<int64_t, int64_t>(line, colstart));
+      tokenized.push_back(source_.substr(start, stop - start));
+      linecol.push_back(std::pair<int64_t, int64_t>(line, colstart));
     }
   }
 
@@ -1566,7 +1566,7 @@ namespace awkward {
 
     // Start recursive parsing.
     std::vector<I> bytecodes;
-    dictionary.emplace_back(bytecodes);
+    dictionary.push_back(bytecodes);
     parse("",
           tokenized,
           linecol,
@@ -1579,12 +1579,12 @@ namespace awkward {
     dictionary[0] = bytecodes;
 
     // Copy std::vector<std::vector<I>> to flattened contents and offsets.
-    bytecodes_offsets_.emplace_back(0);
+    bytecodes_offsets_.push_back(0);
     for (auto segment : dictionary) {
       for (auto bytecode : segment) {
-        bytecodes_.emplace_back(bytecode);
+        bytecodes_.push_back(bytecode);
       }
-      bytecodes_offsets_.emplace_back((int64_t)bytecodes_.size());
+      bytecodes_offsets_.push_back((int64_t)bytecodes_.size());
     }
   }
 
@@ -1690,12 +1690,12 @@ namespace awkward {
         // Add the new word to the dictionary before parsing it so that recursive
         // functions can be defined.
         I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
-        dictionary_names_.emplace_back(name);
-        dictionary_bytecodes_.emplace_back(bytecode);
+        dictionary_names_.push_back(name);
+        dictionary_bytecodes_.push_back(bytecode);
 
         // Now parse the subroutine and add it to the dictionary.
         std::vector<I> body;
-        dictionary.emplace_back(body);
+        dictionary.push_back(body);
         parse(name,
               tokenized,
               linecol,
@@ -1720,7 +1720,7 @@ namespace awkward {
         }
         for (IndexTypeOf<I> i = 0;  i < dictionary_names_.size();  i++) {
           if (dictionary_names_[i] == defn) {
-            bytecodes.emplace_back(dictionary_bytecodes_[i]);
+            bytecodes.push_back(dictionary_bytecodes_[i]);
           }
         }
 
@@ -1748,8 +1748,8 @@ namespace awkward {
           );
         }
 
-        variable_names_.emplace_back(name);
-        variables_.emplace_back(0);
+        variable_names_.push_back(name);
+        variables_.push_back(0);
 
         pos += 2;
       }
@@ -1774,7 +1774,7 @@ namespace awkward {
           );
         }
 
-        input_names_.emplace_back(name);
+        input_names_.push_back(name);
 
         pos += 2;
       }
@@ -1804,8 +1804,8 @@ namespace awkward {
         bool found_dtype = false;
         for (auto pair : output_dtype_words_) {
           if (pair.first == dtype_string) {
-            output_names_.emplace_back(name);
-            output_dtypes_.emplace_back(pair.second);
+            output_names_.push_back(name);
+            output_dtypes_.push_back(pair.second);
             found_dtype = true;
             break;
           }
@@ -1821,13 +1821,13 @@ namespace awkward {
       }
 
       else if (word == "halt") {
-        bytecodes.emplace_back(CODE_HALT);
+        bytecodes.push_back(CODE_HALT);
 
         pos++;
       }
 
       else if (word == "pause") {
-        bytecodes.emplace_back(CODE_PAUSE);
+        bytecodes.push_back(CODE_PAUSE);
 
         pos++;
       }
@@ -1861,7 +1861,7 @@ namespace awkward {
           // without special instruction pointer manipulation at runtime.
           I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> consequent;
-          dictionary.emplace_back(consequent);
+          dictionary.push_back(consequent);
           parse(defn,
                 tokenized,
                 linecol,
@@ -1873,8 +1873,8 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode - BOUND_DICTIONARY] = consequent;
 
-          bytecodes.emplace_back(CODE_IF);
-          bytecodes.emplace_back(bytecode);
+          bytecodes.push_back(CODE_IF);
+          bytecodes.push_back(bytecode);
 
           pos = substop + 1;
         }
@@ -1882,7 +1882,7 @@ namespace awkward {
           // Same as above, except that two new definitions must be made.
           I bytecode1 = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> consequent;
-          dictionary.emplace_back(consequent);
+          dictionary.push_back(consequent);
           parse(defn,
                 tokenized,
                 linecol,
@@ -1896,7 +1896,7 @@ namespace awkward {
 
           I bytecode2 = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> alternate;
-          dictionary.emplace_back(alternate);
+          dictionary.push_back(alternate);
           parse(defn,
                 tokenized,
                 linecol,
@@ -1908,9 +1908,9 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode2 - BOUND_DICTIONARY] = alternate;
 
-          bytecodes.emplace_back(CODE_IF_ELSE);
-          bytecodes.emplace_back(bytecode1);
-          bytecodes.emplace_back(bytecode2);
+          bytecodes.push_back(CODE_IF_ELSE);
+          bytecodes.push_back(bytecode1);
+          bytecodes.push_back(bytecode2);
 
           pos = substop + 1;
         }
@@ -1948,7 +1948,7 @@ namespace awkward {
         // without special instruction pointer manipulation at runtime.
         I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
         std::vector<I> body;
-        dictionary.emplace_back(body);
+        dictionary.push_back(body);
         parse(defn,
               tokenized,
               linecol,
@@ -1961,12 +1961,12 @@ namespace awkward {
         dictionary[(IndexTypeOf<int64_t>)bytecode - BOUND_DICTIONARY] = body;
 
         if (is_step) {
-          bytecodes.emplace_back(CODE_DO_STEP);
-          bytecodes.emplace_back(bytecode);
+          bytecodes.push_back(CODE_DO_STEP);
+          bytecodes.push_back(bytecode);
         }
         else {
-          bytecodes.emplace_back(CODE_DO);
-          bytecodes.emplace_back(bytecode);
+          bytecodes.push_back(CODE_DO);
+          bytecodes.push_back(bytecode);
         }
 
         pos = substop + 1;
@@ -2029,7 +2029,7 @@ namespace awkward {
           // used without special instruction pointer manipulation at runtime.
           I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> body;
-          dictionary.emplace_back(body);
+          dictionary.push_back(body);
           parse(defn,
                 tokenized,
                 linecol,
@@ -2041,8 +2041,8 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode - BOUND_DICTIONARY] = body;
 
-          bytecodes.emplace_back(bytecode);
-          bytecodes.emplace_back(CODE_AGAIN);
+          bytecodes.push_back(bytecode);
+          bytecodes.push_back(CODE_AGAIN);
 
           pos = substop + 1;
         }
@@ -2050,7 +2050,7 @@ namespace awkward {
           // Same for the 'begin .. until' body.
           I bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> body;
-          dictionary.emplace_back(body);
+          dictionary.push_back(body);
           parse(defn,
                 tokenized,
                 linecol,
@@ -2062,8 +2062,8 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode - BOUND_DICTIONARY] = body;
 
-          bytecodes.emplace_back(bytecode);
-          bytecodes.emplace_back(CODE_UNTIL);
+          bytecodes.push_back(bytecode);
+          bytecodes.push_back(CODE_UNTIL);
 
           pos = substop + 1;
         }
@@ -2071,7 +2071,7 @@ namespace awkward {
           // Same for the 'begin .. repeat' statements.
           I bytecode1 = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> precondition;
-          dictionary.emplace_back(precondition);
+          dictionary.push_back(precondition);
           parse(defn,
                 tokenized,
                 linecol,
@@ -2086,7 +2086,7 @@ namespace awkward {
           // Same for the 'repeat .. until' statements.
           I bytecode2 = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> postcondition;
-          dictionary.emplace_back(postcondition);
+          dictionary.push_back(postcondition);
           parse(defn,
                 tokenized,
                 linecol,
@@ -2098,17 +2098,17 @@ namespace awkward {
                 dodepth);
           dictionary[(IndexTypeOf<int64_t>)bytecode2 - BOUND_DICTIONARY] = postcondition;
 
-          bytecodes.emplace_back(bytecode1);
-          bytecodes.emplace_back(CODE_WHILE);
-          bytecodes.emplace_back(bytecode2);
+          bytecodes.push_back(bytecode1);
+          bytecodes.push_back(CODE_WHILE);
+          bytecodes.push_back(bytecode2);
 
           pos = substop + 1;
         }
       }
 
       else if (word == "exit") {
-        bytecodes.emplace_back(CODE_EXIT);
-        bytecodes.emplace_back((int32_t)exitdepth);
+        bytecodes.push_back(CODE_EXIT);
+        bytecodes.push_back((int32_t)exitdepth);
 
         pos++;
       }
@@ -2121,20 +2121,20 @@ namespace awkward {
           }
         }
         if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "!") {
-          bytecodes.emplace_back(CODE_PUT);
-          bytecodes.emplace_back((int32_t)variable_index);
+          bytecodes.push_back(CODE_PUT);
+          bytecodes.push_back((int32_t)variable_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "+!") {
-          bytecodes.emplace_back(CODE_INC);
-          bytecodes.emplace_back((int32_t)variable_index);
+          bytecodes.push_back(CODE_INC);
+          bytecodes.push_back((int32_t)variable_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "@") {
-          bytecodes.emplace_back(CODE_GET);
-          bytecodes.emplace_back((int32_t)variable_index);
+          bytecodes.push_back(CODE_GET);
+          bytecodes.push_back((int32_t)variable_index);
 
           pos += 2;
         }
@@ -2155,32 +2155,32 @@ namespace awkward {
         }
 
         if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "len") {
-          bytecodes.emplace_back(CODE_LEN_INPUT);
-          bytecodes.emplace_back((int32_t)input_index);
+          bytecodes.push_back(CODE_LEN_INPUT);
+          bytecodes.push_back((int32_t)input_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "pos") {
-          bytecodes.emplace_back(CODE_POS);
-          bytecodes.emplace_back((int32_t)input_index);
+          bytecodes.push_back(CODE_POS);
+          bytecodes.push_back((int32_t)input_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "end") {
-          bytecodes.emplace_back(CODE_END);
-          bytecodes.emplace_back((int32_t)input_index);
+          bytecodes.push_back(CODE_END);
+          bytecodes.push_back((int32_t)input_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "seek") {
-          bytecodes.emplace_back(CODE_SEEK);
-          bytecodes.emplace_back((int32_t)input_index);
+          bytecodes.push_back(CODE_SEEK);
+          bytecodes.push_back((int32_t)input_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "skip") {
-          bytecodes.emplace_back(CODE_SKIP);
-          bytecodes.emplace_back((int32_t)input_index);
+          bytecodes.push_back(CODE_SKIP);
+          bytecodes.push_back((int32_t)input_index);
 
           pos += 2;
         }
@@ -2295,10 +2295,10 @@ namespace awkward {
           }
 
           // Parser instructions are bit-flipped to detect them by the sign bit.
-          bytecodes.emplace_back(~bytecode);
-          bytecodes.emplace_back((int32_t)input_index);
+          bytecodes.push_back(~bytecode);
+          bytecodes.push_back((int32_t)input_index);
           if (found_output) {
-            bytecodes.emplace_back((int32_t)output_index);
+            bytecodes.push_back((int32_t)output_index);
           }
 
           pos += 3;
@@ -2322,8 +2322,8 @@ namespace awkward {
         }
         if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "<-") {
           if (pos + 2 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 2] == "stack") {
-            bytecodes.emplace_back(CODE_WRITE);
-            bytecodes.emplace_back((int32_t)output_index);
+            bytecodes.push_back(CODE_WRITE);
+            bytecodes.push_back((int32_t)output_index);
 
             pos += 3;
           }
@@ -2335,14 +2335,14 @@ namespace awkward {
           }
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "len") {
-          bytecodes.emplace_back(CODE_LEN_OUTPUT);
-          bytecodes.emplace_back((int32_t)output_index);
+          bytecodes.push_back(CODE_LEN_OUTPUT);
+          bytecodes.push_back((int32_t)output_index);
 
           pos += 2;
         }
         else if (pos + 1 < stop  &&  tokenized[(IndexTypeOf<std::string>)pos + 1] == "rewind") {
-          bytecodes.emplace_back(CODE_REWIND);
-          bytecodes.emplace_back((int32_t)output_index);
+          bytecodes.push_back(CODE_REWIND);
+          bytecodes.push_back((int32_t)output_index);
 
           pos += 2;
         }
@@ -2378,7 +2378,7 @@ namespace awkward {
                 + FILENAME(__LINE__)
               );
             }
-            bytecodes.emplace_back((int32_t)pair.second);
+            bytecodes.push_back((int32_t)pair.second);
 
             pos++;
           }
@@ -2389,7 +2389,7 @@ namespace awkward {
           for (IndexTypeOf<std::string> i = 0;  i < dictionary_names_.size();  i++) {
             if (dictionary_names_[i] == word) {
               found_in_dictionary = true;
-              bytecodes.emplace_back((int32_t)dictionary_bytecodes_[i]);
+              bytecodes.push_back((int32_t)dictionary_bytecodes_[i]);
 
               pos++;
             }
@@ -2398,8 +2398,8 @@ namespace awkward {
           if (!found_in_dictionary) {
             int64_t num;
             if (is_integer(word, num)) {
-              bytecodes.emplace_back(CODE_LITERAL);
-              bytecodes.emplace_back((int32_t)num);
+              bytecodes.push_back(CODE_LITERAL);
+              bytecodes.push_back((int32_t)num);
 
               pos++;
             }

--- a/src/libawkward/forth/ForthOutputBuffer.cpp
+++ b/src/libawkward/forth/ForthOutputBuffer.cpp
@@ -527,7 +527,7 @@ namespace awkward {
                                         bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(bool) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(bool) * (size_t)num_items);
     length_ = next;
   }
 
@@ -538,7 +538,7 @@ namespace awkward {
                                           bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(int8_t) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(int8_t) * (size_t)num_items);
     length_ = next;
   }
 
@@ -549,7 +549,7 @@ namespace awkward {
                                             bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(int16_t) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(int16_t) * (size_t)num_items);
     if (byteswap) {
       byteswap16(num_items, &ptr_.get()[length_]);
     }
@@ -563,7 +563,7 @@ namespace awkward {
                                             bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(int32_t) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(int32_t) * (size_t)num_items);
     if (byteswap) {
       byteswap32(num_items, &ptr_.get()[length_]);
     }
@@ -577,7 +577,7 @@ namespace awkward {
                                             bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(int64_t) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(int64_t) * (size_t)num_items);
     if (byteswap) {
       byteswap64(num_items, &ptr_.get()[length_]);
     }
@@ -591,7 +591,7 @@ namespace awkward {
                                             bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(uint8_t) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(uint8_t) * (size_t)num_items);
     length_ = next;
   }
 
@@ -602,7 +602,7 @@ namespace awkward {
                                               bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(uint16_t) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(uint16_t) * (size_t)num_items);
     if (byteswap) {
       byteswap16(num_items, &ptr_.get()[length_]);
     }
@@ -616,7 +616,7 @@ namespace awkward {
                                               bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(uint32_t) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(uint32_t) * (size_t)num_items);
     if (byteswap) {
       byteswap32(num_items, &ptr_.get()[length_]);
     }
@@ -630,7 +630,7 @@ namespace awkward {
                                               bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(uint64_t) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(uint64_t) * (size_t)num_items);
     if (byteswap) {
       byteswap64(num_items, &ptr_.get()[length_]);
     }
@@ -644,7 +644,7 @@ namespace awkward {
                                             bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(float) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(float) * (size_t)num_items);
     if (byteswap) {
       byteswap32(num_items, &ptr_.get()[length_]);
     }
@@ -658,7 +658,7 @@ namespace awkward {
                                              bool byteswap) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], values, sizeof(double) * num_items);
+    std::memcpy(&ptr_.get()[length_], values, sizeof(double) * (size_t)num_items);
     if (byteswap) {
       byteswap64(num_items, &ptr_.get()[length_]);
     }
@@ -675,7 +675,7 @@ namespace awkward {
       }
       std::shared_ptr<OUT> new_buffer = std::shared_ptr<OUT>(new OUT[reservation],
                                                              kernel::array_deleter<OUT>());
-      std::memcpy(new_buffer.get(), ptr_.get(), sizeof(OUT) * reserved_);
+      std::memcpy(new_buffer.get(), ptr_.get(), sizeof(OUT) * (size_t)reserved_);
       ptr_ = new_buffer;
       reserved_ = reservation;
     }


### PR DESCRIPTION
@jpivarski - these commits apply modifications suggested by `cppcheck` and fix the `ForthOutputBuffer` warnings. 

Excluding the `inconclusive` and `style` suggestions:
```
include/awkward/forth/ForthMachine.h:92:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::stack_can_push' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      stack_can_push() const noexcept {
      ^
include/awkward/forth/ForthMachine.h:98:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::stack_can_pop' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      stack_can_pop() const noexcept {
      ^
include/awkward/forth/ForthMachine.h:111:7: style:inconclusive: Technically the member function 'awkward::ForthMachineOf::stack_pop' can be const. [functionConst]
      stack_pop() noexcept {
      ^
include/awkward/forth/ForthMachine.h:373:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::stack_cannot_push' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      stack_cannot_push() const noexcept {
      ^
include/awkward/forth/ForthMachine.h:379:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::stack_cannot_pop' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      stack_cannot_pop() const noexcept {
      ^
include/awkward/forth/ForthMachine.h:385:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::stack_cannot_pop2' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      stack_cannot_pop2() const noexcept {
      ^
include/awkward/forth/ForthMachine.h:391:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::stack_cannot_pop3' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      stack_cannot_pop3() const noexcept {
      ^
include/awkward/forth/ForthMachine.h:424:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::bytecodes_pointer_push' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      bytecodes_pointer_push(int64_t which) noexcept {
      ^
include/awkward/forth/ForthMachine.h:432:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::bytecodes_pointer_pop' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      bytecodes_pointer_pop() noexcept {
      ^
include/awkward/forth/ForthMachine.h:450:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::do_loop_push' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      do_loop_push(int64_t start, int64_t stop) noexcept {
      ^
include/awkward/forth/ForthMachine.h:459:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::do_steploop_push' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      do_steploop_push(int64_t start, int64_t stop) noexcept {
      ^
include/awkward/forth/ForthMachine.h:474:5: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::do_abs_recursion_depth' can be static (but you may consider moving to unnamed namespace). [functionStatic]
    do_abs_recursion_depth() const noexcept {
    ^
include/awkward/forth/ForthMachine.h:486:7: performance:inconclusive: Technically the member function 'awkward::ForthMachineOf::do_loop_is_step' can be static (but you may consider moving to unnamed namespace). [functionStatic]
      do_loop_is_step() const noexcept {
      ^
```
```
src/libawkward/forth/ForthMachine.cpp:988:33: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
        if (pair.first == name) {
                                ^
src/libawkward/forth/ForthMachine.cpp:1411:25: style: Consider using std::any_of algorithm instead of a raw loop. [useStlAlgorithm]
      if (name == word) {
                        ^
src/libawkward/forth/ForthMachine.cpp:1806:43: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
          if (pair.first == dtype_string) {
                                          ^
```