### PR TITLE
Feature: add `ak.packed`

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1448,7 +1448,8 @@ class Array(
         return numba.typeof(self._numbaview)
 
     def __getstate__(self):
-        form, length, container = ak.operations.convert.to_buffers(self.layout)
+        packed = ak.operations.structure.packed(self.layout, highlevel=False)
+        form, length, container = ak.operations.convert.to_buffers(packed)
         if self._behavior is ak.behavior:
             behavior = None
         else:
@@ -2033,12 +2034,13 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
         return numba.typeof(self._numbaview)
 
     def __getstate__(self):
-        form, length, container = ak.operations.convert.to_buffers(self.layout.array)
+        packed = ak.operations.structure.packed(self._layout, highlevel=False)
+        form, length, container = ak.operations.convert.to_buffers(packed.array)
         if self._behavior is ak.behavior:
             behavior = None
         else:
             behavior = self._behavior
-        return form, length, container, behavior, self.layout.at
+        return form, length, container, behavior, packed.at
 
     def __setstate__(self, state):
         if isinstance(state[1], dict):

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3980,7 +3980,10 @@ def to_buffers(
         >>> ak.partitions(reconstituted)
         [3, 1, 3, 1]
 
-    See also #ak.from_buffers.
+    If you intend to use this function for saving data, you may want to pack it
+    first with #ak.packed.
+
+    See also #ak.from_buffers and #ak.packed.
     """
     if container is None:
         container = {}

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2088,7 +2088,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 
     else:
 
-        def getfunction(layout, depth, posaxis, apply):
+        def getfunction(layout, depth, posaxis):
             posaxis = layout.axis_wrap_if_negative(posaxis)
             if posaxis == depth and isinstance(layout, ak._util.listtypes):
                 # We are one *above* the level where we want to apply this.
@@ -2130,7 +2130,6 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
                         getfunction,
                         pass_depth=True,
                         pass_user=True,
-                        pass_apply=True,
                         user=axis,
                     )
                 )
@@ -2141,7 +2140,6 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
                 getfunction,
                 pass_depth=True,
                 pass_user=True,
-                pass_apply=True,
                 user=axis,
             )
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2205,24 +2205,7 @@ def packed(array, axis=None, highlevel=True):
                 ak.layout.ListArray64,
             ),
         ):
-            starts = nplike.asarray(layout.starts)
-            stops = nplike.asarray(layout.stops)
-            intervals = stops - starts
-            indices = nplike.repeat(
-                stops - nplike.cumsum(intervals), intervals
-            ) + nplike.arange(nplike.sum(intervals))
-            inner = ak.layout.IndexedArray64(ak.layout.Index64(indices), layout.content)
-
-            outer_offsets = nplike.asarray(layout.compact_offsets64(True))
-            outer_starts = outer_offsets[:-1]
-            outer_stops = outer_offsets[1:]
-            return ak.layout.ListArray64(
-                ak.layout.Index64(outer_starts),
-                ak.layout.Index64(outer_stops),
-                apply(inner, depth + 1, posaxis),
-                layout.identities,
-                layout.parameters,
-            )
+            return apply(layout.toListOffsetArray64(True), depth, posaxis)
 
         # ListOffsetArray performs resizing
         if isinstance(

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2180,11 +2180,11 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             return layout.contiguous()
 
         # EmptyArray is a no-op
-        if isinstance(layout, ak.layout.EmptyArray):
+        elif isinstance(layout, ak.layout.EmptyArray):
             return layout
 
         # Project indexed arrays
-        if isinstance(layout, ak._util.indexedoptiontypes):
+        elif isinstance(layout, ak._util.indexedoptiontypes):
             if isinstance(layout.content, ak._util.optiontypes):
                 return apply(layout.simplify(), depth, posaxis)
 
@@ -2200,11 +2200,11 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             )
 
         # Project indexed arrays
-        if isinstance(layout, ak._util.indexedtypes):
+        elif isinstance(layout, ak._util.indexedtypes):
             return apply(layout.project(), depth, posaxis)
 
         # ListArray performs both ordering and resizing
-        if isinstance(
+        elif isinstance(
             layout,
             (
                 ak.layout.ListArray32,
@@ -2215,7 +2215,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             return apply(layout.toListOffsetArray64(True), depth, posaxis)
 
         # ListOffsetArray performs resizing
-        if isinstance(
+        elif isinstance(
             layout,
             (
                 ak.layout.ListOffsetArray32,
@@ -2232,12 +2232,12 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             )
 
         # UnmaskedArray just wraps another array
-        if isinstance(layout, ak.layout.UnmaskedArray):
+        elif isinstance(layout, ak.layout.UnmaskedArray):
             return ak.layout.UnmaskedArray(apply(layout.content, depth, posaxis))
 
         # UnionArrays can be simplified
         # and their contents too
-        if isinstance(layout, ak._util.uniontypes):
+        elif isinstance(layout, ak._util.uniontypes):
             layout = layout.simplify()
 
             # If we managed to lose the drop type entirely
@@ -2267,7 +2267,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             )
 
         # RecordArray contents can be truncated
-        if isinstance(layout, ak.layout.RecordArray):
+        elif isinstance(layout, ak.layout.RecordArray):
             return ak.layout.RecordArray(
                 [
                     apply(truncate(c, len(layout)), depth, posaxis)
@@ -2280,7 +2280,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             )
 
         # RegularArrays can change length
-        if isinstance(layout, ak.layout.RegularArray):
+        elif isinstance(layout, ak.layout.RegularArray):
             if not len(layout):
                 return layout
 
@@ -2297,7 +2297,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             )
 
         # BitMaskedArrays can change length
-        if isinstance(layout, ak.layout.BitMaskedArray):
+        elif isinstance(layout, ak.layout.BitMaskedArray):
             layout = layout.simplify()
 
             if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
@@ -2314,7 +2314,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             )
 
         # ByteMaskedArrays can change length
-        if isinstance(layout, ak.layout.ByteMaskedArray):
+        elif isinstance(layout, ak.layout.ByteMaskedArray):
             layout = layout.simplify()
 
             if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
@@ -2328,7 +2328,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
                 layout.parameters,
             )
 
-        if isinstance(layout, ak.layout.VirtualArray):
+        elif isinstance(layout, ak.layout.VirtualArray):
             return apply(layout.array, depth, posaxis)
 
         # Finally, fall through to failure

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2332,7 +2332,12 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             return apply(layout.array, depth, posaxis)
 
         # Finally, fall through to failure
-        raise NotImplementedError
+        else:
+            raise AssertionError(
+                "unrecognized layout: "
+                + repr(layout)
+                + ak._util.exception_suffix(__file__)
+            )
 
     out = apply(layout, 1, axis)
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2227,7 +2227,6 @@ def packed(array, axis=None, highlevel=True, behavior=None):
             ),
         ):
             new_layout = layout.toListOffsetArray64(True)
-
             return ak.layout.ListOffsetArray64(
                 new_layout.offsets,
                 apply(new_layout.content, depth + 1, posaxis),
@@ -2294,7 +2293,7 @@ def packed(array, axis=None, highlevel=True, behavior=None):
             # multiple of the RegularArray size
             n, r = divmod(len(content), layout.size)
             if r:
-                content = truncate(content, r * layout.size)
+                content = truncate(content, n * layout.size)
 
             return ak.layout.RegularArray(
                 apply(content, depth + 1, posaxis), layout.size

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2177,17 +2177,22 @@ def simplify(array, axis=None, highlevel=True):
     )
 
     def getfunction(layout, depth, posaxis, apply):
-        # RegularArrays cannot change length or ordering
-        if isinstance(layout, ak.layout.RegularArray):
+        # Do not handle arrays which either leave length + order unchanged
+        # or are proxies to other arrays (e.g. VirtualArray)
+        if isinstance(
+            layout,
+            (
+                ak.layout.EmptyArray,
+                ak.layout.NumpyArray,
+                ak.layout.VirtualArray,
+                ak.layout.RegularArray,
+            ),
+        ):
             return posaxis
 
         # Project indexed arrays
         if isinstance(layout, ak._util.indexedoptiontypes + ak._util.indexedtypes):
             return lambda: apply(layout.project(), depth, posaxis)
-
-        # EmptyArray doesnt have contents
-        if isinstance(layout, (ak.layout.EmptyArray, ak.layout.NumpyArray)):
-            return posaxis
 
         # ListArray performs both ordering and resizing
         if isinstance(
@@ -2241,7 +2246,6 @@ def simplify(array, axis=None, highlevel=True):
         # RecordArray
         # Record
         # UnionArray
-        # VirtualArray
         # Partitioned
 
         # Finally, fall through to failure

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2170,8 +2170,6 @@ def packed(array, axis=None, highlevel=True):
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.layout.Content subclass.
     """
-    nplike = ak.nplike.of(array)
-
     layout = ak.operations.convert.to_layout(
         array, allow_record=False, allow_other=False
     )
@@ -2216,16 +2214,13 @@ def packed(array, axis=None, highlevel=True):
                 ak.layout.ListOffsetArrayU32,
             ),
         ):
