### PR TITLE
check for an out of bounds index in a tuple builder

### DIFF
--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -298,6 +298,14 @@ namespace awkward {
         std::string("called 'index' without 'begin_tuple' at the same level before it")
         + FILENAME(__LINE__));
     }
+    else if (index >= (int64_t)contents_.size()) {
+      throw std::invalid_argument(
+        std::string("'index' ")
+        + std::to_string(index)
+        + (" is out of bounds for a tuple with number of fields ")
+        + std::to_string(contents_.size())
+        + FILENAME(__LINE__));
+    }
     else if (nextindex_ == -1  ||
              !contents_[(size_t)nextindex_].get()->active()) {
       nextindex_ = index;


### PR DESCRIPTION
@jpivarski - yes, it was observed both in C++ and in Python:
```python
>>> import awkward as ak
>>> a = ak.layout.ArrayBuilder()
>>> a.begintuple(2)
>>> a.index(2)
>>> a.boolean(True)
zsh: segmentation fault  python
```
now is fixed with "an out of bounds" message:
```python
>>> import awkward as ak
>>> a = ak.layout.ArrayBuilder()
>>> a.begintuple(2)
>>> a.index(2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: 'index' 2 is out of bounds for a tuple with number of fields 2

(https://github.com/scikit-hep/awkward-1.0/blob/1.1.0rc2/src/libawkward/builder/TupleBuilder.cpp#L307)

```