### PR TITLE
Bugfix: use `ak.packed` in `ak.unflatten`

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2011,6 +2011,10 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
     layout = ak.operations.convert.to_layout(
         array, allow_record=False, allow_other=False
     )
+    # Pack the layout above the axis that will be unflattened. This ensures that
+    # the `counts` array, which is computed through these layouts, aligns with
+    # the layout to be unflattened (#910)
+    layout = _packed(layout, axis=axis - 1, highlevel=False)
 
     if isinstance(counts, (numbers.Integral, np.integer)):
         current_offsets = None

--- a/tests/test_0910-unflatten-counts-relation.py
+++ b/tests/test_0910-unflatten-counts-relation.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    layout = ak.layout.IndexedArray64(
+        ak.layout.Index64(np.array([3, 1, 0, 2])),
+        ak.layout.ListOffsetArray64(
+            ak.layout.Index64(np.array([0, 3, 6, 9, 12])),
+            ak.layout.NumpyArray(np.array([0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 3, 3])),
+        ),
+    )
+
+    assert ak.unflatten(
+        layout, ak.flatten(ak.run_lengths(layout)), axis=1
+    ).tolist() == [[[3, 3, 3]], [[1, 1, 1]], [[0, 0, 0]], [[2, 2], [3]]]


### PR DESCRIPTION
This fixes #910 by ensuring that the structure *above* the flatten site is regular. This will sometimes lead to projections of arrays *at* the flatten axis, but that's because `packed` decides not to introduce another indirection and instead just forces the copy. We could look at modifying that at a later date if it proves problematic.