### PR TITLE
`ak.values_astype` support `dtype` specifier `np.datetime64` to convert `?int` or `?float` typed unix timestamps to `datetime64`

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -4239,10 +4239,13 @@ def values_astype(array, to, highlevel=True, behavior=None):
     to_dtype = np.dtype(to)
     to_str = _dtype_to_string.get(to_dtype)
     if to_str is None:
-        raise ValueError(
-            "cannot use {0} to cast the numeric type of an array".format(to_dtype)
-            + ak._util.exception_suffix(__file__)
-        )
+        if to_dtype.name.startswith("datetime64"):
+            to_str = to_dtype.name
+        else:
+            raise ValueError(
+                "cannot use {0} to cast the numeric type of an array".format(to_dtype)
+                + ak._util.exception_suffix(__file__)
+            )
 
     layout = ak.operations.convert.to_layout(
         array, allow_record=False, allow_other=False

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -4234,6 +4234,21 @@ def values_astype(array, to, highlevel=True, behavior=None):
         >>> ak.values_astype(array, np.int32)
         <Array [[1, 2, 3], [], [4, 5]] type='3 * var * int32'>
 
+    Note, when converting values to a `np.datetime64` type that is unitless, a
+    default '[us]' unit is assumed - until further specified as numpy dtypes.
+
+    For example,
+
+        >>> array = ak.Array([1567416600000])
+        >>> ak.values_astype(array, "datetime64[ms]")
+        <Array [2019-09-02T09:30:00.000] type='1 * datetime64'>
+
+    or
+
+        >>> array = ak.Array([1567416600000])
+        >>> ak.values_astype(array, np.dtype("M8[ms]"))
+        <Array [2019-09-02T09:30:00.000] type='1 * datetime64'>
+
     See also #ak.strings_astype.
     """
     to_dtype = np.dtype(to)

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -5198,6 +5198,11 @@ namespace awkward {
           std::string("cannot recast NumpyArray with format \"")
           + format_ + std::string("\"") + FILENAME(__LINE__));
       }
+      std::string nextformat = util::dtype_to_format(dtype);
+      if (dtype == util::dtype::datetime64) {
+        nextformat.append(std::to_string(dtype_to_itemsize(dtype)));
+        nextformat.append(util::format_to_units(name));
+      }
 
       return std::make_shared<NumpyArray>(identities,
                                           contiguous_self.parameters(),
@@ -5206,7 +5211,7 @@ namespace awkward {
                                           strides,
                                           0,
                                           (ssize_t)util::dtype_to_itemsize(dtype),
-                                          util::dtype_to_format(dtype),
+                                          nextformat,
                                           dtype,
                                           ptr_lib_);
     }

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -5688,6 +5688,9 @@ namespace awkward {
         std::string("FIXME: as_type for complex256 not implemented")
         + FILENAME(__LINE__));
       break;
+    case util::dtype::datetime64:
+       ptr = cast_to_type<int64_t>(data, length);
+       break;
     default:
       throw std::invalid_argument(
         std::string("cannot recast NumpyArray with format \"")

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -291,7 +291,7 @@ namespace awkward {
           return format.substr(format.find('['), format.find(']'));
         }
       }
-      return std::string("[ns]");
+      return std::string("[us]");
     }
 
     const std::string

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -291,7 +291,7 @@ namespace awkward {
           return format.substr(format.find('['), format.find(']'));
         }
       }
-      return std::string("[no units]");
+      return std::string("[ns]");
     }
 
     const std::string

--- a/tests/test_0916-datetime-values-astype.py
+++ b/tests/test_0916-datetime-values-astype.py
@@ -30,3 +30,19 @@ def test_modulo_units():
 
     array2 = ak.values_astype(ak.Array([1]), np.dtype("datetime64[10s/2]"))
     assert array2.to_list() == [np.datetime64("1970-01-01T00:00:05.000", "5000ms")]
+
+
+def test_float_values_astype_datetime():
+    array = ak.Array([1.9999, 1567416600000, 0, None, 11, 0.555])
+    assert str(array.type) == "6 * ?float64"
+
+    dt_array = ak.values_astype(array, "datetime64[ms]")
+    assert str(dt_array.type) == "6 * ?datetime64"
+    assert dt_array.to_list() == [
+        np.datetime64("1970-01-01T00:00:00.001"),
+        np.datetime64("2019-09-02T09:30:00.000"),
+        np.datetime64("1970-01-01T00:00:00.000"),
+        None,
+        np.datetime64("1970-01-01T00:00:00.011"),
+        np.datetime64("1970-01-01T00:00:00.000"),
+    ]

--- a/tests/test_0916-datetime-values-astype.py
+++ b/tests/test_0916-datetime-values-astype.py
@@ -8,13 +8,15 @@ import awkward as ak  # noqa: F401
 
 
 def test_values_astype_datetime():
-    array = ak.values_astype(
-        ak.Array([1567416600000]), "datetime64[ms]"
-    )  # np.datetime64)
-    assert str(array.type) == "1 * datetime64"
-    assert array.to_list() == [np.datetime64("2019-09-02T09:30:00")]
+    array1 = ak.values_astype(ak.Array([1567416600000]), "datetime64[ms]")
+    assert str(array1.type) == "1 * datetime64"
+    assert array1.to_list() == [np.datetime64("2019-09-02T09:30:00")]
 
-    # arr = ak.Array(['2019-09-02T09:30:00',  None])
-    arr = ak.Array([1567416600000000, None])  # default unit is 'us'
-    dt_arr = ak.values_astype(arr, np.datetime64)
-    assert dt_arr.to_list() == [np.datetime64("2019-09-02T09:30:00"), None]
+    array2 = ak.values_astype(ak.Array([1567416600000]), np.dtype("M8[ms]"))
+    assert str(array2.type) == "1 * datetime64"
+    assert array2.to_list() == [np.datetime64("2019-09-02T09:30:00")]
+
+    array3 = ak.values_astype(
+        ak.Array([1567416600000000, None]), np.datetime64  # default unit is 'us'
+    )
+    assert array3.to_list() == [np.datetime64("2019-09-02T09:30:00"), None]

--- a/tests/test_0916-datetime-values-astype.py
+++ b/tests/test_0916-datetime-values-astype.py
@@ -7,6 +7,14 @@ import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
 
-def test_date_time_values_astype():
-    array = ak.values_astype(ak.Array([1567416600000]), np.datetime64)
+def test_values_astype_datetime():
+    array = ak.values_astype(
+        ak.Array([1567416600000]), "datetime64[ms]"
+    )  # np.datetime64)
     assert str(array.type) == "1 * datetime64"
+    assert array.to_list() == [np.datetime64("2019-09-02T09:30:00")]
+
+    # arr = ak.Array(['2019-09-02T09:30:00',  None])
+    arr = ak.Array([1567416600000000, None])  # default unit is 'us'
+    dt_arr = ak.values_astype(arr, np.datetime64)
+    assert dt_arr.to_list() == [np.datetime64("2019-09-02T09:30:00"), None]

--- a/tests/test_0916-datetime-values-astype.py
+++ b/tests/test_0916-datetime-values-astype.py
@@ -20,3 +20,13 @@ def test_values_astype_datetime():
         ak.Array([1567416600000000, None]), np.datetime64  # default unit is 'us'
     )
     assert array3.to_list() == [np.datetime64("2019-09-02T09:30:00"), None]
+
+
+def test_modulo_units():
+    array1 = ak.values_astype(ak.Array([1]), np.dtype("datetime64[100as/1]"))
+    assert array1.to_list() == [
+        np.datetime64("1970-01-01T00:00:00.000000000000000100", "100as")
+    ]
+
+    array2 = ak.values_astype(ak.Array([1]), np.dtype("datetime64[10s/2]"))
+    assert array2.to_list() == [np.datetime64("1970-01-01T00:00:05.000", "5000ms")]

--- a/tests/test_0916-datetime-values-astype.py
+++ b/tests/test_0916-datetime-values-astype.py
@@ -1,0 +1,12 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_date_time_values_astype():
+    array = ak.values_astype(ak.Array([1567416600000]), np.datetime64)
+    assert str(array.type) == "1 * datetime64"


### PR DESCRIPTION
issue https://github.com/scikit-hep/awkward-1.0/issues/909