### PR TITLE
fix: manylinux1 couldn't take None/newaxis

### DIFF
--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -470,7 +470,8 @@ toslice_part(ak::Slice& slice, py::object obj) {
     slice.append(std::make_shared<ak::SliceEllipsis>());
   }
 
-  else if (obj.is(py::module::import("numpy").attr("newaxis"))) {
+  // NumPy on Manylinux1 doesn't pass the is comparison, but it is None
+  else if (obj.is_none() || obj.is(py::module::import("numpy").attr("newaxis"))) {
     slice.append(std::make_shared<ak::SliceNewAxis>());
   }
 


### PR DESCRIPTION
The current wheel building infrastructure does not test the wheels after building them. Manylinux1 wheels were broken due to a really weird bug - see https://github.com/pybind/pybind11/issues/3056 - that I don't understand yet. This should fix the wheels for now. The replacement wheel building infrastructure does test the wheels. :)
