### PR TITLE
Fix cleanup script

### DIFF
--- a/dev/clean-generated.py
+++ b/dev/clean-generated.py
@@ -6,6 +6,8 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 def clean_tests():
+    if (os.path.exists(os.path.join(CURRENT_DIR, "..", "tests-spec", "kernels.py"))):
+        os.remove(os.path.join(CURRENT_DIR, "..", "tests-spec", "kernels.py"))
     cpu_kernel_tests = glob.glob(
         os.path.join(CURRENT_DIR, "..", "tests-cpu-kernels", "test") + "*"
     )
@@ -31,19 +33,12 @@ def clean_cuda_kernels():
         os.remove(kernel)
 
 
-def clean_python_kernels():
-    os.remove(os.path.join(CURRENT_DIR, "..", "tests-spec", "kernels.py"))
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Cleanup generated files")
     parser.add_argument("--tests", default=True)
     parser.add_argument("--cuda-kernels", default=True)
-    parser.add_argument("--python-kernels", default=True)
     args = parser.parse_args()
     if args.tests:
         clean_tests()
     if args.cuda_kernels:
         clean_cuda_kernels()
-    if args.python_kernels:
-        clean_python_kernels()


### PR DESCRIPTION
We shouldn't use an additional flag to delete `kernels.py` since that file is generated along with the tests.
Earlier, the script threw an error if `kernels.py` didn't exist.