### PR TITLE
Bugfix: fix `with_cache` implementation

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -4125,7 +4125,7 @@ def materialized(array, highlevel=True, behavior=None):
         return out
 
 
-def with_cache(array, cache, highlevel=True, behavior=None):
+def with_cache(array, cache, behavior=None):
     """
     Args:
         array: Data to search for nested virtual arrays.
@@ -4135,8 +4135,6 @@ def with_cache(array, cache, highlevel=True, behavior=None):
             re-generated if `__getitem__` raises a `KeyError`. This mapping may
             evict elements according to any caching algorithm (LRU, LFR, RR,
             TTL, etc.). If "new", a new dict (keep-forever cache) is created.
-        highlevel (bool): If True, return an #ak.Array; otherwise, return
-            a low-level #ak.layout.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
 
@@ -4177,13 +4175,9 @@ def with_cache(array, cache, highlevel=True, behavior=None):
 
     def getfunction(layout):
         if isinstance(layout, ak.layout.VirtualArray):
-            if cache is None:
-                newcache = layout.cache
-            elif layout.cache is None:
-                newcache = cache
             return lambda: ak.layout.VirtualArray(
                 layout.generator,
-                newcache,
+                cache,
                 layout.cache_key,
                 layout.identities,
                 layout.parameters,
@@ -4194,10 +4188,7 @@ def with_cache(array, cache, highlevel=True, behavior=None):
     out = ak._util.recursively_apply(
         ak.operations.convert.to_layout(array), getfunction, pass_depth=False
     )
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
 
 
 @ak._connect._numpy.implements("size")

--- a/tests/test_940-with-cache-already-exists.py
+++ b/tests/test_940-with-cache-already-exists.py
@@ -1,0 +1,22 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    def func():
+        return ak.Array([1, 2, 3, 4, 5])
+
+    generator = ak.layout.ArrayGenerator(func, (), length=5)
+    hold_cache = ak._util.MappingProxy({})
+    cache = ak.layout.ArrayCache(hold_cache)
+    layout = ak.layout.VirtualArray(generator, cache=cache)
+    cache_2 = {}
+    layout_2 = ak.with_cache(layout, cache_2, highlevel=False)
+    ak.materialized(layout_2)
+    assert len(cache_2) > 0
+    assert len(cache) == 0

--- a/tests/test_940-with-cache-already-exists.py
+++ b/tests/test_940-with-cache-already-exists.py
@@ -7,16 +7,22 @@ import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
 
-def test():
-    def func():
-        return ak.Array([1, 2, 3, 4, 5])
+def func():
+    return ak.Array([1, 2, 3, 4, 5])
 
-    generator = ak.layout.ArrayGenerator(func, (), length=5)
+
+generator = ak.layout.ArrayGenerator(func, (), length=5)
+
+
+def test():
     hold_cache = ak._util.MappingProxy({})
     cache = ak.layout.ArrayCache(hold_cache)
     layout = ak.layout.VirtualArray(generator, cache=cache)
+    array = ak.Array(layout)
+
     cache_2 = {}
-    layout_2 = ak.with_cache(layout, cache_2, highlevel=False)
-    ak.materialized(layout_2)
+    array_2 = ak.with_cache(array, cache_2)
+    ak.materialized(array_2)
+
     assert len(cache_2) > 0
     assert len(cache) == 0


### PR DESCRIPTION
This PR fixes #940 and #941.

`with_cache` is one of two places (there's also something going on in the `convert` module w.r.t cache handling) the current cache handling is slightly broken. This PR simplifies the scope of the function by requiring the user to have created the cache prior to calling `with_cache`. Currently, the lifetime of the cache proxy that is created in the removed cases is not associated with the lifetime of the cache.

It would be possible to retain the existing API by storing a reference to the proxy on the cache object, but this will break the assumption that the cache is populated exclusively for virtual materialisation.