### PR TITLE
chore: flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@ repos:
   rev: 3.8.4
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear]
+    additional_dependencies: [flake8-bugbear, flake8-print]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,9 @@ repos:
   rev: 20.8b1
   hooks:
   - id: black
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.4
+  hooks:
+  - id: flake8
+    additional_dependencies: [flake8-bugbear]

--- a/dev/generate-cuda.py
+++ b/dev/generate-cuda.py
@@ -81,10 +81,7 @@ def getthread_dim(pos):
     return code
 
 
-def traverse(node, args=None, forvars=None, declared=None):
-    args = args or {}
-    forvars = forvars or []
-    declared = declared or []
+def traverse(node, args={}, forvars=[], declared=[]):  # noqa: B006
     if node.__class__.__name__ == "For":
         forvars.append(traverse(node.target, args, [], declared))
         if len(forvars) == 1:

--- a/dev/generate-cuda.py
+++ b/dev/generate-cuda.py
@@ -81,7 +81,10 @@ def getthread_dim(pos):
     return code
 
 
-def traverse(node, args={}, forvars=[], declared=[]):
+def traverse(node, args=None, forvars=None, declared=None):
+    args = args or {}
+    forvars = forvars or []
+    declared = declared or []
     if node.__class__.__name__ == "For":
         forvars.append(traverse(node.target, args, [], declared))
         if len(forvars) == 1:

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -12,6 +12,8 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 class Argument(object):
+    __slots__ = ("name", "typename", "direction", "role")
+
     def __init__(self, name, typename, direction, role="default"):
         self.name = name
         self.typename = typename

