### PR TITLE
sorting an indexed option array in `axis0` bug fix; argsort to account `None`s

### DIFF
--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -838,8 +838,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const = 0;
+                bool stable) const = 0;
 
     virtual const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -813,7 +813,7 @@ namespace awkward {
                   bool mask,
                   bool keepdims) const = 0;
 
-    /// @brief This array with one axis removed by applying a Reducer
+    /// @brief This array sorted
     ///
     /// The user's entry point for this operation is #sort.
     ///
@@ -824,7 +824,7 @@ namespace awkward {
     /// structure into this structure with the same meaning as in
     /// {@link ListArrayOf ListArray}.
     /// @param parents Groups to combine as an {@link IndexOf Index} of
-    /// upward pointers from this structure to the outer structure to reduce.
+    /// upward pointers from this structure to the outer structure to sort.
     /// @param outlength The length of the array, after the operation
     /// completes.
     /// @param ascending If `true`, the values will be sorted in an ascending
@@ -840,9 +840,32 @@ namespace awkward {
                 bool ascending,
                 bool stable) const = 0;
 
+    /// @brief This array sorted indices
+    ///
+    /// The user's entry point for this operation is #argsort.
+    ///
+    /// @param negaxis The negative axis: `-axis`. That is, `negaxis = 1`
+    /// means the deepest axis level.
+    /// @param starts Staring positions of each group to combine as an
+    /// {@link IndexOf Index}. These are downward pointers from an outer
+    /// structure into this structure with the same meaning as in
+    /// {@link ListArrayOf ListArray}.
+    /// @param shifts Per-element adjustments that allows
+    /// for variable-length lists with axis != -1 and for missing values
+    /// (None).
+    /// @param parents Groups to combine as an {@link IndexOf Index} of
+    /// upward pointers from this structure to the outer structure to sort.
+    /// @param outlength The length of the array, after the operation
+    /// completes.
+    /// @param ascending If `true`, the values will be sorted in an ascending
+    /// order.
+    /// @param stable If `true`, the values will be sorted by a
+    /// stable sort algorithm to maintain the relative order of records with
+    /// equal keys (i.e. values).
     virtual const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -846,8 +846,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const = 0;
+                   bool stable) const = 0;
 
     /// @brief A (possibly nested) array of integers indicating the
     /// positions of elements within each nested list.

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -399,8 +399,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -396,6 +396,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -391,8 +391,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -362,6 +362,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -357,8 +357,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -365,8 +365,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -266,8 +266,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -274,8 +274,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -271,6 +271,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -453,8 +453,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -450,6 +450,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -445,8 +445,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -384,6 +384,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -379,8 +379,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -387,8 +387,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -367,8 +367,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -375,8 +375,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -372,6 +372,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -227,6 +227,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -222,8 +222,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -230,8 +230,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     /// @exception std::runtime_error is always thrown
     const ContentPtr

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -471,8 +471,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       as_unique_strings(const Index64& offsets) const;

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -482,8 +482,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -479,6 +479,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
@@ -804,6 +805,7 @@ namespace awkward {
     const std::shared_ptr<void> index_sort(const T* data,
                                            int64_t length,
                                            const Index64& starts,
+                                           const Index64& shifts,
                                            const Index64& parents,
                                            int64_t outlength,
                                            bool ascending,

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -1087,6 +1087,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -1090,8 +1090,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override {
+                   bool stable) const override {
       std::shared_ptr<int64_t> ptr =
           kernel::malloc<int64_t>(kernel::lib::cpu,   // DERIVE
                                   length_*sizeof(int64_t));

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -1049,8 +1049,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override {
+                bool stable) const override {
       std::shared_ptr<T> ptr = kernel::malloc<T>(kernel::lib::cpu,   // DERIVE
                                                  length_*sizeof(T));
       Index64 offsets(2);

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -232,8 +232,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -237,6 +237,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/Record.h
+++ b/include/awkward/array/Record.h
@@ -240,8 +240,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -361,8 +361,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -366,6 +366,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -369,8 +369,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -343,8 +343,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -335,8 +335,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -340,6 +340,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -389,8 +389,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -386,6 +386,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -381,8 +381,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -315,8 +315,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -320,6 +320,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -323,8 +323,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
     const ContentPtr
       localindex(int64_t axis, int64_t depth) const override;

--- a/include/awkward/array/VirtualArray.h
+++ b/include/awkward/array/VirtualArray.h
@@ -337,6 +337,7 @@ namespace awkward {
     const ContentPtr
       argsort_next(int64_t negaxis,
                    const Index64& starts,
+                   const Index64& shifts,
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,

--- a/include/awkward/array/VirtualArray.h
+++ b/include/awkward/array/VirtualArray.h
@@ -332,8 +332,7 @@ namespace awkward {
                 const Index64& parents,
                 int64_t outlength,
                 bool ascending,
-                bool stable,
-                bool keepdims) const override;
+                bool stable) const override;
 
     const ContentPtr
       argsort_next(int64_t negaxis,

--- a/include/awkward/array/VirtualArray.h
+++ b/include/awkward/array/VirtualArray.h
@@ -340,8 +340,7 @@ namespace awkward {
                    const Index64& parents,
                    int64_t outlength,
                    bool ascending,
-                   bool stable,
-                   bool keepdims) const override;
+                   bool stable) const override;
 
 
     const ContentPtr

--- a/include/awkward/kernel-dispatch.h
+++ b/include/awkward/kernel-dispatch.h
@@ -1289,6 +1289,11 @@ namespace awkward {
       int64_t target,
       int64_t length);
 
+    ERROR Index_nones_as_index_64(
+      kernel::lib ptr_lib,
+      int64_t* toindex,
+      int64_t length);
+
     ERROR RegularArray_rpad_and_clip_axis1_64(
       kernel::lib ptr_lib,
       int64_t* toindex,

--- a/include/awkward/kernel-dispatch.h
+++ b/include/awkward/kernel-dispatch.h
@@ -537,6 +537,15 @@ namespace awkward {
       int64_t lenindex);
 
     template <typename T>
+    ERROR IndexedArray_index_of_nulls(
+      kernel::lib ptr_lib,
+      int64_t* toindex,
+      const T* fromindex,
+      int64_t lenindex,
+      const int64_t* parents,
+      const int64_t* starts);
+
+    template <typename T>
     ERROR IndexedArray_getitem_nextcarry_outindex_64(
       kernel::lib ptr_lib,
       int64_t* tocarry,

--- a/include/awkward/kernel-dispatch.h
+++ b/include/awkward/kernel-dispatch.h
@@ -1098,6 +1098,19 @@ namespace awkward {
       double scale);
 
     template <typename FROM, typename TO>
+    ERROR NumpyArray_rearrange_shifted(
+      kernel::lib ptr_lib,
+      TO* toptr,
+      const FROM* fromshifts,
+      int64_t length,
+      const FROM* fromoffsets,
+      int64_t offsetslength,
+      const FROM* fromparents,
+      int64_t parentslength,
+      const FROM* fromstarts,
+      int64_t startslength);
+
+    template <typename FROM, typename TO>
     ERROR ListArray_fill(
       kernel::lib ptr_lib,
       TO* tostarts,

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -1303,6 +1303,40 @@ kernels:
     automatic-tests: true
     manual-tests: []
 
+  - name: awkward_IndexedArray_index_of_nulls
+    specializations:
+      - name: awkward_IndexedArray32_index_of_nulls
+        args:
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: fromindex, type: "Const[List[int32_t]]", dir: in, role: IndexedArray-index}
+          - {name: lenindex, type: "int64_t", dir: in, role: default}
+          - {name: parents, type: "Const[List[int64_t]]", dir: in}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in}
+      - name: awkward_IndexedArray64_index_of_nulls
+        args:
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: fromindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
+          - {name: lenindex, type: "int64_t", dir: in, role: default}
+          - {name: parents, type: "Const[List[int64_t]]", dir: in}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in}
+      - name: awkward_IndexedArrayU32_index_of_nulls
+        args:
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: fromindex, type: "Const[List[uint32_t]]", dir: in, role: IndexedArray-index}
+          - {name: lenindex, type: "int64_t", dir: in, role: default}
+          - {name: parents, type: "Const[List[int64_t]]", dir: in}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in}
+    description: null
+    definition: |
+      def awkward_IndexedArray_index_of_nulls(toindex, fromindex, lenindex):
+          j = 0
+          for i in range(lenindex):
+              if fromindex[i] < 0:
+                  toindex[j] = i
+                  j = j + 1
+    automatic-tests: true
+    manual-tests: []
+
   - name: awkward_IndexedArray_overlay_mask
     specializations:
       - name: awkward_IndexedArray32_overlay_mask8_to64

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -4498,6 +4498,27 @@ kernels:
     automatic-tests: false
     manual-tests: []
 
+  - name: awkward_NumpyArray_rearrange_shifted
+    specializations:
+      - name: awkward_NumpyArray_rearrange_shifted_toint64_fromint64
+        args:
+          - {name: toptr, type: "List[int64_t]", dir: out}
+          - {name: fromshifts, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
+          - {name: length, type: "int64_t", dir: in, role: default}
+          - {name: fromoffsets, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
+          - {name: offsetslength, type: "int64_t", dir: in, role: default}
+          - {name: fromparents, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
+          - {name: parentslength, type: "int64_t", dir: in, role: default}
+          - {name: fromstarts, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
+          - {name: startslength, type: "int64_t", dir: in, role: default}
+    description: null
+    definition: |
+      def awkward_NumpyArray_rearrange_shifted(toptr, fromshifts, length, fromoffsets, offsetslength, fromparents, parentslength):
+          for i in range(length):
+              toptr[i] = toptr[i] + fromshifts[toptr[i]]
+    automatic-tests: false
+    manual-tests: []
+
   - name: awkward_NumpyArray_getitem_boolean_nonzero
     specializations:
       - name: awkward_NumpyArray_getitem_boolean_nonzero_64

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -6293,11 +6293,11 @@ kernels:
           for i in range(length):
               if toindex[i] > last_index:
                   last_index = toindex[i]
-          for i in ragne(length):
+          for i in range(length):
               if toindex[i] == -1:
                   last_index = last_index + 1
                   toindex[i] = last_index
-    automatic-tests: true
+    automatic-tests: false
     manual-tests: []
 
   - name: awkward_localindex

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -4514,8 +4514,16 @@ kernels:
     description: null
     definition: |
       def awkward_NumpyArray_rearrange_shifted(toptr, fromshifts, length, fromoffsets, offsetslength, fromparents, parentslength):
+          k = 0
+          for i in range(offsetslength - 1):
+              for j in rage(fromoffsets[i + 1] - fromoffsets[i]):
+                  toptr[k] = toptr[k] + fromoffsets[i]
+                  k = k + 1
+
           for i in range(length):
-              toptr[i] = toptr[i] + fromshifts[toptr[i]]
+              parent = fromparents[i]
+              start = fromstarts[parent]
+              toptr[i] = toptr[i] + fromshifts[toptr[i]] - start
     automatic-tests: false
     manual-tests: []
 

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -1328,11 +1328,13 @@ kernels:
           - {name: starts, type: "Const[List[int64_t]]", dir: in}
     description: null
     definition: |
-      def awkward_IndexedArray_index_of_nulls(toindex, fromindex, lenindex):
+      def awkward_IndexedArray_index_of_nulls(toindex, fromindex, lenindex, parents, starts):
           j = 0
           for i in range(lenindex):
               if fromindex[i] < 0:
-                  toindex[j] = i
+                  parent = parents[i]
+                  start = starts[parent]
+                  toindex[j] = i - start
                   j = j + 1
     automatic-tests: true
     manual-tests: []

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -6280,6 +6280,26 @@ kernels:
     automatic-tests: true
     manual-tests: []
 
+  - name: awkward_Index_nones_as_index
+    specializations:
+      - name: awkward_Index_nones_as_index_64
+        args:
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: length, type: "int64_t", dir: in, role: default}
+    description: null
+    definition: |
+      def awkward_Index_nones_as_index(toindex, length):
+          last_index = 0
+          for i in range(length):
+              if toindex[i] > last_index:
+                  last_index = toindex[i]
+          for i in ragne(length):
+              if toindex[i] == -1:
+                  last_index = last_index + 1
+                  toindex[i] = last_index
+    automatic-tests: true
+    manual-tests: []
+
   - name: awkward_localindex
     specializations:
       - name: awkward_localindex_64

--- a/src/cpu-kernels/awkward_Index_nones_as_index.cpp
+++ b/src/cpu-kernels/awkward_Index_nones_as_index.cpp
@@ -1,0 +1,26 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/awkward_Index_nones_as_index.cpp", line)
+
+#include "awkward/kernels.h"
+
+template <typename T>
+ERROR awkward_Index_nones_as_index(
+  T* toindex,
+  int64_t length) {
+  int64_t last_index = 0;
+  for (int64_t i = 0; i < length; i++) {
+    toindex[i] > last_index ? last_index = toindex[i] : last_index;
+  }
+  for (int64_t i = 0; i < length; i++) {
+    toindex[i] == -1 ? toindex[i] = ++last_index : toindex[i];
+  }
+  return success();
+}
+ERROR awkward_Index_nones_as_index_64(
+  int64_t* toindex,
+  int64_t length) {
+  return awkward_Index_nones_as_index<int64_t>(
+    toindex,
+    length);
+}

--- a/src/cpu-kernels/awkward_IndexedArray_index_of_nulls.cpp
+++ b/src/cpu-kernels/awkward_IndexedArray_index_of_nulls.cpp
@@ -1,0 +1,62 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/awkward_IndexedArray_index_of_nulls.cpp", line)
+
+#include "awkward/kernels.h"
+
+template <typename C>
+ERROR awkward_IndexedArray_index_of_nulls(
+  int64_t* toindex,
+  const C* fromindex,
+  int64_t lenindex,
+  const int64_t* parents,
+  const int64_t* starts) {
+  int64_t j = 0;
+  for (int64_t i = 0;  i < lenindex;  i++) {
+    if (fromindex[i] < 0) {
+      int64_t parent = parents[i];
+      int64_t start = starts[parent];
+      toindex[j++] = i - start;
+    }
+  }
+  return success();
+}
+ERROR awkward_IndexedArray32_index_of_nulls(
+  int64_t* toindex,
+  const int32_t* fromindex,
+  int64_t lenindex,
+  const int64_t* parents,
+  const int64_t* starts) {
+  return awkward_IndexedArray_index_of_nulls<int32_t>(
+    toindex,
+    fromindex,
+    lenindex,
+    parents,
+    starts);
+}
+ERROR awkward_IndexedArrayU32_index_of_nulls(
+  int64_t* toindex,
+  const uint32_t* fromindex,
+  int64_t lenindex,
+  const int64_t* parents,
+  const int64_t* starts) {
+  return awkward_IndexedArray_index_of_nulls<uint32_t>(
+    toindex,
+    fromindex,
+    lenindex,
+    parents,
+    starts);
+}
+ERROR awkward_IndexedArray64_index_of_nulls(
+  int64_t* toindex,
+  const int64_t* fromindex,
+  int64_t lenindex,
+  const int64_t* parents,
+  const int64_t* starts) {
+  return awkward_IndexedArray_index_of_nulls<int64_t>(
+    toindex,
+    fromindex,
+    lenindex,
+    parents,
+    starts);
+}

--- a/src/cpu-kernels/awkward_NumpyArray_rearrange_shifted.cpp
+++ b/src/cpu-kernels/awkward_NumpyArray_rearrange_shifted.cpp
@@ -1,0 +1,45 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/awkward_NumpyArray_rearrange_shifted.cpp", line)
+
+#include "awkward/kernels.h"
+
+template <typename FROM, typename TO>
+ERROR
+awkward_NumpyArray_rearrange_shifted(TO* toptr,
+                                     const FROM* shifts,
+                                     int64_t length,
+                                     const FROM* offsets,
+                                     int64_t offsetslength,
+                                     const FROM* parents,
+                                     int64_t parentslength,
+                                     const FROM* starts,
+                                     int64_t startslength) {
+  int64_t k = 0;
+  for (int64_t i = 0; i < offsetslength - 1; i++) {
+    for (int64_t j = 0; j < offsets[i + 1] - offsets[i]; j++) {
+      toptr[k] = toptr[k] + offsets[i];
+      k++;
+    }
+  }
+  for (int64_t i = 0;  i < length;  i++) {
+    int64_t parent = parents[i];
+    int64_t start = starts[parent];
+    toptr[i] = toptr[i] + shifts[toptr[i]] - start;
+  }
+
+  return success();
+}
+ERROR
+awkward_NumpyArray_rearrange_shifted_toint64_fromint64(int64_t* toptr,
+                                                       const int64_t* fromshifts,
+                                                       int64_t length,
+                                                       const int64_t* fromoffsets,
+                                                       int64_t offsetslength,
+                                                       const int64_t* fromparents,
+                                                       int64_t parentslength,
+                                                       const int64_t* fromstarts,
+                                                       int64_t startslength) {
+  return awkward_NumpyArray_rearrange_shifted<int64_t, int64_t>(
+      toptr, fromshifts, length, fromoffsets, offsetslength, fromparents, parentslength, fromstarts, startslength);
+}

--- a/src/cpu-kernels/awkward_argsort.cpp
+++ b/src/cpu-kernels/awkward_argsort.cpp
@@ -12,13 +12,13 @@
 template <typename T>
 bool argsort_order_ascending(T l, T r)
 {
-  return !std::isnan(r) && (std::isnan(l) || l < r);
+  return !std::isnan(static_cast<double>(r)) && (std::isnan(static_cast<double>(l)) || l < r);
 }
 
 template <typename T>
 bool argsort_order_descending(T l, T r)
 {
-  return !std::isnan(r) && (std::isnan(l) || l > r);
+  return !std::isnan(static_cast<double>(r)) && (std::isnan(static_cast<double>(l)) || l > r);
 }
 
 template <typename T>

--- a/src/cpu-kernels/awkward_argsort.cpp
+++ b/src/cpu-kernels/awkward_argsort.cpp
@@ -25,7 +25,7 @@ ERROR awkward_argsort(
       auto start = std::next(result.begin(), offsets[i]);
       auto stop = std::next(result.begin(), offsets[i + 1]);
       std::stable_sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return fromptr[i1] < fromptr[i2];
+        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] < fromptr[i2]);
       });
       std::transform(start, stop, start, [&](int64_t j) -> int64_t {
         return j - offsets[i];
@@ -37,7 +37,7 @@ ERROR awkward_argsort(
       auto start = std::next(result.begin(), offsets[i]);
       auto stop = std::next(result.begin(), offsets[i + 1]);
       std::stable_sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return fromptr[i1] > fromptr[i2];
+        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] > fromptr[i2]);
       });
       std::transform(start, stop, start, [&](int64_t j) -> int64_t {
         return j - offsets[i];
@@ -49,7 +49,7 @@ ERROR awkward_argsort(
       auto start = std::next(result.begin(), offsets[i]);
       auto stop = std::next(result.begin(), offsets[i + 1]);
       std::sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return fromptr[i1] < fromptr[i2];
+        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] < fromptr[i2]);
       });
       std::transform(start, stop, start, [&](int64_t j) -> int64_t {
         return j - offsets[i];
@@ -61,7 +61,7 @@ ERROR awkward_argsort(
       auto start = std::next(result.begin(), offsets[i]);
       auto stop = std::next(result.begin(), offsets[i + 1]);
       std::sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return fromptr[i1] > fromptr[i2];
+        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] > fromptr[i2]);
       });
       std::transform(start, stop, start, [&](int64_t j) -> int64_t {
         return j - offsets[i];

--- a/src/cpu-kernels/awkward_argsort.cpp
+++ b/src/cpu-kernels/awkward_argsort.cpp
@@ -10,6 +10,18 @@
 #include "awkward/kernels.h"
 
 template <typename T>
+bool argsort_order_ascending(T l, T r)
+{
+  return !std::isnan(r) && (std::isnan(l) || l < r);
+}
+
+template <typename T>
+bool argsort_order_descending(T l, T r)
+{
+  return !std::isnan(r) && (std::isnan(l) || l > r);
+}
+
+template <typename T>
 ERROR awkward_argsort(
   int64_t* toptr,
   const T* fromptr,
@@ -26,7 +38,7 @@ ERROR awkward_argsort(
       auto start = std::next(result.begin(), offsets[i]);
       auto stop = std::next(result.begin(), offsets[i + 1]);
       std::stable_sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] < fromptr[i2]);
+        return argsort_order_ascending<T>(fromptr[i1], fromptr[i2]);
       });
       std::transform(start, stop, start, [&](int64_t j) -> int64_t {
         return j - offsets[i];
@@ -38,7 +50,7 @@ ERROR awkward_argsort(
       auto start = std::next(result.begin(), offsets[i]);
       auto stop = std::next(result.begin(), offsets[i + 1]);
       std::stable_sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] > fromptr[i2]);
+        return argsort_order_descending<T>(fromptr[i1], fromptr[i2]);
       });
       std::transform(start, stop, start, [&](int64_t j) -> int64_t {
         return j - offsets[i];
@@ -50,7 +62,7 @@ ERROR awkward_argsort(
       auto start = std::next(result.begin(), offsets[i]);
       auto stop = std::next(result.begin(), offsets[i + 1]);
       std::sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] < fromptr[i2]);
+        return argsort_order_ascending<T>(fromptr[i1], fromptr[i2]);
       });
       std::transform(start, stop, start, [&](int64_t j) -> int64_t {
         return j - offsets[i];
@@ -62,7 +74,7 @@ ERROR awkward_argsort(
       auto start = std::next(result.begin(), offsets[i]);
       auto stop = std::next(result.begin(), offsets[i + 1]);
       std::sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] > fromptr[i2]);
+        return argsort_order_descending<T>(fromptr[i1], fromptr[i2]);
       });
       std::transform(start, stop, start, [&](int64_t j) -> int64_t {
         return j - offsets[i];
@@ -272,4 +284,16 @@ ERROR awkward_argsort_float64(
     offsetslength,
     ascending,
     stable);
+}
+
+template <>
+bool argsort_order_ascending(bool l, bool r)
+{
+  return l < r;
+}
+
+template <>
+bool argsort_order_descending(bool l, bool r)
+{
+  return l > r;
 }

--- a/src/cpu-kernels/awkward_argsort.cpp
+++ b/src/cpu-kernels/awkward_argsort.cpp
@@ -3,6 +3,7 @@
 #define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/awkward_argsort.cpp", line)
 
 #include <algorithm>
+#include <cmath>
 #include <numeric>
 #include <vector>
 

--- a/src/cpu-kernels/awkward_argsort.cpp
+++ b/src/cpu-kernels/awkward_argsort.cpp
@@ -68,7 +68,6 @@ ERROR awkward_argsort(
       });
     }
   }
