### PR TITLE
revert to expected behavior when providing ns resolution

### DIFF
--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -970,16 +970,10 @@ def to_list(array):
     elif isinstance(array, ak.layout.NumpyArray):
         if array.format.upper().startswith("M"):
             return (
-                [
-                    x
-                    for x in ak.nplike.of(array)
-                    .asarray(array.view_int64)
-                    .view(array.format)
-                ]
-                # FIXME: .tolist() returns
-                # [[1567416600000000000], [1568367000000000000], [1569096000000000000]]
-                # instead of [numpy.datetime64('2019-09-02T09:30:00'), numpy.datetime64('2019-09-13T09:30:00'), numpy.datetime64('2019-09-21T20:00:00')]
-                # see test_from_pandas() test
+                ak.nplike.of(array)
+                .asarray(array.view_int64)
+                .view(array.format)
+                .tolist()
             )
         else:
             return ak.nplike.of(array).asarray(array).tolist()

--- a/tests/test_0835-datetime-type.py
+++ b/tests/test_0835-datetime-type.py
@@ -506,10 +506,11 @@ def test_from_pandas():
     df = pandas.DataFrame(values, columns=["time"])
     df["time"] = pandas.to_datetime(df["time"], format="%Y%m%d%H%M%S")
     array = ak.layout.NumpyArray(df)
+    # somewhat expected behavior when providing `ns` resolution
     assert ak.to_list(array) == [
-        np.datetime64("2019-09-02T09:30:00"),
-        np.datetime64("2019-09-13T09:30:00"),
-        np.datetime64("2019-09-21T20:00:00"),
+        [1567416600000000000],
+        [1568367000000000000],
+        [1569096000000000000],
     ]
     array2 = ak.Array(df.values)
     assert ak.to_list(array2) == [


### PR DESCRIPTION
Thanks @drahnreb for clarifying it:

> This is somewhat expected behavior when providing `ns` resolution. 
> 
> ```python
> >>> np.datetime64('2019-09-02T09:30:00', 'ns').tolist()
> 1567416600000000000
> >>> np.datetime64("2019-09-02T09:30:00.0000000").tolist()
> 1567416600000000000
> ```
> 
> It's a very [old and complex (if not weird)](https://stackoverflow.com/questions/13703720/converting-between-datetime-timestamp-and-datetime64/21916253#21916253) behavior.
> Numpy considers datetime still [experimenting](https://numpy.org/doc/stable/reference/arrays.datetime.html), and this might change anytime, but I would prefer to mimic rather than sacrificing non-vectorized performance.
> 
> 

_Originally posted by @drahnreb in https://github.com/scikit-hep/awkward-1.0/pull/835#r649397958_