--- a/localbuild.py
+++ b/localbuild.py
@@ -47,11 +47,11 @@ thisstate = {
 
 try:
     localbuild_time = os.stat("localbuild").st_mtime
-except:
+except Exception:
     localbuild_time = 0
 try:
     laststate = json.load(open("localbuild/laststate.json"))
-except:
+except Exception:
     laststate = None
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,12 @@
 norecursedirs = src pybind11 rapidjson dependent-project studies
 
 [flake8]
-ignore = E203, W503, E501, E266, N801, N802, N806
+# F401 can be fixed by adding __all__'s
+# E712 should be dropped, False/True should compared by "is" or checked as booleans, but not "=="
+# E711 should be dropped, always compare None with is, not ==.
+# F841 should be removed, use nothing or _ or _<name> for an unused variable
+# E402 can be improved in the future with isort
+# F403 should be removed, import * is evil
+# B007 should be removed, variables that are not used should start with _
+ignore = E203, W503, E501, E266, N801, N802, N806, F401, E711, E712, F841, E402, F403, B007
 max-complexity = 100
-exclude = .git, dev, tests, studies, pybind11, rapidjson, dlpack, dependent-project, docs-sphinx, setup.py, localbuild.py awkward/__init__.py awkward/layout.py awkward/types.py awkward/forms.py awkward/_io.py awkward/forth.py src/awkward/__init__.py src/awkward/layout.py src/awkward/types.py src/awkward/forms.py src/awkward/_io.py src/awkward/forth.py build

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 norecursedirs = src pybind11 rapidjson dependent-project studies
 
 [flake8]
+select = C,E,F,W,B,B9,T
 # F401 can be fixed by adding __all__'s
 # E712 should be dropped, False/True should compared by "is" or checked as booleans, but not "=="
 # E711 should be dropped, always compare None with is, not ==.
@@ -9,5 +10,12 @@ norecursedirs = src pybind11 rapidjson dependent-project studies
 # E402 can be improved in the future with isort
 # F403 should be removed, import * is evil
 # B007 should be removed, variables that are not used should start with _
-ignore = E203, W503, E501, E266, N801, N802, N806, F401, E711, E712, F841, E402, F403, B007
+ignore = E203, W503, E501, E266, N801, N802, N806, B950, F401, E711, E712, F841, E402, F403, B007
 max-complexity = 100
+exclude = studies, pybind11, rapidjson, dlpack, docs-*
+per-file-ignores =
+    tests/*: T
+    dependent-project/*: T
+    dev/*: T
+    setup.py: T
+    localbuild.py: T

--- a/src/awkward/_connect/_numba/arrayview.py
+++ b/src/awkward/_connect/_numba/arrayview.py
@@ -15,11 +15,11 @@ np = ak.nplike.NumpyMetadata.instance()
 ########## for code that's built up from strings
 
 
-def code_to_function(code, function_name, externals={}, debug=False):
+def code_to_function(code, function_name, externals=None, debug=False):
     if debug:
         print("################### " + function_name)  # noqa: T001
         print(code)  # noqa: T001
-    namespace = dict(externals)
+    namespace = {} if externals is None else dict(externals)
     exec(code, namespace)
     return namespace[function_name]
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -3144,7 +3144,7 @@ def repartition(array, lengths, highlevel=True):
 def virtual(
     generate,
     args=(),
-    kwargs={},
+    kwargs=None,
     form=None,
     length=None,
     cache="new",
@@ -3319,7 +3319,9 @@ def virtual(
     elif form is not None and not isinstance(form, ak.forms.Form):
         form = ak.forms.Form.fromjson(json.dumps(form))
 
-    gen = ak.layout.ArrayGenerator(generate, args, kwargs, form=form, length=length)
+    gen = ak.layout.ArrayGenerator(
+        generate, args, kwargs or {}, form=form, length=length
+    )
     if cache == "new":
         hold_cache = ak._util.MappingProxy({})
         cache = ak.layout.ArrayCache(hold_cache)

--- a/tests/test_0001-refcount.py
+++ b/tests/test_0001-refcount.py
@@ -14,11 +14,11 @@ def test_refcount():
     o = np.arange(10, dtype="i4")
     c = np.arange(12).reshape(3, 4)
 
-    for order in itertools.permutations(["del i, n", "del l", "del l2"]):
+    for order in itertools.permutations(["del i, n", "del l1", "del l2"]):
         i = ak.layout.Index32(o)
         n = ak.layout.NumpyArray(c)
-        l = ak.layout.ListOffsetArray32(i, n)
-        l2 = ak.layout.ListOffsetArray32(i, l)
+        l1 = ak.layout.ListOffsetArray32(i, n)
+        l2 = ak.layout.ListOffsetArray32(i, l1)
 
         for statement in order:
             assert sys.getrefcount(o), sys.getrefcount(c) == (3, 3)

--- a/tests/test_0603-concatenate-should-minimally-touch-laziness.py
+++ b/tests/test_0603-concatenate-should-minimally-touch-laziness.py
@@ -9,7 +9,6 @@ import awkward as ak  # noqa: F401
 
 class Verbose(dict):
     def __getitem__(self, key):
-        print(key)
         self.touched = True
         if "data" in key:
             self.data_touched = True

--- a/tests/test_0648-add-forth-machine-to-codebase.py
+++ b/tests/test_0648-add-forth-machine-to-codebase.py
@@ -367,7 +367,6 @@ until
     )
 
     vm32 = awkward.forth.ForthMachine32("begin while repeat")
-    print(ak.to_list(vm32.bytecodes))
     assert (
         vm32.decompiled
         == """begin
@@ -377,7 +376,6 @@ repeat
     )
 
     vm32 = awkward.forth.ForthMachine32("begin 123 while 321 repeat")
-    print(ak.to_list(vm32.bytecodes))
     assert (
         vm32.decompiled
         == """begin
@@ -492,8 +490,6 @@ x i-> stack
     )
 
     vm32 = awkward.forth.ForthMachine32("input x output y int32 x i-> y")
-    print(ak.to_list(vm32.bytecodes))
-    print(vm32.decompiled)
     assert (
         vm32.decompiled
         == """input x

--- a/tests/test_0648-add-forth-machine-to-codebase.py
+++ b/tests/test_0648-add-forth-machine-to-codebase.py
@@ -2322,7 +2322,7 @@ begin
   dup stream pos 4 - <=
 until
 """.format(
-            bit_width=2, rle_byte_width=1, rle_format="B"
+            bit_width=2, rle_format="B"
         )
     )
     assert (


### PR DESCRIPTION
Each fix is a commit, which the full error message from the check fixed.

This now includes the pre-commit flake8 check; it checks the last few items as well, #682 and #681. I've disabled quite a few checks, but hopefully over time we'll turn them back on; each disabled check has a note in the cfg.

Have all committers had a chance to play with pre-commit? I can turn on checking in CI once I'm pretty sure everyone is able to run locally, as I think it's a good skill to have before letting CI help with it. @ianna @reikdas @trickarcher 

Can be rebased and merged or squashed and merged, flake8 needs hand fixes, so not `style:` commits.