### PR TITLE
Simplify 'ak.to_arrow' list handling.

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -914,9 +914,7 @@ def broadcast_and_apply(  # noqa: C901
         elif any(isinstance(x, recordtypes) for x in inputs):
             if not allow_records:
                 raise ValueError(
-                    "cannot broadcast: {0}".format(
-                        ", ".join(repr(type(x)) for x in inputs)
-                    )
+                    "cannot broadcast records in this type of operation"
                     + exception_suffix(__file__)
                 )
 

--- a/tests/test_0224-arrow-to-awkward.py
+++ b/tests/test_0224-arrow-to-awkward.py
@@ -110,7 +110,7 @@ def test_toarrow_ListArray_RegularArray():
         [[[3.3, 4.4], [5.5]], [[6.6, 7.7, 8.8, 9.9], []]],
     ]
 
-    assert isinstance(ak.to_arrow(regulararray), (pyarrow.ListArray))
+    assert isinstance(ak.to_arrow(regulararray), (pyarrow.LargeListArray))
     assert ak.to_arrow(regulararray).to_pylist() == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],


### PR DESCRIPTION
There had been two code paths that do the same thing. The one that was active (called before the other had a chance) was wrong.

Fixes #759.