### PR TITLE
check content length before arg/sorting

### DIFF
--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -1090,15 +1090,20 @@ namespace awkward {
       parents.data(),
       length());
     util::handle_error(err, classname(), identities_.get());
-    ContentPtr next = argsort_next(negaxis,
-                                   starts,
-                                   parents,
-                                   1,
-                                   ascending,
-                                   stable,
-                                   true);
+    ContentPtr out = argsort_next(negaxis,
+                                  starts,
+                                  parents,
+                                  1,
+                                  ascending,
+                                  stable,
+                                  true);
 
-    return next.get()->getitem_at_nowrap(0);
+     if (out.get()->length() == 0) {
+       return out.get()->getitem_nothing();
+     }
+     else {
+       return out.get()->getitem_at_nowrap(0);
+     }
   }
 
   const ContentPtr
@@ -1151,15 +1156,20 @@ namespace awkward {
       length());
     util::handle_error(err, classname(), identities_.get());
 
-    ContentPtr next = sort_next(negaxis,
-                                starts,
-                                parents,
-                                1,
-                                ascending,
-                                stable,
-                                true);
+    ContentPtr out = sort_next(negaxis,
+                               starts,
+                               parents,
+                               1,
+                               ascending,
+                               stable,
+                               true);
 
-    return next.get()->getitem_at_nowrap(0);
+    if (out.get()->length() == 0) {
+      return out.get()->getitem_nothing();
+    }
+    else {
+      return out.get()->getitem_at_nowrap(0);
+    }
   }
 
   const util::Parameters

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -1236,6 +1236,10 @@ namespace awkward {
                              bool ascending,
                              bool stable,
                              bool keepdims) const {
+    if (length() == 0 ) {
+      return shallow_copy();
+    }
+
     int64_t numnull;
     struct Error err1 = kernel::ByteMaskedArray_numnull(
       kernel::lib::cpu,   // DERIVE

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -2244,6 +2244,10 @@ namespace awkward {
                                          bool ascending,
                                          bool stable,
                                          bool keepdims) const {
+    if (length() == 0 ) {
+      return shallow_copy();
+    }
+
     int64_t index_length = index_.length();
     int64_t parents_length = parents.length();
 
@@ -2372,6 +2376,10 @@ namespace awkward {
                                             bool ascending,
                                             bool stable,
                                             bool keepdims) const {
+    if (length() == 0 ) {
+      return shallow_copy();
+    }
+
     int64_t index_length = index_.length();
     int64_t parents_length = parents.length();
 

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1654,6 +1654,10 @@ namespace awkward {
     bool stable,
     bool keepdims) const {
 
+    if (length() == 0 ) {
+      return shallow_copy();
+    }
+
     // if this is array of strings, axis parameter is ignored
     // and this array is sorted
     if (util::parameter_isstring(parameters_, "__array__")) {
@@ -1821,6 +1825,10 @@ namespace awkward {
                                            bool ascending,
                                            bool stable,
                                            bool keepdims) const {
+    if (length() == 0 ) {
+     return shallow_copy();
+    }
+
     // if this is array of strings, axis parameter is ignored
     // and this array is sorted
     if (util::parameter_isstring(parameters_, "__array__")) {

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -3232,6 +3232,10 @@ namespace awkward {
                         bool ascending,
                         bool stable,
                         bool keepdims) const {
+    if (length() == 0 ) {
+      return shallow_copy();
+    }
+
     if (shape_.empty()) {
       throw std::runtime_error(
         std::string("attempting to sort a scalar") + FILENAME(__LINE__));
@@ -3406,6 +3410,10 @@ namespace awkward {
                            bool ascending,
                            bool stable,
                            bool keepdims) const {
+    if (length() == 0 ) {
+      return shallow_copy();
+    }
+
     if (shape_.empty()) {
       throw std::runtime_error(
         std::string("attempting to argsort a scalar") + FILENAME(__LINE__));

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -1601,6 +1601,9 @@ namespace awkward {
                          bool ascending,
                          bool stable,
                          bool keepdims) const {
+    if (length() == 0) {
+      return shallow_copy();
+    }
     std::vector<ContentPtr> contents;
     for (auto content : contents_) {
       ContentPtr trimmed = content.get()->getitem_range_nowrap(0, length());
@@ -1628,6 +1631,9 @@ namespace awkward {
                             bool ascending,
                             bool stable,
                             bool keepdims) const {
+    if (length() == 0) {
+      return shallow_copy();
+    }
     std::vector<ContentPtr> contents;
     for (auto content : contents_) {
       ContentPtr trimmed = content.get()->getitem_range_nowrap(0, length());

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -1224,6 +1224,9 @@ namespace awkward {
                           bool ascending,
                           bool stable,
                           bool keepdims) const {
+    if (length() == 0) {
+      return shallow_copy();
+    }
     std::shared_ptr<Content> out = toListOffsetArray64(true).get()->sort_next(
                                        negaxis,
                                        starts,
@@ -1255,6 +1258,9 @@ namespace awkward {
                              bool ascending,
                              bool stable,
                              bool keepdims) const {
+    if (length() == 0) {
+      return shallow_copy();
+    }
     std::shared_ptr<Content> out = toListOffsetArray64(true).get()->argsort_next(
                                        negaxis,
                                        starts,

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -2077,6 +2077,9 @@ namespace awkward {
                                 bool ascending,
                                 bool stable,
                                 bool keepdims) const {
+    if (length() == 0) {
+      return shallow_copy();
+    }
     ContentPtr simplified = simplify_uniontype(true, true);
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||
@@ -2102,6 +2105,9 @@ namespace awkward {
                                    bool ascending,
                                    bool stable,
                                    bool keepdims) const {
+    if (length() == 0) {
+      return shallow_copy();
+    }
     ContentPtr simplified = simplify_uniontype(true, true);
     if (dynamic_cast<UnionArray8_32*>(simplified.get())  ||
         dynamic_cast<UnionArray8_U32*>(simplified.get())  ||

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -915,6 +915,9 @@ namespace awkward {
                            bool ascending,
                            bool stable,
                            bool keepdims) const {
+    if (length() == 0) {
+      return shallow_copy();
+    }
     std::shared_ptr<Content> out = content_.get()->sort_next(negaxis,
                                                              starts,
                                                              parents,
@@ -947,6 +950,9 @@ namespace awkward {
                               bool ascending,
                               bool stable,
                               bool keepdims) const {
+    if (length() == 0) {
+      return shallow_copy();
+    }
     std::shared_ptr<Content> out = content_.get()->argsort_next(negaxis,
                                                                 starts,
                                                                 parents,

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -497,3 +497,52 @@ def test_sort_bytestrings():
         b"two",
         b"two",
     ]
+
+
+def test_sort_zero_length_arrays():
+    array = ak.layout.IndexedArray64(ak.layout.Index64([]), ak.layout.NumpyArray([1,2,3]))
+    assert ak.to_list(array) == []
+    assert ak.to_list(ak.sort(array)) == []
+    assert ak.to_list(ak.argsort(array)) == []
+
+    content0 = ak.from_iter([[1.1, 2.2, 3.3], [], [4.4, 5.5]], highlevel=False)
+    content1 = ak.from_iter(["one", "two", "three", "four", "five"], highlevel=False)
+    tags = ak.layout.Index8([])
+    index = ak.layout.Index32([])
+    array = ak.layout.UnionArray8_32(tags, index, [content0, content1])
+    assert ak.to_list(array) == []
+    assert ak.to_list(ak.sort(array)) == []
+    assert ak.to_list(ak.argsort(array)) == []
+
+    content = ak.from_iter(
+        [[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]], highlevel=False
+    )
+    mask = ak.layout.Index8([])
+    array = ak.layout.ByteMaskedArray(mask, content, valid_when=False)
+    assert ak.to_list(array) == []
+    assert ak.to_list(ak.sort(array)) == []
+    assert ak.to_list(ak.argsort(array)) == []
+
+    array = ak.layout.NumpyArray([])
+    assert ak.to_list(array) == []
+    assert ak.to_list(ak.sort(array)) == []
+    assert ak.to_list(ak.argsort(array)) == []
+
+    array = ak.layout.RecordArray([])
+    assert ak.to_list(array) == []
+    assert ak.to_list(ak.sort(array)) == []
+    assert ak.to_list(ak.argsort(array)) == []
+
+    content = ak.layout.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]))
+    starts1 = ak.layout.Index64([])
+    stops1 = ak.layout.Index64([])
+    offsets1 = ak.layout.Index64(np.array([0]))
+    array = ak.layout.ListArray64(starts1, stops1, content)
+    assert ak.to_list(array) == []
+    assert ak.to_list(ak.sort(array)) == []
+    assert ak.to_list(ak.argsort(array)) == []
+
+    array = ak.layout.ListOffsetArray64(offsets1, content)
+    assert ak.to_list(array) == []
+    assert ak.to_list(ak.sort(array)) == []
+    assert ak.to_list(ak.argsort(array)) == []

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -500,7 +500,7 @@ def test_sort_bytestrings():
 
 
 def test_sort_zero_length_arrays():
-    array = ak.layout.IndexedArray64(ak.layout.Index64([]), ak.layout.NumpyArray([1,2,3]))
+    array = ak.layout.IndexedArray64(ak.layout.Index64([]), ak.layout.NumpyArray([1, 2, 3]))
     assert ak.to_list(array) == []
     assert ak.to_list(ak.sort(array)) == []
     assert ak.to_list(ak.argsort(array)) == []


### PR DESCRIPTION
adresses https://github.com/scikit-hep/awkward-1.0/issues/686

```python
>>> import awkward as ak
>>> arr = ak.layout.IndexedArray64(ak.layout.Index64([]), ak.layout.NumpyArray([1,2,3]))
>>> ak.argsort(arr)
<Array [] type='0 * int64'>
>>> ak.sort(arr)
<Array [] type='0 * int64'>
>>> 

```