### PR TITLE
Avoid specifying target CUDA architecture

### DIFF
--- a/cuda-build.sh
+++ b/cuda-build.sh
@@ -38,7 +38,7 @@ echo "cuda_version ='"$CUDA_VERSION"'" >> build/awkward_cuda_kernels/__init__.py
 echo "docker_image ='docker.io/nvidia/cuda:"$DOCKER_IMAGE_TAG"'" >> build/awkward_cuda_kernels/__init__.py
 
 export DOCKER_ARGS="-v`pwd`:/home -w/home docker.io/nvidia/cuda:"$DOCKER_IMAGE_TAG
-export BUILD_SHARED_LIBRARY="nvcc -arch=sm_35 -std=c++11 -Xcompiler -fPIC -Xcompiler -DVERSION_INFO="$AWKWARD_VERSION" -Iinclude src/cuda-kernels/*.cu --shared -o build/awkward_cuda_kernels/libawkward-cuda-kernels.so"
+export BUILD_SHARED_LIBRARY="nvcc -std=c++11 -Xcompiler -fPIC -Xcompiler -DVERSION_INFO="$AWKWARD_VERSION" -Iinclude src/cuda-kernels/*.cu --shared -o build/awkward_cuda_kernels/libawkward-cuda-kernels.so"
 
 docker run $DOCKER_ARGS $BUILD_SHARED_LIBRARY
 


### PR DESCRIPTION
I think we should avoid specifying a target CUDA architecture unless there is a reason we need to.

I think CUDA >= 9 implies a lower bound of sm_30 - https://docs.nvidia.com/cuda/archive/9.0/cuda-compiler-driver-nvcc/index.html#ptxas-options so if we want to be verbose, maybe we should set it to `sm_30` instead?