### PR TITLE
Refactor: use `maybe_wrap` in source

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -449,6 +449,10 @@ def maybe_wrap(content, behavior, highlevel):
         return content
 
 
+def maybe_wrap_like(content, array, behavior, highlevel):
+    return maybe_wrap(content, behaviorof(array, behavior=behavior), highlevel)
+
+
 def extra(args, kwargs, defaults):
     out = []
     for i in range(len(defaults)):

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -162,10 +162,7 @@ def from_numpy(
             contents.append(recurse(array[name], mask))
         layout = ak.layout.RecordArray(contents, array.dtype.names)
 
-    if highlevel:
-        return ak._util.wrap(layout, behavior)
-    else:
-        return layout
+    return ak._util.maybe_wrap(layout, behavior, highlevel)
 
 
 def to_numpy(array, allow_missing=True):
@@ -419,10 +416,7 @@ def from_cupy(array, regulararray=False, highlevel=True, behavior=None):
 
     layout = recurse(array)
 
-    if highlevel:
-        return ak._util.wrap(layout, behavior)
-    else:
-        return layout
+    return ak._util.maybe_wrap(layout, behavior, highlevel)
 
 
 def to_cupy(array):
@@ -590,10 +584,7 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
 
     layout = recurse(array)
 
-    if highlevel:
-        return ak._util.wrap(layout, behavior)
-    else:
-        return layout
+    return ak._util.maybe_wrap(layout, behavior, highlevel)
 
 
 def to_jax(array):
@@ -897,10 +888,7 @@ def from_iter(
     for x in iterable:
         out.fromiter(x)
     layout = out.snapshot()
-    if highlevel:
-        return ak._util.wrap(layout, behavior)
-    else:
-        return layout
+    return ak._util.maybe_wrap(layout, behavior, highlevel)
 
 
 def to_list(array):
@@ -1121,10 +1109,7 @@ def from_json(
     if complex_imag_string is not None:
         layout = ak._util.recursively_apply(layout, getfunction, pass_depth=False)
 
-    if highlevel:
-        return ak._util.wrap(layout, behavior)
-    else:
-        return layout
+    return ak._util.maybe_wrap(layout, behavior, highlevel)
 
 
 def to_json(
@@ -1637,10 +1622,7 @@ def from_awkward0(
             )
 
     out = recurse(array, 0)
-    if highlevel:
-        return ak._util.wrap(out, behavior)
-    else:
-        return out
+    return ak._util.maybe_wrap(out, behavior, highlevel)
 
 
 from_awkward0.int8max = np.iinfo(np.int8).max
@@ -2941,10 +2923,7 @@ def _from_arrow(
                 + ak._util.exception_suffix(__file__)
             )
 
-    if highlevel:
-        return ak._util.wrap(handle_arrow(array), behavior)
-    else:
-        return handle_arrow(array)
+    return ak._util.maybe_wrap(handle_arrow(array), behavior, highlevel)
 
 
 def to_parquet(
@@ -5119,10 +5098,7 @@ def from_buffers(
             + ak._util.exception_suffix(__file__)
         )
 
-    if highlevel:
-        return ak._util.wrap(out, behavior)
-    else:
-        return out
+    return ak._util.maybe_wrap(out, behavior, highlevel)
 
 
 def to_pandas(

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -818,10 +818,7 @@ def to_kernels(array, kernels, highlevel=True, behavior=None):
     arr = ak.to_layout(array)
     out = arr.copy_to(kernels)
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def from_iter(
@@ -1290,15 +1287,9 @@ def from_awkward0(
         else:
             return array._layout.snapshot()
     elif isinstance(array, (ak.layout.Content, ak.layout.Record)):
-        if highlevel:
-            return ak._util.wrap(array, behavior)
-        else:
-            return array
+        return ak._util.maybe_wrap(array, behavior, highlevel)
     elif isinstance(array, ak.layout.ArrayBuilder):
-        if highlevel:
-            return ak._util.wrap(array.snapshot(), behavior)
-        else:
-            return array.snapshot()
+        return ak._util.maybe_wrap(array.snapshot(), behavior, highlevel)
 
     def recurse(array, level):
         if isinstance(array, dict):
@@ -1941,10 +1932,7 @@ def regularize_numpyarray(array, allow_empty=True, highlevel=True, behavior=None
             return None
 
     out = ak._util.recursively_apply(to_layout(array), getfunction, pass_depth=False)
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def _import_pyarrow(name):

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -1891,7 +1891,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
         else:
             out = apply(layout)
 
-        return ak._util.maybe_wrap(out, array, behavior, highlevel)
+        return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
     else:
         out = layout.flatten(axis)

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -251,12 +251,7 @@ def num(array, axis=1, highlevel=True, behavior=None):
         array, allow_record=False, allow_other=False
     )
     out = layout.num(axis=axis)
-    if highlevel:
-        return ak._util.wrap(
-            out, behavior=ak._util.behaviorof(array, behavior=behavior)
-        )
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def run_lengths(array, highlevel=True, behavior=None):
@@ -471,10 +466,7 @@ def run_lengths(array, highlevel=True, behavior=None):
             pass_user=False,
         )
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def zip(
@@ -745,10 +737,7 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
             numpy_to_regular=True,
         )
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def from_regular(array, axis=1, highlevel=True, behavior=None):
@@ -804,10 +793,7 @@ def from_regular(array, axis=1, highlevel=True, behavior=None):
             numpy_to_regular=True,
         )
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def with_name(array, name, highlevel=True, behavior=None):
@@ -859,10 +845,7 @@ def with_name(array, name, highlevel=True, behavior=None):
 
     out2 = ak._util.recursively_apply(out, getfunction2, pass_depth=False)
 
-    if highlevel:
-        return ak._util.wrap(out2, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out2
+    return ak._util.maybe_wrap_like(out2, array, behavior, highlevel)
 
 
 def with_field(base, what, where=None, highlevel=True, behavior=None):
@@ -987,10 +970,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 
         assert isinstance(out, tuple) and len(out) == 1
 
-        if highlevel:
-            return ak._util.wrap(out[0], behavior=behavior)
-        else:
-            return out[0]
+        return ak._util.maybe_wrap(out[0], behavior, highlevel)
 
 
 def with_parameter(array, parameter, value, highlevel=True, behavior=None):
@@ -1024,12 +1004,7 @@ def with_parameter(array, parameter, value, highlevel=True, behavior=None):
     else:
         out = layout.withparameter(parameter, value)
 
-    if highlevel:
-        return ak._util.wrap(
-            out, behavior=ak._util.behaviorof(array, behavior=behavior)
-        )
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def without_parameters(array, highlevel=True, behavior=None):
@@ -1055,12 +1030,7 @@ def without_parameters(array, highlevel=True, behavior=None):
         layout, lambda layout: None, pass_depth=False, keep_parameters=False
     )
 
-    if highlevel:
-        return ak._util.wrap(
-            out, behavior=ak._util.behaviorof(array, behavior=behavior)
-        )
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 _ZEROS = object()
@@ -1271,10 +1241,7 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
     if dtype is not None:
         out = strings_astype(out, dtype)
         out = values_astype(out, dtype)
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 @ak._connect._numpy.implements("broadcast_arrays")
@@ -1659,12 +1626,9 @@ def concatenate(
             pass_depth=True,
         )[0]
 
-    if highlevel:
-        return ak._util.wrap(
-            out, behavior=ak._util.behaviorof(*arrays, behavior=behavior)
-        )
-    else:
-        return out
+    return ak._util.maybe_wrap(
+        out, ak._util.behaviorof(*arrays, behavior=behavior), highlevel
+    )
 
 
 @ak._connect._numpy.implements("where")
@@ -1766,10 +1730,7 @@ def where(condition, *args, **kwargs):
             [akcondition, left, right], getfunction, behavior, pass_depth=False
         )
 
-        if highlevel:
-            return ak._util.wrap(out[0], behavior=behavior)
-        else:
-            return out[0]
+        return ak._util.maybe_wrap(out[0], behavior, highlevel)
 
     else:
         raise TypeError(
@@ -1930,20 +1891,12 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
         else:
             out = apply(layout)
 
-        if highlevel:
-            return ak._util.wrap(
-                out, behavior=ak._util.behaviorof(array, behavior=behavior)
-            )
-        else:
-            return out
+        return ak._util.maybe_wrap(out, array, behavior, highlevel)
 
     else:
         out = layout.flatten(axis)
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
@@ -2149,10 +2102,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
             "at axis={0}".format(axis) + ak._util.exception_suffix(__file__)
         )
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def _packed(array, axis=None, highlevel=True, behavior=None):
@@ -2349,9 +2299,7 @@ def _packed(array, axis=None, highlevel=True, behavior=None):
 
     out = apply(layout, 1, axis)
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def packed(array, highlevel=True, behavior=None):
@@ -2477,10 +2425,7 @@ def local_index(array, axis=-1, highlevel=True, behavior=None):
         array, allow_record=True, allow_other=False
     )
     out = layout.localindex(axis)
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 @ak._connect._numpy.implements("sort")
@@ -2513,10 +2458,7 @@ def sort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=N
         array, allow_record=False, allow_other=False
     )
     out = layout.sort(axis, ascending, stable)
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 @ak._connect._numpy.implements("argsort")
@@ -2560,10 +2502,7 @@ def argsort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavio
         array, allow_record=False, allow_other=False
     )
     out = layout.argsort(axis, ascending, stable)
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def pad_none(array, target, axis=1, clip=False, highlevel=True, behavior=None):
@@ -2689,10 +2628,7 @@ def pad_none(array, target, axis=1, clip=False, highlevel=True, behavior=None):
         out = layout.rpad_and_clip(target, axis)
     else:
         out = layout.rpad(target, axis)
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def fill_none(array, value, highlevel=True, behavior=None):
@@ -2767,10 +2703,7 @@ def fill_none(array, value, highlevel=True, behavior=None):
 
         out = arraylayout.fillna(valuelayout)
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def is_none(array, axis=0, highlevel=True, behavior=None):
@@ -2821,10 +2754,7 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
         layout, getfunction, pass_depth=True, pass_user=True, user=axis
     )
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def singletons(array, highlevel=True, behavior=None):
@@ -2867,10 +2797,7 @@ def singletons(array, highlevel=True, behavior=None):
     layout = ak.operations.convert.to_layout(array)
     out = ak._util.recursively_apply(layout, getfunction, pass_depth=False)
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def firsts(array, axis=1, highlevel=True, behavior=None):
@@ -2929,10 +2856,7 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
             toslice
         ]
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def cartesian(
@@ -3500,10 +3424,7 @@ def argcartesian(
             layouts, axis=axis, nested=nested, parameters=parameters, highlevel=False
         )
 
-        if highlevel:
-            return ak._util.wrap(result, behavior)
-        else:
-            return result
+        return ak._util.maybe_wrap(result, behavior, highlevel)
 
 
 def combinations(
@@ -3668,12 +3589,7 @@ def combinations(
     out = layout.combinations(
         n, replacement=replacement, keys=fields, parameters=parameters, axis=axis
     )
-    if highlevel:
-        return ak._util.wrap(
-            out, behavior=ak._util.behaviorof(array, behavior=behavior)
-        )
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def argcombinations(
@@ -3738,12 +3654,7 @@ def argcombinations(
         out = layout.combinations(
             n, replacement=replacement, keys=fields, parameters=parameters, axis=axis
         )
-        if highlevel:
-            return ak._util.wrap(
-                out, behavior=ak._util.behaviorof(array, behavior=behavior)
-            )
-        else:
-            return out
+        return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def partitions(array):
@@ -3802,12 +3713,9 @@ def partitioned(arrays, highlevel=True, behavior=None):
         stops.append(total_length)
 
     out = ak.partition.IrregularlyPartitionedArray(partitions, stops)
-    if highlevel:
-        return ak._util.wrap(
-            out, behavior=ak._util.behaviorof(*arrays, behavior=behavior)
-        )
-    else:
-        return out
+    return ak._util.maybe_wrap(
+        out, ak._util.behaviorof(*arrays, behavior=behavior), highlevel
+    )
 
 
 def repartition(array, lengths, highlevel=True, behavior=None):
@@ -3880,12 +3788,7 @@ def repartition(array, lengths, highlevel=True, behavior=None):
         else:
             out = ak.partition.IrregularlyPartitionedArray.toPartitioned(layout, stops)
 
-    if highlevel:
-        return ak._util.wrap(
-            out, behavior=ak._util.behaviorof(array, behavior=behavior)
-        )
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def virtual(
@@ -4108,10 +4011,7 @@ def materialized(array, highlevel=True, behavior=None):
     out = ak._util.recursively_apply(
         layout, getfunction, pass_depth=False, pass_user=False
     )
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def with_cache(array, cache, highlevel=True, behavior=None):
@@ -4193,10 +4093,7 @@ def with_cache(array, cache, highlevel=True, behavior=None):
     out = ak._util.recursively_apply(
         ak.operations.convert.to_layout(array), getfunction, pass_depth=False
     )
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 @ak._connect._numpy.implements("size")
@@ -4376,10 +4273,7 @@ def nan_to_num(
     out = ak._util.recursively_apply(
         layout, getfunction, pass_depth=False, pass_user=False
     )
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 @ak._connect._numpy.implements("isclose")
@@ -4518,10 +4412,7 @@ def values_astype(array, to, highlevel=True, behavior=None):
     )
     out = layout.numbers_to_type(to_str)
 
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def strings_astype(array, to, highlevel=True, behavior=None):
@@ -4589,10 +4480,7 @@ def strings_astype(array, to, highlevel=True, behavior=None):
         pass_depth=False,
         pass_user=False,
     )
-    if highlevel:
-        return ak._util.wrap(out, ak._util.behaviorof(array, behavior=behavior))
-    else:
-        return out
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 __all__ = [

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -183,10 +183,7 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
         pass_depth=False,
     )
     assert isinstance(out, tuple) and len(out) == 1
-    if highlevel:
-        return ak._util.wrap(out[0], behavior)
-    else:
-        return out[0]
+    return ak._util.maybe_wrap(out[0], behavior, highlevel)
 
 
 def num(array, axis=1, highlevel=True, behavior=None):
@@ -660,10 +657,7 @@ def zip(
         out = out[0]
         assert isinstance(out, ak.layout.Record)
 
-    if highlevel:
-        return ak._util.wrap(out, behavior)
-    else:
-        return out
+    return ak._util.maybe_wrap(out, behavior, highlevel)
 
 
 def unzip(array):
@@ -3400,10 +3394,7 @@ def cartesian(
             flatten_axis = toflatten.pop()
             result = flatten(result, axis=flatten_axis, highlevel=False)
 
-    if highlevel:
-        return ak._util.wrap(result, behavior)
-    else:
-        return result
+    return ak._util.maybe_wrap(result, behavior, highlevel)
 
 
 def argcartesian(
@@ -4089,10 +4080,7 @@ def virtual(
 
     out = ak.layout.VirtualArray(gen, cache, cache_key=cache_key, parameters=parameters)
 
-    if highlevel:
-        return ak._util.wrap(out, behavior=behavior)
-    else:
-        return out
+    return ak._util.maybe_wrap(out, behavior, highlevel)
 
 
 def materialized(array, highlevel=True, behavior=None):
@@ -4443,10 +4431,7 @@ def isclose(
     assert isinstance(out, tuple) and len(out) == 1
     result = out[0]
 
-    if highlevel:
-        return ak._util.wrap(result, behavior)
-    else:
-        return result
+    return ak._util.maybe_wrap(result, behavior, highlevel)
 
 
 _dtype_to_string = {


### PR DESCRIPTION
This PR adds a new `maybe_wrap_like` to handle the altogether more common case that we want to `maybe_wrap` and take the behaviour from an existing array. 

@jpivarski you might feel this is starting to lead to creep of helper functions, but I think it's reasonable given that these two patterns are very common in the codebase.