### PR TITLE
Bugfix: return correct `nbytes` value for multidimensional NumPy arrays

### DIFF
--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -995,8 +995,8 @@ namespace awkward {
   void
   NumpyArray::nbytes_part(std::map<size_t, int64_t>& largest) const {
     int64_t len = 1;
-    if (!shape_.empty()) {
-      len = shape_[0];
+    for (auto size: shape_) {
+      len *= size;
     }
     size_t x = (size_t)ptr_.get();
     auto it = largest.find(x);

--- a/tests/test_0927-numpy-array-nbytes.py
+++ b/tests/test_0927-numpy-array-nbytes.py
@@ -1,0 +1,13 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    np_data = np.random.random(size=(4, 100 * 1024 * 1024 // 8 // 4))
+    array = ak.from_numpy(np_data, regulararray=False)
+    assert np_data.nbytes == array.nbytes


### PR DESCRIPTION
Fixes #927 