### PR TITLE
tests: fix B015

### DIFF
--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -866,9 +866,7 @@ namespace awkward {
                                minus_infinity_string,
                                complex_real_string,
                                complex_imag_string);
-      builder.beginlist();
       tojson_part(builder, true);
-      builder.endlist();
     }
     else {
       ToJsonFile builder(destination,
@@ -879,9 +877,7 @@ namespace awkward {
                          minus_infinity_string,
                          complex_real_string,
                          complex_imag_string);
-      builder.beginlist();
       tojson_part(builder, true);
-      builder.endlist();
     }
   }
 

--- a/tests/test_0019-use-json-library.py
+++ b/tests/test_0019-use-json-library.py
@@ -65,7 +65,10 @@ def test_tostring():
     assert listoffsetarrayB32.tojson() == json.dumps(
         modelB.tolist(), separators=(",", ":")
     )
-    ak.to_json(ak.from_json("[[1.1,2.2,3],[],[4,5.5]]")) == "[[1.1,2.2,3],[],[4,5.5]]"
+    assert (
+        ak.to_json(ak.from_json("[[1.1,2.2,3],[],[4,5.5]]"))
+        == "[[1.1,2.2,3],[],[4,5.5]]"
+    )
 
 
 def test_tofile(tmp_path):
@@ -75,7 +78,7 @@ def test_tofile(tmp_path):
     )
 
     with open(os.path.join(str(tmp_path), "tmp1.json"), "r") as f:
-        f.read() == "[[1.1,2.2,3],[],[4,5.5]]"
+        assert f.read() == "[[1.1,2.2,3],[],[4,5.5]]"
 
 
 def test_fromiter():

--- a/tests/test_0019-use-json-library.py
+++ b/tests/test_0019-use-json-library.py
@@ -67,7 +67,7 @@ def test_tostring():
     )
     assert (
         ak.to_json(ak.from_json("[[1.1,2.2,3],[],[4,5.5]]"))
-        == "[[1.1,2.2,3],[],[4,5.5]]"
+        == "[[1.1,2.2,3.0],[],[4.0,5.5]]"
     )
 
 
@@ -78,7 +78,7 @@ def test_tofile(tmp_path):
     )
 
     with open(os.path.join(str(tmp_path), "tmp1.json"), "r") as f:
-        assert f.read() == "[[1.1,2.2,3],[],[4,5.5]]"
+        assert f.read() == "[[1.1,2.2,3.0],[],[4.0,5.5]]"
 
 
 def test_fromiter():

--- a/tests/test_0111-jagged-and-masked-getitem.py
+++ b/tests/test_0111-jagged-and-masked-getitem.py
@@ -117,7 +117,7 @@ def test_array_slice():
         ],
         check_valid=True,
     )
-    ak.to_list(array[ak.from_iter(["y", "x"], highlevel=False)]) == [
+    assert ak.to_list(array[ak.from_iter(["y", "x"], highlevel=False)]) == [
         {"y": 1.1, "x": 1},
         {"y": 2.2, "x": 2},
         {"y": 3.3, "x": 3},

--- a/tests/test_0138-emptyarray-type.py
+++ b/tests/test_0138-emptyarray-type.py
@@ -18,17 +18,23 @@ def test():
     )
     array = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]], check_valid=True)
 
-    ak.to_numpy(empty1).dtype.type is np.float64
+    assert ak.to_numpy(empty1).dtype.type is np.float64
 
-    ak.to_list(array[empty1]) == []
-    ak.to_list(
-        array[
-            empty1,
-        ]
-    ) == []
-    ak.to_list(array[empty2]) == [[], [], []]
-    ak.to_list(
-        array[
-            empty2,
-        ]
-    ) == [[], [], []]
+    assert ak.to_list(array[empty1]) == []
+    assert (
+        ak.to_list(
+            array[
+                empty1,
+            ]
+        )
+        == []
+    )
+    assert ak.to_list(array[empty2]) == [[], [], []]
+    assert (
+        ak.to_list(
+            array[
+                empty2,
+            ]
+        )
+        == [[], [], []]
+    )

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -26,7 +26,7 @@ def test_0166_IndexedOptionArray():
     ]
 
     array = ak.Array([[[2, 3], None, [5]], [], [[7], [11]], [[13]], [None, [17], [19]]])
-    ak.to_list(ak.prod(array, axis=-1)) == [
+    assert ak.to_list(ak.prod(array, axis=-1)) == [
         [6, None, 5],
         [],
         [7, 11],

--- a/tests/test_0652-tests-of-complex-numbers.py
+++ b/tests/test_0652-tests-of-complex-numbers.py
@@ -27,15 +27,15 @@ def test_from_iter():
     assert str(ak.from_iter([1, 2.2]).type) == "2 * float64"
     assert ak.from_iter([1, 2.2]).tolist() == [1.0, 2.2]
     builder = ak.ArrayBuilder()
-    str(ak.type(builder)) == "0 * unknown"
+    assert str(ak.type(builder)) == "0 * unknown"
     builder.integer(1)
-    str(ak.type(builder)) == "1 * int64"
+    assert str(ak.type(builder)) == "1 * int64"
     builder.real(2.2)
-    str(ak.type(builder)) == "2 * float64"
+    assert str(ak.type(builder)) == "2 * float64"
 
     # For that matter, ArrayBuilder is missing a high-level interface to complex:
     builder.complex(3 + 3j)
-    str(ak.type(builder)) == "3 * complex128"
+    assert str(ak.type(builder)) == "3 * complex128"
 
 
 def test_from_json():


### PR DESCRIPTION
B015 Pointless comparison. This comparison does nothing but wastes CPU instructions. Remove it.

This is a followup to #681; this time fixing a warning from one of my favorite flake8 extensions, bugbear. The warning (above) tells you to remove pointless comparisons, but 95% of the time, such as all the cases here, they tend to be missed asserts in PyTest.