### PR TITLE
Fix #879

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -959,7 +959,12 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
                 nplike = ak.nplike.of(*inputs)
                 base, what = inputs
                 if isinstance(base, ak.layout.RecordArray):
-                    if not isinstance(what, ak.layout.Content):
+                    if what is None:
+                        what = ak.layout.IndexedOptionArray64(
+                            ak.layout.Index64(nplike.full(len(base), -1, np.int64)),
+                            ak.layout.EmptyArray(),
+                        )
+                    elif not isinstance(what, ak.layout.Content):
                         what = ak.layout.NumpyArray(nplike.repeat(what, len(base)))
                     if base.istuple and where is None:
                         recordlookup = None

--- a/tests/test_0879-non-primitive-with-field.py
+++ b/tests/test_0879-non-primitive-with-field.py
@@ -10,7 +10,7 @@ import awkward as ak  # noqa: F401
 def test():
     x = ak.Array({"x": np.arange(10)})
 
-    xy = ak.with_field(base=x, what=object(), where="y")
+    xy = ak.with_field(base=x, what=None, where="y")
 
     # Try to access the type of a single element
     # This raises a ValueError in #879

--- a/tests/test_0879-non-primitive-with-field.py
+++ b/tests/test_0879-non-primitive-with-field.py
@@ -1,0 +1,17 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    x = ak.Array({"x": np.arange(10)})
+
+    xy = ak.with_field(base=x, what=object(), where="y")
+
+    # Try to access the type of a single element
+    # This raises a ValueError in #879
+    xy_type = xy.type  # noqa: F841

--- a/tests/test_0879-non-primitive-with-field.py
+++ b/tests/test_0879-non-primitive-with-field.py
@@ -7,11 +7,21 @@ import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
 
-def test():
-    x = ak.Array({"x": np.arange(10)})
-
-    xy = ak.with_field(base=x, what=None, where="y")
+def test_unknown_type():
+    array = ak.Array({"x": np.arange(10)})
+    array = ak.with_field(base=array, what=None, where="unknown field1")
+    array = ak.with_field(base=array, what=[None], where="unknown field2")
 
     # Try to access the type of a single element
     # This raises a ValueError in #879
-    xy_type = xy.type  # noqa: F841
+    tpe1 = array["unknown field1"].type
+    tpe2 = array["unknown field2"].type
+    assert str(tpe1) == "10 * ?unknown"
+    assert str(tpe2) == "10 * ?unknown"
+
+
+def test_in_place_wrapper_broadcasting():
+    array = ak.Array({"x": np.arange(3)})
+    array["unknown field"] = None
+
+    assert array["unknown field"].tolist() == [None, None, None]


### PR DESCRIPTION
This PR:
- adds a test to trigger the ValueError that is produced in the high-level API.
- adds a special case treatment of `what=None` in `ak.with_field` in accordance with the suggestion given by @jpivarski 