### PR TITLE
Don't prevent other Numba extensions from using operators.

### DIFF
--- a/src/awkward/_connect/_numba/arrayview.py
+++ b/src/awkward/_connect/_numba/arrayview.py
@@ -964,9 +964,9 @@ def register_unary_operator(unaryop):
                     left = args[0].arrayviewtype.type
                     behavior = args[0].arrayviewtype.behavior
 
-                for typer, lower in ak._util.numba_unaryops(unaryop, left, behavior):
-                    numba.extending.lower_builtin(unaryop, *args)(lower)
-                    return typer(unaryop, args[0])
+                    for typer, lower in ak._util.numba_unaryops(unaryop, left, behavior):
+                        numba.extending.lower_builtin(unaryop, *args)(lower)
+                        return typer(unaryop, args[0])
 
 
 for unaryop in (
@@ -997,9 +997,10 @@ def register_binary_operator(binop):
                     if behavior is None:
                         behavior = args[1].arrayviewtype.behavior
 
-                for typer, lower in ak._util.numba_binops(binop, left, right, behavior):
-                    numba.extending.lower_builtin(binop, *args)(lower)
-                    return typer(binop, args[0], args[1])
+                if left is not None or right is not None:
+                    for typer, lower in ak._util.numba_binops(binop, left, right, behavior):
+                        numba.extending.lower_builtin(binop, *args)(lower)
+                        return typer(binop, args[0], args[1])
 
 
 for binop in (

--- a/src/awkward/_connect/_numba/arrayview.py
+++ b/src/awkward/_connect/_numba/arrayview.py
@@ -964,7 +964,9 @@ def register_unary_operator(unaryop):
                     left = args[0].arrayviewtype.type
                     behavior = args[0].arrayviewtype.behavior
 
-                    for typer, lower in ak._util.numba_unaryops(unaryop, left, behavior):
+                    for typer, lower in ak._util.numba_unaryops(
+                        unaryop, left, behavior
+                    ):
                         numba.extending.lower_builtin(unaryop, *args)(lower)
                         return typer(unaryop, args[0])
 
@@ -998,7 +1000,9 @@ def register_binary_operator(binop):
                         behavior = args[1].arrayviewtype.behavior
 
                 if left is not None or right is not None:
-                    for typer, lower in ak._util.numba_binops(binop, left, right, behavior):
+                    for typer, lower in ak._util.numba_binops(
+                        binop, left, right, behavior
+                    ):
                         numba.extending.lower_builtin(binop, *args)(lower)
                         return typer(binop, args[0], args[1])
 


### PR DESCRIPTION
If another Numba extension (such as [Vector](https://github.com/scikit-hep/vector)) is trying to overload an operator and Awkward's check goes first, Awkward's check has a bug (variable not defined because the other-library object is not an Awkward object) that gets reported in the Numba error message, even though it has _nothing to do_ with any data types that are present in the function being compiled:

```
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
No implementation of function Function(<built-in function abs>) found for signature:
 
 >>> abs(VectorObject2DType(AzimuthalObjectXY(int64 x 2)))
 
There are 8 candidate implementations:
  - Of which 2 did not match due to:
  Type Restricted Function in function 'abs': File: unknown: Line unknown.
    With argument(s): '(VectorObject2DType(AzimuthalObjectXY(int64 x 2)))':
   No match for registered cases:
    * (int8,) -> int8
    * (int16,) -> int16
    * (int32,) -> int32
    * (int64,) -> int64
    * (uint8,) -> uint8
    * (uint16,) -> uint16
    * (uint32,) -> uint32
    * (uint64,) -> uint64
    * (float32,) -> float32
    * (float64,) -> float64
    * (complex64,) -> float32
    * (complex128,) -> float64
  - Of which 2 did not match due to:
  Overload in function 'operator_abs.generic': File: ../../../../irishep/vector/vector/backends/numba_object.py: Line 2996.
    With argument(s): '(VectorObject2DType(AzimuthalObjectXY(int64 x 2)))':
   Rejected as the implementation raised a specific error:
     TypeError: 'builtin_function_or_method' object is not subscriptable
  raised from /home/jpivarski/irishep/vector/vector/backends/numba_object.py:3002
  - Of which 2 did not match due to:
  Overload in function 'register_unary_operator.<locals>.type_binary_operator.generic': File: awkward/_connect/_numba/arrayview.py: Line 959.
    With argument(s): '(VectorObject2DType(AzimuthalObjectXY(int64 x 2)))':
   Rejected as the implementation raised a specific error:
     UnboundLocalError: local variable 'left' referenced before assignment
  raised from /home/jpivarski/miniconda3/lib/python3.8/site-packages/awkward/_connect/_numba/arrayview.py:967
  - Of which 2 did not match due to:
  Overload of function 'abs': File: numba/core/typing/npdatetime.py: Line 20.
    With argument(s): '(VectorObject2DType(AzimuthalObjectXY(int64 x 2)))':
   No match.

During: resolving callee type: Function(<built-in function abs>)
During: typing of call at /home/jpivarski/irishep/vector/tests/backends/test_numba_object.py (1320)


File "tests/backends/test_numba_object.py", line 1320:
    def get_abs(v):
        return abs(v)
        ^

../../miniconda3/lib/python3.8/site-packages/numba/core/dispatcher.py:357: TypingError
```

Note the reference to `awkward/_connect/_numba/arrayview.py`. The function being compiled was

```python
@numba.njit
def get_abs(v):
    return abs(v)
```

where `v` is `vector.obj(x=3, y=4)`, which has _nothing to do_ with Awkward Array. With this fix, Awkward Array stays out of the way and Numba error messages refer only to the types of data in question.