### PR TITLE
Bugfix: truncate `ListOffsetArray` contents

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2226,7 +2226,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             ),
         ):
             new_layout = layout.toListOffsetArray64(True)
-            new_length = new_layout.stops[-1]
+            new_length = new_layout.offsets[-1]
             return ak.layout.ListOffsetArray64(
                 new_layout.offsets,
                 apply(truncate(new_layout.content, new_length), depth + 1, posaxis),

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2226,9 +2226,10 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
             ),
         ):
             new_layout = layout.toListOffsetArray64(True)
+            new_length = new_layout.stops[-1]
             return ak.layout.ListOffsetArray64(
                 new_layout.offsets,
-                apply(new_layout.content, depth + 1, posaxis),
+                apply(truncate(new_layout.content, new_length), depth + 1, posaxis),
                 new_layout.identities,
                 new_layout.parameters,
             )

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -71,6 +71,7 @@ def test_list_offset_array():
     assert ak.to_list(packed) == ak.to_list(layout)
     assert isinstance(packed, ak.layout.ListOffsetArray64)
     assert packed.offsets[0] == 0
+    assert len(packed.content) == packed.offsets[-1]
 
 
 def test_unmasked_array():


### PR DESCRIPTION
Currently, `ak.packed` doesn't truncate the contents of a `ListOffsetArray`, so buffers can be larger than necessary after calling the function.

Fixes #938 