### PR TITLE
AwkwardForth: add an s" core word to define strings

### DIFF
--- a/include/awkward/forth/ForthMachine.h
+++ b/include/awkward/forth/ForthMachine.h
@@ -209,7 +209,8 @@ namespace awkward {
     const Index64
       output_Index64_at(int64_t index) const;
 
-    /// @brief HERE
+    /// @brief Returns a string at 'index'.
+    /// The strings are defined with an 's"' core word.
     const std::string
       string_at(int64_t index) const noexcept;
 

--- a/include/awkward/forth/ForthMachine.h
+++ b/include/awkward/forth/ForthMachine.h
@@ -210,6 +210,10 @@ namespace awkward {
       output_Index64_at(int64_t index) const;
 
     /// @brief HERE
+    const std::string
+      string_at(int64_t index) const noexcept;
+
+    /// @brief HERE
     void
       reset();
 

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -130,7 +130,7 @@ namespace awkward {
     "<-", "+<-", "stack", "rewind",
     // print (for debugging)
     ".\"",
-    // errors
+    // user defined strings
     "s\""
   });
 
@@ -999,7 +999,8 @@ namespace awkward {
   const std::string
   ForthMachineOf<T, I>::string_at(int64_t index) const noexcept {
     return (index < (int64_t)strings_.size() ?
-      strings_[(IndexTypeOf<int64_t>)index] : std::string(""));
+      strings_[(IndexTypeOf<int64_t>)index] : std::string("a string at ")
+      + std::to_string(index) + std::string(" is undefined"));
   }
 
   template <typename T, typename I>

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -61,49 +61,50 @@ namespace awkward {
   #define CODE_LEN_OUTPUT 22
   #define CODE_REWIND 23
   // generic builtin instructions
-  #define CODE_PRINT_STRING 24
-  #define CODE_PRINT 25
-  #define CODE_PRINT_CR 26
-  #define CODE_PRINT_STACK 27
-  #define CODE_I 28
-  #define CODE_J 29
-  #define CODE_K 30
-  #define CODE_DUP 31
-  #define CODE_DROP 32
-  #define CODE_SWAP 33
-  #define CODE_OVER 34
-  #define CODE_ROT 35
-  #define CODE_NIP 36
-  #define CODE_TUCK 37
-  #define CODE_ADD 38
-  #define CODE_SUB 39
-  #define CODE_MUL 40
-  #define CODE_DIV 41
-  #define CODE_MOD 42
-  #define CODE_DIVMOD 43
-  #define CODE_NEGATE 44
-  #define CODE_ADD1 45
-  #define CODE_SUB1 46
-  #define CODE_ABS 47
-  #define CODE_MIN 48
-  #define CODE_MAX 49
-  #define CODE_EQ 50
-  #define CODE_NE 51
-  #define CODE_GT 52
-  #define CODE_GE 53
-  #define CODE_LT 54
-  #define CODE_LE 55
-  #define CODE_EQ0 56
-  #define CODE_INVERT 57
-  #define CODE_AND 58
-  #define CODE_OR 59
-  #define CODE_XOR 60
-  #define CODE_LSHIFT 61
-  #define CODE_RSHIFT 62
-  #define CODE_FALSE 63
-  #define CODE_TRUE 64
+  #define CODE_STRING_ERROR 24
+  #define CODE_PRINT_STRING 25
+  #define CODE_PRINT 26
+  #define CODE_PRINT_CR 27
+  #define CODE_PRINT_STACK 28
+  #define CODE_I 29
+  #define CODE_J 30
+  #define CODE_K 31
+  #define CODE_DUP 32
+  #define CODE_DROP 33
+  #define CODE_SWAP 34
+  #define CODE_OVER 35
+  #define CODE_ROT 36
+  #define CODE_NIP 37
+  #define CODE_TUCK 38
+  #define CODE_ADD 39
+  #define CODE_SUB 40
+  #define CODE_MUL 41
+  #define CODE_DIV 42
+  #define CODE_MOD 43
+  #define CODE_DIVMOD 44
+  #define CODE_NEGATE 45
+  #define CODE_ADD1 46
+  #define CODE_SUB1 47
+  #define CODE_ABS 48
+  #define CODE_MIN 49
+  #define CODE_MAX 50
+  #define CODE_EQ 51
+  #define CODE_NE 52
+  #define CODE_GT 53
+  #define CODE_GE 54
+  #define CODE_LT 55
+  #define CODE_LE 56
+  #define CODE_EQ0 57
+  #define CODE_INVERT 58
+  #define CODE_AND 59
+  #define CODE_OR 60
+  #define CODE_XOR 61
+  #define CODE_LSHIFT 62
+  #define CODE_RSHIFT 63
+  #define CODE_FALSE 64
+  #define CODE_TRUE 65
   // beginning of the user-defined dictionary
-  #define BOUND_DICTIONARY 65
+  #define BOUND_DICTIONARY 66
 
   const std::set<std::string> reserved_words_({
     // comments
@@ -128,7 +129,9 @@ namespace awkward {
     // output actions
     "<-", "+<-", "stack", "rewind",
     // print (for debugging)
-    ".\""
+    ".\"",
+    // errors
+    "s\""
   });
 
   const std::set<std::string> input_parser_words_({
@@ -567,6 +570,10 @@ namespace awkward {
           int64_t out_num = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 1];
           return output_names_[(IndexTypeOf<int64_t>)out_num] + " rewind";
         }
+        case CODE_STRING_ERROR: {
+          int64_t string_num = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 1];
+          return "s\" " + strings_[(IndexTypeOf<int64_t>)string_num] + "\"";
+        }
         case CODE_PRINT_STRING: {
           int64_t string_num = bytecodes_[(IndexTypeOf<int64_t>)bytecode_position + 1];
           return ".\" " + strings_[(IndexTypeOf<int64_t>)string_num] + "\"";
@@ -989,6 +996,13 @@ namespace awkward {
   }
 
   template <typename T, typename I>
+  const std::string
+  ForthMachineOf<T, I>::string_at(int64_t index) const noexcept {
+    return (index < (int64_t)strings_.size() ?
+      strings_[(IndexTypeOf<int64_t>)index] : std::string(""));
+  }
+
+  template <typename T, typename I>
   void
   ForthMachineOf<T, I>::reset() {
     stack_depth_ = 0;
@@ -1256,9 +1270,13 @@ namespace awkward {
             "call 'begin' to 'step' again (note: check 'is_done')");
         }
         case util::ForthError::user_halt: {
-          throw std::invalid_argument(
-            "'user halt' in AwkwardForth runtime: user-defined error or stopping "
-            "condition");
+          std::string error_message("'user halt' in AwkwardForth runtime: user-defined error or stopping "
+          "condition");
+          if (stack_can_pop()) {
+            error_message = string_at(stack().back()).empty() ? error_message :
+              string_at(stack().back());
+          }
+          throw std::invalid_argument(error_message);
         }
         case util::ForthError::recursion_depth_exceeded: {
           throw std::invalid_argument(
@@ -1544,6 +1562,7 @@ namespace awkward {
         case CODE_WRITE_DUP:
         case CODE_LEN_OUTPUT:
         case CODE_REWIND:
+        case CODE_STRING_ERROR:
         case CODE_PRINT_STRING:
           return 2;
         default:
@@ -1634,11 +1653,12 @@ namespace awkward {
       stop++;
       colstop++;
 
-      if (!tokenized.empty()  &&  tokenized[tokenized.size() - 1] == ".\"") {
+      if (!tokenized.empty()  &&  (tokenized[tokenized.size() - 1] == ".\""
+        ||  tokenized[tokenized.size() - 1] == "s\"")) {
         // Strings are tokenized differently.
         if (stop == source_.size()) {
           throw std::invalid_argument(
-            std::string("unclosed string after .\" word") + FILENAME(__LINE__));
+            std::string("unclosed string after .\" or s\" word") + FILENAME(__LINE__));
         }
         int64_t nextline = line;
         current = source_[stop];
@@ -1653,7 +1673,7 @@ namespace awkward {
           colstop++;
           if (stop == source_.size()) {
             throw std::invalid_argument(
-              std::string("unclosed string after .\" word") + FILENAME(__LINE__));
+              std::string("unclosed string after .\" or s\" word") + FILENAME(__LINE__));
           }
           current = source_[stop];
         }
@@ -1669,7 +1689,7 @@ namespace awkward {
           colstop++;
           if (stop == source_.size()) {
             throw std::invalid_argument(
-              std::string("unclosed string after .\" word") + FILENAME(__LINE__));
+              std::string("unclosed string after .\" or s\" word") + FILENAME(__LINE__));
           }
           current = source_[stop];
         }
@@ -2534,6 +2554,21 @@ namespace awkward {
         }
       }
 
+      else if (word == "s\"") {
+        bytecodes.push_back(CODE_STRING_ERROR);
+        bytecodes.push_back((int32_t)strings_.size());
+
+        if (pos + 1 >= stop) {
+          throw std::invalid_argument(
+            err_linecol(linecol, pos, pos + 2, "unclosed string after s\" word")
+            + FILENAME(__LINE__)
+          );
+        }
+        strings_.push_back(tokenized[(IndexTypeOf<std::string>)pos + 1]);
+
+        pos += 2;
+      }
+
       else if (word == ".\"") {
         bytecodes.push_back(CODE_PRINT_STRING);
         bytecodes.push_back((int32_t)strings_.size());
@@ -3307,6 +3342,13 @@ namespace awkward {
               if (current_error_ != util::ForthError::none) {
                 return;
               }
+              break;
+            }
+
+            case CODE_STRING_ERROR: {
+              I string_num = bytecode_get();
+              bytecodes_pointer_where()++;
+              stack_push(string_num);
               break;
             }
 

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -998,7 +998,7 @@ namespace awkward {
   template <typename T, typename I>
   const std::string
   ForthMachineOf<T, I>::string_at(int64_t index) const noexcept {
-    return (index < (int64_t)strings_.size() ?
+    return ((index >= 0  &&  index < (int64_t)strings_.size()) ?
       strings_[(IndexTypeOf<int64_t>)index] : std::string("a string at ")
       + std::to_string(index) + std::string(" is undefined"));
   }

--- a/src/python/forth.cpp
+++ b/src/python/forth.cpp
@@ -174,10 +174,7 @@ make_ForthMachineOf(const py::handle& m, const std::string& name) {
           .def("stack_clear", &ak::ForthMachineOf<T, I>::stack_clear)
           .def("string_at", [](ak::ForthMachineOf<T, I>& self,
                                int64_t at) -> py::str {
-            if (self.stack_can_pop()) {
-              return self.string_at(at);
-            }
-            return py::str("undefined");
+            return self.string_at(at);
           })
           .def_property_readonly("variables", &ak::ForthMachineOf<T, I>::variables)
           .def("input_position", [](ak::ForthMachineOf<T, I>& self,

--- a/src/python/forth.cpp
+++ b/src/python/forth.cpp
@@ -172,6 +172,13 @@ make_ForthMachineOf(const py::handle& m, const std::string& name) {
               return self.stack_pop();
           })
           .def("stack_clear", &ak::ForthMachineOf<T, I>::stack_clear)
+          .def("string_at", [](ak::ForthMachineOf<T, I>& self,
+                               int64_t at) -> py::str {
+            if (self.stack_can_pop()) {
+              return self.string_at(at);
+            }
+            return py::str("undefined");
+          })
           .def_property_readonly("variables", &ak::ForthMachineOf<T, I>::variables)
           .def("input_position", [](ak::ForthMachineOf<T, I>& self,
                                     const std::string& name) -> int64_t {

--- a/tests/test_0781-forth-machine-error-handling.py
+++ b/tests/test_0781-forth-machine-error-handling.py
@@ -22,6 +22,37 @@ s" this is an error"
 """
     )
 
+def test_user_defined_strings():
+    vm32 = awkward.forth.ForthMachine32(
+        """
+s" this is a first string"
+s" this is a second string"
+s" this is a third string"
+s" this is a forth string"
+"""
+    )
+
+    assert (
+        vm32.string_at(0)
+        == "this is a first string"
+    )
+    assert (
+        vm32.string_at(1)
+        == "this is a second string"
+    )
+    assert (
+        vm32.string_at(2)
+        == "this is a third string"
+    )
+    assert (
+        vm32.string_at(3)
+        == "this is a forth string"
+    )
+    assert (
+        vm32.string_at(4)
+        == "a string at 4 is undefined"
+    )
+
 
 def test_user_defined_exception():
     vm32 = awkward.forth.ForthMachine32(

--- a/tests/test_0781-forth-machine-error-handling.py
+++ b/tests/test_0781-forth-machine-error-handling.py
@@ -22,6 +22,7 @@ s" this is an error"
 """
     )
 
+
 def test_user_defined_strings():
     vm32 = awkward.forth.ForthMachine32(
         """
@@ -32,26 +33,11 @@ s" this is a forth string"
 """
     )
 
-    assert (
-        vm32.string_at(0)
-        == "this is a first string"
-    )
-    assert (
-        vm32.string_at(1)
-        == "this is a second string"
-    )
-    assert (
-        vm32.string_at(2)
-        == "this is a third string"
-    )
-    assert (
-        vm32.string_at(3)
-        == "this is a forth string"
-    )
-    assert (
-        vm32.string_at(4)
-        == "a string at 4 is undefined"
-    )
+    assert vm32.string_at(0) == "this is a first string"
+    assert vm32.string_at(1) == "this is a second string"
+    assert vm32.string_at(2) == "this is a third string"
+    assert vm32.string_at(3) == "this is a forth string"
+    assert vm32.string_at(4) == "a string at 4 is undefined"
 
 
 def test_user_defined_exception():

--- a/tests/test_0781-forth-machine-error-handling.py
+++ b/tests/test_0781-forth-machine-error-handling.py
@@ -47,7 +47,8 @@ again
     )
     with pytest.raises(ValueError) as err:
         vm32.run()
-    assert str(err.value) == "variable x reached its maximum 10"
+    assert vm32.stack[-1] == 0
+    assert vm32.string_at(vm32.stack[-1]) == "variable x reached its maximum 10"
 
 
 def test_undefined_error():

--- a/tests/test_0781-forth-machine-error-handling.py
+++ b/tests/test_0781-forth-machine-error-handling.py
@@ -38,6 +38,7 @@ s" this is a forth string"
     assert vm32.string_at(2) == "this is a third string"
     assert vm32.string_at(3) == "this is a forth string"
     assert vm32.string_at(4) == "a string at 4 is undefined"
+    assert vm32.string_at(-1) == "a string at -1 is undefined"
 
 
 def test_user_defined_exception():

--- a/tests/test_0781-forth-machine-error-handling.py
+++ b/tests/test_0781-forth-machine-error-handling.py
@@ -1,0 +1,77 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+import awkward.forth
+
+
+def test_user_defined_error():
+    vm32 = awkward.forth.ForthMachine32(
+        """
+s" this is an error"
+"""
+    )
+
+    assert (
+        vm32.decompiled
+        == """s" this is an error"
+"""
+    )
+
+
+def test_user_defined_exception():
+    vm32 = awkward.forth.ForthMachine32(
+        """
+variable x 0 x !
+variable err
+
+s" variable x reached its maximum 10"
+
+: foo
+    5 x +! x @
+    dup 10 = if
+        0 err ! err @ halt
+    then
+;
+
+0
+begin
+    foo
+    1+
+again
+"""
+    )
+    with pytest.raises(ValueError) as err:
+        vm32.run()
+    assert str(err.value) == "variable x reached its maximum 10"
+
+
+def test_undefined_error():
+    vm32 = awkward.forth.ForthMachine32(
+        """
+variable x 0 x !
+
+: foo
+    5 x +! x @
+    dup 10 = if
+        halt
+    then
+;
+
+0
+begin
+    foo
+    1+
+again
+"""
+    )
+    with pytest.raises(ValueError) as err:
+        vm32.run()
+    assert (
+        str(err.value)
+        == "'user halt' in AwkwardForth runtime: user-defined error or stopping condition"
+    )


### PR DESCRIPTION
User defined error messages can be passed to a `halt` command exception handling. For example:

```python
def test_user_defined_exception():
    vm32 = awkward.forth.ForthMachine32(
        """
variable x 0 x !
variable err
s" variable x reached its maximum 10"
: foo
    5 x +! x @
    dup 10 = if
        0 err ! err @ halt
    then
;
0
begin
    foo
    1+
again
"""
    )
    with pytest.raises(ValueError) as err:
        vm32.run()
    assert vm32.stack[-1] == 0
    assert vm32.string_at(vm32.stack[-1]) == "variable x reached its maximum 10"
```