### PR TITLE
Bugfix: check for `file`-like objects in `from_parquet`

### DIFF
--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3613,7 +3613,11 @@ def from_parquet(
             relative_to = source
             source = sorted(glob.glob(source + "/**/*.parquet", recursive=True))
 
-    if not isinstance(source, str) and isinstance(source, Iterable):
+    if (
+        not isinstance(source, str)
+        and isinstance(source, Iterable)
+        and not hasattr(source, "read")
+    ):
         source = [_regularize_path(x) for x in source]
         if relative_to is None:
             relative_to = os.path.commonpath(source)

--- a/tests/test_0921-parquet-from-file-like.py
+++ b/tests/test_0921-parquet-from-file-like.py
@@ -1,0 +1,18 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import io
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array([1, 2, 3])
+    file_ = io.BytesIO()
+    ak.to_parquet(array, file_)
+    file_.seek(0)
+
+    array_from_file = ak.from_parquet(file_)
+    assert ak.to_list(array) == ak.to_list(array_from_file)

--- a/tests/test_0921-parquet-from-file-like.py
+++ b/tests/test_0921-parquet-from-file-like.py
@@ -8,6 +8,9 @@ import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
 
+pytest.importorskip("pyarrow.parquet")
+
+
 def test():
     array = ak.Array([1, 2, 3])
     file_ = io.BytesIO()


### PR DESCRIPTION
This doesn't fully address the larger changes that we probably need to make w.r.t #886, but does fix #921.

Perhaps this is a good stop-gap fix until we address the larger changes.