-            offsets = nplike.asarray(layout.offsets)
-            indices = nplike.arange(offsets[0], offsets[-1])
-            inner = ak.layout.IndexedArray64(ak.layout.Index64(indices), layout.content)
+            new_layout = layout.toListOffsetArray64(True)
 
-            outer_offsets = nplike.asarray(layout.compact_offsets64(True))
             return ak.layout.ListOffsetArray64(
-                ak.layout.Index64(outer_offsets),
-                apply(inner, depth + 1, posaxis),
-                layout.identities,
-                layout.parameters,
+                new_layout.offsets,
+                apply(new_layout.content, depth + 1, posaxis),
+                new_layout.identities,
+                new_layout.parameters,
             )
 
         # ByteMaskedArray

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2308,6 +2308,18 @@ def packed(array, axis=None, highlevel=True):
                 layout.parameters,
             )
 
+        if isinstance(layout, ak.layout.ByteMaskedArray):
+            if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
+                return apply(layout.toIndexedOptionArray64(), depth, posaxis)
+
+            return ak.layout.ByteMaskedArray(
+                layout.mask,
+                apply(truncate(layout.content, len(layout)), depth, posaxis),
+                layout.valid_when,
+                layout.identities,
+                layout.parameters,
+            )
+
         # Finally, fall through to failure
         raise NotImplementedError
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2193,7 +2193,15 @@ def packed(array, axis=None, highlevel=True):
             if isinstance(layout.content, ak._util.optiontypes):
                 return apply(layout.simplify(), depth, posaxis)
 
