### PR TITLE
Bugfix: fix #846 - matrix multiplication with numpy array 

### DIFF
--- a/src/awkward/_connect/_numpy.py
+++ b/src/awkward/_connect/_numpy.py
@@ -144,12 +144,12 @@ def array_ufunc(ufunc, method, inputs, kwargs):
         if custom is not None:
             return lambda: adjust(custom, inputs, kwargs)
 
-        inputs = [deregulate(x) for x in inputs]
-
         if ufunc is numpy.matmul:
             custom_matmul = getfunction_matmul(inputs)
             if custom_matmul is not None:
                 return custom_matmul
+
+        inputs = [deregulate(x) for x in inputs]
 
         if all(
             isinstance(x, ak.layout.NumpyArray)
@@ -290,6 +290,13 @@ matmul_for_numba.numbafied = None
 
 
 def getfunction_matmul(inputs):
+    inputs = [
+        ak._util.recursively_apply(
+            x, (lambda _: _), pass_depth=False, numpy_to_regular=True
+        )
+        for x in inputs
+    ]
+
     if len(inputs) == 2 and all(
         isinstance(x, ak._util.listtypes)
         and isinstance(x.content, ak._util.listtypes)

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -563,7 +563,10 @@ def broadcast_and_apply(  # noqa: C901
                 ):
                     return False
             elif isinstance(x, ak.layout.RegularArray):
-                my_offsets = nplike.arange(0, len(x.content), x.size)
+                if x.size == 0:
+                    my_offsets = nplike.empty(0, dtype=np.int64)
+                else:
+                    my_offsets = nplike.arange(0, len(x.content), x.size)
                 if offsets is None:
                     offsets = my_offsets
                 elif not nplike.array_equal(offsets, my_offsets):

--- a/tests/test_0846-matrix-multiplication-numpy.py
+++ b/tests/test_0846-matrix-multiplication-numpy.py
@@ -1,0 +1,43 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_numpy_rhs():
+    transform = ak.Array(
+        [
+            [0, 1, 0],
+            [4, 0, 0],
+            [0, 0, 2],
+        ]
+    )
+
+    vector = ak.Array(
+        np.r_[4, 5, 6].reshape(3, 1)    
+    )
+
+    result = np.matmul(transform, vector)
+
+    assert result.tolist() == [5, 16, 12]
+    
+    
+def test_numpy_lhs():
+    transform = ak.Array(
+        [
+            [0, 4, 0],
+            [1, 0, 0],
+            [0, 0, 2],
+        ]
+    )
+
+    vector = ak.Array(
+        np.r_[4, 5, 6].reshape(1, 3)    
+    )
+
+    result = np.matmul(vector,transform)
+
+    assert result.tolist() == [[5, 16, 12]]

--- a/tests/test_0846-matrix-multiplication-numpy.py
+++ b/tests/test_0846-matrix-multiplication-numpy.py
@@ -16,15 +16,13 @@ def test_numpy_rhs():
         ]
     )
 
-    vector = ak.Array(
-        np.r_[4, 5, 6].reshape(3, 1)    
-    )
+    vector = ak.Array(np.r_[4, 5, 6].reshape(3, 1))
 
     result = np.matmul(transform, vector)
 
     assert result.tolist() == [5, 16, 12]
-    
-    
+
+
 def test_numpy_lhs():
     transform = ak.Array(
         [
@@ -34,10 +32,8 @@ def test_numpy_lhs():
         ]
     )
 
-    vector = ak.Array(
-        np.r_[4, 5, 6].reshape(1, 3)    
-    )
+    vector = ak.Array(np.r_[4, 5, 6].reshape(1, 3))
 
-    result = np.matmul(vector,transform)
+    result = np.matmul(vector, transform)
 
     assert result.tolist() == [[5, 16, 12]]

--- a/tests/test_0846-matrix-multiplication-numpy.py
+++ b/tests/test_0846-matrix-multiplication-numpy.py
@@ -6,6 +6,8 @@ import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
+pytest.importorskip("numba")
+
 
 def test_numpy_rhs():
     transform = ak.Array(

--- a/tests/test_0846-matrix-multiplication-numpy.py
+++ b/tests/test_0846-matrix-multiplication-numpy.py
@@ -20,7 +20,7 @@ def test_numpy_rhs():
 
     result = np.matmul(transform, vector)
 
-    assert result.tolist() == [5, 16, 12]
+    assert result.tolist() == [[5], [16], [12]]
 
 
 def test_numpy_lhs():


### PR DESCRIPTION
This PR tracks the fix for #846 (assuming that this is indeed a bug). For now, it just adds a test to demonstrate the issue.