### PR TITLE
Implemented 'ak.run_lengths' to enable group-by operations.

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -262,6 +262,188 @@ def num(array, axis=1, highlevel=True, behavior=None):
         return out
 
 
+def run_lengths(array, highlevel=True, behavior=None):
+    """
+    Args:
+        array: Data containing runs of numbers to count.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.layout.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Computes the lengths of sequences of identical values at the deepest level
+    of nesting, returning an array with the same structure but with `int64` type.
+
+    For example,
+
+        >>> array = ak.Array([1.1, 1.1, 1.1, 2.2, 3.3, 3.3, 4.4, 4.4, 5.5])
+        >>> ak.run_lengths(array)
+        <Array [3, 1, 2, 2, 1] type='5 * int64'>
+
+    There are 3 instances of 1.1, followed by 1 instance of 2.2, 2 instances of 3.3,
+    2 instances of 4.4, and 1 instance of 5.5.
+
+    The order and uniqueness of the input data doesn't matter,
+
+        >>> array = ak.Array([1.1, 1.1, 1.1, 5.5, 4.4, 4.4, 1.1, 1.1, 5.5])
+        >>> ak.run_lengths(array)
+        <Array [3, 1, 2, 2, 1] type='5 * int64'>
+
+    just the difference between each value and its neighbors.
+
+    The data can be nested, but runs don't cross list boundaries.
+
+        >>> array = ak.Array([[1.1, 1.1, 1.1, 2.2, 3.3], [3.3, 4.4], [4.4, 5.5]])
+        >>> ak.run_lengths(array)
+        <Array [[3, 1, 1], [1, 1], [1, 1]] type='3 * var * int64'>
+
+    Note that this can be combined with #ak.argsort and #ak.unflatten to compute
+    a "group by" operation:
+
+        >>> array = ak.Array([{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 1, "y": 1.1},
+        ...                   {"x": 3, "y": 3.3}, {"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}])
+        >>> sorted = array[ak.argsort(array.x)]
+        >>> sorted.x
+        <Array [1, 1, 1, 2, 2, 3] type='6 * int64'>
+        >>> ak.run_lengths(sorted.x)
+        <Array [3, 2, 1] type='3 * int64'>
+        >>> ak.unflatten(sorted, ak.run_lengths(sorted.x)).tolist()
+        [[{'x': 1, 'y': 1.1}, {'x': 1, 'y': 1.1}, {'x': 1, 'y': 1.1}],
+         [{'x': 2, 'y': 2.2}, {'x': 2, 'y': 2.2}],
+         [{'x': 3, 'y': 3.3}]]
+
+    Unlike a database "group by," this operation can be applied in bulk to many sublists
+    (though the run lengths need to be fully flattened to be used as `counts` for
+    #ak.unflatten, and you need to specify `axis=-1` as the depth).
+
+        >>> array = ak.Array([[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 1, "y": 1.1}],
+        ...                   [{"x": 3, "y": 3.3}, {"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}]])
+        >>> sorted = array[ak.argsort(array.x)]
+        >>> sorted.x
+        <Array [[1, 1, 2], [1, 2, 3]] type='2 * var * int64'>
+        >>> ak.run_lengths(sorted.x)
+        <Array [[2, 1], [1, 1, 1]] type='2 * var * int64'>
+        >>> counts = ak.flatten(ak.run_lengths(sorted.x), axis=None)
+        >>> ak.unflatten(sorted, counts, axis=-1).tolist()
+        [[[{'x': 1, 'y': 1.1}, {'x': 1, 'y': 1.1}],
+          [{'x': 2, 'y': 2.2}]],
+         [[{'x': 1, 'y': 1.1}],
+          [{'x': 2, 'y': 2.2}],
+          [{'x': 3, 'y': 3.3}]]]
+
+    See also #ak.num, #ak.argsort, #ak.unflatten.
+    """
+    nplike = ak.nplike.of(array)
+
+    def lengths_of(data, offsets):
+        if len(data) == 0:
+            return nplike.empty(0, np.int64), offsets
+        else:
+            diffs = data[1:] != data[:-1]
+            if offsets is not None:
+                diffs[offsets[1:-1] - 1] = True
+            positions = nplike.nonzero(diffs)[0]
+            full_positions = nplike.empty(len(positions) + 2, np.int64)
+            full_positions[0] = 0
+            full_positions[-1] = len(data)
+            full_positions[1:-1] = positions + 1
+            nextcontent = full_positions[1:] - full_positions[:-1]
+            if offsets is None:
+                nextoffsets = None
+            else:
+                nextoffsets = nplike.searchsorted(full_positions, offsets, side="left")
+            return nextcontent, nextoffsets
+
+    def getfunction(layout):
+        if layout.branch_depth == (False, 1):
+            if isinstance(layout, ak._util.indexedtypes):
+                layout = layout.project()
+
+            if not isinstance(layout, (ak.layout.NumpyArray, ak.layout.EmptyArray)):
+                raise NotImplementedError(
+                    "run_lengths on "
+                    + type(layout).__name__
+                    + ak._util.exception_suffix(__file__)
+                )
+
+            nextcontent, _ = lengths_of(nplike.asarray(layout), None)
+            return lambda: ak.layout.NumpyArray(nextcontent)
+
+        elif layout.branch_depth == (False, 2):
+            if not isinstance(layout, ak._util.listtypes):
+                raise NotImplementedError(
+                    "run_lengths on "
+                    + type(layout).__name__
+                    + ak._util.exception_suffix(__file__)
+                )
+
+            listoffsetarray = layout.toListOffsetArray64(False)
+            offsets = nplike.asarray(listoffsetarray.offsets)
+            content = listoffsetarray.content[offsets[0] : offsets[-1]]
+
+            if isinstance(content, ak._util.indexedtypes):
+                content = content.project()
+
+            if not isinstance(content, (ak.layout.NumpyArray, ak.layout.EmptyArray)):
+                raise NotImplementedError(
+                    "run_lengths on "
+                    + type(layout).__name__
+                    + " with content "
+                    + type(content).__name__
+                    + ak._util.exception_suffix(__file__)
+                )
+
+            nextcontent, nextoffsets = lengths_of(
+                nplike.asarray(content), offsets - offsets[0]
+            )
+            return lambda: ak.layout.ListOffsetArray64(
+                ak.layout.Index64(nextoffsets), ak.layout.NumpyArray(nextcontent)
+            )
+
+        else:
+            return None
+
+    layout = ak.operations.convert.to_layout(
+        array, allow_record=False, allow_other=False
+    )
+
+    if isinstance(layout, ak.partition.PartitionedArray):
+        if len(layout.partitions) != 0 and layout.partitions[0].branch_depth == (
+            False,
+            1,
+        ):
+            out = ak._util.recursively_apply(
+                layout.toContent(),
+                getfunction,
+                pass_depth=False,
+                pass_user=False,
+            )
+        else:
+            outparts = []
+            for part in layout.partitions:
+                outparts.append(
+                    ak._util.recursively_apply(
+                        part,
+                        getfunction,
+                        pass_depth=False,
+                        pass_user=False,
+                    )
+                )
+            out = ak.partition.IrregularlyPartitionedArray(outparts)
+    else:
+        out = ak._util.recursively_apply(
+            layout,
+            getfunction,
+            pass_depth=False,
+            pass_user=False,
+        )
+
+    if highlevel:
+        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
+    else:
+        return out
+
+
 def zip(
     arrays,
     depth_limit=None,

--- a/tests/test_0733-run_lengths.py
+++ b/tests/test_0733-run_lengths.py
@@ -1,0 +1,59 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array([3, 3, 3, 5, 5, 9, 9, 9, 9, 1, 3, 3])
+    assert ak.run_lengths(array).tolist() == [3, 2, 4, 1, 2]
+
+    array = ak.Array([[3, 3, 3, 5], [5], [], [9, 9], [9, 9], [1, 3, 3]])
+    assert ak.run_lengths(array).tolist() == [[3, 1], [1], [], [2], [2], [1, 2]]
+
+    array = ak.repartition(ak.Array([3, 3, 3, 5, 5, 9, 9, 9, 9, 1, 3, 3]), 7)
+    assert ak.run_lengths(array).tolist() == [3, 2, 4, 1, 2]
+
+    array = ak.repartition(
+        ak.Array([[3, 3, 3, 5], [5], [], [9, 9], [9, 9], [1, 3, 3]]), 4
+    )
+    assert ak.run_lengths(array).tolist() == [[3, 1], [1], [], [2], [2], [1, 2]]
+
+
+def test_groupby():
+    array = ak.Array(
+        [
+            {"x": 1, "y": 1.1},
+            {"x": 2, "y": 2.2},
+            {"x": 1, "y": 1.1},
+            {"x": 3, "y": 3.3},
+            {"x": 1, "y": 1.1},
+            {"x": 2, "y": 2.2},
+        ]
+    )
+    sorted = array[ak.argsort(array.x)]
+    assert sorted.x.tolist() == [1, 1, 1, 2, 2, 3]
+    assert ak.run_lengths(sorted.x).tolist() == [3, 2, 1]
+    assert ak.unflatten(sorted, ak.run_lengths(sorted.x)).tolist() == [
+        [{"x": 1, "y": 1.1}, {"x": 1, "y": 1.1}, {"x": 1, "y": 1.1}],
+        [{"x": 2, "y": 2.2}, {"x": 2, "y": 2.2}],
+        [{"x": 3, "y": 3.3}],
+    ]
+
+    array = ak.Array(
+        [
+            [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 1, "y": 1.1}],
+            [{"x": 3, "y": 3.3}, {"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}],
+        ]
+    )
+    sorted = array[ak.argsort(array.x)]
+    assert sorted.x.tolist() == [[1, 1, 2], [1, 2, 3]]
+    assert ak.run_lengths(sorted.x).tolist() == [[2, 1], [1, 1, 1]]
+    counts = ak.flatten(ak.run_lengths(sorted.x), axis=None)
+    assert ak.unflatten(sorted, counts, axis=-1).tolist() == [
+        [[{"x": 1, "y": 1.1}, {"x": 1, "y": 1.1}], [{"x": 2, "y": 2.2}]],
+        [[{"x": 1, "y": 1.1}], [{"x": 2, "y": 2.2}], [{"x": 3, "y": 3.3}]],
+    ]


### PR DESCRIPTION
You might be interested in this, @nsmith-.

This was motivated by trying to write example problems for the SciPy tutorials. The `ak.run_lengths` function is the reason `ak.unflatten` needed an `axis` parameter (PR #731).