### PR TITLE
fix some issues of categorical arrays

### DIFF
--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -2860,9 +2860,12 @@ def _from_arrow(
                 arrays = [handle_arrow(batch) for batch in batches if len(batch) > 0]
                 return ak.operations.structure.concatenate(arrays, highlevel=False)
 
-        elif isinstance(obj, Iterable) and len(obj) > 0 and all(
-            isinstance(x, pyarrow.lib.RecordBatch) for x in obj
-        ) and any(len(x) > 0 for x in obj):
+        elif (
+            isinstance(obj, Iterable)
+            and len(obj) > 0
+            and all(isinstance(x, pyarrow.lib.RecordBatch) for x in obj)
+            and any(len(x) > 0 for x in obj)
+        ):
             chunks = []
             for batch in obj:
                 chunk = handle_arrow(batch)

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -2608,7 +2608,11 @@ def _from_arrow(
 
             if isinstance(index, ak.layout.BitMaskedArray):
                 return ak.layout.BitMaskedArray(
-                    index.mask, out, True, len(index), True,
+                    index.mask,
+                    out,
+                    True,
+                    len(index),
+                    True,
                     parameters={"__array__": "categorical"},
                 ).simplify()
             else:
@@ -2846,15 +2850,15 @@ def _from_arrow(
                 return ak.layout.RecordArray(child_array, obj.schema.names)
 
         elif isinstance(obj, pyarrow.lib.Table):
-            chunks = []
-            for batch in obj.to_batches():
-                chunk = handle_arrow(batch)
-                if len(chunk) > 0:
-                    chunks.append(chunk)
-            if len(chunks) == 1:
-                return chunks[0]
+            batches = []
+            for record_batch in obj.combine_chunks().to_batches():
+                batch = handle_arrow(record_batch)
+                if len(batch) > 0:
+                    batches.append(batch)
+            if len(batches) == 1:
+                return batches[0]
             else:
-                return ak.operations.structure.concatenate(chunks, highlevel=False)
+                return ak.operations.structure.concatenate(batches, highlevel=False)
 
         elif isinstance(obj, Iterable) and all(
             isinstance(x, pyarrow.lib.RecordBatch) for x in obj

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -2608,7 +2608,8 @@ def _from_arrow(
 
             if isinstance(index, ak.layout.BitMaskedArray):
                 return ak.layout.BitMaskedArray(
-                    index.mask, out, True, len(index), True
+                    index.mask, out, True, len(index), True,
+                    parameters={"__array__": "categorical"},
                 ).simplify()
             else:
                 return out

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -2608,7 +2608,11 @@ def _from_arrow(
 
             if isinstance(index, ak.layout.BitMaskedArray):
                 return ak.layout.BitMaskedArray(
-                    index.mask, out, True, len(index), True,
+                    index.mask,
+                    out,
+                    True,
+                    len(index),
+                    True,
                     parameters={"__array__": "categorical"},
                 ).simplify()
             else:

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -1827,21 +1827,31 @@ namespace awkward {
     }
 
     if (parameter_equals("__array__", "\"categorical\"")) {
-      if (dynamic_cast<const IndexedArray32*>(this)  ||
-          dynamic_cast<const IndexedArrayU32*>(this)  ||
-          dynamic_cast<const IndexedArray64*>(this)  ||
-          dynamic_cast<const IndexedOptionArray32*>(this)  ||
-          dynamic_cast<const IndexedOptionArray64*>(this)) {
-        if (!is_unique()) {
-          return (std::string("at ") + path + std::string(" (") + classname()
-                  + std::string("): __array__ = \"categorical\" requires contents "
-                                "to be unique"));
-        }
+      ContentPtr content(nullptr);
+      if (const IndexedArray32* raw = dynamic_cast<const IndexedArray32*>(this)) {
+        content = raw->content();
+      }
+      else if (const IndexedArrayU32* raw = dynamic_cast<const IndexedArrayU32*>(this)) {
+        content = raw->content();
+      }
+      else if (const IndexedArray64* raw = dynamic_cast<const IndexedArray64*>(this)) {
+        content = raw->content();
+      }
+      else if (const IndexedOptionArray32* raw = dynamic_cast<const IndexedOptionArray32*>(this)) {
+        content = raw->content();
+      }
+      else if (const IndexedOptionArray64* raw = dynamic_cast<const IndexedOptionArray64*>(this)) {
+        content = raw->content();
       }
       else {
         return (std::string("at ") + path + std::string(" (") + classname()
                 + std::string("): __array__ = \"categorical\" only allowed for "
                               "IndexedArray and IndexedOptionArray"));
+      }
+      if (!content.get()->is_unique()) {
+        return (std::string("at ") + path + std::string(" (") + classname()
+            + std::string("): __array__ = \"categorical\" requires contents "
+                            "to be unique"));
       }
     }
 

--- a/tests/test_0674-categorical-validation.py
+++ b/tests/test_0674-categorical-validation.py
@@ -30,3 +30,36 @@ def test_optional_categorical_from_arrow():
     option_dict_array = pyarrow.DictionaryArray.from_arrays(nan_indices, dictionary)
     option_categorical_array = ak.from_arrow(option_dict_array)
     assert option_categorical_array.layout.parameter("__array__") == "categorical"
+
+
+def test_categorical_from_arrow_ChunkedArray():
+    indices = [0, 1, 0, 1, 2, 0, 2]
+    indices_new_schema = [0, 1, 0, 1, 0]
+
+    dictionary = pyarrow.array([2019, 2020, 2021])
+    dictionary_new_schema = pyarrow.array([2019, 2020])
+
+    dict_array = pyarrow.DictionaryArray.from_arrays(pyarrow.array(indices), dictionary)
+    dict_array_new_schema = pyarrow.DictionaryArray.from_arrays(
+        pyarrow.array(indices_new_schema), dictionary_new_schema
+    )
+
+    batch = pyarrow.RecordBatch.from_arrays([dict_array], ["year"])
+    batch_new_schema = pyarrow.RecordBatch.from_arrays(
+        [dict_array_new_schema], ["year"]
+    )
+
+    batches = [batch] * 3
+    batches_mixed_schema = [batch] + [batch_new_schema]
+
+    table = pyarrow.Table.from_batches(batches)
+    table_mixed_schema = pyarrow.Table.from_batches(batches_mixed_schema)
+
+    array = ak.from_arrow(table)
+    array_mixed_schema = ak.from_arrow(table_mixed_schema)
+
+    assert np.asarray(array.layout.field(0).content.index).tolist() == indices * 3
+    assert (
+        np.asarray(array_mixed_schema.layout.field(0).content.index).tolist()
+        == indices + indices_new_schema
+    )

--- a/tests/test_0674-categorical-validation.py
+++ b/tests/test_0674-categorical-validation.py
@@ -1,0 +1,32 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+pyarrow = pytest.importorskip("pyarrow")
+
+
+def test_categorical_is_valid():
+    # validate a categorical array by its content
+    arr = ak.Array([2019, 2020, 2021, 2020, 2019])
+    categorical = ak.to_categorical(arr)
+    assert ak.is_valid(categorical)
+
+
+def test_optional_categorical_from_arrow():
+    # construct categorical array from option-typed DictionaryArray
+    indices = pyarrow.array([0, 1, 0, 1, 2, 0, 2])
+    nan_indices = pyarrow.array([0, 1, 0, 1, 2, None, 0, 2])
+    dictionary = pyarrow.array([2019, 2020, 2021])
+
+    dict_array = pyarrow.DictionaryArray.from_arrays(indices, dictionary)
+    categorical_array = ak.from_arrow(dict_array)
+    assert categorical_array.layout.parameter("__array__") == "categorical"
+
+    option_dict_array = pyarrow.DictionaryArray.from_arrays(nan_indices, dictionary)
+    option_categorical_array = ak.from_arrow(option_dict_array)
+    assert option_categorical_array.layout.parameter("__array__") == "categorical"


### PR DESCRIPTION
I tried my luck with a partial fix as part of #674.

- [x] 1. Validation of valid categorical arrays
- [x] 2. fix minimization for ChunkedArray with categoricals using ak.from_arrow()
- [x] 3. add parameter `__array__ = "categorical"` for option-typed categorical arrays
- [x] 4. add tests

Feedback very welcome.

You mentioned that it is purely on python level but I think the validation checks were C++ based. If I am mistaken please advise.