### PR TITLE
Separate `from_parquet` into different routines

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -418,6 +418,13 @@ def wrap(content, behavior):
         return content
 
 
+def maybe_wrap(content, behavior, highlevel):
+    if highlevel:
+        return ak._util.wrap(content, behavior)
+    else:
+        return content
+
+
 def extra(args, kwargs, defaults):
     out = []
     for i in range(len(defaults)):

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -13,10 +13,10 @@ import glob
 import re
 
 try:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Sized
     from collections.abc import MutableMapping
 except ImportError:
-    from collections import Iterable, Sequence
+    from collections import Iterable, Sized
     from collections import MutableMapping
 
 import awkward as ak
@@ -2904,7 +2904,8 @@ def _from_arrow(
                 return ak.operations.structure.concatenate(arrays, highlevel=False)
 
         elif (
-            isinstance(obj, Sequence)
+            isinstance(obj, Iterable)
+            and isinstance(obj, Sized)
             and len(obj) > 0
             and all(isinstance(x, pyarrow.lib.RecordBatch) for x in obj)
             and any(len(x) > 0 for x in obj)

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3463,7 +3463,7 @@ class _ArrowReader(object):
 
 class _ParquetFileReader(_ArrowReader):
     def __init__(
-        self, source, use_threads, row_groups=None, columns=None, options=None
+        self, source, row_groups=None, columns=None, use_threads=True, options=None
     ):
         import pyarrow.parquet
 
@@ -3503,10 +3503,10 @@ class _ParquetDatasetReader(_ArrowReader):
         self,
         directory,
         metadata_filename,
-        use_threads,
-        include_partition_columns,
         row_groups=None,
         columns=None,
+        use_threads=True,
+        include_partition_columns=True,
         options=None,
     ):
         import pyarrow.parquet
@@ -3605,10 +3605,10 @@ class _ParquetDatasetOfFilesReader(_ArrowReader):
         self,
         source,
         relative_to,
-        include_partition_columns,
-        use_threads,
         row_groups=None,
         columns=None,
+        use_threads=True,
+        include_partition_columns=True,
         options=None,
     ):
         schema, lookup, paths_and_counts = self._get_dataset_metadata(
@@ -3887,10 +3887,10 @@ def from_parquet(
             reader = _ParquetDatasetReader(
                 source,
                 metadata_filename,
-                use_threads,
-                include_partition_columns,
                 row_groups,
                 columns,
+                use_threads,
+                include_partition_columns,
                 options,
             )
         else:
@@ -3902,10 +3902,10 @@ def from_parquet(
             reader = _ParquetDatasetOfFilesReader(
                 source,
                 relative_to,
-                use_threads,
-                include_partition_columns,
                 row_groups,
                 columns,
+                use_threads,
+                include_partition_columns,
                 options,
             )
 
@@ -3919,15 +3919,15 @@ def from_parquet(
         reader = _ParquetDatasetOfFilesReader(
             source,
             relative_to,
-            use_threads,
-            include_partition_columns,
             row_groups,
             columns,
+            use_threads,
+            include_partition_columns,
             options,
         )
 
     else:
-        reader = _ParquetFileReader(source, use_threads, row_groups, columns, options)
+        reader = _ParquetFileReader(source, row_groups, columns, use_threads, options)
 
     if reader.is_empty:
         return ak.layout.RecordArray(

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3648,10 +3648,7 @@ def _from_parquet_dataset(
             fields = [x[1] for x in partition_columns] + out.contents
             out = ak.layout.RecordArray(fields, field_names)
 
-    if highlevel:
-        return ak._util.wrap(out, behavior)
-    else:
-        return out
+    return ak._util.maybe_wrap(out, behavior, highlevel)
 
 
 def _from_parquet_list_of_files(
@@ -3743,18 +3740,15 @@ def _from_parquet_list_of_files(
         out = _from_arrow(batches, False, highlevel=False)
         assert isinstance(out, ak.layout.RecordArray) and not out.istuple
 
-        if partition_columns == [] and schema.names == [""]:
+        if partition_columns != []:
+            field_names, fields = zip(*partition_columns)
+            out = ak.layout.RecordArray(
+                fields + tuple(out.contents), field_names + tuple(out.keys())
+            )
+        elif schema.names == [""]:
             out = out[""]
 
-        if partition_columns != []:
-            field_names = [x[0] for x in partition_columns] + out.keys()
-            fields = [x[1] for x in partition_columns] + out.contents
-            out = ak.layout.RecordArray(fields, field_names)
-
-    if highlevel:
-        return ak._util.wrap(out, behavior)
-    else:
-        return out
+    return ak._util.maybe_wrap(out, behavior, highlevel)
 
 
 def _generate_outer_lazy_array(
@@ -3903,10 +3897,7 @@ def _from_parquet_file(
         if schema.names == [""]:
             out = out[""]
 
-    if highlevel:
-        return ak._util.wrap(out, behavior)
-    else:
-        return out
+    return ak._util.maybe_wrap(out, behavior, highlevel)
 
 
 def from_parquet(

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3698,9 +3698,8 @@ def _from_parquet_list_of_files(
         row_groups = range(len(lookup))
         sublookup = lookup
     else:
-        sublookup = []
-        for row_group in row_groups:
-            sublookup.append(lookup[row_group])
+        sublookup = [lookup[g] for g in row_groups]
+
     if include_partition_columns:
         partition_columns = _parquet_partitions_to_awkward(paths_and_counts)
     else:

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3403,8 +3403,7 @@ class _ParquetFileReader(object):
 
 
 class _ParquetDatasetReader(object):
-    def __init__(self, pq, directory, metadata_file, use_threads, options):
-        self.pq = pq
+    def __init__(self, directory, metadata_file, use_threads, options):
         self.use_threads = use_threads
         self.options = options
 
@@ -3429,9 +3428,13 @@ class _ParquetDatasetReader(object):
         self.open_files = {}
 
     def read(self, row_group, column_name):
+        import pyarrow.parquet
+
         filename, local_row_group = self.lookup[row_group]
         if filename not in self.open_files:
-            self.open_files[filename] = self.pq.ParquetFile(filename, **self.options)
+            self.open_files[filename] = pyarrow.parquet.ParquetFile(
+                filename, **self.options
+            )
         return self.open_files[filename].read_row_group(
             local_row_group, [column_name], use_threads=self.use_threads
         )
@@ -3612,7 +3615,7 @@ def _from_parquet_dataset(
 
     if lazy:
         state = _ParquetGenerator(
-            _ParquetDatasetReader(pyarrow.parquet, source, file, use_threads, options)
+            _ParquetDatasetReader(source, file, use_threads, options)
         )
         lengths = [file.metadata.row_group(i).num_rows for i in row_groups]
 

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3541,6 +3541,7 @@ def _partial_schema_from_columns(schema, columns):
 
 def _from_parquet_dataset(
     source,
+    metadata_filename,
     columns,
     row_groups,
     use_threads,
@@ -3555,7 +3556,6 @@ def _from_parquet_dataset(
     pyarrow = _import_pyarrow("ak.from_parquet")
     import pyarrow.parquet
 
-    metadata_filename = os.path.join(source, "_metadata")
     file = pyarrow.parquet.ParquetFile(metadata_filename, **options)
     schema = file.schema_arrow
     if row_groups is None:
@@ -3969,6 +3969,7 @@ def from_parquet(
         if os.path.exists(metadata_filename):
             layout = _from_parquet_dataset(
                 source,
+                metadata_filename,
                 columns,
                 row_groups,
                 use_threads,

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3692,8 +3692,8 @@ def _parquet_partition_values(path):
 def _parquet_partitions_to_awkward(paths_and_counts):
     path, count = paths_and_counts[0]
     columns = [column for column, value in _parquet_partition_values(path)]
-    values = [[]] * len(columns)
-    indexes = [[]] * len(columns)
+    values = [[] for _ in columns]
+    indexes = [[] for _ in columns]
     for path, count in paths_and_counts:
         for i, (column, value) in enumerate(_parquet_partition_values(path)):
             if i >= len(columns) or column != columns[i]:

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3678,7 +3678,7 @@ def _from_parquet_list_of_files(
     lookup = []
     paths_and_counts = []
     for filename in source:
-        single_file = pyarrow.parquet.ParquetFile(filename)
+        single_file = pyarrow.parquet.ParquetFile(filename, **options)
         if schema is None:
             schema = single_file.schema_arrow
             first_filename = filename
@@ -3856,7 +3856,6 @@ def _from_parquet_file(
     columns,
     row_groups,
     use_threads,
-    include_partition_columns,
     lazy,
     lazy_cache,
     lazy_cache_key,
@@ -4031,7 +4030,6 @@ def from_parquet(
             columns,
             row_groups,
             use_threads,
-            include_partition_columns,
             lazy,
             lazy_cache,
             lazy_cache_key,

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -13,10 +13,10 @@ import glob
 import re
 
 try:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
     from collections.abc import MutableMapping
 except ImportError:
-    from collections import Iterable
+    from collections import Iterable, Sequence
     from collections import MutableMapping
 
 import awkward as ak
@@ -2904,7 +2904,7 @@ def _from_arrow(
                 return ak.operations.structure.concatenate(arrays, highlevel=False)
 
         elif (
-            isinstance(obj, Iterable)
+            isinstance(obj, Sequence)
             and len(obj) > 0
             and all(isinstance(x, pyarrow.lib.RecordBatch) for x in obj)
             and any(len(x) > 0 for x in obj)
@@ -3715,15 +3715,12 @@ def _from_parquet_list_of_files(
 
     if lazy:
         state = _ParquetDatasetOfFiles(lookup, use_threads)
-        lengths = []
-        for single_file, local_row_group in sublookup:
-            lengths.append(single_file.metadata.row_group(local_row_group).num_rows)
+        lengths = [f.metadata.row_group(g).num_rows for f, g in sublookup]
 
         lazy_cache, hold_cache = _regularize_lazy_cache(lazy_cache)
         lazy_cache_key = _regularize_parquet_lazy_cache_key(lazy_cache_key)
 
         form = _parquet_schema_to_form(schema)
-
         out = _generate_outer_lazy_array(
             form,
             state,

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3594,9 +3594,7 @@ def _from_parquet_dataset(
         lengths = [file.metadata.row_group(i).num_rows for i in row_groups]
 
         lazy_cache = _regularize_lazy_cache(lazy_cache)
-
-        if lazy_cache_key is None:
-            lazy_cache_key = "ak.from_parquet:{0}".format(_from_parquet_key())
+        lazy_cache_key = _regularize_parquet_lazy_cache_key(lazy_cache_key)
 
         form = _parquet_schema_to_form(schema)
 
@@ -3718,9 +3716,7 @@ def _from_parquet_list_of_files(
             lengths.append(single_file.metadata.row_group(local_row_group).num_rows)
 
         lazy_cache = _regularize_lazy_cache(lazy_cache)
-
-        if lazy_cache_key is None:
-            lazy_cache_key = "ak.from_parquet:{0}".format(_from_parquet_key())
+        lazy_cache_key = _regularize_parquet_lazy_cache_key(lazy_cache_key)
 
         form = _parquet_schema_to_form(schema)
 
@@ -3839,6 +3835,12 @@ def _regularize_lazy_cache(lazy_cache):
         return lazy_cache
 
 
+def _regularize_parquet_lazy_cache_key(lazy_cache_key):
+    if lazy_cache_key is None:
+        lazy_cache_key = "ak.from_parquet:{0}".format(_from_parquet_key())
+    return lazy_cache_key
+
+
 def _from_parquet_file(
     source,
     columns,
@@ -3870,9 +3872,7 @@ def _from_parquet_file(
         state = _ParquetFile(file, use_threads)
         lengths = [file.metadata.row_group(i).num_rows for i in row_groups]
         lazy_cache = _regularize_lazy_cache(lazy_cache)
-
-        if lazy_cache_key is None:
-            lazy_cache_key = "ak.from_parquet:{0}".format(_from_parquet_key())
+        lazy_cache_key = _regularize_parquet_lazy_cache_key(lazy_cache_key)
 
         form = _parquet_schema_to_form(schema)
 

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3431,10 +3431,10 @@ class _ParquetGenerator(object):
 
 
 class _ParquetReader(object):
-    def get_row_group_metadata(self):
+    def get_row_group_metadata(self, row_groups):
         raise NotImplementedError
 
-    def read(self):
+    def read(self, row_group, column_name):
         raise NotImplementedError
 
 

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3403,8 +3403,8 @@ def _parquet_partition_values(path):
 def _parquet_partitions_to_awkward(paths_and_counts):
     path, count = paths_and_counts[0]
     columns = [column for column, value in _parquet_partition_values(path)]
-    values = [[] for column in columns]
-    indexes = [[] for column in columns]
+    values = [[] for _ in columns]
+    indexes = [[] for _ in columns]
     for path, count in paths_and_counts:
         for i, (column, value) in enumerate(_parquet_partition_values(path)):
             if i >= len(columns) or column != columns[i]:

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3968,7 +3968,7 @@ def from_parquet(
     if isinstance(source, str) and os.path.isdir(source):
         metadata_filename = os.path.join(source, "_metadata")
         if os.path.exists(metadata_filename):
-            layout = _from_parquet_dataset(
+            return _from_parquet_dataset(
                 source,
                 metadata_filename,
                 columns,
@@ -3986,7 +3986,7 @@ def from_parquet(
             relative_to = source
             source = sorted(glob.glob(source + "/**/*.parquet", recursive=True))
 
-            layout = _from_parquet_list_of_files(
+            return _from_parquet_list_of_files(
                 source,
                 relative_to,
                 columns,
@@ -4006,7 +4006,7 @@ def from_parquet(
         and isinstance(source, Iterable)
         and not hasattr(source, "read")
     ):
-        layout = _from_parquet_list_of_files(
+        return _from_parquet_list_of_files(
             source,
             None,
             columns,
@@ -4022,7 +4022,7 @@ def from_parquet(
         )
 
     else:
-        layout = _from_parquet_file(
+        return _from_parquet_file(
             source,
             columns,
             row_groups,
@@ -4034,13 +4034,6 @@ def from_parquet(
             behavior,
             options,
         )
-
-    if highlevel:
-        return ak._util.wrap(layout, behavior)
-    else:
-        return layout
-
-    raise RuntimeError
 
 
 def to_buffers(

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3265,7 +3265,7 @@ def _parquet_schema_to_form(schema):
     return ak.forms.RecordForm(contents, schema.names)
 
 
-class _ParquetGenerator(object):
+class _LazyDatasetGenerator(object):
     def __init__(self, reader):
         self._reader = reader
 
@@ -3940,7 +3940,7 @@ def from_parquet(
         lazy_cache_key = _regularize_parquet_lazy_cache_key(lazy_cache_key)
 
         lengths = [r.num_rows for r in reader.row_group_metadata]
-        state = _ParquetGenerator(reader)
+        state = _LazyDatasetGenerator(reader)
 
         form = _parquet_schema_to_form(reader.schema)
         out = _create_partitioned_array_from_form(

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3443,11 +3443,6 @@ class _ParquetReader(object):
     def is_empty(self):
         return len(self.row_groups) == 0
 
-    def empty_like(self):
-        return ak.layout.RecordArray(
-            [ak.layout.EmptyArray() for _ in self.columns], self.columns, 0
-        )
-
     @property
     def row_group_metadata(self):
         raise NotImplementedError
@@ -3953,7 +3948,9 @@ def from_parquet(
         reader = _ParquetFileReader(source, use_threads, row_groups, columns, options)
 
     if reader.is_empty:
-        return reader.empty_like()
+        return ak.layout.RecordArray(
+            [ak.layout.EmptyArray() for _ in reader.columns], reader.columns, 0
+        )
 
     if lazy:
         lazy_cache, hold_cache = _regularize_lazy_cache(lazy_cache)

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3543,7 +3543,8 @@ class _ParquetDatasetReader(_ParquetReader):
             schema, row_groups, columns, partition_columns
         )
 
-    def _build_row_group_lookup(self, directory, metadata_file):
+    @staticmethod
+    def _build_row_group_lookup(directory, metadata_file):
         last_filename = None
         lookup = []
         for i in range(metadata_file.num_row_groups):
@@ -3563,7 +3564,8 @@ class _ParquetDatasetReader(_ParquetReader):
             lookup.append((os.path.join(directory, last_filename), i - start_i))
         return lookup
 
-    def _get_paths_and_counts(self, file, row_groups):
+    @staticmethod
+    def _get_paths_and_counts(file, row_groups):
         paths_and_counts = []
         last_filename = None
         for i in row_groups:
@@ -3648,7 +3650,8 @@ class _ParquetDatasetOfFilesReader(_ParquetReader):
             schema, row_groups, columns, partition_columns
         )
 
-    def _get_dataset_metadata(self, source, relative_to, options):
+    @staticmethod
+    def _get_dataset_metadata(source, relative_to, options):
         import pyarrow.parquet
 
         schema = None


### PR DESCRIPTION
This PR refactors the `from_parquet` implementation into several `Reader` classes. These objects are used by the reduced-scope `_ParquetGenerator` class to build a lazy array, or by the greedy (up-front) construction of an Array when `lazy=False`.

Some initial work is done to prepare for `_ArrowDatasetReader`.

This PR should *not* add any new functionality or (hopefully) break anything.

I plan in another PR to then remove all of the dataset readers, add an `_ArrowDatasetReader`, and leave only the `_ParquetFileReader` to handle file-like source arguments.