### PR TITLE
corrected the class names in documentation

### DIFF
--- a/docs-sphinx/ak.layout.BitMaskedArray.rst
+++ b/docs-sphinx/ak.layout.BitMaskedArray.rst
@@ -30,7 +30,7 @@ If the logical size of the array is not a multiple of 8, the ``mask``
 has to be padded. Thus, an explicit ``length`` is also part of the
 class's definition.
 
-Below is a simplified implementation of a RecordArray class in pure Python
+Below is a simplified implementation of a BitMaskedArray class in pure Python
 that exhaustively checks validity in its constructor (see
 :doc:`_auto/ak.is_valid`) and can generate random valid arrays. The
 ``random_number()`` function returns a random float and the

--- a/docs-sphinx/ak.layout.ByteMaskedArray.rst
+++ b/docs-sphinx/ak.layout.ByteMaskedArray.rst
@@ -14,7 +14,7 @@ There is no Apache Arrow equivalent because Arrow
 `uses bitmaps <https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps>`__
 to mask all node types.
 
-Below is a simplified implementation of a RecordArray class in pure Python
+Below is a simplified implementation of a ByteMaskedArray class in pure Python
 that exhaustively checks validity in its constructor (see
 :doc:`_auto/ak.is_valid`) and can generate random valid arrays. The
 ``random_number()`` function returns a random float and the

--- a/docs-sphinx/ak.layout.UnionArray.rst
+++ b/docs-sphinx/ak.layout.UnionArray.rst
@@ -25,7 +25,7 @@ Awkward Array has no direct equivalent for Apache Arrow's
 but an appropriate index may be generated with
 `sparse_index <#ak.layout.UnionArray.sparse_index>`_.
 
-Below is a simplified implementation of a RecordArray class in pure Python
+Below is a simplified implementation of a UnionArrays class in pure Python
 that exhaustively checks validity in its constructor (see
 :doc:`_auto/ak.is_valid`) and can generate random valid arrays. The
 ``random_number()`` function returns a random float and the

--- a/docs-sphinx/ak.layout.UnionArray.rst
+++ b/docs-sphinx/ak.layout.UnionArray.rst
@@ -25,7 +25,7 @@ Awkward Array has no direct equivalent for Apache Arrow's
 but an appropriate index may be generated with
 `sparse_index <#ak.layout.UnionArray.sparse_index>`_.
 
-Below is a simplified implementation of a UnionArrays class in pure Python
+Below is a simplified implementation of a UnionArray class in pure Python
 that exhaustively checks validity in its constructor (see
 :doc:`_auto/ak.is_valid`) and can generate random valid arrays. The
 ``random_number()`` function returns a random float and the

--- a/docs-sphinx/ak.layout.UnmaskedArray.rst
+++ b/docs-sphinx/ak.layout.UnmaskedArray.rst
@@ -14,7 +14,7 @@ It is also like Apache Arrow's
 `validity bitmaps <https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps>`__
 because the bitmap can be omitted when all values are valid.
 
-Below is a simplified implementation of a RecordArray class in pure Python
+Below is a simplified implementation of a UnmaskedArray class in pure Python
 that exhaustively checks validity in its constructor (see
 :doc:`_auto/ak.is_valid`) and can generate random valid arrays. The
 ``random_number()`` function returns a random float and the

--- a/docs-sphinx/ak.layout.UnmaskedArray.rst
+++ b/docs-sphinx/ak.layout.UnmaskedArray.rst
@@ -14,7 +14,7 @@ It is also like Apache Arrow's
 `validity bitmaps <https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps>`__
 because the bitmap can be omitted when all values are valid.
 
-Below is a simplified implementation of a UnmaskedArray class in pure Python
+Below is a simplified implementation of an UnmaskedArray class in pure Python
 that exhaustively checks validity in its constructor (see
 :doc:`_auto/ak.is_valid`) and can generate random valid arrays. The
 ``random_number()`` function returns a random float and the


### PR DESCRIPTION
@jpivarski - I've noticed the name mismatch when looking at the links you've posted on Slack.