### PR TITLE
Feature: add `pass_apply` argument to util

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -1097,6 +1097,7 @@ def recursively_apply(
     getfunction,
     pass_depth=True,
     pass_user=False,
+    pass_apply=False,
     user=None,
     keep_parameters=True,
     numpy_to_regular=False,
@@ -1110,6 +1111,8 @@ def recursively_apply(
             args = args + (depth,)
         if pass_user:
             args = args + (user,)
+        if pass_apply:
+            args = args + (apply,)
 
         custom = getfunction(layout, *args)
         if callable(custom):


### PR DESCRIPTION
This is a very simple PR to add `pass_apply` to `recursively_apply`. This permits clients of this function to re-enter, without re-implementing the same logic. This is not useful for #912 but is useful for #917