-            return apply(layout.project(), depth, posaxis)
+            index = nplike.asarray(layout.index)
+
+            n_options = nplike.sum(index < 0)
+            index[:n_options] = -1
+            index[n_options:] = nplike.arange(len(index) - n_options)
+
+            return ak.layout.IndexedOptionArray64(
+                ak.layout.Index64(index), apply(layout.project(), depth, posaxis)
+            )
 
         # Project indexed arrays
         if isinstance(layout, ak._util.indexedtypes):

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2180,12 +2180,8 @@ def packed(array, axis=None, highlevel=True):
         if isinstance(layout, ak.layout.NumpyArray):
             return layout.contiguous()
 
-        # Do not handle arrays which either leave length + order unchanged
-        # or are proxies to other arrays (e.g. VirtualArray)
-        if isinstance(
-            layout,
-            (ak.layout.EmptyArray, ak.layout.VirtualArray),
-        ):
+        # EmptyArray is a no-op
+        if isinstance(layout, ak.layout.EmptyArray):
             return layout
 
         # Project indexed arrays
@@ -2194,7 +2190,6 @@ def packed(array, axis=None, highlevel=True):
                 return apply(layout.simplify(), depth, posaxis)
 
             index = nplike.asarray(layout.index)
-
             n_options = nplike.sum(index < 0)
             index[:n_options] = -1
             index[n_options:] = nplike.arange(len(index) - n_options)
@@ -2335,6 +2330,9 @@ def packed(array, axis=None, highlevel=True):
                 layout.identities,
                 layout.parameters,
             )
+
+        if isinstance(layout, ak.layout.VirtualArray):
+            return apply(layout.array, depth, posaxis)
 
         # Finally, fall through to failure
         raise NotImplementedError

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2191,7 +2191,14 @@ def packed(array, axis=None, highlevel=True):
             return layout
 
         # Project indexed arrays
-        if isinstance(layout, ak._util.indexedoptiontypes + ak._util.indexedtypes):
+        if isinstance(layout, ak._util.indexedoptiontypes):
+            if isinstance(layout.content, ak._util.optiontypes):
+                return apply(layout.simplify(), depth, posaxis)
+
+            return apply(layout.project(), depth, posaxis)
+
+        # Project indexed arrays
+        if isinstance(layout, ak._util.indexedtypes):
             return apply(layout.project(), depth, posaxis)
 
         # ListArray performs both ordering and resizing

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2294,6 +2294,20 @@ def packed(array, axis=None, highlevel=True):
                 apply(content, depth + 1, posaxis), layout.size
             )
 
+        if isinstance(layout, ak.layout.BitMaskedArray):
+            if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
+                return apply(layout.toIndexedOptionArray64(), depth, posaxis)
+
+            return ak.layout.BitMaskedArray(
+                layout.mask,
+                apply(truncate(layout.content, len(layout)), depth, posaxis),
+                layout.valid_when,
+                len(layout),
+                layout.lsb_order,
+                layout.identities,
+                layout.parameters,
+            )
+
         # Finally, fall through to failure
         raise NotImplementedError
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2177,13 +2177,15 @@ def packed(array, axis=None, highlevel=True):
     )
 
     def apply(layout, depth, posaxis):
