### PR TITLE
Refactor: remove `ak.deprecations_as_errors`

### DIFF
--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -14,8 +14,6 @@ if distutils.version.LooseVersion(numpy.__version__) < distutils.version.LooseVe
 ):
     raise ImportError("Numpy 1.13.1 or later required")
 
-deprecations_as_errors = False
-
 # NumPy-like alternatives
 import awkward.nplike
 

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -46,12 +46,18 @@ def exception_suffix(filename):
     )
 
 
-def deprecate(message, version, date=None, category=FutureWarning):
+# Enable warnings for the Awkward package
+warnings.filterwarnings("default", module="awkward.*")
+
+
+def deprecate(message, version, date=None, category=DeprecationWarning):
     if date is None:
         date = ""
     else:
         date = " (target date: " + date + ")"
     warning = """In version {0}{1}, this will be an error.
+
+To raise these warnings as errors, run `warnings.filterwarnings("error", module="awkward.*")`.
 
 {2}""".format(
         version, date, message

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -46,21 +46,17 @@ def exception_suffix(filename):
     )
 
 
-def deprecate(exception, version, date=None):
-    if ak.deprecations_as_errors:
-        raise exception
+def deprecate(message, version, date=None, category=FutureWarning):
+    if date is None:
+        date = ""
     else:
-        if date is None:
-            date = ""
-        else:
-            date = " (target date: " + date + ")"
-        message = """In version {0}{1}, this will be an error.
-(Set ak.deprecations_as_errors = True to get a stack trace now.)
+        date = " (target date: " + date + ")"
+    warning = """In version {0}{1}, this will be an error.
 
-{2}: {3}""".format(
-            version, date, type(exception).__name__, str(exception)
-        )
-        warnings.warn(message, FutureWarning)
+{2}""".format(
+        version, date, message
+    )
+    warnings.warn(warning, category)
 
 
 virtualtypes = (ak.layout.VirtualArray,)

--- a/tests/test_0184-concatenate-operation.py
+++ b/tests/test_0184-concatenate-operation.py
@@ -298,8 +298,6 @@ def test_numpyarray_concatenate():
 
 
 def test_numbers_and_records_concatenate():
-    ak.deprecations_as_errors = True
-
     numbers = [
         ak.Array(
             [

--- a/tests/test_0348-form-keys.py
+++ b/tests/test_0348-form-keys.py
@@ -336,8 +336,6 @@ def test_lazy():
 
 
 def test_lazy_partitioned():
-    ak.deprecations_as_errors = False
-
     array = ak.repartition(ak.Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 3)
     form, length, container = ak.to_buffers(array)
     assert length == [3, 3, 3, 1]

--- a/tests/test_0457-remove-broadcasting-over-fields.py
+++ b/tests/test_0457-remove-broadcasting-over-fields.py
@@ -8,8 +8,6 @@ import awkward as ak  # noqa: F401
 
 
 def test_this_should_raise_a_warning():
-    ak.deprecations_as_errors = True
-
     one = ak.Array([{"x": 1}, {"x": 2}, {"x": 3}])
     two = ak.Array([{"x": 1.1}, {"x": 2.2}, {"x": 3.3}])
 

--- a/tests/test_0504-block-ufuncs-for-strings.py
+++ b/tests/test_0504-block-ufuncs-for-strings.py
@@ -8,8 +8,6 @@ import awkward as ak  # noqa: F401
 
 
 def test():
-    ak.deprecations_as_errors = True
-
     array = ak.to_categorical(ak.Array([321, 1.1, 123, 1.1, 999, 1.1, 2.0]))
     assert ak.to_list(array * 10) == [3210, 11, 1230, 11, 9990, 11, 20]
 


### PR DESCRIPTION
This behaviour can be replicated with `warnings.simplefilter("error", category)`
Additionally remove usage in tests where no deprecated behaviour exists.

From `grep`ing the code, there are currently no clients of this global variable besides that of `deprecate`.

This will be useful for making the tests pass in #917, but is not directly related to it.