### PR TITLE
fix(setup): sync with cmake_example

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ import setuptools.command.build_ext
 import setuptools.command.install
 from setuptools import setup, Extension
 
-
 if sys.version_info < (3,):
     # Note: never import from distutils before setuptools!
     from distutils.util import get_platform
@@ -27,6 +26,15 @@ try:
     CMAKE = os.path.join(cmake.CMAKE_BIN_DIR, "cmake")
 except ImportError:
     CMAKE = "cmake"
+
+
+# Convert distutils Windows platform specifiers to CMake -A arguments
+PLAT_TO_CMAKE = {
+    "win32": "Win32",
+    "win-amd64": "x64",
+    "win-arm32": "ARM",
+    "win-arm64": "ARM64",
+}
 
 
 with open("VERSION_INFO") as f:
@@ -64,43 +72,65 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
                 + ", ".join(x.name for x in self.extensions)
             )
 
-        for x in self.extensions:
-            self.build_extension(x)
+        setuptools.command.build_ext.build_ext.build_extensions(self)
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        build_args = []
+
+        # required for auto-detection of auxiliary "native" libs
+        if not extdir.endswith(os.path.sep):
+            extdir += os.path.sep
+
+        cfg = "Debug" if self.debug else "Release"
+
+        # CMake lets you override the generator - we need to check this.
+        # Can be set with Conda-Build, for example.
+        cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
+
+        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
+        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
+        # from Python.
         cmake_args = [
+            "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}".format(extdir),
+            "-DPYTHON_EXECUTABLE={}".format(sys.executable),
+            "-DEXAMPLE_VERSION_INFO={}".format(self.distribution.get_version()),
+            "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
             "-DCMAKE_INSTALL_PREFIX={0}".format(extdir),
             "-DPYTHON_EXECUTABLE={0}".format(sys.executable),
             "-DPYBUILD=ON",
-            "-DPYBUILD=ON",
             "-DBUILD_TESTING=OFF",
         ]
+        build_args = []
+
         try:
             compiler_path = self.compiler.compiler_cxx[0]
             cmake_args += ["-DCMAKE_CXX_COMPILER={0}".format(compiler_path)]
         except AttributeError:
             print("Not able to access compiler path, using CMake default")
 
-        cfg = "Debug" if self.debug else "Release"
-        build_args += ["--config", cfg]
-        cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
+        if self.compiler.compiler_type == "msvc":
+            cmake_args.append("-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE")
 
-        if platform.system() == "Windows":
-            cmake_args += [
-                "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{0}={1}".format(cfg.upper(), extdir),
-                "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE",
-            ]
-            cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
-            if (
-                sys.maxsize > 2 ** 32
-                and cmake_generator != "NMake Makefiles"
-                and "Win64" not in cmake_generator
-            ):
-                cmake_args += ["-A", "x64"]
+            # Single config generators are handled "normally"
+            single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
 
-        elif "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            # CMake allows an arch-in-generator style for backward compatibility
+            contains_arch = any(x in cmake_generator for x in {"ARM", "Win64"})
+
+            # Specify the arch if using MSVC generator, but only if it doesn't
+            # contain a backward-compatibility arch spec already in the
+            # generator name.
+            if not single_config and not contains_arch:
+                cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
+
+            # Multi-config generators have a different way to specify configs
+            if not single_config:
+                cmake_args += [
+                    "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir)
+                ]
+                build_args += ["--config", cfg]
+
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
             build_args += ["-j", str(multiprocessing.cpu_count())]
 
         if (
@@ -111,15 +141,12 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        build_dir = self.build_temp
 
         subprocess.check_call(
-            [CMAKE, "-S", ext.sourcedir, "-B", build_dir] + cmake_args
+            [CMAKE, "-S", ext.sourcedir, "-B", self.build_temp] + cmake_args
         )
-        subprocess.check_call([CMAKE, "--build", build_dir] + build_args)
-        subprocess.check_call(
-            [CMAKE, "--build", build_dir, "--config", cfg, "--target", "install"]
-        )
+        subprocess.check_call([CMAKE, "--build", self.build_temp] + build_args)
+        subprocess.check_call([CMAKE, "--install", self.build_temp, "--config", cfg])
 
 
 def tree(x):


### PR DESCRIPTION
The current version of the setup.py wasn't loading the correct MSVC reliably. I've synced this up with the work done on the `cmake_example`, which fixes this issue and is arguably a bit nicer with more docs.