+        if isinstance(layout, ak.layout.NumpyArray):
+            return layout.contiguous()
+
         # Do not handle arrays which either leave length + order unchanged
         # or are proxies to other arrays (e.g. VirtualArray)
         if isinstance(
             layout,
             (
                 ak.layout.EmptyArray,
-                ak.layout.NumpyArray,
                 ak.layout.VirtualArray,
                 ak.layout.RegularArray,
             ),

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2159,7 +2159,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 
 def _packed(array, axis=None, highlevel=True, behavior=None):
     layout = ak.operations.convert.to_layout(
-        array, allow_record=False, allow_other=False
+        array, allow_record=True, allow_other=False
     )
     nplike = ak.nplike.of(layout)
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2184,11 +2184,7 @@ def packed(array, axis=None, highlevel=True):
         # or are proxies to other arrays (e.g. VirtualArray)
         if isinstance(
             layout,
-            (
-                ak.layout.EmptyArray,
-                ak.layout.VirtualArray,
-                ak.layout.RegularArray,
-            ),
+            (ak.layout.EmptyArray, ak.layout.VirtualArray),
         ):
             return layout
 
@@ -2280,6 +2276,22 @@ def packed(array, axis=None, highlevel=True):
                 len(layout),
                 layout.identities,
                 layout.parameters,
+            )
+
+        if isinstance(layout, ak.layout.RegularArray):
+            if not len(layout):
+                return layout
+
+            content = layout.content
+
+            # Truncate content if it is larger than a perfect
+            # multiple of the RegularArray size
+            n, r = divmod(len(content), layout.size)
+            if r:
+                content = truncate(content, r * layout.size)
+
+            return ak.layout.RegularArray(
+                apply(content, depth + 1, posaxis), layout.size
             )
 
         # Finally, fall through to failure

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2358,11 +2358,52 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
 def packed(array, highlevel=True, behavior=None):
     """
     Args:
-        array: Array to simplify.
+        array: Array whose internal structure will be packed.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.layout.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
+
+    Returns an array with the same data as the input, but with packed inner structures:
+
+    - #ak.layout.NumpyArray becomes C-contiguous (if it isn't already)
+    - #ak.layout.RegularArray trims unrechable content
+    - #ak.layout.ListArray becomes #ak.layout.ListOffsetArray, making all list data contiguous
+    - #ak.layout.ListOffsetArray starts at `offsets[0] == 0`, trimming unreachable content
+    - #ak.layout.RecordArray trims unreachable contents
+    - #ak.layout.IndexedArray gets projected
+    - #ak.layout.IndexedOptionArray remains an #ak.layout.IndexedOptionArray (with simplified `index`) if it contains records, becomes #ak.layout.ByteMaskedArray otherwise
+    - #ak.layout.ByteMaskedArray becomes an #ak.layout.IndexedOptionArray if it contains records, stays a #ak.layout.ByteMaskedArray otherwise
+    - #ak.layout.BitMaskedArray becomes an #ak.layout.IndexedOptionArray if it contains records, stays a #ak.layout.BitMaskedArray otherwise
+    - #ak.layout.UnionArray gets projected contents
+    - #ak.layout.VirtualArray gets materialized
+
+    Example:
+
+        >>> a = ak.Array([[1, 2, 3], [], [4, 5], [6], [7, 8, 9, 10]])
+        >>> b = a[::-1]
+        >>> b
+        <Array [[7, 8, 9, 10], [6, ... [], [1, 2, 3]] type='5 * var * int64'>
+        >>> b.layout
+        <ListArray64>
+            <starts><Index64 i="[6 5 3 3 0]" offset="0" length="5" at="0x55e091c2b1f0"/></starts>
+            <stops><Index64 i="[10 6 5 3 3]" offset="0" length="5" at="0x55e091a6ce80"/></stops>
+            <content><NumpyArray format="l" shape="10" data="1 2 3 4 5 6 7 8 9 10" at="0x55e091c47260"/></content>
+        </ListArray64>
+        >>> c = ak.packed(b)
+        >>> c
+        <Array [[7, 8, 9, 10], [6, ... [], [1, 2, 3]] type='5 * var * int64'>
+        >>> c.layout
+        <ListOffsetArray64>
+            <offsets><Index64 i="[0 4 5 7 7 10]" offset="0" length="6" at="0x55e091b077a0"/></offsets>
+            <content><NumpyArray format="l" shape="10" data="7 8 9 10 6 4 5 1 2 3" at="0x55e091d04d30"/></content>
+        </ListOffsetArray64>
+
+    Performing these operations will minimize the output size of data sent to
+    #ak.to_buffers (though conversions through Arrow, #ak.to_arrow and
+    #ak.to_parquet, do not need this because packing is part of that conversion).
+
+    See also #ak.to_buffers.
     """
     return _packed(array, highlevel=highlevel, behavior=behavior)
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2206,6 +2206,7 @@ def packed(array, axis=None, highlevel=True, behavior=None):
         if isinstance(layout, ak._util.indexedtypes):
             return apply(layout.project(), depth, posaxis)
 