-
   for (int64_t i = 0;  i < length;  i++) {
     toptr[i] = result[i];
   }

--- a/src/cpu-kernels/awkward_sort.cpp
+++ b/src/cpu-kernels/awkward_sort.cpp
@@ -26,7 +26,7 @@ ERROR awkward_sort(
       auto start = std::next(index.begin(), offsets[i]);
       auto stop = std::next(index.begin(), offsets[i + 1]);
       std::stable_sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return fromptr[i1] < fromptr[i2];
+        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] < fromptr[i2]);
       });
     }
   }
@@ -35,7 +35,7 @@ ERROR awkward_sort(
       auto start = std::next(index.begin(), offsets[i]);
       auto stop = std::next(index.begin(), offsets[i + 1]);
       std::stable_sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return fromptr[i1] > fromptr[i2];
+        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] > fromptr[i2]);
       });
     }
   }
@@ -44,7 +44,7 @@ ERROR awkward_sort(
       auto start = std::next(index.begin(), offsets[i]);
       auto stop = std::next(index.begin(), offsets[i + 1]);
       std::sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return fromptr[i1] < fromptr[i2];
+        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] < fromptr[i2]);
       });
     }
   }
@@ -53,7 +53,7 @@ ERROR awkward_sort(
       auto start = std::next(index.begin(), offsets[i]);
       auto stop = std::next(index.begin(), offsets[i + 1]);
       std::sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return fromptr[i1] > fromptr[i2];
+        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] > fromptr[i2]);
       });
     }
   }

--- a/src/cpu-kernels/awkward_sort.cpp
+++ b/src/cpu-kernels/awkward_sort.cpp
@@ -12,13 +12,13 @@
 template <typename T>
 bool sort_order_ascending(T l, T r)
 {
-  return !std::isnan(r) && (std::isnan(l) || l < r);
+  return !std::isnan(static_cast<double>(r)) && (std::isnan(static_cast<double>(l)) || l < r);
 }
 
 template <typename T>
 bool sort_order_descending(T l, T r)
 {
-  return !std::isnan(r) && (std::isnan(l) || l > r);
+  return !std::isnan(static_cast<double>(r)) && (std::isnan(static_cast<double>(l)) || l > r);
 }
 
 template <typename T>

--- a/src/cpu-kernels/awkward_sort.cpp
+++ b/src/cpu-kernels/awkward_sort.cpp
@@ -10,6 +10,18 @@
 #include <vector>
 
 template <typename T>
+bool sort_order_ascending(T l, T r)
+{
+  return !std::isnan(r) && (std::isnan(l) || l < r);
+}
+
+template <typename T>
+bool sort_order_descending(T l, T r)
+{
+  return !std::isnan(r) && (std::isnan(l) || l > r);
+}
+
+template <typename T>
 ERROR awkward_sort(
   T* toptr,
   const T* fromptr,
@@ -27,7 +39,7 @@ ERROR awkward_sort(
       auto start = std::next(index.begin(), offsets[i]);
       auto stop = std::next(index.begin(), offsets[i + 1]);
       std::stable_sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] < fromptr[i2]);
+        return sort_order_ascending<T>(fromptr[i1], fromptr[i2]);
       });
     }
   }
@@ -36,7 +48,7 @@ ERROR awkward_sort(
       auto start = std::next(index.begin(), offsets[i]);
       auto stop = std::next(index.begin(), offsets[i + 1]);
       std::stable_sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] > fromptr[i2]);
+        return sort_order_descending<T>(fromptr[i1], fromptr[i2]);
       });
     }
   }
@@ -45,7 +57,7 @@ ERROR awkward_sort(
       auto start = std::next(index.begin(), offsets[i]);
       auto stop = std::next(index.begin(), offsets[i + 1]);
       std::sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] < fromptr[i2]);
+        return sort_order_ascending<T>(fromptr[i1], fromptr[i2]);
       });
     }
   }
@@ -54,7 +66,7 @@ ERROR awkward_sort(
       auto start = std::next(index.begin(), offsets[i]);
       auto stop = std::next(index.begin(), offsets[i + 1]);
       std::sort(start, stop, [&fromptr](int64_t i1, int64_t i2) {
-        return !std::isnan(fromptr[i2]) && (std::isnan(fromptr[i1]) || fromptr[i1] > fromptr[i2]);
+        return sort_order_descending<T>(fromptr[i1], fromptr[i2]);
       });
     }
   }
@@ -273,4 +285,16 @@ ERROR awkward_sort_float64(
     parentslength,
     ascending,
     stable);
+}
+
+template <>
+bool sort_order_ascending(bool l, bool r)
+{
+  return l < r;
+}
+
+template <>
+bool sort_order_descending(bool l, bool r)
+{
+  return l > r;
 }

