### PR TITLE
Fix bug raised on StackOverflow.

### DIFF
--- a/src/awkward/_connect/_numba/layout.py
+++ b/src/awkward/_connect/_numba/layout.py
@@ -562,7 +562,7 @@ class NumpyArrayType(ContentType):
         elif form.primitive == "uint8":
             arraytype = numba.types.Array(numba.uint8, 1, "A")
         elif form.primitive == "bool":
-            arraytype = numba.types.Array(numba.bool, 1, "A")
+            arraytype = numba.types.Array(numba.boolean, 1, "A")
         else:
             raise ValueError(
                 "unrecognized NumpyForm.primitive type: {0}".format(form.primitive)
@@ -2595,7 +2595,7 @@ class VirtualArrayType(ContentType):
                 elif form.primitive == "uint8":
                     return numba.uint8
                 elif form.primitive == "bool":
-                    return numba.bool
+                    return numba.boolean
                 else:
                     raise ValueError(
                         "unrecognized NumpyForm.primitive type: {0}".format(

--- a/tests/test_0776-numba-booleans-in-virtual-array.py
+++ b/tests/test_0776-numba-booleans-in-virtual-array.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+numba = pytest.importorskip("numba")
+
+
+def test():
+    @numba.njit
+    def f1(array):
+        return array[2][0].x
+
+    array = ak.virtual(
+        lambda: ak.Array([[{"x": True}, {"x": False}], [], [{"x": True}]])
+    )
+    assert f1(array) is True


### PR DESCRIPTION
This one: https://stackoverflow.com/q/66449170/1623645

The problem was that `numba.bool` does not exist; it's spelled `numba.boolean`. This error only shows up in _virtual_ arrays with booleans.