+        # ListOffsetArray performs resizing
         # ListArray performs both ordering and resizing
         if isinstance(
             layout,
@@ -2213,14 +2214,6 @@ def packed(array, axis=None, highlevel=True, behavior=None):
                 ak.layout.ListArray32,
                 ak.layout.ListArrayU32,
                 ak.layout.ListArray64,
-            ),
-        ):
-            return apply(layout.toListOffsetArray64(True), depth, posaxis)
-
-        # ListOffsetArray performs resizing
-        if isinstance(
-            layout,
-            (
                 ak.layout.ListOffsetArray32,
                 ak.layout.ListOffsetArray64,
                 ak.layout.ListOffsetArrayU32,

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2289,7 +2289,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             # Truncate content if it is larger than a perfect
             # multiple of the RegularArray size
             n, r = divmod(len(content), layout.size)
-            if r:
+            if r != 0:
                 content = truncate(content, n * layout.size)
 
             return ak.layout.RegularArray(

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2157,7 +2157,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
         return out
 
 
-def packed(array, axis=None, highlevel=True):
+def packed(array, axis=None, highlevel=True, behavior=None):
     """
     Args:
         array: Array to simplify.
@@ -2167,6 +2167,8 @@ def packed(array, axis=None, highlevel=True):
             dimension, `-2` is the next level up, etc.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.layout.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
     """
     layout = ak.operations.convert.to_layout(
         array, allow_record=False, allow_other=False
@@ -2339,7 +2341,7 @@ def packed(array, axis=None, highlevel=True):
     out = apply(layout, 1, axis)
 
     if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array))
+        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
     return out
 
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2206,7 +2206,6 @@ def packed(array, axis=None, highlevel=True, behavior=None):
         if isinstance(layout, ak._util.indexedtypes):
             return apply(layout.project(), depth, posaxis)
 
-        # ListOffsetArray performs resizing
         # ListArray performs both ordering and resizing
         if isinstance(
             layout,
@@ -2214,6 +2213,14 @@ def packed(array, axis=None, highlevel=True, behavior=None):
                 ak.layout.ListArray32,
                 ak.layout.ListArrayU32,
                 ak.layout.ListArray64,
+            ),
+        ):
+            return apply(layout.toListOffsetArray64(True), depth, posaxis)
+
+        # ListOffsetArray performs resizing
+        if isinstance(
+            layout,
+            (
                 ak.layout.ListOffsetArray32,
                 ak.layout.ListOffsetArray64,
                 ak.layout.ListOffsetArrayU32,

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2254,15 +2254,10 @@ def packed(array, axis=None, highlevel=True):
             new_index = nplike.zeros_like(index)
 
             # Compact indices
-            for i, content in enumerate(layout.contents):
+            for i in range(len(layout.contents)):
                 is_i = tags == i
 
-                # Wrap content in IndexedArray to old indices, in order to
-                # simplify the index for all types
-                wrapped_content = ak.layout.IndexedArray64(
-                    ak.layout.Index64(index[is_i]), content
-                )
-                new_contents[i] = apply(wrapped_content, depth, posaxis)
+                new_contents[i] = apply(layout.project(i), depth, posaxis)
                 new_index[is_i] = nplike.arange(nplike.sum(is_i))
 
             return ak.layout.UnionArray8_64(

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2159,7 +2159,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
         return out
 
 
-def simplify(array, axis=None, highlevel=True):
+def packed(array, axis=None, highlevel=True):
     """
     Args:
         array: Array to simplify.

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2230,13 +2230,8 @@ def packed(array, axis=None, highlevel=True):
                 new_layout.parameters,
             )
 
-        # ByteMaskedArray
-        # BitMasked
-        # Unmasked
-        # RecordArray
-        # Record
-        # UnionArray
-        # Partitioned
+        if isinstance(layout, ak.layout.UnmaskedArray):
+            return ak.layout.UnmaskedArray(apply(layout.content, depth, posaxis))
 
         # Finally, fall through to failure
         raise NotImplementedError

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2260,6 +2260,8 @@ def packed(array, axis=None, highlevel=True):
                 ak.layout.Index8(tags),
                 ak.layout.Index64(index),
                 contents,
+                simplified.identities,
+                simplified.parameters,
             )
 
         # Finally, fall through to failure

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2334,6 +2334,12 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
                 [apply(x, depth, posaxis) for x in layout.partitions]
             )
 
+        elif isinstance(layout, ak.layout.Record):
+            return ak.layout.Record(
+                apply(layout.array, depth, posaxis),
+                layout.at,
+            )
+
         # Finally, fall through to failure
         else:
             raise AssertionError(

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2329,6 +2329,11 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
         elif isinstance(layout, ak.layout.VirtualArray):
             return apply(layout.array, depth, posaxis)
 
+        elif isinstance(layout, ak.partition.PartitionedArray):
+            return ak.partition.IrregularlyPartitionedArray(
+                [apply(x, depth, posaxis) for x in layout.partitions]
+            )
+
         # Finally, fall through to failure
         else:
             raise AssertionError(

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2164,9 +2164,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
     nplike = ak.nplike.of(layout)
 
     def truncate(layout, n):
-        return ak.layout.IndexedArray64(
-            ak.layout.Index64(nplike.arange(n)), layout
-        ).project()
+        return layout[:n]
 
     def apply(layout, depth, posaxis):
         if posaxis is not None:

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -82,6 +82,23 @@ def test_unmasked_array():
     assert ak.to_list(packed) == ak.to_list(layout)
 
 
+def test_union_array():
+    a = ak.layout.NumpyArray(np.arange(4))
+    b = ak.layout.NumpyArray(np.arange(4) + 4)
+    c = ak.layout.RegularArray(ak.layout.NumpyArray(np.arange(12)), 3)
+    layout = ak.layout.UnionArray8_64(
+        ak.layout.Index8([1, 1, 2, 2, 0, 0]),
+        ak.layout.Index64([0, 1, 0, 1, 0, 1]),
+        [a, b, c],
+    )
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    # Check that it merges like contents
+    assert len(packed.contents) == 2
+    index_0 = np.asarray(packed.index)[np.asarray(packed.tags) == 0]
+    assert index_0.tolist() == [0, 1, 2, 3]
+
+
 def test_virtual_array():
     n_called = [0]
 

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -17,3 +17,8 @@ def test_indexed_numpy_array():
 
     assert isinstance(packed, ak.layout.NumpyArray)
     assert len(packed) == len(index)
+
+
+def test_empty_array():
+    layout = ak.layout.EmptyArray()
+    assert ak.packed(layout, highlevel=False) is layout

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -163,7 +163,7 @@ def test_partitioned_array():
     index_0 = ak.layout.Index64(np.array([0, 1, 2, 3, 6, 7, 8]))
     content_0 = ak.layout.NumpyArray(np.arange(10))
     content = ak.layout.IndexedArray64(index_0, content_0)
-    layout = ak.partitioned((content, content), highlevel=False)
+    layout = ak.partitioned([content, content], highlevel=False)
     packed = ak.packed(layout, highlevel=False)
 
     assert ak.to_list(layout) == ak.to_list(packed)
@@ -174,6 +174,16 @@ def test_partitioned_array():
 
     assert isinstance(packed.partitions[1], ak.layout.NumpyArray)
     assert len(packed.partitions[1]) == len(index_0)
+
+
+def test_record():
+    a = ak.layout.NumpyArray(np.arange(10))
+    b = ak.layout.NumpyArray(np.arange(10) * 2 + 4)
+    layout = ak.layout.RecordArray([a, b], None, 5)
+    first = layout[0]
+    packed = ak.packed(first, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(first)
+    assert len(packed.array) == len(layout)
 
 
 def test_axis():

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -7,6 +7,16 @@ import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
 
+def test_numpy_array():
+    matrix = np.arange(64).reshape(8, -1)
+    layout = ak.layout.NumpyArray(matrix[:, 0])
+    assert not layout.iscontiguous
+
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    assert packed.iscontiguous
+
+
 def test_indexed_numpy_array():
     index = ak.layout.Index64(np.array([0, 1, 2, 3, 6, 7, 8]))
     content = ak.layout.NumpyArray(np.arange(10))

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -22,3 +22,22 @@ def test_indexed_numpy_array():
 def test_empty_array():
     layout = ak.layout.EmptyArray()
     assert ak.packed(layout, highlevel=False) is layout
+
+
+def test_virtual_array():
+    n_called = [0]
+
+    def generate():
+        n_called[0] += 1
+        return ak.layout.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
+
+    generator = ak.layout.ArrayGenerator(
+        generate, form=ak.forms.NumpyForm([], 8, "d"), length=5
+    )
+    layout = ak.layout.VirtualArray(generator)
+    assert n_called[0] == 0
+    packed = ak.packed(layout, highlevel=False)
+    assert n_called[0] == 1
+
+    assert isinstance(packed, ak.layout.NumpyArray)
+    assert ak.to_list(packed) == [1.1, 2.2, 3.3, 4.4, 5.5]

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -159,6 +159,23 @@ def test_virtual_array():
     assert ak.to_list(packed) == ak.to_list(layout)
 
 
+def test_partitioned_array():
+    index_0 = ak.layout.Index64(np.array([0, 1, 2, 3, 6, 7, 8]))
+    content_0 = ak.layout.NumpyArray(np.arange(10))
+    content = ak.layout.IndexedArray64(index_0, content_0)
+    layout = ak.partitioned((content, content), highlevel=False)
+    packed = ak.packed(layout, highlevel=False)
+
+    assert ak.to_list(layout) == ak.to_list(packed)
+    assert isinstance(packed, ak.partition.PartitionedArray)
+
+    assert isinstance(packed.partitions[0], ak.layout.NumpyArray)
+    assert len(packed.partitions[0]) == len(index_0)
+
+    assert isinstance(packed.partitions[1], ak.layout.NumpyArray)
+    assert len(packed.partitions[1]) == len(index_0)
+
+
 def test_axis():
     content_0 = ak.layout.NumpyArray(np.arange(10))
 

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -109,6 +109,15 @@ def test_record_array():
     assert len(packed.contents[1]) == 5
 
 
+def test_regular_array():
+    content = ak.layout.NumpyArray(np.arange(10))
+    layout = ak.layout.RegularArray(content, 4)
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    assert len(packed.content) == 8
+    assert packed.size == layout.size
+
+
 def test_virtual_array():
     n_called = [0]
 

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -127,6 +127,19 @@ def test_bit_masked_aray():
     assert len(packed.content) == 8
 
 
+def test_byte_masked_aray():
+    mask = ak.layout.Index8(np.array([1, 0, 1, 0, 1, 0, 1, 0]))
+    content = ak.layout.NumpyArray(np.arange(16))
+    layout = ak.layout.ByteMaskedArray(
+        mask,
+        content,
+        False,
+    )
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    assert len(packed.content) == 8
+
+
 def test_virtual_array():
     n_called = [0]
 

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -13,7 +13,7 @@ def test_indexed_numpy_array():
     layout = ak.layout.IndexedArray64(index, content)
 
     packed = ak.packed(layout, highlevel=False)
-    assert ak.to_list(layout) == ak.to_list(packed)
+    assert ak.to_list(packed) == ak.to_list(layout)
 
     assert isinstance(packed, ak.layout.NumpyArray)
     assert len(packed) == len(index)
@@ -40,4 +40,4 @@ def test_virtual_array():
     assert n_called[0] == 1
 
     assert isinstance(packed, ak.layout.NumpyArray)
-    assert ak.to_list(packed) == [1.1, 2.2, 3.3, 4.4, 5.5]
+    assert ak.to_list(packed) == ak.to_list(layout)

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -17,6 +17,20 @@ def test_numpy_array():
     assert packed.iscontiguous
 
 
+def test_empty_array():
+    layout = ak.layout.EmptyArray()
+    assert ak.packed(layout, highlevel=False) is layout
+
+
+def test_indexed_option_array():
+    index = ak.layout.Index64(np.r_[0, -1, 2, -1, 4])
+    content = ak.layout.NumpyArray(np.arange(8))
+    layout = ak.layout.IndexedOptionArray64(index, content)
+
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(layout) == ak.to_list(packed)
+
+
 def test_indexed_numpy_array():
     index = ak.layout.Index64(np.array([0, 1, 2, 3, 6, 7, 8]))
     content = ak.layout.NumpyArray(np.arange(10))
@@ -27,11 +41,6 @@ def test_indexed_numpy_array():
 
     assert isinstance(packed, ak.layout.NumpyArray)
     assert len(packed) == len(index)
-
-
-def test_empty_array():
-    layout = ak.layout.EmptyArray()
-    assert ak.packed(layout, highlevel=False) is layout
 
 
 def test_virtual_array():

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -29,9 +29,12 @@ def test_indexed_option_array():
 
     packed = ak.packed(layout, highlevel=False)
     assert ak.to_list(layout) == ak.to_list(packed)
+    assert isinstance(packed, ak.layout.IndexedOptionArray64)
+    assert packed.index.tolist() == [0, -1, 1, -1, 2]
+    assert len(packed.content) == 3
 
 
-def test_indexed_numpy_array():
+def test_indexed_array():
     index = ak.layout.Index64(np.array([0, 1, 2, 3, 6, 7, 8]))
     content = ak.layout.NumpyArray(np.arange(10))
     layout = ak.layout.IndexedArray64(index, content)

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -41,3 +41,17 @@ def test_virtual_array():
 
     assert isinstance(packed, ak.layout.NumpyArray)
     assert ak.to_list(packed) == ak.to_list(layout)
+
+
+def test_list_array():
+    content = ak.layout.NumpyArray(
+        np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+    )
+    starts = ak.layout.Index64(np.array([0, 3, 3, 5, 6]))
+    stops = ak.layout.Index64(np.array([3, 3, 5, 6, 9]))
+    layout = ak.layout.ListArray64(starts, stops, content)
+
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    assert isinstance(packed, ak.layout.ListOffsetArray64)
+    assert packed.offsets[0] == 0

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_indexed_numpy_array():
+    index = ak.layout.Index64(np.array([0, 1, 2, 3, 6, 7, 8]))
+    content = ak.layout.NumpyArray(np.arange(10))
+    layout = ak.layout.IndexedArray64(index, content)
+
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(layout) == ak.to_list(packed)
+
+    assert isinstance(packed, ak.layout.NumpyArray)
+    assert len(packed) == len(index)

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -118,6 +118,15 @@ def test_regular_array():
     assert packed.size == layout.size
 
 
+def test_bit_masked_aray():
+    mask = ak.layout.IndexU8(np.array([0b10101010]))
+    content = ak.layout.NumpyArray(np.arange(16))
+    layout = ak.layout.BitMaskedArray(mask, content, False, 8, False)
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    assert len(packed.content) == 8
+
+
 def test_virtual_array():
     n_called = [0]
 

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -30,7 +30,7 @@ def test_indexed_option_array():
     packed = ak.packed(layout, highlevel=False)
     assert ak.to_list(layout) == ak.to_list(packed)
     assert isinstance(packed, ak.layout.IndexedOptionArray64)
-    assert packed.index.tolist() == [0, -1, 1, -1, 2]
+    assert np.asarray(packed.index).tolist() == [0, -1, 1, -1, 2]
     assert len(packed.content) == 3
 
 

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -157,3 +157,17 @@ def test_virtual_array():
 
     assert isinstance(packed, ak.layout.NumpyArray)
     assert ak.to_list(packed) == ak.to_list(layout)
+
+
+def test_axis():
+    content_0 = ak.layout.NumpyArray(np.arange(10))
+
+    offsets_1 = ak.layout.Index64(np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    content_1 = ak.layout.ListOffsetArray64(offsets_1, content_0)
+
+    layout = ak.layout.RegularArray(content_1, 3)
+
+    packed = ak.operations.structure._packed(layout, axis=0, highlevel=False)
+    assert ak.to_list(layout) == ak.to_list(packed)
+
+    assert np.asarray(packed.content.content).tolist() == np.asarray(content_0).tolist()

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -111,10 +111,10 @@ def test_record_array():
 
 def test_regular_array():
     content = ak.layout.NumpyArray(np.arange(10))
-    layout = ak.layout.RegularArray(content, 4)
+    layout = ak.layout.RegularArray(content, 3)
     packed = ak.packed(layout, highlevel=False)
     assert ak.to_list(packed) == ak.to_list(layout)
-    assert len(packed.content) == 8
+    assert len(packed.content) == 9
     assert packed.size == layout.size
 
 
@@ -127,7 +127,7 @@ def test_bit_masked_aray():
     assert len(packed.content) == 8
 
 
-def test_byte_masked_aray():
+def test_byte_masked_array():
     mask = ak.layout.Index8(np.array([1, 0, 1, 0, 1, 0, 1, 0]))
     content = ak.layout.NumpyArray(np.arange(16))
     layout = ak.layout.ByteMaskedArray(

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -46,6 +46,20 @@ def test_indexed_array():
     assert len(packed) == len(index)
 
 
+def test_list_array():
+    content = ak.layout.NumpyArray(
+        np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+    )
+    starts = ak.layout.Index64(np.array([0, 3, 3, 5, 6]))
+    stops = ak.layout.Index64(np.array([3, 3, 5, 6, 9]))
+    layout = ak.layout.ListArray64(starts, stops, content)
+
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    assert isinstance(packed, ak.layout.ListOffsetArray64)
+    assert packed.offsets[0] == 0
+
+
 def test_virtual_array():
     n_called = [0]
 
@@ -63,17 +77,3 @@ def test_virtual_array():
 
     assert isinstance(packed, ak.layout.NumpyArray)
     assert ak.to_list(packed) == ak.to_list(layout)
-
-
-def test_list_array():
-    content = ak.layout.NumpyArray(
-        np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
-    )
-    starts = ak.layout.Index64(np.array([0, 3, 3, 5, 6]))
-    stops = ak.layout.Index64(np.array([3, 3, 5, 6, 9]))
-    layout = ak.layout.ListArray64(starts, stops, content)
-
-    packed = ak.packed(layout, highlevel=False)
-    assert ak.to_list(packed) == ak.to_list(layout)
-    assert isinstance(packed, ak.layout.ListOffsetArray64)
-    assert packed.offsets[0] == 0

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -60,6 +60,19 @@ def test_list_array():
     assert packed.offsets[0] == 0
 
 
+def test_list_offset_array():
+    content = ak.layout.NumpyArray(
+        np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+    )
+    offsets = ak.layout.Index64(np.array([0, 3, 3, 5, 6]))
+    layout = ak.layout.ListOffsetArray64(offsets, content)
+
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    assert isinstance(packed, ak.layout.ListOffsetArray64)
+    assert packed.offsets[0] == 0
+
+
 def test_virtual_array():
     n_called = [0]
 

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -99,6 +99,16 @@ def test_union_array():
     assert index_0.tolist() == [0, 1, 2, 3]
 
 
+def test_record_array():
+    a = ak.layout.NumpyArray(np.arange(10))
+    b = ak.layout.NumpyArray(np.arange(10) * 2 + 4)
+    layout = ak.layout.RecordArray([a, b], None, 5)
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+    assert len(packed.contents[0]) == 5
+    assert len(packed.contents[1]) == 5
+
+
 def test_virtual_array():
     n_called = [0]
 

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -73,6 +73,15 @@ def test_list_offset_array():
     assert packed.offsets[0] == 0
 
 
+def test_unmasked_array():
+    content = ak.layout.NumpyArray(
+        np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+    )
+    layout = ak.layout.UnmaskedArray(content)
+    packed = ak.packed(layout, highlevel=False)
+    assert ak.to_list(packed) == ak.to_list(layout)
+
+
 def test_virtual_array():
     n_called = [0]
 


### PR DESCRIPTION
This will simplify the length and order violating layouts such that external operations are compatible with per-layout transformations like `ak.unflatten`.

- [x] **EmptyArray:** unchanged
- [x] **NumpyArray:** converted to contiguous, if not already
- [x] **RegularArray:** truncate the `content` to `len(original) * size` with special handling (pass through) if `size == 0`
- [x] **ListArray:** convert `toListOffsetArray64(true)` (the `true` means starting at zero)
- [x] **ListOffsetArray:** convert `toListOffsetArray64(true)` (it's a pass-through if it's already true that `offsets[0] == 0`)
- [x] **RecordArray:** truncate all the `contents` to `len(original)`
- [x] **IndexedArray:** `project()` it
- [x] **ByteMaskedArray:** convert `toIndexedOptionArray` if the `content` does not have `PrimitiveType`. Doing so will naturally lead to the right kind of `index`. If not changing the type (because the `content` has `PrimitiveType`), at least truncate the `content` length to `len(original)`.
- [x] **IndexedOptionArray:** convert `toByteMaskedArray` if the `content` has `PrimitiveType`; otherwise, we want to project the `content` such that the non-negative `index` values become simple counting... the `index` should end up looking like `0, 1, 2, -1, 3, -1, -1, -1, 4, 5...`. That will take some thought.
- [x] **BitMaskedArray:** convert `toIndexedOptionArray` if the `content` does not have `PrimitiveType`. If not changing the type, at least truncate the `content` length to `len(original)`.
- [x] **UnmaskedArray:** unchanged (but recursively descend, of course)
- [x] **UnionArray:** simplify the `index` by `project`ing each of the `contents`
- [x] **VirtualArray:** materialize and recursively descend
- ~~**PartitionedArray** concatenate partitions?~~