--- a/src/cpu-kernels/awkward_sort.cpp
+++ b/src/cpu-kernels/awkward_sort.cpp
@@ -5,6 +5,7 @@
 #include "awkward/kernels.h"
 
 #include <algorithm>
+#include <cmath>
 #include <numeric>
 #include <vector>
 

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -1175,8 +1175,7 @@ namespace awkward {
                                parents,
                                1,
                                ascending,
-                               stable,
-                               true);
+                               stable);
 
     if (out.get()->length() == 0) {
       return out.get()->getitem_nothing();

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -1182,7 +1182,7 @@ namespace awkward {
       return out.get()->getitem_nothing();
     }
     else {
-      return out.get()->getitem_at_nowrap(0);
+      return out;
     }
   }
 

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -1109,14 +1109,13 @@ namespace awkward {
                                   parents,
                                   1,
                                   ascending,
-                                  stable,
-                                  true);
+                                  stable);
 
      if (out.get()->length() == 0) {
        return out.get()->getitem_nothing();
      }
      else {
-       return out.get()->getitem_at_nowrap(0);
+       return out;
      }
   }
 

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -1098,14 +1098,19 @@ namespace awkward {
 
     Index64 starts(1);
     starts.setitem_at_nowrap(0, 0);
+
+    Index64 shifts(0);
+
     Index64 parents(length());
     struct Error err = kernel::content_reduce_zeroparents_64(
       kernel::lib::cpu,   // DERIVE
       parents.data(),
       length());
     util::handle_error(err, classname(), identities_.get());
+
     ContentPtr out = argsort_next(negaxis,
                                   starts,
+                                  shifts,
                                   parents,
                                   1,
                                   ascending,

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -1011,15 +1011,13 @@ namespace awkward {
                                const Index64& parents,
                                int64_t outlength,
                                bool ascending,
-                               bool stable,
-                               bool keepdims) const {
+                               bool stable) const {
     return toByteMaskedArray().get()->argsort_next(negaxis,
                                                    starts,
                                                    parents,
                                                    outlength,
                                                    ascending,
-                                                   stable,
-                                                   keepdims);
+                                                   stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -1008,12 +1008,14 @@ namespace awkward {
   const ContentPtr
   BitMaskedArray::argsort_next(int64_t negaxis,
                                const Index64& starts,
+                               const Index64& shifts,
                                const Index64& parents,
                                int64_t outlength,
                                bool ascending,
                                bool stable) const {
     return toByteMaskedArray().get()->argsort_next(negaxis,
                                                    starts,
+                                                   shifts,
                                                    parents,
                                                    outlength,
                                                    ascending,

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -996,15 +996,13 @@ namespace awkward {
                             const Index64& parents,
                             int64_t outlength,
                             bool ascending,
-                            bool stable,
-                            bool keepdims) const {
+                            bool stable) const {
     return toByteMaskedArray().get()->sort_next(negaxis,
                                                 starts,
                                                 parents,
                                                 outlength,
                                                 ascending,
-                                                stable,
-                                                keepdims);
+                                                stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -1290,12 +1290,14 @@ namespace awkward {
   const ContentPtr
   ByteMaskedArray::argsort_next(int64_t negaxis,
                                 const Index64& starts,
+                                const Index64& shifts,
                                 const Index64& parents,
                                 int64_t outlength,
                                 bool ascending,
                                 bool stable) const {
     return toIndexedOptionArray64().get()->argsort_next(negaxis,
                                                         starts,
+                                                        shifts,
                                                         parents,
                                                         outlength,
                                                         ascending,

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -1293,15 +1293,13 @@ namespace awkward {
                                 const Index64& parents,
                                 int64_t outlength,
                                 bool ascending,
-                                bool stable,
-                                bool keepdims) const {
+                                bool stable) const {
     return toIndexedOptionArray64().get()->argsort_next(negaxis,
                                                         starts,
                                                         parents,
                                                         outlength,
                                                         ascending,
-                                                        stable,
-                                                        keepdims);
+                                                        stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -1278,15 +1278,13 @@ namespace awkward {
                              const Index64& parents,
                              int64_t outlength,
                              bool ascending,
-                             bool stable,
-                             bool keepdims) const {
+                             bool stable) const {
     return toIndexedOptionArray64().get()->sort_next(negaxis,
                                                      starts,
                                                      parents,
                                                      outlength,
                                                      ascending,
-                                                     stable,
-                                                     keepdims);
+                                                     stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -616,20 +616,21 @@ namespace awkward {
   const ContentPtr
   EmptyArray::argsort_next(int64_t negaxis,
                            const Index64& starts,
+                           const Index64& shifts,
                            const Index64& parents,
                            int64_t outlength,
                            bool ascending,
                            bool stable) const {
     ContentPtr asnumpy = toNumpyArray(util::dtype_to_format(util::dtype::int64),
-                                      8,
+                                      util::dtype_to_itemsize(util::dtype::int64),
                                       util::dtype::int64);
-    ContentPtr out = asnumpy.get()->argsort_next(negaxis,
-                                                 starts,
-                                                 parents,
-                                                 outlength,
-                                                 ascending,
-                                                 stable);
-    return out;
+    return asnumpy.get()->argsort_next(negaxis,
+                                       starts,
+                                       shifts,
+                                       parents,
+                                       outlength,
+                                       ascending,
+                                       stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -603,16 +603,14 @@ namespace awkward {
                         const Index64& parents,
                         int64_t outlength,
                         bool ascending,
-                        bool stable,
-                        bool keepdims) const {
+                        bool stable) const {
     ContentPtr asnumpy = toNumpyArray("d", 8, util::dtype::float64);
     return asnumpy.get()->sort_next(negaxis,
                                     starts,
                                     parents,
                                     outlength,
                                     ascending,
-                                    stable,
-                                    keepdims);
+                                    stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -619,8 +619,7 @@ namespace awkward {
                            const Index64& parents,
                            int64_t outlength,
                            bool ascending,
-                           bool stable,
-                           bool keepdims) const {
+                           bool stable) const {
     ContentPtr asnumpy = toNumpyArray(util::dtype_to_format(util::dtype::int64),
                                       8,
                                       util::dtype::int64);
@@ -629,8 +628,7 @@ namespace awkward {
                                                  parents,
                                                  outlength,
                                                  ascending,
-                                                 stable,
-                                                 keepdims);
+                                                 stable);
     return out;
   }
 

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -2471,6 +2471,9 @@ namespace awkward {
                                               parameters_,
                                               outindex,
                                               raw->content());
+        if (inject_nones) {
+          return tmp.simplify_optiontype();
+        }
         return std::make_shared<ListOffsetArray64>(
           raw->identities(),
           raw->parameters(),

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -2501,8 +2501,7 @@ namespace awkward {
                                             const Index64& parents,
                                             int64_t outlength,
                                             bool ascending,
-                                            bool stable,
-                                            bool keepdims) const {
+                                            bool stable) const {
     if (length() == 0 ) {
       return std::make_shared<NumpyArray>(Index64(0));
     }
@@ -2538,7 +2537,6 @@ namespace awkward {
     bool inject_nones = false;
     std::pair<bool, int64_t> branchdepth = branch_depth();
     if (numnull > 0  &&  !branchdepth.first  &&  negaxis != branchdepth.second) {
-      keepdims = false;
       inject_nones = true;
     }
     ContentPtr out = next.get()->argsort_next(negaxis,
@@ -2546,8 +2544,7 @@ namespace awkward {
                                               nextparents,
                                               outlength,
                                               ascending,
-                                              stable,
-                                              keepdims);
+                                              stable);
 
     Index64 nextoutindex(parents_length);
     struct Error err3 = kernel::IndexedArray_local_preparenext_64(
@@ -2603,6 +2600,9 @@ namespace awkward {
                                               util::Parameters(),
                                               outindex,
                                               raw->content());
+        if (inject_nones) {
+          return tmp.simplify_optiontype();
+        }
         return std::make_shared<ListOffsetArray64>(
           raw->identities(),
           raw->parameters(),

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -2525,7 +2525,7 @@ namespace awkward {
     Index64 nextcarry(next_length);
     Index64 outindex(index_length);
 
-    struct Error err3 = kernel::IndexedArray_reduce_next_64<T>(
+    struct Error err2 = kernel::IndexedArray_reduce_next_64<T>(
       kernel::lib::cpu,   // DERIVE
       nextcarry.data(),
       nextparents.data(),
@@ -2533,7 +2533,7 @@ namespace awkward {
       index_.data(),
       parents.data(),
       index_length);
-    util::handle_error(err3, classname(), identities_.get());
+    util::handle_error(err2, classname(), identities_.get());
 
     std::pair<bool, int64_t> branchdepth = branch_depth();
     bool make_shifts = (isoption()  &&
@@ -2542,23 +2542,23 @@ namespace awkward {
     Index64 nextshifts(make_shifts ? index_.length() - numnull : 0);
     if (make_shifts) {
       if (shifts.length() == 0) {
-        struct Error err4 =
+        struct Error err3 =
             kernel::IndexedArray_reduce_next_nonlocal_nextshifts_64<T>(
           kernel::lib::cpu,   // DERIVE
           nextshifts.data(),
           index_.data(),
           index_.length());
-        util::handle_error(err4, classname(), identities_.get());
+        util::handle_error(err3, classname(), identities_.get());
       }
       else {
-        struct Error err5 =
+        struct Error err4 =
             kernel::IndexedArray_reduce_next_nonlocal_nextshifts_fromshifts_64<T>(
           kernel::lib::cpu,   // DERIVE
           nextshifts.data(),
           index_.data(),
           index_.length(),
           shifts.data());
-        util::handle_error(err5, classname(), identities_.get());
+        util::handle_error(err4, classname(), identities_.get());
       }
     }
 
@@ -2580,14 +2580,14 @@ namespace awkward {
     if (isoption()) {
 
       Index64 nulls_index(numnull);
-      struct Error err2 = kernel::IndexedArray_index_of_nulls<T>(
+      struct Error err5 = kernel::IndexedArray_index_of_nulls<T>(
         kernel::lib::cpu,   // DERIVE
         nulls_index.data(),
         index_.data(),
         index_length,
         parents.data(),
         starts.data());
-      util::handle_error(err2, classname(), identities_.get());
+      util::handle_error(err5, classname(), identities_.get());
 
       ContentPtr ind = std::make_shared<NumpyArray>(nulls_index);
 
@@ -2609,16 +2609,11 @@ namespace awkward {
     util::handle_error(err6, classname(), identities_.get());
 
     if (isoption()  &&  nulls_merged) {
-      // FIXME: move to kernels
-      int64_t last_index = 0;
-      for( int64_t i = 0; i < nextoutindex.length(); i++) {
-        nextoutindex.data()[i] > last_index ? last_index = nextoutindex.data()[i] : last_index;
-      }
-
-      // FIXME: move to kernels
-      for(int64_t i = 0; i < nextoutindex.length(); i++) {
-        nextoutindex.data()[i] == -1 ? nextoutindex.data()[i] = ++last_index : nextoutindex.data()[i];
-      }
+      struct Error err7 = kernel::Index_nones_as_index_64(
+        kernel::lib::cpu,   // DERIVE
+        nextoutindex.data(),
+        nextoutindex.length());
+      util::handle_error(err7, classname(), identities_.get());
     }
 
     IndexedArrayOf<int64_t, ISOPTION> tmp(Identities::none(),
@@ -2652,13 +2647,13 @@ namespace awkward {
                         "ListOffsetArray64 whose offsets start at zero")
             + FILENAME(__LINE__));
         }
-        struct Error err4 = kernel::IndexedArray_reduce_next_fix_offsets_64(
+        struct Error err8 = kernel::IndexedArray_reduce_next_fix_offsets_64(
           kernel::lib::cpu,   // DERIVE
           outoffsets.data(),
           starts.data(),
           starts_length,
           outindex.length());
-        util::handle_error(err4, classname(), identities_.get());
+        util::handle_error(err8, classname(), identities_.get());
 
         IndexedArrayOf<int64_t, ISOPTION> tmp(Identities::none(),
                                               util::Parameters(),

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -2369,8 +2369,7 @@ namespace awkward {
                                          const Index64& parents,
                                          int64_t outlength,
                                          bool ascending,
-                                         bool stable,
-                                         bool keepdims) const {
+                                         bool stable) const {
     if (length() == 0 ) {
       return shallow_copy();
     }
@@ -2406,7 +2405,6 @@ namespace awkward {
     bool inject_nones = false;
     std::pair<bool, int64_t> branchdepth = branch_depth();
     if (numnull > 0  &&  !branchdepth.first  &&  negaxis != branchdepth.second) {
-      keepdims = false;
       inject_nones = true;
     }
     ContentPtr out = next.get()->sort_next(negaxis,
@@ -2414,8 +2412,7 @@ namespace awkward {
                                            nextparents,
                                            outlength,
                                            ascending,
-                                           stable,
-                                           keepdims);
+                                           stable);
 
     Index64 nextoutindex(parents_length);
     struct Error err3 = kernel::IndexedArray_local_preparenext_64(

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1564,15 +1564,13 @@ namespace awkward {
                                const Index64& parents,
                                int64_t outlength,
                                bool ascending,
-                               bool stable,
-                               bool keepdims) const {
+                               bool stable) const {
     return toListOffsetArray64(true).get()->argsort_next(negaxis,
                                                          starts,
                                                          parents,
                                                          outlength,
                                                          ascending,
-                                                         stable,
-                                                         keepdims);
+                                                         stable);
   }
 
   template <typename T>

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1548,15 +1548,13 @@ namespace awkward {
                             const Index64& parents,
                             int64_t outlength,
                             bool ascending,
-                            bool stable,
-                            bool keepdims) const {
+                            bool stable) const {
     return toListOffsetArray64(true).get()->sort_next(negaxis,
                                                       starts,
                                                       parents,
                                                       outlength,
                                                       ascending,
-                                                      stable,
-                                                      keepdims);
+                                                      stable);
   }
 
   template <typename T>

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -1561,12 +1561,14 @@ namespace awkward {
   const ContentPtr
   ListArrayOf<T>::argsort_next(int64_t negaxis,
                                const Index64& starts,
+                               const Index64& shifts,
                                const Index64& parents,
                                int64_t outlength,
                                bool ascending,
                                bool stable) const {
     return toListOffsetArray64(true).get()->argsort_next(negaxis,
                                                          starts,
+                                                         shifts,
                                                          parents,
                                                          outlength,
                                                          ascending,

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1691,15 +1691,13 @@ namespace awkward {
                                   const Index64& parents,
                                   int64_t outlength,
                                   bool ascending,
-                                  bool stable,
-                                  bool keepdims) const {
+                                  bool stable) const {
     return toListOffsetArray64(true).get()->sort_next(negaxis,
                                                       starts,
                                                       parents,
                                                       outlength,
                                                       ascending,
-                                                      stable,
-                                                      keepdims);
+                                                      stable);
   }
 
   template <>
@@ -1709,8 +1707,7 @@ namespace awkward {
     const Index64& parents,
     int64_t outlength,
     bool ascending,
-    bool stable,
-    bool keepdims) const {
+    bool stable) const {
 
     if (length() == 0 ) {
       return shallow_copy();
@@ -1815,7 +1812,7 @@ namespace awkward {
 
       ContentPtr outcontent = nextcontent.get()->sort_next(
         negaxis - 1, nextstarts, nextparents, nextcontent.get()->length(),
-        ascending, stable, false);
+        ascending, stable);
 
       Index64 outcarry(nextlen);
       struct Error err5 = kernel::ListOffsetArray_local_preparenext_64(
@@ -1857,7 +1854,7 @@ namespace awkward {
 
       ContentPtr outcontent = trimmed.get()->sort_next(
         negaxis, util::make_starts(offsets_), nextparents,
-        offsets_.length() - 1, ascending, stable, false);
+        offsets_.length() - 1, ascending, stable);
 
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            parameters_,

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1824,12 +1824,7 @@ namespace awkward {
 
       outcontent = outcontent.get()->carry(outcarry, false);
 
-      Index64 outoffsets(offsets_.length());
-      // FIXME: move to kernel
-      for (int64_t i = 0; i < offsets_.length(); i++) {
-        outoffsets.data()[i] = offsets_.data()[i] - offsets_.data()[0];
-      }
-
+      Index64 outoffsets = compact_offsets64(true);
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            parameters_,
                                                            outoffsets,
@@ -1862,12 +1857,7 @@ namespace awkward {
         negaxis, util::make_starts(offsets_), nextparents,
         offsets_.length() - 1, ascending, stable);
 
-      Index64 outoffsets(offsets_.length());
-      // FIXME: move to kernel
-      for (int64_t i = 0; i < offsets_.length(); i++) {
-        outoffsets.data()[i] = offsets_.data()[i] - offsets_.data()[0];
-      }
-
+      Index64 outoffsets = compact_offsets64(true);
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            parameters_,
                                                            outoffsets,
@@ -2041,12 +2031,7 @@ namespace awkward {
 
       outcontent = outcontent.get()->carry(outcarry, false);
 
-      Index64 outoffsets(offsets_.length());
-      // FIXME: move to kernel
-      for (int64_t i = 0; i < offsets_.length(); i++) {
-        outoffsets.data()[i] = offsets_.data()[i] - offsets_.data()[0];
-      }
-
+      Index64 outoffsets = compact_offsets64(true);;
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            util::Parameters(),
                                                            outoffsets,
@@ -2083,12 +2068,7 @@ namespace awkward {
         ascending,
         stable);
 
-      Index64 outoffsets(offsets_.length());
-      // FIXME: move to kernel
-      for (int64_t i = 0; i < offsets_.length(); i++) {
-        outoffsets.data()[i] = offsets_.data()[i] - offsets_.data()[0];
-      }
-
+      Index64 outoffsets = compact_offsets64(true);
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            util::Parameters(),
                                                            outoffsets,

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1824,9 +1824,15 @@ namespace awkward {
 
       outcontent = outcontent.get()->carry(outcarry, false);
 
+      Index64 outoffsets(offsets_.length());
+      // FIXME: move to kernel
+      for (int64_t i = 0; i < offsets_.length(); i++) {
+        outoffsets.data()[i] = offsets_.data()[i] - offsets_.data()[0];
+      }
+
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            parameters_,
-                                                           offsets_,
+                                                           outoffsets,
                                                            outcontent);
       return out;
     }
@@ -1856,9 +1862,15 @@ namespace awkward {
         negaxis, util::make_starts(offsets_), nextparents,
         offsets_.length() - 1, ascending, stable);
 
+      Index64 outoffsets(offsets_.length());
+      // FIXME: move to kernel
+      for (int64_t i = 0; i < offsets_.length(); i++) {
+        outoffsets.data()[i] = offsets_.data()[i] - offsets_.data()[0];
+      }
+
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            parameters_,
-                                                           offsets_,
+                                                           outoffsets,
                                                            outcontent);
       return out;
     }
@@ -1991,26 +2003,22 @@ namespace awkward {
         nextlen);
       util::handle_error(err4, classname(), identities_.get());
 
-      bool make_shifts = true;
-
       Index64 nextshifts(nextlen);
-      if (make_shifts) {
-        Index64 nummissing(maxcount);
-        Index64 missing(offsets_.getitem_at(offsets_.length() - 1));
-        struct Error err7 = kernel::ListOffsetArray_reduce_nonlocal_nextshifts_64(
-          kernel::lib::cpu,   // DERIVE
-          nummissing.data(),
-          missing.data(),
-          nextshifts.data(),
-          offsets_.data(),
-          offsets_.length() - 1,
-          starts.data(),
-          parents.data(),
-          maxcount,
-          nextlen,
-          nextcarry.data());
-        util::handle_error(err7, classname(), identities_.get());
-      }
+      Index64 nummissing(maxcount);
+      Index64 missing(offsets_.getitem_at(offsets_.length() - 1));
+      struct Error err7 = kernel::ListOffsetArray_reduce_nonlocal_nextshifts_64(
+        kernel::lib::cpu,   // DERIVE
+        nummissing.data(),
+        missing.data(),
+        nextshifts.data(),
+        offsets_.data(),
+        offsets_.length() - 1,
+        starts.data(),
+        parents.data(),
+        maxcount,
+        nextlen,
+        nextcarry.data());
+      util::handle_error(err7, classname(), identities_.get());
 
       ContentPtr nextcontent = content_.get()->carry(nextcarry, false);
 
@@ -2033,9 +2041,15 @@ namespace awkward {
 
       outcontent = outcontent.get()->carry(outcarry, false);
 
+      Index64 outoffsets(offsets_.length());
+      // FIXME: move to kernel
+      for (int64_t i = 0; i < offsets_.length(); i++) {
+        outoffsets.data()[i] = offsets_.data()[i] - offsets_.data()[0];
+      }
+
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            util::Parameters(),
-                                                           offsets_,
+                                                           outoffsets,
                                                            outcontent);
       return out;
     }
@@ -2069,9 +2083,15 @@ namespace awkward {
         ascending,
         stable);
 
+      Index64 outoffsets(offsets_.length());
+      // FIXME: move to kernel
+      for (int64_t i = 0; i < offsets_.length(); i++) {
+        outoffsets.data()[i] = offsets_.data()[i] - offsets_.data()[0];
+      }
+
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            util::Parameters(),
-                                                           offsets_,
+                                                           outoffsets,
                                                            outcontent);
       return out;
     }

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1871,15 +1871,13 @@ namespace awkward {
                                      const Index64& parents,
                                      int64_t outlength,
                                      bool ascending,
-                                     bool stable,
-                                     bool keepdims) const {
+                                     bool stable) const {
     return toListOffsetArray64(true).get()->argsort_next(negaxis,
                                                          starts,
                                                          parents,
                                                          outlength,
                                                          ascending,
-                                                         stable,
-                                                         keepdims);
+                                                         stable);
   }
 
   template <>
@@ -1889,8 +1887,7 @@ namespace awkward {
                                            const Index64& parents,
                                            int64_t outlength,
                                            bool ascending,
-                                           bool stable,
-                                           bool keepdims) const {
+                                           bool stable) const {
     if (length() == 0 ) {
      return shallow_copy();
     }
@@ -1927,15 +1924,7 @@ namespace awkward {
 
       ContentPtr out = std::make_shared<NumpyArray>(output);
 
-      if (keepdims) {
-        return std::make_shared<RegularArray>(Identities::none(),
-                                              util::Parameters(),
-                                              out,
-                                              out.get()->length());
-      }
-      else {
-        return out;
-      }
+      return out;
     }
 
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -2003,7 +1992,7 @@ namespace awkward {
 
       ContentPtr outcontent = nextcontent.get()->argsort_next(
         negaxis - 1, nextstarts, nextparents, maxnextparents + 1,
-        ascending, stable, false);
+        ascending, stable);
 
       Index64 outcarry(nextlen);
       struct Error err5 = kernel::ListOffsetArray_local_preparenext_64(
@@ -2019,13 +2008,6 @@ namespace awkward {
                                                            util::Parameters(),
                                                            offsets_,
                                                            outcontent);
-      if (keepdims) {
-        out = std::make_shared<RegularArray>(Identities::none(),
-                                             util::Parameters(),
-                                             out,
-                                             out.get()->length(),
-                                             length());
-      }
       return out;
     }
     else {
@@ -2052,19 +2034,12 @@ namespace awkward {
 
       ContentPtr outcontent = trimmed.get()->argsort_next(
         negaxis, util::make_starts(offsets_), nextparents,
-        offsets_.length() - 1, ascending, stable, false);
+        offsets_.length() - 1, ascending, stable);
 
       ContentPtr out = std::make_shared<ListOffsetArray64>(Identities::none(),
                                                            util::Parameters(),
                                                            offsets_,
                                                            outcontent);
-      if (keepdims) {
-        out = std::make_shared<RegularArray>(Identities::none(),
-                                             util::Parameters(),
-                                             out,
-                                             out.get()->length(),
-                                             length());
-      }
       return out;
     }
   }

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -1748,15 +1748,7 @@ namespace awkward {
 
       ContentPtr out = carry(tocarry, false);
 
-      if (keepdims) {
-        return std::make_shared<RegularArray>(Identities::none(),
-                                              util::Parameters(),
-                                              out,
-                                              out.get()->length());
-      }
-      else {
-        return out;
-      }
+      return out;
     }
 
     if (!branchdepth.first  &&  negaxis == branchdepth.second) {
@@ -1839,13 +1831,6 @@ namespace awkward {
                                                            parameters_,
                                                            offsets_,
                                                            outcontent);
-      if (keepdims) {
-        out = std::make_shared<RegularArray>(Identities::none(),
-                                             util::Parameters(),
-                                             out,
-                                             out.get()->length(),
-                                             length());
-      }
       return out;
     }
     else {
@@ -1878,13 +1863,6 @@ namespace awkward {
                                                            parameters_,
                                                            offsets_,
                                                            outcontent);
-      if (keepdims) {
-        out = std::make_shared<RegularArray>(Identities::none(),
-                                             util::Parameters(),
-                                             out,
-                                             out.get()->length(),
-                                             length());
-      }
       return out;
     }
   }

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -354,8 +354,7 @@ namespace awkward {
                   const Index64& parents,
                   int64_t outlength,
                   bool ascending,
-                  bool stable,
-                  bool keepdims) const {
+                  bool stable) const {
     throw std::runtime_error(
       std::string("undefined operation: None::sort_next")
       + FILENAME(__LINE__));

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -363,6 +363,7 @@ namespace awkward {
   const ContentPtr
   None::argsort_next(int64_t negaxis,
                      const Index64& starts,
+                     const Index64& shifts,
                      const Index64& parents,
                      int64_t outlength,
                      bool ascending,

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -366,8 +366,7 @@ namespace awkward {
                      const Index64& parents,
                      int64_t outlength,
                      bool ascending,
-                     bool stable,
-                     bool keepdims) const {
+                     bool stable) const {
     throw std::runtime_error(
       std::string("undefined operation: None::argsort_next")
       + FILENAME(__LINE__));

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -3574,6 +3574,7 @@ namespace awkward {
   const ContentPtr
   NumpyArray::argsort_next(int64_t negaxis,
                            const Index64& starts,
+                           const Index64& shifts,
                            const Index64& parents,
                            int64_t outlength,
                            bool ascending,
@@ -3585,6 +3586,7 @@ namespace awkward {
     else if (shape_.size() != 1  ||  !iscontiguous()) {
       return toRegularArray().get()->argsort_next(negaxis,
                                                   starts,
+                                                  shifts,
                                                   parents,
                                                   outlength,
                                                   ascending,
@@ -3599,6 +3601,7 @@ namespace awkward {
         ptr = index_sort<bool>(reinterpret_cast<bool*>(data()),
                                length(),
                                starts,
+                               shifts,
                                parents,
                                outlength,
                                ascending,
@@ -3608,6 +3611,7 @@ namespace awkward {
         ptr = index_sort<int8_t>(reinterpret_cast<int8_t*>(data()),
                                  length(),
                                  starts,
+                                 shifts,
                                  parents,
                                  outlength,
                                  ascending,
@@ -3617,6 +3621,7 @@ namespace awkward {
         ptr = index_sort<int16_t>(reinterpret_cast<int16_t*>(data()),
                                   length(),
                                   starts,
+                                  shifts,
                                   parents,
                                   outlength,
                                   ascending,
@@ -3626,6 +3631,7 @@ namespace awkward {
         ptr = index_sort<int32_t>(reinterpret_cast<int32_t*>(data()),
                                   length(),
                                   starts,
+                                  shifts,
                                   parents,
                                   outlength,
                                   ascending,
@@ -3635,6 +3641,7 @@ namespace awkward {
         ptr = index_sort<int64_t>(reinterpret_cast<int64_t*>(data()),
                                   length(),
                                   starts,
+                                  shifts,
                                   parents,
                                   outlength,
                                   ascending,
@@ -3644,6 +3651,7 @@ namespace awkward {
         ptr = index_sort<uint8_t>(reinterpret_cast<uint8_t*>(data()),
                                   length(),
                                   starts,
+                                  shifts,
                                   parents,
                                   outlength,
                                   ascending,
@@ -3653,6 +3661,7 @@ namespace awkward {
         ptr = index_sort<uint16_t>(reinterpret_cast<uint16_t*>(data()),
                                    length(),
                                    starts,
+                                   shifts,
                                    parents,
                                    outlength,
                                    ascending,
@@ -3662,6 +3671,7 @@ namespace awkward {
         ptr = index_sort<uint32_t>(reinterpret_cast<uint32_t*>(data()),
                                    length(),
                                    starts,
+                                   shifts,
                                    parents,
                                    outlength,
                                    ascending,
@@ -3671,6 +3681,7 @@ namespace awkward {
         ptr = index_sort<uint64_t>(reinterpret_cast<uint64_t*>(data()),
                                    length(),
                                    starts,
+                                   shifts,
                                    parents,
                                    outlength,
                                    ascending,
@@ -3684,6 +3695,7 @@ namespace awkward {
         ptr = index_sort<float>(reinterpret_cast<float*>(data()),
                                 length(),
                                 starts,
+                                shifts,
                                 parents,
                                 outlength,
                                 ascending,
@@ -3693,6 +3705,7 @@ namespace awkward {
         ptr = index_sort<double>(reinterpret_cast<double*>(data()),
                                  length(),
                                  starts,
+                                 shifts,
                                  parents,
                                  outlength,
                                  ascending,
@@ -5379,6 +5392,7 @@ namespace awkward {
   NumpyArray::index_sort(const T* data,
                          int64_t length,
                          const Index64& starts,
+                         const Index64& shifts,
                          const Index64& parents,
                          int64_t outlength,
                          bool ascending,
@@ -5407,38 +5421,32 @@ namespace awkward {
       parents.length());
     util::handle_error(err2, classname(), nullptr);
 
-    if (stable) {
-      struct Error err3 = kernel::NumpyArray_argsort<T>(
-        kernel::lib::cpu,   // DERIVE
-        ptr.get(),
-        data,
-        length,
-        offsets.data(),
-        offsets_length,
-        ascending,
-        stable);
-      util::handle_error(err3, classname(), nullptr);
-    }
-    else {
-      std::shared_ptr<int64_t> tmp_beg_ptr = kernel::malloc<int64_t>(kernel::lib::cpu,   // DERIVE
-                                                                     kMaxLevels*((int64_t)sizeof(int64_t)));
-      std::shared_ptr<int64_t> tmp_end_ptr = kernel::malloc<int64_t>(kernel::lib::cpu,   // DERIVE
-                                                                     kMaxLevels*((int64_t)sizeof(int64_t)));
+    struct Error err3 = kernel::NumpyArray_argsort<T>(
+      kernel::lib::cpu,   // DERIVE
+      ptr.get(),
+      data,
+      length,
+      offsets.data(),
+      offsets_length,
+      ascending,
+      stable);
+    util::handle_error(err3, classname(), nullptr);
 
-      struct Error err3 = kernel::NumpyArray_quick_argsort<T>(
-        kernel::lib::cpu,   // DERIVE
-        ptr.get(),
-        data,
-        length,
-        tmp_beg_ptr.get(),
-        tmp_end_ptr.get(),
-        offsets.data(),
-        offsets_length,
-        ascending,
-        stable,
-        kMaxLevels);
-      util::handle_error(err3, classname(), nullptr);
+    if (shifts.length() > 0) {
+        struct Error err4 = kernel::NumpyArray_rearrange_shifted(
+          kernel::lib::cpu,   // DERIVE
+          ptr.get(),
+          shifts.data(),
+          shifts.length(),
+          offsets.data(),
+          offsets_length,
+          parents.data(),
+          parents.length(),
+          starts.data(),
+          starts.length());
+         util::handle_error(err4, classname(), nullptr);
     }
+
     return ptr;
   }
 

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -5404,6 +5404,12 @@ namespace awkward {
       return ptr;
     }
 
+    // int64_t num_nullls = 0;
+    // for(int64_t i = 0; i < shifts.length(); i++) {
+    //   shifts.data()[i] > num_nullls ? num_nullls = shifts.data()[i] : num_nullls;
+    // }
+    // std::cout << "Num nulls " << num_nullls << "\n";
+
     int64_t offsets_length = 0;
     struct Error err1 = kernel::sorting_ranges_length(
       kernel::lib::cpu,   // DERIVE

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -3577,8 +3577,7 @@ namespace awkward {
                            const Index64& parents,
                            int64_t outlength,
                            bool ascending,
-                           bool stable,
-                           bool keepdims) const {
+                           bool stable) const {
     if (shape_.empty()) {
       throw std::runtime_error(
         std::string("attempting to argsort a scalar") + FILENAME(__LINE__));
@@ -3589,8 +3588,7 @@ namespace awkward {
                                                   parents,
                                                   outlength,
                                                   ascending,
-                                                  stable,
-                                                  keepdims);
+                                                  stable);
     }
     else {
       std::shared_ptr<Content> out;
@@ -3741,14 +3739,6 @@ namespace awkward {
                                          dtype,
                                          ptr_lib_);
 
-      if (keepdims) {
-        out = std::make_shared<RegularArray>(
-          Identities::none(),
-          util::Parameters(),
-          out,
-          parents.length() / starts.length(),
-          length());
-      }
       return out;
     }
   }

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -3569,15 +3569,6 @@ namespace awkward {
                                          dtype_,
                                          ptr_lib_);
 
-      if (keepdims) {
-        out = std::make_shared<RegularArray>(
-          Identities::none(),
-          util::Parameters(),
-          out,
-          parents.length() / starts.length(),
-          length());
-      }
-
       return out;
     }
   }

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -3410,8 +3410,7 @@ namespace awkward {
                         const Index64& parents,
                         int64_t outlength,
                         bool ascending,
-                        bool stable,
-                        bool keepdims) const {
+                        bool stable) const {
     if (length() == 0 ) {
       return shallow_copy();
     }
@@ -3426,8 +3425,7 @@ namespace awkward {
                                                parents,
                                                outlength,
                                                ascending,
-                                               stable,
-                                               keepdims);
+                                               stable);
     }
     else {
       std::shared_ptr<Content> out;

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -512,16 +512,14 @@ namespace awkward {
                     const Index64& parents,
                     int64_t outlength,
                     bool ascending,
-                    bool stable,
-                    bool keepdims) const {
+                    bool stable) const {
     ContentPtr next = array_.get()->getitem_at_nowrap(at_);
     return next.get()->sort_next(negaxis,
                                  starts,
                                  parents,
                                  outlength,
                                  ascending,
-                                 stable,
-                                 keepdims);
+                                 stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -525,6 +525,7 @@ namespace awkward {
   const ContentPtr
   Record::argsort_next(int64_t negaxis,
                        const Index64& starts,
+                       const Index64& shifts,
                        const Index64& parents,
                        int64_t outlength,
                        bool ascending,
@@ -532,6 +533,7 @@ namespace awkward {
     ContentPtr next = array_.get()->getitem_at_nowrap(at_);
     return next.get()->argsort_next(negaxis,
                                     starts,
+                                    shifts,
                                     parents,
                                     outlength,
                                     ascending,

--- a/src/libawkward/array/Record.cpp
+++ b/src/libawkward/array/Record.cpp
@@ -528,16 +528,14 @@ namespace awkward {
                        const Index64& parents,
                        int64_t outlength,
                        bool ascending,
-                       bool stable,
-                       bool keepdims) const {
+                       bool stable) const {
     ContentPtr next = array_.get()->getitem_at_nowrap(at_);
     return next.get()->argsort_next(negaxis,
                                     starts,
                                     parents,
                                     outlength,
                                     ascending,
-                                    stable,
-                                    keepdims);
+                                    stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -1641,8 +1641,7 @@ namespace awkward {
                             const Index64& parents,
                             int64_t outlength,
                             bool ascending,
-                            bool stable,
-                            bool keepdims) const {
+                            bool stable) const {
     if (length() == 0) {
       return std::make_shared<NumpyArray>(Index64(0));
     }
@@ -1654,8 +1653,13 @@ namespace awkward {
                                                     parents,
                                                     outlength,
                                                     ascending,
-                                                    stable,
-                                                    keepdims);
+                                                    stable);
+      next = std::make_shared<RegularArray>(
+        Identities::none(),
+        util::Parameters(),
+        next,
+        next.get()->length(),
+        next.get()->length());
       contents.push_back(next);
     }
     return std::make_shared<RecordArray>(
@@ -1663,7 +1667,7 @@ namespace awkward {
       util::Parameters(),
       contents,
       recordlookup_,
-      outlength);
+      outlength).get()->getitem_at_nowrap(0);
   }
 
   const ContentPtr

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -1638,6 +1638,7 @@ namespace awkward {
   const ContentPtr
   RecordArray::argsort_next(int64_t negaxis,
                             const Index64& starts,
+                            const Index64& shifts,
                             const Index64& parents,
                             int64_t outlength,
                             bool ascending,
@@ -1650,6 +1651,7 @@ namespace awkward {
       ContentPtr trimmed = content.get()->getitem_range_nowrap(0, length());
       ContentPtr next = trimmed.get()->argsort_next(negaxis,
                                                     starts,
+                                                    shifts,
                                                     parents,
                                                     outlength,
                                                     ascending,

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -19,6 +19,7 @@
 #include "awkward/array/BitMaskedArray.h"
 #include "awkward/array/UnmaskedArray.h"
 #include "awkward/array/NumpyArray.h"
+#include "awkward/array/RegularArray.h"
 #include "awkward/array/VirtualArray.h"
 
 #include "awkward/array/RecordArray.h"
@@ -1620,13 +1621,20 @@ namespace awkward {
                                                  ascending,
                                                  stable,
                                                  keepdims);
+      next = std::make_shared<RegularArray>(
+        Identities::none(),
+        util::Parameters(),
+        next,
+        next.get()->length(),
+        next.get()->length());
+
       contents.push_back(next);
     }
     return std::make_shared<RecordArray>(Identities::none(),
                                          parameters_,
                                          contents,
                                          recordlookup_,
-                                         outlength);
+                                         outlength).get()->getitem_at_nowrap(0);
   }
 
   const ContentPtr

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -1606,8 +1606,7 @@ namespace awkward {
                          const Index64& parents,
                          int64_t outlength,
                          bool ascending,
-                         bool stable,
-                         bool keepdims) const {
+                         bool stable) const {
     if (length() == 0) {
       return shallow_copy();
     }
@@ -1619,8 +1618,7 @@ namespace awkward {
                                                  parents,
                                                  outlength,
                                                  ascending,
-                                                 stable,
-                                                 keepdims);
+                                                 stable);
       next = std::make_shared<RegularArray>(
         Identities::none(),
         util::Parameters(),

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -1307,6 +1307,7 @@ namespace awkward {
   const ContentPtr
   RegularArray::argsort_next(int64_t negaxis,
                              const Index64& starts,
+                             const Index64& shifts,
                              const Index64& parents,
                              int64_t outlength,
                              bool ascending,
@@ -1317,6 +1318,7 @@ namespace awkward {
     std::shared_ptr<Content> out = toListOffsetArray64(true).get()->argsort_next(
                                        negaxis,
                                        starts,
+                                       shifts,
                                        parents,
                                        outlength,
                                        ascending,

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -1310,8 +1310,7 @@ namespace awkward {
                              const Index64& parents,
                              int64_t outlength,
                              bool ascending,
-                             bool stable,
-                             bool keepdims) const {
+                             bool stable) const {
     if (length() == 0) {
       return std::make_shared<NumpyArray>(Index64(0));
     }
@@ -1321,8 +1320,7 @@ namespace awkward {
                                        parents,
                                        outlength,
                                        ascending,
-                                       stable,
-                                       keepdims);
+                                       stable);
     if (RegularArray* raw1 =
             dynamic_cast<RegularArray*>(out.get())) {
       if (ListOffsetArray64* raw2 =

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -1278,8 +1278,7 @@ namespace awkward {
                           const Index64& parents,
                           int64_t outlength,
                           bool ascending,
-                          bool stable,
-                          bool keepdims) const {
+                          bool stable) const {
     if (length() == 0) {
       return shallow_copy();
     }
@@ -1289,8 +1288,7 @@ namespace awkward {
                                        parents,
                                        outlength,
                                        ascending,
-                                       stable,
-                                       keepdims);
+                                       stable);
     if (RegularArray* raw1 =
             dynamic_cast<RegularArray*>(out.get())) {
       if (ListOffsetArray64* raw2 =

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -2097,8 +2097,7 @@ namespace awkward {
                                 const Index64& parents,
                                 int64_t outlength,
                                 bool ascending,
-                                bool stable,
-                                bool keepdims) const {
+                                bool stable) const {
     if (length() == 0) {
       return shallow_copy();
     }
@@ -2114,8 +2113,7 @@ namespace awkward {
                                        parents,
                                        outlength,
                                        ascending,
-                                       stable,
-                                       keepdims);
+                                       stable);
   }
 
   template <typename T, typename I>

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -2120,6 +2120,7 @@ namespace awkward {
   const ContentPtr
   UnionArrayOf<T, I>::argsort_next(int64_t negaxis,
                                    const Index64& starts,
+                                   const Index64& shifts,
                                    const Index64& parents,
                                    int64_t outlength,
                                    bool ascending,
@@ -2136,6 +2137,7 @@ namespace awkward {
     }
     return simplified.get()->argsort_next(negaxis,
                                           starts,
+                                          shifts,
                                           parents,
                                           outlength,
                                           ascending,

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -2123,8 +2123,7 @@ namespace awkward {
                                    const Index64& parents,
                                    int64_t outlength,
                                    bool ascending,
-                                   bool stable,
-                                   bool keepdims) const {
+                                   bool stable) const {
     if (length() == 0) {
       return std::make_shared<NumpyArray>(Index64(0));
     }
@@ -2140,8 +2139,7 @@ namespace awkward {
                                           parents,
                                           outlength,
                                           ascending,
-                                          stable,
-                                          keepdims);
+                                          stable);
   }
 
   template <typename T, typename I>

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -968,8 +968,7 @@ namespace awkward {
                            const Index64& parents,
                            int64_t outlength,
                            bool ascending,
-                           bool stable,
-                           bool keepdims) const {
+                           bool stable) const {
     if (length() == 0) {
       return shallow_copy();
     }
@@ -978,8 +977,7 @@ namespace awkward {
                                                              parents,
                                                              outlength,
                                                              ascending,
-                                                             stable,
-                                                             keepdims);
+                                                             stable);
     if (RegularArray* raw = dynamic_cast<RegularArray*>(out.get())) {
       UnmaskedArray tmp(Identities::none(),
                         parameters_,

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -1000,8 +1000,7 @@ namespace awkward {
                               const Index64& parents,
                               int64_t outlength,
                               bool ascending,
-                              bool stable,
-                              bool keepdims) const {
+                              bool stable) const {
     if (length() == 0) {
       return std::make_shared<NumpyArray>(Index64(0));
     }
@@ -1010,8 +1009,7 @@ namespace awkward {
                                                                 parents,
                                                                 outlength,
                                                                 ascending,
-                                                                stable,
-                                                                keepdims);
+                                                                stable);
     if (RegularArray* raw = dynamic_cast<RegularArray*>(out.get())) {
       UnmaskedArray tmp(Identities::none(),
                         parameters_,

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -997,6 +997,7 @@ namespace awkward {
   const ContentPtr
   UnmaskedArray::argsort_next(int64_t negaxis,
                               const Index64& starts,
+                              const Index64& shifts,
                               const Index64& parents,
                               int64_t outlength,
                               bool ascending,
@@ -1006,6 +1007,7 @@ namespace awkward {
     }
     std::shared_ptr<Content> out = content_.get()->argsort_next(negaxis,
                                                                 starts,
+                                                                shifts,
                                                                 parents,
                                                                 outlength,
                                                                 ascending,

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -900,15 +900,13 @@ namespace awkward {
                              const Index64& parents,
                              int64_t outlength,
                              bool ascending,
-                             bool stable,
-                             bool keepdims) const {
+                             bool stable) const {
     return array().get()->argsort_next(negaxis,
                                        starts,
                                        parents,
                                        outlength,
                                        ascending,
-                                       stable,
-                                       keepdims);
+                                       stable);
   }
 
   const ContentPtr

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -897,12 +897,14 @@ namespace awkward {
   const ContentPtr
   VirtualArray::argsort_next(int64_t negaxis,
                              const Index64& starts,
+                             const Index64& shifts,
                              const Index64& parents,
                              int64_t outlength,
                              bool ascending,
                              bool stable) const {
     return array().get()->argsort_next(negaxis,
                                        starts,
+                                       shifts,
                                        parents,
                                        outlength,
                                        ascending,

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -885,15 +885,13 @@ namespace awkward {
                           const Index64& parents,
                           int64_t outlength,
                           bool ascending,
-                          bool stable,
-                          bool keepdims) const {
+                          bool stable) const {
     return array().get()->sort_next(negaxis,
                                     starts,
                                     parents,
                                     outlength,
                                     ascending,
-                                    stable,
-                                    keepdims);
+                                    stable);
   }
 
   const ContentPtr

--- a/src/libawkward/kernel-dispatch.cpp
+++ b/src/libawkward/kernel-dispatch.cpp
@@ -11167,6 +11167,42 @@ namespace awkward {
       }
     }
 
+    template <>
+    ERROR NumpyArray_rearrange_shifted<int64_t, int64_t>(
+      kernel::lib ptr_lib,
+      int64_t* toptr,
+      const int64_t* fromshifts,
+      int64_t length,
+      const int64_t* fromoffsets,
+      int64_t offsetslength,
+      const int64_t* fromparents,
+      int64_t parentslength,
+      const int64_t* fromstarts,
+      int64_t startslength) {
+      if (ptr_lib == kernel::lib::cpu) {
+        return awkward_NumpyArray_rearrange_shifted_toint64_fromint64(
+          reinterpret_cast<int64_t*>(toptr),
+          reinterpret_cast<const int64_t*>(fromshifts),
+          length,
+          reinterpret_cast<const int64_t*>(fromoffsets),
+          offsetslength,
+          reinterpret_cast<const int64_t*>(fromparents),
+          parentslength,
+          reinterpret_cast<const int64_t*>(fromstarts),
+          startslength);
+      }
+      else if (ptr_lib == kernel::lib::cuda) {
+        throw std::runtime_error(
+          std::string("not implemented: ptr_lib == cuda_kernels for NumpyArray_rearrange_shifted<int64_t, int64_t>")
+          + FILENAME(__LINE__));
+      }
+      else {
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib for NumpyArray_rearrange_shifted<int64_t, int64_t>")
+          + FILENAME(__LINE__));
+      }
+    }
+
     template<>
     ERROR ListArray_fill(
       kernel::lib ptr_lib,

--- a/src/libawkward/kernel-dispatch.cpp
+++ b/src/libawkward/kernel-dispatch.cpp
@@ -12535,6 +12535,27 @@ namespace awkward {
       }
     }
 
+    ERROR Index_nones_as_index_64(
+      kernel::lib ptr_lib,
+      int64_t *toindex,
+      int64_t length) {
+      if (ptr_lib == kernel::lib::cpu) {
+        return awkward_Index_nones_as_index_64(
+          toindex,
+          length);
+      }
+      else if (ptr_lib == kernel::lib::cuda) {
+        throw std::runtime_error(
+          std::string("not implemented: ptr_lib == cuda_kernels for Index_nones_as_index_64")
+          + FILENAME(__LINE__));
+      }
+      else {
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib for Index_nones_as_index_64")
+          + FILENAME(__LINE__));
+      }
+    }
+
     ERROR RegularArray_rpad_and_clip_axis1_64(
       kernel::lib ptr_lib,
       int64_t *toindex,

--- a/src/libawkward/kernel-dispatch.cpp
+++ b/src/libawkward/kernel-dispatch.cpp
@@ -2517,6 +2517,90 @@ namespace awkward {
     }
 
     template<>
+    ERROR IndexedArray_index_of_nulls<int32_t>(
+      kernel::lib ptr_lib,
+      int64_t *toindex,
+      const int32_t *fromindex,
+      int64_t lenindex,
+      const int64_t* parents,
+      const int64_t* starts) {
+      if (ptr_lib == kernel::lib::cpu) {
+        return awkward_IndexedArray32_index_of_nulls(
+          toindex,
+          fromindex,
+          lenindex,
+          parents,
+          starts);
+      }
+      else if (ptr_lib == kernel::lib::cuda) {
+        throw std::runtime_error(
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_index_of_nulls<int32_t>")
+          + FILENAME(__LINE__));
+      }
+      else {
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib for IndexedArray_index_of_nulls<int32_t>")
+          + FILENAME(__LINE__));
+      }
+    }
+
+    template<>
+    ERROR IndexedArray_index_of_nulls<uint32_t>(
+      kernel::lib ptr_lib,
+      int64_t *toindex,
+      const uint32_t *fromindex,
+      int64_t lenindex,
+      const int64_t* parents,
+      const int64_t* starts) {
+      if (ptr_lib == kernel::lib::cpu) {
+        return awkward_IndexedArrayU32_index_of_nulls(
+          toindex,
+          fromindex,
+          lenindex,
+          parents,
+          starts);
+      }
+      else if (ptr_lib == kernel::lib::cuda) {
+        throw std::runtime_error(
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_index_of_nulls<uint32_t>")
+          + FILENAME(__LINE__));
+      }
+      else {
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib for IndexedArray_index_of_nulls<uint32_t>")
+          + FILENAME(__LINE__));
+      }
+    }
+
+    template<>
+    ERROR IndexedArray_index_of_nulls<int64_t>(
+      kernel::lib ptr_lib,
+      int64_t *toindex,
+      const int64_t *fromindex,
+      int64_t lenindex,
+      const int64_t* parents,
+      const int64_t* starts) {
+      if (ptr_lib == kernel::lib::cpu) {
+        return awkward_IndexedArray64_index_of_nulls(
+          toindex,
+          fromindex,
+          lenindex,
+          parents,
+          starts);
+      }
+      else if (ptr_lib == kernel::lib::cuda) {
+        throw std::runtime_error(
+          std::string("not implemented: ptr_lib == cuda_kernels for IndexedArray_index_of_nulls<int64_t>")
+          + FILENAME(__LINE__));
+      }
+      else {
+        throw std::runtime_error(
+          std::string("unrecognized ptr_lib for IndexedArray_index_of_nulls<int64_t>")
+          + FILENAME(__LINE__));
+      }
+    }
+
+    template<>
     ERROR IndexedArray_getitem_nextcarry_outindex_64<int32_t>(
       kernel::lib ptr_lib,
       int64_t *tocarry,

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -127,6 +127,7 @@ def test_IndexedOffsetArray():
 
     array2 = ak.Array([None, None, 1, -1, 30]).layout
     assert ak.to_list(array2.sort(0, True, False)) == [-1, 1, 30, None, None]
+    assert ak.to_list(array2.argsort(0, True, False)) == [1, 0, 2, None, None]
 
     array3 = ak.Array(
         [[2.2, 1.1, 3.3], [], [4.4, 5.5], [5.5], [-4.4, -5.5, -6.6]]
@@ -401,7 +402,13 @@ def test_ByteMaskedArray():
     )
     mask = ak.layout.Index8(np.array([0, 0, 1, 1, 0], dtype=np.int8))
     array = ak.layout.ByteMaskedArray(mask, content, valid_when=False)
-    assert ak.to_list(array.argsort(0, True, False)) == [[0, 0, 0], [], [1, 1, 1, 0]]
+    assert ak.to_list(array.argsort(0, True, False)) == [
+        [0, 0, 0],
+        [],
+        [1, 1, 1, 0],
+        None,
+        None,
+    ]
 
     assert ak.to_list(array.sort(0, True, False)) == [
         [0.0, 1.1, 2.2],

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -125,6 +125,9 @@ def test_IndexedOffsetArray():
         [0, 1, 2],
     ]
 
+    array2 = ak.Array([None, None, 1, -1, 30]).layout
+    assert ak.to_list(array2.sort(0, True, False)) == [-1, 1, 30, None, None]
+
     array3 = ak.Array(
         [[2.2, 1.1, 3.3], [], [4.4, 5.5], [5.5], [-4.4, -5.5, -6.6]]
     ).layout
@@ -404,12 +407,16 @@ def test_ByteMaskedArray():
         [0.0, 1.1, 2.2],
         [],
         [6.6, 7.7, 8.8, 9.9],
+        None,
+        None,
     ]
 
     assert ak.to_list(array.sort(0, False, False)) == [
         [6.6, 7.7, 8.8],
         [],
         [0.0, 1.1, 2.2, 9.9],
+        None,
+        None,
     ]
 
     assert ak.to_list(array.argsort(1, True, False)) == [

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -152,64 +152,56 @@ def test_IndexedOptionArray():
 
     assert ak.to_list(ak.argsort(array, axis=0, ascending=True, stable=True)) == [
         [4, 4, 4, 0, 0],
-        [2, None, 0],
-        [3, None, 2],
-        [None, None, None],
-        [None, None, None],
+        [2, 0, 0],
+        [3, 1, 2],
+        [0, 2, 1],
+        [1, 3, 3],
     ]
 
     assert ak.to_list(ak.argsort(array, axis=0, ascending=True, stable=False)) == [
         [4, 4, 4, 0, 0],
-        [2, None, 0],
-        [3, None, 2],
-        [None, None, None],
-        [None, None, None],
+        [2, 0, 0],
+        [3, 1, 2],
+        [0, 2, 1],
+        [1, 3, 3],
     ]
 
     assert ak.to_list(ak.argsort(array, axis=0, ascending=False, stable=True)) == [
         [3, 4, 2, 0, 0],
-        [2, None, 0],
-        [4, None, 4],
-        [None, None, None],
-        [None, None, None],
+        [2, 0, 0],
+        [4, 1, 4],
+        [0, 2, 1],
+        [1, 3, 3],
     ]
     assert ak.to_list(ak.argsort(array, axis=0, ascending=False, stable=False)) == [
         [3, 4, 2, 0, 0],
-        [2, None, 0],
-        [4, None, 4],
-        [None, None, None],
-        [None, None, None],
+        [2, 0, 0],
+        [4, 1, 4],
+        [0, 2, 1],
+        [1, 3, 3],
     ]
 
     assert ak.to_list(ak.argsort(array, axis=1, ascending=True, stable=True)) == [
-        [3, 2, 4, None, None],
-        [None, None, None],
-        [0, 2, None],
-        [0, None, None],
+        [3, 2, 4, 0, 1],
+        [0, 1, 2],
+        [0, 2, 1],
+        [0, 1, 2],
         [2, 1, 0],
     ]
 
     assert ak.to_list(ak.argsort(array, axis=1, ascending=True, stable=False)) == [
-        [3, 2, 4, None, None],
-        [None, None, None],
-        [0, 2, None],
-        [0, None, None],
+        [3, 2, 4, 0, 1],
+        [0, 1, 2],
+        [0, 2, 1],
+        [0, 1, 2],
         [2, 1, 0],
     ]
 
-    assert ak.to_list(ak.sort(array, axis=1, ascending=False, stable=False)) == [
-        [3.3, 2.2, 1.1, None, None],
-        [None, None, None],
-        [5.5, 4.4, None],
-        [5.5, None, None],
-        [-4.4, -5.5, -6.6],
-    ]
-
     assert ak.to_list(ak.argsort(array, axis=1, ascending=False, stable=True)) == [
-        [4, 2, 3, None, None],
-        [None, None, None],
-        [2, 0, None],
-        [0, None, None],
+        [4, 2, 3, 0, 1],
+        [0, 1, 2],
+        [2, 0, 1],
+        [0, 1, 2],
         [0, 1, 2],
     ]
 
@@ -218,8 +210,8 @@ def test_IndexedOptionArray():
         3,
         2,
         4,
-        None,
-        None,
+        0,
+        1,
     ]
 
     array3 = ak.Array(
@@ -299,11 +291,11 @@ def test_IndexedOptionArray():
 
     array5 = ak.argsort(array4, axis=0, ascending=True, stable=False)
     assert ak.to_list(array5) == [
-        [4, 4, 4, None, None],
-        [0, 0, 0, None, None],
-        [2, 2, None, None, None],
-        [3, None, None, None, None],
-        [None, None, None, None, None],
+        [4, 4, 4, 0, 0],
+        [0, 0, 0, 1, 1],
+        [2, 2, 1, 2, 2],
+        [3, 1, 2, 3, 3],
+        [1, 3, 3, 4, 4],
     ]
 
     # FIXME: implement dropna to strip off the None's

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -9,131 +9,224 @@ import awkward as ak  # noqa: F401
 
 def test_bool_sort():
     array = ak.layout.NumpyArray(np.array([True, False, True, False, False]))
-    assert ak.to_list(array.sort(0, True, False)) == [False, False, False, True, True]
+    assert ak.to_list(ak.sort(array, axis=0, ascending=True, stable=False)) == [
+        False,
+        False,
+        False,
+        True,
+        True,
+    ]
 
 
 def test_keep_None_in_place_test():
-    assert ak.to_list(ak.argsort(ak.Array([[3, 2, 1], [], None, [4, 5]]), axis=1)) == [
+    array = ak.Array([[3, 2, 1], [], None, [4, 5]])
+
+    assert ak.to_list(ak.argsort(array, axis=1)) == [
         [2, 1, 0],
         [],
         None,
         [0, 1],
     ]
-    assert ak.to_list(ak.sort(ak.Array([[3, 2, 1], [], None, [4, 5]]), axis=1)) == [
+
+    assert ak.to_list(ak.sort(array, axis=1)) == [
         [1, 2, 3],
         [],
         None,
         [4, 5],
     ]
 
+    assert ak.to_list(array[ak.argsort(array, axis=1)]) == ak.to_list(
+        ak.sort(array, axis=1)
+    )
+
 
 def test_EmptyArray():
     array = ak.layout.EmptyArray()
-    assert ak.to_list(array.sort(0, True, False)) == []
-    assert ak.to_list(array.argsort(0, True, False)) == []
-    assert str(ak.type(array.sort(0, True, False))) == "float64"
-    assert str(ak.type(array.argsort(0, True, False))) == "int64"
+    assert ak.to_list(ak.sort(array)) == []
+    assert ak.to_list(ak.argsort(array)) == []
+    assert str(ak.type(ak.sort(array))) == "0 * float64"
+    assert str(ak.type(ak.argsort(array))) == "0 * int64"
+
+    array2 = ak.Array([[], [], []])
+    assert ak.to_list(ak.argsort(array2)) == [[], [], []]
+    assert str(ak.type(ak.argsort(array2))) == "3 * var * int64"
 
 
 def test_NumpyArray():
     array = ak.layout.NumpyArray(np.array([3.3, 2.2, 1.1, 5.5, 4.4]))
-    assert ak.to_list(array.argsort(0, True, False)) == [2, 1, 0, 4, 3]
-    assert ak.to_list(array.argsort(0, False, False)) == [3, 4, 0, 1, 2]
+    assert ak.to_list(ak.argsort(array, axis=0, ascending=True, stable=False)) == [
+        2,
+        1,
+        0,
+        4,
+        3,
+    ]
+    assert ak.to_list(ak.argsort(array, axis=0, ascending=False, stable=False)) == [
+        3,
+        4,
+        0,
+        1,
+        2,
+    ]
 
-    assert ak.to_list(array.sort(0, True, False)) == [1.1, 2.2, 3.3, 4.4, 5.5]
-    assert ak.to_list(array.sort(0, False, False)) == [5.5, 4.4, 3.3, 2.2, 1.1]
+    assert ak.to_list(ak.sort(array, axis=0, ascending=True, stable=False)) == [
+        1.1,
+        2.2,
+        3.3,
+        4.4,
+        5.5,
+    ]
+    assert ak.to_list(ak.sort(array, axis=0, ascending=False, stable=False)) == [
+        5.5,
+        4.4,
+        3.3,
+        2.2,
+        1.1,
+    ]
 
     array2 = ak.layout.NumpyArray(np.array([[3.3, 2.2, 4.4], [1.1, 5.5, 3.3]]))
 
-    assert ak.to_list(array2.sort(1, True, False)) == ak.to_list(
-        np.sort(array2, axis=1)
-    )
-    assert ak.to_list(array2.sort(0, True, False)) == ak.to_list(
-        np.sort(array2, axis=0)
-    )
+    assert ak.to_list(
+        ak.sort(array2, axis=1, ascending=True, stable=False)
+    ) == ak.to_list(np.sort(array2, axis=1))
+    assert ak.to_list(
+        ak.sort(array2, axis=0, ascending=True, stable=False)
+    ) == ak.to_list(np.sort(array2, axis=0))
 
-    assert ak.to_list(array2.argsort(1, True, False)) == ak.to_list(
-        np.argsort(array2, 1)
-    )
-    assert ak.to_list(array2.argsort(0, True, False)) == ak.to_list(
-        np.argsort(array2, 0)
-    )
+    assert ak.to_list(
+        ak.argsort(array2, axis=1, ascending=True, stable=False)
+    ) == ak.to_list(np.argsort(array2, 1))
+    assert ak.to_list(
+        ak.argsort(array2, axis=0, ascending=True, stable=False)
+    ) == ak.to_list(np.argsort(array2, 0))
 
     with pytest.raises(ValueError) as err:
-        array2.sort(2, True, False)
+        ak.sort(array2, axis=2, ascending=True, stable=False)
     assert str(err.value).startswith(
         "axis=2 exceeds the depth of the nested list structure (which is 2)"
     )
 
 
-def test_IndexedOffsetArray():
+def test_IndexedOptionArray():
     array = ak.Array(
         [
-            [2.2, 1.1, 3.3],
+            [None, None, 2.2, 1.1, 3.3],
             [None, None, None],
             [4.4, None, 5.5],
             [5.5, None, None],
             [-4.4, -5.5, -6.6],
         ]
-    ).layout
+    )
 
-    assert ak.to_list(array.sort(0, True, False)) == [
-        [-4.4, -5.5, -6.6],
-        [2.2, 1.1, 3.3],
-        [4.4, None, 5.5],
-        [5.5, None, None],
+    assert ak.to_list(ak.sort(array, axis=0, ascending=True, stable=False)) == [
+        [-4.4, -5.5, -6.6, 1.1, 3.3],
+        [4.4, None, 2.2],
+        [5.5, None, 5.5],
+        [None, None, None],
         [None, None, None],
     ]
 
-    assert ak.to_list(array.argsort(0, True, False)) == [
-        [3, 1, 2],
-        [0, 0, 0],
-        [1, None, 1],
-        [2, None, None],
-        [None, None, None],
-    ]
-
-    assert ak.to_list(array.sort(1, True, False)) == [
-        [1.1, 2.2, 3.3],
+    assert ak.to_list(ak.sort(array, axis=1, ascending=True, stable=False)) == [
+        [1.1, 2.2, 3.3, None, None],
         [None, None, None],
         [4.4, 5.5, None],
         [5.5, None, None],
         [-6.6, -5.5, -4.4],
     ]
 
-    assert ak.to_list(array.argsort(1, True, False)) == [
-        [1, 0, 2],
-        [None, None, None],
-        [0, 1, None],
-        [0, None, None],
-        [2, 1, 0],
-    ]
-
-    assert ak.to_list(array.sort(1, False, False)) == [
-        [3.3, 2.2, 1.1],
+    assert ak.to_list(ak.sort(array, axis=1, ascending=False, stable=True)) == [
+        [3.3, 2.2, 1.1, None, None],
         [None, None, None],
         [5.5, 4.4, None],
         [5.5, None, None],
         [-4.4, -5.5, -6.6],
     ]
 
-    assert ak.to_list(array.argsort(1, False, False)) == [
-        [2, 0, 1],
+    assert ak.to_list(ak.sort(array, axis=1, ascending=False, stable=False)) == [
+        [3.3, 2.2, 1.1, None, None],
         [None, None, None],
-        [1, 0, None],
+        [5.5, 4.4, None],
+        [5.5, None, None],
+        [-4.4, -5.5, -6.6],
+    ]
+
+    assert ak.to_list(ak.argsort(array, axis=0, ascending=True, stable=True)) == [
+        [4, 4, 4, 0, 0],
+        [2, None, 0],
+        [3, None, 2],
+        [None, None, None],
+        [None, None, None],
+    ]
+
+    assert ak.to_list(ak.argsort(array, axis=0, ascending=True, stable=False)) == [
+        [4, 4, 4, 0, 0],
+        [2, None, 0],
+        [3, None, 2],
+        [None, None, None],
+        [None, None, None],
+    ]
+
+    assert ak.to_list(ak.argsort(array, axis=0, ascending=False, stable=True)) == [
+        [3, 4, 2, 0, 0],
+        [2, None, 0],
+        [4, None, 4],
+        [None, None, None],
+        [None, None, None],
+    ]
+    assert ak.to_list(ak.argsort(array, axis=0, ascending=False, stable=False)) == [
+        [3, 4, 2, 0, 0],
+        [2, None, 0],
+        [4, None, 4],
+        [None, None, None],
+        [None, None, None],
+    ]
+
+    assert ak.to_list(ak.argsort(array, axis=1, ascending=True, stable=True)) == [
+        [3, 2, 4, None, None],
+        [None, None, None],
+        [0, 2, None],
+        [0, None, None],
+        [2, 1, 0],
+    ]
+
+    assert ak.to_list(ak.argsort(array, axis=1, ascending=True, stable=False)) == [
+        [3, 2, 4, None, None],
+        [None, None, None],
+        [0, 2, None],
+        [0, None, None],
+        [2, 1, 0],
+    ]
+
+    assert ak.to_list(ak.sort(array, axis=1, ascending=False, stable=False)) == [
+        [3.3, 2.2, 1.1, None, None],
+        [None, None, None],
+        [5.5, 4.4, None],
+        [5.5, None, None],
+        [-4.4, -5.5, -6.6],
+    ]
+
+    assert ak.to_list(ak.argsort(array, axis=1, ascending=False, stable=True)) == [
+        [4, 2, 3, None, None],
+        [None, None, None],
+        [2, 0, None],
         [0, None, None],
         [0, 1, 2],
     ]
 
-    array2 = ak.Array([None, None, 1, -1, 30]).layout
-    assert ak.to_list(array2.sort(0, True, False)) == [-1, 1, 30, None, None]
-    assert ak.to_list(array2.argsort(0, True, False)) == [1, 0, 2, None, None]
+    array2 = ak.Array([None, None, 1, -1, 30])
+    assert ak.to_list(ak.argsort(array2, axis=0, ascending=True, stable=True)) == [
+        3,
+        2,
+        4,
+        None,
+        None,
+    ]
 
     array3 = ak.Array(
         [[2.2, 1.1, 3.3], [], [4.4, 5.5], [5.5], [-4.4, -5.5, -6.6]]
     ).layout
 
-    assert ak.to_list(array3.sort(1, False, False)) == [
+    assert ak.to_list(ak.sort(array3, axis=1, ascending=False, stable=False)) == [
         [3.3, 2.2, 1.1],
         [],
         [5.5, 4.4],
@@ -141,7 +234,7 @@ def test_IndexedOffsetArray():
         [-4.4, -5.5, -6.6],
     ]
 
-    assert ak.to_list(array3.sort(0, True, False)) == [
+    assert ak.to_list(ak.sort(array3, axis=0, ascending=True, stable=False)) == [
         [-4.4, -5.5, -6.6],
         [],
         [2.2, 1.1],
@@ -177,7 +270,7 @@ def test_IndexedOffsetArray():
         [-4.4, -5.5, -6.6],
     ]
 
-    array5 = array4.sort(0, True, False)
+    array5 = ak.sort(array4, axis=0, ascending=True, stable=False)
     assert ak.to_list(array5) == [
         [-4.4, -5.5, -6.6],
         [2.2, 1.1, 3.3],
@@ -195,7 +288,7 @@ def test_IndexedOffsetArray():
         [-4.4, -5.5, -6.6, None, None],
     ]
 
-    array5 = array4.sort(0, True, False)
+    array5 = ak.sort(array4, axis=0, ascending=True, stable=False)
     assert ak.to_list(array5) == [
         [-4.4, -5.5, -6.6, None, None],
         [2.2, 1.1, 3.3, None, None],
@@ -204,12 +297,12 @@ def test_IndexedOffsetArray():
         [None, None, None, None, None],
     ]
 
-    array5 = array4.argsort(0, True, False)
+    array5 = ak.argsort(array4, axis=0, ascending=True, stable=False)
     assert ak.to_list(array5) == [
-        [3, 2, 1, None, None],
+        [4, 4, 4, None, None],
         [0, 0, 0, None, None],
-        [1, 1, None, None, None],
-        [2, None, None, None, None],
+        [2, 2, None, None, None],
+        [3, None, None, None, None],
         [None, None, None, None, None],
     ]
 
@@ -223,34 +316,25 @@ def test_IndexedOffsetArray():
     #     [  5.5 ],
     #     []]
 
-    assert ak.to_list(array.argsort(1, True, False)) == [
-        [1, 0, 2],
-        [None, None, None],
-        [0, 1, None],
-        [0, None, None],
-        [2, 1, 0],
-    ]
-
-    assert ak.to_list(array.argsort(0, True, False)) == [
-        [3, 1, 2],
-        [0, 0, 0],
-        [1, None, 1],
-        [2, None, None],
-        [None, None, None],
-    ]
-
     content = ak.layout.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
     index1 = ak.layout.Index32(np.array([1, 2, 3, 4], dtype=np.int32))
     indexedarray1 = ak.layout.IndexedArray32(index1, content)
-    assert ak.to_list(indexedarray1.argsort(0, True, False)) == [0, 1, 2, 3]
+    assert ak.to_list(
+        ak.argsort(indexedarray1, axis=0, ascending=True, stable=False)
+    ) == [0, 1, 2, 3]
 
     index2 = ak.layout.Index64(np.array([1, 2, 3], dtype=np.int64))
     indexedarray2 = ak.layout.IndexedArray64(index2, indexedarray1)
-    assert ak.to_list(indexedarray2.sort(0, False, False)) == [5.5, 4.4, 3.3]
+    assert ak.to_list(
+        ak.sort(indexedarray2, axis=0, ascending=False, stable=False)
+    ) == [5.5, 4.4, 3.3]
 
     index3 = ak.layout.Index32(np.array([1, 2], dtype=np.int32))
     indexedarray3 = ak.layout.IndexedArray32(index3, indexedarray2)
-    assert ak.to_list(indexedarray3.sort(0, True, False)) == [4.4, 5.5]
+    assert ak.to_list(ak.sort(indexedarray3, axis=0, ascending=True, stable=False)) == [
+        4.4,
+        5.5,
+    ]
 
 
 def test_3d():
@@ -271,12 +355,20 @@ def test_3d():
             ]
         )
     )  # 5
-    assert ak.to_list(array.argsort(2, True, False)) == ak.to_list(np.argsort(array, 2))
-    assert ak.to_list(array.sort(2, True, False)) == ak.to_list(np.sort(array, 2))
-    assert ak.to_list(array.argsort(1, True, False)) == ak.to_list(np.argsort(array, 1))
-    assert ak.to_list(array.sort(1, True, False)) == ak.to_list(np.sort(array, 1))
+    assert ak.to_list(
+        ak.argsort(array, axis=2, ascending=True, stable=False)
+    ) == ak.to_list(np.argsort(array, 2))
+    assert ak.to_list(
+        ak.sort(array, axis=2, ascending=True, stable=False)
+    ) == ak.to_list(np.sort(array, 2))
+    assert ak.to_list(
+        ak.argsort(array, axis=1, ascending=True, stable=False)
+    ) == ak.to_list(np.argsort(array, 1))
+    assert ak.to_list(
+        ak.sort(array, axis=1, ascending=True, stable=False)
+    ) == ak.to_list(np.sort(array, 1))
 
-    assert ak.to_list(array.sort(1, False, False)) == [
+    assert ak.to_list(ak.sort(array, axis=1, ascending=False, stable=False)) == [
         [
             [11.11, 12.12, 13.13, 14.14, 15.15],
             [6.6, 7.7, 8.8, 9.9, 10.1],
@@ -289,8 +381,12 @@ def test_3d():
         ],
     ]
 
-    assert ak.to_list(array.sort(0, True, False)) == ak.to_list(np.sort(array, 0))
-    assert ak.to_list(array.argsort(0, True, False)) == ak.to_list(np.argsort(array, 0))
+    assert ak.to_list(
+        ak.sort(array, axis=0, ascending=True, stable=False)
+    ) == ak.to_list(np.sort(array, 0))
+    assert ak.to_list(
+        ak.argsort(array, axis=0, ascending=True, stable=False)
+    ) == ak.to_list(np.argsort(array, 0))
 
 
 def test_RecordArray():
@@ -331,9 +427,7 @@ def test_RecordArray():
 
     assert ak.to_list(array.layout.argsort(-1, True, False)) == {
         "x": [0, 1, 2, 3, 4, 5, 6, 7, 8],
-        # FIXME: argsort is not stable
-        # "y": [[], [0], [0, 1], [0, 1, 2], [0, 1, 2, 3], [0, 1, 2], [0, 1], [0], []],
-        "y": [[], [0], [1, 0], [1, 2, 0], [2, 0, 3, 1], [1, 2, 0], [1, 0], [0], []],
+        "y": [[], [0], [0, 1], [0, 1, 2], [0, 1, 2, 3], [0, 1, 2], [0, 1], [0], []],
     }
 
     assert ak.to_list(array.x.layout.argsort(0, True, False)) == [
@@ -372,15 +466,25 @@ def test_RecordArray():
         [],
     ]
     assert ak.to_list(array.y.layout.argsort(0, True, False)) == [
+        # FIXME?
         [],
-        [0],
-        [1, 0],
-        [2, 1, 0],
-        [3, 2, 1, 0],
-        [4, 3, 2],
-        [5, 4],
-        [6],
-        [],
+        [1],
+        [2, 2],
+        [3, 3, 3],
+        [4, 4, 4, 4],
+        [5, 5, 5],
+        [6, 6],
+        [7],
+        []
+        # [],
+        # [0],
+        # [1, 0],
+        # [2, 1, 0],
+        # [3, 2, 1, 0],
+        # [4, 3, 2],
+        # [5, 4],
+        # [6],
+        # [],
     ]
 
     assert ak.to_list(array.y.layout.argsort(1, True, True)) == [
@@ -402,15 +506,15 @@ def test_ByteMaskedArray():
     )
     mask = ak.layout.Index8(np.array([0, 0, 1, 1, 0], dtype=np.int8))
     array = ak.layout.ByteMaskedArray(mask, content, valid_when=False)
-    assert ak.to_list(array.argsort(0, True, False)) == [
+    assert ak.to_list(ak.argsort(array, axis=0, ascending=True, stable=False)) == [
         [0, 0, 0],
         [],
-        [1, 1, 1, 0],
+        [2, 2, 2, 2],
         None,
         None,
     ]
 
-    assert ak.to_list(array.sort(0, True, False)) == [
+    assert ak.to_list(ak.sort(array, axis=0, ascending=True, stable=False)) == [
         [0.0, 1.1, 2.2],
         [],
         [6.6, 7.7, 8.8, 9.9],
@@ -418,7 +522,7 @@ def test_ByteMaskedArray():
         None,
     ]
 
-    assert ak.to_list(array.sort(0, False, False)) == [
+    assert ak.to_list(ak.sort(array, axis=0, ascending=False, stable=False)) == [
         [6.6, 7.7, 8.8],
         [],
         [0.0, 1.1, 2.2, 9.9],
@@ -426,7 +530,7 @@ def test_ByteMaskedArray():
         None,
     ]
 
-    assert ak.to_list(array.argsort(1, True, False)) == [
+    assert ak.to_list(ak.argsort(array, axis=1, ascending=True, stable=False)) == [
         [0, 1, 2],
         [],
         None,
@@ -453,7 +557,7 @@ def test_UnionArray():
     array = ak.layout.UnionArray8_32(tags, index, [content0, content1])
 
     with pytest.raises(ValueError) as err:
-        array.sort(1, True, False)
+        ak.sort(array, axis=1, ascending=True, stable=False)
     assert str(err.value).startswith("cannot sort UnionArray8_32")
 
 
@@ -461,14 +565,14 @@ def test_sort_strings():
     content1 = ak.from_iter(["one", "two", "three", "four", "five"], highlevel=False)
     assert ak.to_list(content1) == ["one", "two", "three", "four", "five"]
 
-    assert ak.to_list(content1.sort(0, True, False)) == [
+    assert ak.to_list(ak.sort(content1, axis=0, ascending=True, stable=False)) == [
         "five",
         "four",
         "one",
         "three",
         "two",
     ]
-    assert ak.to_list(content1.sort(0, False, False)) == [
+    assert ak.to_list(ak.sort(content1, axis=0, ascending=False, stable=False)) == [
         "two",
         "three",
         "one",
@@ -491,7 +595,7 @@ def test_sort_bytestrings():
         b"three",
     ]
 
-    assert ak.to_list(array.sort(0, True, False)) == [
+    assert ak.to_list(ak.sort(array, axis=0, ascending=True, stable=False)) == [
         b"one",
         b"one",
         b"three",
@@ -499,6 +603,16 @@ def test_sort_bytestrings():
         b"two",
         b"two",
         b"two",
+    ]
+
+    assert ak.to_list(ak.argsort(array, axis=0, ascending=True, stable=True)) == [
+        0,
+        5,
+        2,
+        6,
+        1,
+        3,
+        4,
     ]
 
 

--- a/tests/test_0850-argsort-mask-array.py
+++ b/tests/test_0850-argsort-mask-array.py
@@ -19,5 +19,5 @@ def test():
     ]
     assert ak.argsort(array.mask[is_valid]).tolist() == [
         [0, 1, 2, None],
-        [1, 0, None, None, None],
+        [4, 3, None, None, None],
     ]

--- a/tests/test_0850-argsort-mask-array.py
+++ b/tests/test_0850-argsort-mask-array.py
@@ -18,6 +18,6 @@ def test():
         [1, 2, None, None, None],
     ]
     assert ak.argsort(array.mask[is_valid]).tolist() == [
-        [0, 1, 2, None],
-        [4, 3, None, None, None],
+        [0, 1, 2, 3],
+        [4, 3, 0, 1, 2],
     ]

--- a/tests/test_0945-argsort-sort-nan-array.py
+++ b/tests/test_0945-argsort-sort-nan-array.py
@@ -1,0 +1,17 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_nan():
+    array = ak.Array([1, 2, np.nan, 3, 0, np.nan])
+
+    assert ak.argsort(array).tolist() == [
+        2, 5, 4, 0, 1, 3,
+    ]
+    # Note, `nan` comparison with `nan` returns False
+    assert str(ak.sort(array).tolist()) == "[nan, nan, 0.0, 1.0, 2.0, 3.0]"

--- a/tests/test_0945-argsort-sort-nan-array.py
+++ b/tests/test_0945-argsort-sort-nan-array.py
@@ -20,3 +20,10 @@ def test_nan():
     ]
     # Note, `nan` comparison with `nan` returns False
     assert str(ak.sort(array).tolist()) == "[nan, nan, 0.0, 1.0, 2.0, 3.0]"
+
+
+def test_bool():
+    array = ak.Array([True, False, False, True, True, True])
+
+    assert ak.argsort(array).tolist() == [1, 2, 0, 3, 4, 5]
+    assert ak.sort(array).tolist() == [False, False, True, True, True, True]

--- a/tests/test_0945-argsort-sort-nan-array.py
+++ b/tests/test_0945-argsort-sort-nan-array.py
@@ -27,3 +27,39 @@ def test_bool():
 
     assert ak.argsort(array).tolist() == [1, 2, 0, 3, 4, 5]
     assert ak.sort(array).tolist() == [False, False, True, True, True, True]
+
+
+def test_argsort():
+    array = ak.Array([1, 2, None, 3, 0, None])
+    assert ak.argsort(array).tolist() == [4, 0, 1, 3, 2, 5]
+    assert array[ak.argsort(array)].tolist() == [
+        0,
+        1,
+        2,
+        3,
+        None,
+        None,
+    ]
+
+
+def test_argsort_2d():
+    array = ak.Array([[1, 2, None, 3, 0, None], [1, 2, None, 3, 0, None]])
+    assert ak.argsort(array).tolist() == [[4, 0, 1, 3, 2, 5], [4, 0, 1, 3, 2, 5]]
+    assert array[ak.argsort(array)].tolist() == [
+        [
+            0,
+            1,
+            2,
+            3,
+            None,
+            None,
+        ],
+        [
+            0,
+            1,
+            2,
+            3,
+            None,
+            None,
+        ],
+    ]

--- a/tests/test_0945-argsort-sort-nan-array.py
+++ b/tests/test_0945-argsort-sort-nan-array.py
@@ -11,7 +11,12 @@ def test_nan():
     array = ak.Array([1, 2, np.nan, 3, 0, np.nan])
 
     assert ak.argsort(array).tolist() == [
-        2, 5, 4, 0, 1, 3,
+        2,
+        5,
+        4,
+        0,
+        1,
+        3,
     ]
     # Note, `nan` comparison with `nan` returns False
     assert str(ak.sort(array).tolist()) == "[nan, nan, 0.0, 1.0, 2.0, 3.0]"


### PR DESCRIPTION
* do not drop `None`s  when sorting a 1D `IndexedOptionArray`
* `argsort` to account `None`s by passing and post-processing `shifts`:

```python
>>> import awkward as ak
>>> array = ak.Array([None, None, 1, -1, 30])
>>> ak.sort(array)
<Array [-1, 1, 30, None, None] type='5 * ?int64'>
>>> ak.argsort(array)
<Array [3, 2, 4, None, None] type='5 * ?int64'>
>>> array[ak.argsort(array)]
<Array [-1, 1, 30, None, None] type='5 * ?int64'>
```
* unused `keepdim` has been dropped
* `argsort` documentation corrected