### PR TITLE
chore: update pybind11 2.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ C++ projects can link against the shared libraries `libawkward-cpu-kernels.so` a
 
 # Roadmap
 
-Since [version 0.4.0](https://github.com/scikit-hep/awkward-1.0/releases/tag/0.4.0), Awkward Array has been compiled with [pybind11 2.6.0](https://github.com/pybind/pybind11/releases/tag/v2.6.0). Any changes will be posted here.
+Since [version 0.4.0](https://github.com/scikit-hep/awkward-1.0/releases/tag/0.4.0), Awkward Array has been compiled with versions of pybind11 that have [ABI version 4](https://github.com/pybind/pybind11/blob/v2.6.2/include/pybind11/detail/internals.h#L152-L153). Any other Python extension built with pybind11 ABI version 4 can consume and produce Awkward Arrays in the way [described here](https://github.com/scikit-hep/awkward-1.0/tree/main/dependent-project).
 
 The table below indicates when interface-breaking changes are planned; each is discussed in pull requests and issues. It doesn't include new additions that don't interfere with old behavior or corrections to bugs (i.e. behaviors that were _never_ intended and fixed immediately). Each deprecated feature is announced by a `FutureWarning` that indicates the target removal version/date.
 


### PR DESCRIPTION
I just released 2.6.2, would be nice to update, should be a simple bump: https://github.com/pybind/pybind11/releases/tag/v2.6.2