### PR TITLE
Feature: add layout transformer & simplify unpacked

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -1485,7 +1485,7 @@ class LayoutTransformer(object):
 
 class FunctionalTransformer(LayoutTransformer):
     def __init__(self, transformer, numpy_to_regular, keep_parameters):
-        super().__init__(keep_parameters=keep_parameters)
+        super(FunctionalTransformer, self).__init__(keep_parameters=keep_parameters)
         self._numpy_to_regular = numpy_to_regular
         self._transformer = transformer
 

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -1177,228 +1177,31 @@ def recursively_apply(
     getfunction,
     pass_depth=True,
     pass_user=False,
-    pass_apply=False,
     user=None,
     keep_parameters=True,
     numpy_to_regular=False,
 ):
-    def apply(layout, depth, user):
-        if numpy_to_regular and isinstance(layout, ak.layout.NumpyArray):
-            layout = layout.toRegularArray()
-
+    def transform(self, layout, depth, user):
         args = ()
         if pass_depth:
             args = args + (depth,)
         if pass_user:
             args = args + (user,)
-        if pass_apply:
-            args = args + (apply,)
 
         custom = getfunction(layout, *args)
         if callable(custom):
             return custom()
-        else:
-            user = custom
-
-        # the rest of this is one switch statement
-        if isinstance(layout, ak.partition.PartitionedArray):
-            return ak.partition.IrregularlyPartitionedArray(
-                [apply(x, depth, user) for x in layout.partitions]
-            )
-
-        elif isinstance(layout, ak.layout.NumpyArray):
-            if keep_parameters:
-                return layout
-            else:
-                return ak.layout.NumpyArray(
-                    ak.nplike.of(layout).asarray(layout), layout.identities, None
-                )
-
-        elif isinstance(layout, ak.layout.EmptyArray):
-            if keep_parameters:
-                return layout
-            else:
-                return ak.layout.EmptyArray(layout.identities, None)
-
-        elif isinstance(layout, ak.layout.RegularArray):
-            return ak.layout.RegularArray(
-                apply(layout.content, depth + 1, user),
-                layout.size,
-                len(layout),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.ListArray32):
-            return ak.layout.ListArray32(
-                layout.starts,
-                layout.stops,
-                apply(layout.content, depth + 1, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.ListArrayU32):
-            return ak.layout.ListArrayU32(
-                layout.starts,
-                layout.stops,
-                apply(layout.content, depth + 1, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.ListArray64):
-            return ak.layout.ListArray64(
-                layout.starts,
-                layout.stops,
-                apply(layout.content, depth + 1, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.ListOffsetArray32):
-            return ak.layout.ListOffsetArray32(
-                layout.offsets,
-                apply(layout.content, depth + 1, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.ListOffsetArrayU32):
-            return ak.layout.ListOffsetArrayU32(
-                layout.offsets,
-                apply(layout.content, depth + 1, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.ListOffsetArray64):
-            return ak.layout.ListOffsetArray64(
-                layout.offsets,
-                apply(layout.content, depth + 1, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.IndexedArray32):
-            return ak.layout.IndexedArray32(
-                layout.index,
-                apply(layout.content, depth, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.IndexedArrayU32):
-            return ak.layout.IndexedArrayU32(
-                layout.index,
-                apply(layout.content, depth, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.IndexedArray64):
-            return ak.layout.IndexedArray64(
-                layout.index,
-                apply(layout.content, depth, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.IndexedOptionArray32):
-            return ak.layout.IndexedOptionArray32(
-                layout.index,
-                apply(layout.content, depth, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.IndexedOptionArray64):
-            return ak.layout.IndexedOptionArray64(
-                layout.index,
-                apply(layout.content, depth, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.ByteMaskedArray):
-            return ak.layout.ByteMaskedArray(
-                layout.mask,
-                apply(layout.content, depth, user),
-                layout.valid_when,
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.BitMaskedArray):
-            return ak.layout.BitMaskedArray(
-                layout.mask,
-                apply(layout.content, depth, user),
-                layout.valid_when,
-                len(layout),
-                layout.lsb_order,
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.UnmaskedArray):
-            return ak.layout.UnmaskedArray(
-                apply(layout.content, depth, user),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.RecordArray):
-            return ak.layout.RecordArray(
-                [apply(x, depth, user) for x in layout.contents],
-                layout.recordlookup,
-                len(layout),
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.Record):
-            return ak.layout.Record(
-                apply(layout.array, depth, user),
-                layout.at,
-            )
-
-        elif isinstance(layout, ak.layout.UnionArray8_32):
-            return ak.layout.UnionArray8_32(
-                layout.tags,
-                layout.index,
-                [apply(x, depth, user) for x in layout.contents],
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.UnionArray8_U32):
-            return ak.layout.UnionArray8_U32(
-                layout.tags,
-                layout.index,
-                [apply(x, depth, user) for x in layout.contents],
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.UnionArray8_64):
-            return ak.layout.UnionArray8_64(
-                layout.tags,
-                layout.index,
-                [apply(x, depth, user) for x in layout.contents],
-                layout.identities,
-                layout.parameters if keep_parameters else None,
-            )
-
-        elif isinstance(layout, ak.layout.VirtualArray):
-            return apply(layout.array, depth, user)
 
         else:
-            raise AssertionError(
-                "unrecognized Content type: {0}".format(type(layout))
-                + exception_suffix(__file__)
-            )
+            return self.generic_transform(layout, depth, custom)
 
-    return apply(layout, 1, user)
+    return recursively_transform(
+        layout,
+        transform,
+        user=user,
+        keep_parameters=keep_parameters,
+        numpy_to_regular=numpy_to_regular,
+    )
 
 
 def recursive_walk(layout, apply, args=(), depth=1, materialize=False):

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -1469,6 +1469,246 @@ def recursive_walk(layout, apply, args=(), depth=1, materialize=False):
         )
 
 
+class LayoutTransformer(object):
+    def __init__(self, keep_parameters=False):
+        self._keep_parameters = keep_parameters
+
+    @property
+    def keep_parameters(self):
+        return self._keep_parameters
+
+    def generic_transform(self, layout, depth, user):
+        # the rest of this is one switch statement
+        if isinstance(layout, ak.partition.PartitionedArray):
+            return ak.partition.IrregularlyPartitionedArray(
+                [self.transform(x, depth, user) for x in layout.partitions]
+            )
+
+        elif isinstance(layout, ak.layout.NumpyArray):
+            if self._keep_parameters:
+                return layout
+            else:
+                return ak.layout.NumpyArray(
+                    ak.nplike.of(layout).asarray(layout), layout.identities, None
+                )
+
+        elif isinstance(layout, ak.layout.EmptyArray):
+            if self._keep_parameters:
+                return layout
+            else:
+                return ak.layout.EmptyArray(layout.identities, None)
+
+        elif isinstance(layout, ak.layout.RegularArray):
+            return ak.layout.RegularArray(
+                self.transform(layout.content, depth + 1, user),
+                layout.size,
+                len(layout),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.ListArray32):
+            return ak.layout.ListArray32(
+                layout.starts,
+                layout.stops,
+                self.transform(layout.content, depth + 1, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.ListArrayU32):
+            return ak.layout.ListArrayU32(
+                layout.starts,
+                layout.stops,
+                self.transform(layout.content, depth + 1, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.ListArray64):
+            return ak.layout.ListArray64(
+                layout.starts,
+                layout.stops,
+                self.transform(layout.content, depth + 1, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.ListOffsetArray32):
+            return ak.layout.ListOffsetArray32(
+                layout.offsets,
+                self.transform(layout.content, depth + 1, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.ListOffsetArrayU32):
+            return ak.layout.ListOffsetArrayU32(
+                layout.offsets,
+                self.transform(layout.content, depth + 1, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.ListOffsetArray64):
+            return ak.layout.ListOffsetArray64(
+                layout.offsets,
+                self.transform(layout.content, depth + 1, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.IndexedArray32):
+            return ak.layout.IndexedArray32(
+                layout.index,
+                self.transform(layout.content, depth, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.IndexedArrayU32):
+            return ak.layout.IndexedArrayU32(
+                layout.index,
+                self.transform(layout.content, depth, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.IndexedArray64):
+            return ak.layout.IndexedArray64(
+                layout.index,
+                self.transform(layout.content, depth, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.IndexedOptionArray32):
+            return ak.layout.IndexedOptionArray32(
+                layout.index,
+                self.transform(layout.content, depth, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.IndexedOptionArray64):
+            return ak.layout.IndexedOptionArray64(
+                layout.index,
+                self.transform(layout.content, depth, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.ByteMaskedArray):
+            return ak.layout.ByteMaskedArray(
+                layout.mask,
+                self.transform(layout.content, depth, user),
+                layout.valid_when,
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.BitMaskedArray):
+            return ak.layout.BitMaskedArray(
+                layout.mask,
+                self.transform(layout.content, depth, user),
+                layout.valid_when,
+                len(layout),
+                layout.lsb_order,
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.UnmaskedArray):
+            return ak.layout.UnmaskedArray(
+                self.transform(layout.content, depth, user),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.RecordArray):
+            return ak.layout.RecordArray(
+                [self.transform(x, depth, user) for x in layout.contents],
+                layout.recordlookup,
+                len(layout),
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.Record):
+            return ak.layout.Record(
+                self.transform(layout.array, depth, user),
+                layout.at,
+            )
+
+        elif isinstance(layout, ak.layout.UnionArray8_32):
+            return ak.layout.UnionArray8_32(
+                layout.tags,
+                layout.index,
+                [self.transform(x, depth, user) for x in layout.contents],
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.UnionArray8_U32):
+            return ak.layout.UnionArray8_U32(
+                layout.tags,
+                layout.index,
+                [self.transform(x, depth, user) for x in layout.contents],
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.UnionArray8_64):
+            return ak.layout.UnionArray8_64(
+                layout.tags,
+                layout.index,
+                [self.transform(x, depth, user) for x in layout.contents],
+                layout.identities,
+                layout.parameters if self._keep_parameters else None,
+            )
+
+        elif isinstance(layout, ak.layout.VirtualArray):
+            return self.transform(layout.array, depth, user)
+
+        else:
+            raise AssertionError(
+                "unrecognized Content type: {0}".format(type(layout))
+                + exception_suffix(__file__)
+            )
+
+    def transform(self, layout, depth, user):
+        raise NotImplementedError
+
+
+class FunctionalTransformer(LayoutTransformer):
+    def __init__(self, transformer, numpy_to_regular, keep_parameters):
+        super().__init__(keep_parameters=keep_parameters)
+        self._numpy_to_regular = numpy_to_regular
+        self._transformer = transformer
+
+    @property
+    def numpy_to_regular(self):
+        return self._numpy_to_regular
+
+    def transform(self, layout, depth, user):
+        if self._numpy_to_regular and isinstance(layout, ak.layout.NumpyArray):
+            layout = layout.toRegularArray()
+        return self._transformer(self, layout, depth, user)
+
+
+def recursively_transform(
+    layout,
+    transform,
+    user=None,
+    keep_parameters=True,
+    numpy_to_regular=False,
+):
+    transformer = FunctionalTransformer(
+        transform, numpy_to_regular=numpy_to_regular, keep_parameters=keep_parameters
+    )
+    return transformer.transform(layout, 1, user)
+
+
 def find_caches(layout):
     # Both of the implementations below find referentially unique mutablemappings,
     # but the PartitionedArray case is optimized for many unique values (with a set)

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -1958,10 +1958,6 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
     layout = ak.operations.convert.to_layout(
         array, allow_record=False, allow_other=False
     )
-    # Pack the layout above the axis that will be unflattened. This ensures that
-    # the `counts` array, which is computed through these layouts, aligns with
-    # the layout to be unflattened (#910)
-    layout = _packed(layout, axis=axis - 1, highlevel=False)
 
     if isinstance(counts, (numbers.Integral, np.integer)):
         current_offsets = None
@@ -2039,7 +2035,11 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 
     else:
 
-        def getfunction(layout, depth, posaxis):
+        def transform(self, layout, depth, posaxis):
+            # Pack the current layout. This ensures that the `counts` array,
+            # which is computed with these layouts applied, aligns with the
+            # internal layout to be unflattened (#910)
+            layout = _pack_layout(layout)
             posaxis = layout.axis_wrap_if_negative(posaxis)
             if posaxis == depth and isinstance(layout, ak._util.listtypes):
                 # We are one *above* the level where we want to apply this.
@@ -2065,32 +2065,28 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
                         "at axis={0}".format(axis) + ak._util.exception_suffix(__file__)
                     )
 
-                return lambda: ak.layout.ListOffsetArray64(
+                return ak.layout.ListOffsetArray64(
                     ak.layout.Index64(positions), content
                 )
 
             else:
-                return posaxis
+                return self.generic_transform(layout, depth, posaxis)
 
         if isinstance(layout, ak.partition.PartitionedArray):
             outparts = []
             for part in layout.partitions:
                 outparts.append(
-                    ak._util.recursively_apply(
+                    ak._util.recursively_transform(
                         part,
-                        getfunction,
-                        pass_depth=True,
-                        pass_user=True,
+                        transform,
                         user=axis,
                     )
                 )
             out = ak.partition.IrregularlyPartitionedArray(outparts)
         else:
-            out = ak._util.recursively_apply(
+            out = ak._util.recursively_transform(
                 layout,
-                getfunction,
-                pass_depth=True,
-                pass_user=True,
+                transform,
                 user=axis,
             )
 
@@ -2105,201 +2101,171 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
-def _packed(array, axis=None, highlevel=True, behavior=None):
-    layout = ak.operations.convert.to_layout(
-        array, allow_record=True, allow_other=False
-    )
+def _pack_layout(layout):
     nplike = ak.nplike.of(layout)
 
-    def truncate(layout, n):
-        return layout[:n]
+    if isinstance(layout, ak.layout.NumpyArray):
+        return layout.contiguous()
 
-    def apply(layout, depth, posaxis):
-        if posaxis is not None:
-            # If a particular axis was given
-            posaxis = layout.axis_wrap_if_negative(posaxis)
-            # Do not proceed past that axis
-            if posaxis < depth - 1:
-                return layout
+    # EmptyArray is a no-op
+    elif isinstance(layout, ak.layout.EmptyArray):
+        return layout
 
-        if isinstance(layout, ak.layout.NumpyArray):
-            return layout.contiguous()
+    # Project indexed arrays
+    elif isinstance(layout, ak._util.indexedoptiontypes):
+        if isinstance(layout.content, ak._util.optiontypes):
+            return layout.simplify()
 
-        # EmptyArray is a no-op
-        elif isinstance(layout, ak.layout.EmptyArray):
+        index = nplike.asarray(layout.index)
+        new_index = nplike.zeros_like(index)
+
+        is_none = index < 0
+        new_index[is_none] = -1
+        new_index[~is_none] = nplike.arange(len(new_index) - nplike.sum(is_none))
+
+        return ak.layout.IndexedOptionArray64(
+            ak.layout.Index64(new_index), layout.project()
+        )
+
+    # Project indexed arrays
+    elif isinstance(layout, ak._util.indexedtypes):
+        return layout.project()
+
+    # ListArray performs both ordering and resizing
+    elif isinstance(
+        layout,
+        (
+            ak.layout.ListArray32,
+            ak.layout.ListArrayU32,
+            ak.layout.ListArray64,
+        ),
+    ):
+        return layout.toListOffsetArray64(True)
+
+    # ListOffsetArray performs resizing
+    elif isinstance(
+        layout,
+        (
+            ak.layout.ListOffsetArray32,
+            ak.layout.ListOffsetArray64,
+            ak.layout.ListOffsetArrayU32,
+        ),
+    ):
+        new_layout = layout.toListOffsetArray64(True)
+        new_length = new_layout.offsets[-1]
+        return ak.layout.ListOffsetArray64(
+            new_layout.offsets,
+            new_layout.content[:new_length],
+            new_layout.identities,
+            new_layout.parameters,
+        )
+
+    # UnmaskedArray just wraps another array
+    elif isinstance(layout, ak.layout.UnmaskedArray):
+        return ak.layout.UnmaskedArray(layout.content)
+
+    # UnionArrays can be simplified
+    # and their contents too
+    elif isinstance(layout, ak._util.uniontypes):
+        layout = layout.simplify()
+
+        # If we managed to lose the drop type entirely
+        if not isinstance(layout, ak._util.uniontypes):
             return layout
 
-        # Project indexed arrays
-        elif isinstance(layout, ak._util.indexedoptiontypes):
-            if isinstance(layout.content, ak._util.optiontypes):
-                return apply(layout.simplify(), depth, posaxis)
+        # Pack simplified layout
+        tags = nplike.asarray(layout.tags)
+        index = nplike.asarray(layout.index)
 
-            index = nplike.asarray(layout.index)
-            new_index = nplike.zeros_like(index)
+        new_contents = [None] * len(layout.contents)
+        new_index = nplike.zeros_like(index)
 
-            is_none = index < 0
-            new_index[is_none] = -1
-            new_index[~is_none] = nplike.arange(len(new_index) - nplike.sum(is_none))
+        # Compact indices
+        for i in range(len(layout.contents)):
+            is_i = tags == i
 
-            return ak.layout.IndexedOptionArray64(
-                ak.layout.Index64(new_index), apply(layout.project(), depth, posaxis)
-            )
+            new_contents[i] = layout.project(i)
+            new_index[is_i] = nplike.arange(nplike.sum(is_i))
 
-        # Project indexed arrays
-        elif isinstance(layout, ak._util.indexedtypes):
-            return apply(layout.project(), depth, posaxis)
+        return ak.layout.UnionArray8_64(
+            ak.layout.Index8(tags),
+            ak.layout.Index64(new_index),
+            new_contents,
+            layout.identities,
+            layout.parameters,
+        )
 
-        # ListArray performs both ordering and resizing
-        elif isinstance(
-            layout,
-            (
-                ak.layout.ListArray32,
-                ak.layout.ListArrayU32,
-                ak.layout.ListArray64,
-            ),
-        ):
-            return apply(layout.toListOffsetArray64(True), depth, posaxis)
+    # RecordArray contents can be truncated
+    elif isinstance(layout, ak.layout.RecordArray):
+        return ak.layout.RecordArray(
+            [c[: len(layout)] for c in layout.contents],
+            layout.recordlookup,
+            len(layout),
+            layout.identities,
+            layout.parameters,
+        )
 
-        # ListOffsetArray performs resizing
-        elif isinstance(
-            layout,
-            (
-                ak.layout.ListOffsetArray32,
-                ak.layout.ListOffsetArray64,
-                ak.layout.ListOffsetArrayU32,
-            ),
-        ):
-            new_layout = layout.toListOffsetArray64(True)
-            new_length = new_layout.offsets[-1]
-            return ak.layout.ListOffsetArray64(
-                new_layout.offsets,
-                apply(truncate(new_layout.content, new_length), depth + 1, posaxis),
-                new_layout.identities,
-                new_layout.parameters,
-            )
+    # RegularArrays can change length
+    elif isinstance(layout, ak.layout.RegularArray):
+        if not len(layout):
+            return layout
 
-        # UnmaskedArray just wraps another array
-        elif isinstance(layout, ak.layout.UnmaskedArray):
-            return ak.layout.UnmaskedArray(apply(layout.content, depth, posaxis))
+        content = layout.content
 
-        # UnionArrays can be simplified
-        # and their contents too
-        elif isinstance(layout, ak._util.uniontypes):
-            layout = layout.simplify()
+        # Truncate content if it is larger than a perfect
+        # multiple of the RegularArray size
+        n, r = divmod(len(content), layout.size)
+        if r != 0:
+            content = content[: n * layout.size]
 
-            # If we managed to lose the drop type entirely
-            if not isinstance(layout, ak._util.uniontypes):
-                return apply(layout, depth, posaxis)
+        return ak.layout.RegularArray(content, layout.size)
 
-            # Pack simplified layout
-            tags = nplike.asarray(layout.tags)
-            index = nplike.asarray(layout.index)
+    # BitMaskedArrays can change length
+    elif isinstance(layout, ak.layout.BitMaskedArray):
+        layout = layout.simplify()
 
-            new_contents = [None] * len(layout.contents)
-            new_index = nplike.zeros_like(index)
+        if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
+            return layout.toIndexedOptionArray64()
 
-            # Compact indices
-            for i in range(len(layout.contents)):
-                is_i = tags == i
+        return ak.layout.BitMaskedArray(
+            layout.mask,
+            layout.content[: len(layout)],
+            layout.valid_when,
+            len(layout),
+            layout.lsb_order,
+            layout.identities,
+            layout.parameters,
+        )
 
-                new_contents[i] = apply(layout.project(i), depth, posaxis)
-                new_index[is_i] = nplike.arange(nplike.sum(is_i))
+    # ByteMaskedArrays can change length
+    elif isinstance(layout, ak.layout.ByteMaskedArray):
+        layout = layout.simplify()
 
-            return ak.layout.UnionArray8_64(
-                ak.layout.Index8(tags),
-                ak.layout.Index64(new_index),
-                new_contents,
-                layout.identities,
-                layout.parameters,
-            )
+        if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
+            return layout.toIndexedOptionArray64()
 
-        # RecordArray contents can be truncated
-        elif isinstance(layout, ak.layout.RecordArray):
-            return ak.layout.RecordArray(
-                [
-                    apply(truncate(c, len(layout)), depth, posaxis)
-                    for c in layout.contents
-                ],
-                layout.recordlookup,
-                len(layout),
-                layout.identities,
-                layout.parameters,
-            )
+        return ak.layout.ByteMaskedArray(
+            layout.mask,
+            layout.content[: len(layout)],
+            layout.valid_when,
+            layout.identities,
+            layout.parameters,
+        )
 
-        # RegularArrays can change length
-        elif isinstance(layout, ak.layout.RegularArray):
-            if not len(layout):
-                return layout
+    elif isinstance(layout, ak.layout.VirtualArray):
+        return layout.array
 
-            content = layout.content
+    elif isinstance(layout, ak.partition.PartitionedArray):
+        return layout
 
-            # Truncate content if it is larger than a perfect
-            # multiple of the RegularArray size
-            n, r = divmod(len(content), layout.size)
-            if r != 0:
-                content = truncate(content, n * layout.size)
+    elif isinstance(layout, ak.layout.Record):
+        return layout
 
-            return ak.layout.RegularArray(
-                apply(content, depth + 1, posaxis), layout.size
-            )
-
-        # BitMaskedArrays can change length
-        elif isinstance(layout, ak.layout.BitMaskedArray):
-            layout = layout.simplify()
-
-            if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
-                return apply(layout.toIndexedOptionArray64(), depth, posaxis)
-
-            return ak.layout.BitMaskedArray(
-                layout.mask,
-                apply(truncate(layout.content, len(layout)), depth, posaxis),
-                layout.valid_when,
-                len(layout),
-                layout.lsb_order,
-                layout.identities,
-                layout.parameters,
-            )
-
-        # ByteMaskedArrays can change length
-        elif isinstance(layout, ak.layout.ByteMaskedArray):
-            layout = layout.simplify()
-
-            if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
-                return apply(layout.toIndexedOptionArray64(), depth, posaxis)
-
-            return ak.layout.ByteMaskedArray(
-                layout.mask,
-                apply(truncate(layout.content, len(layout)), depth, posaxis),
-                layout.valid_when,
-                layout.identities,
-                layout.parameters,
-            )
-
-        elif isinstance(layout, ak.layout.VirtualArray):
-            return apply(layout.array, depth, posaxis)
-
-        elif isinstance(layout, ak.partition.PartitionedArray):
-            return ak.partition.IrregularlyPartitionedArray(
-                [apply(x, depth, posaxis) for x in layout.partitions]
-            )
-
-        elif isinstance(layout, ak.layout.Record):
-            return ak.layout.Record(
-                apply(layout.array, depth, posaxis),
-                layout.at,
-            )
-
-        # Finally, fall through to failure
-        else:
-            raise AssertionError(
-                "unrecognized layout: "
-                + repr(layout)
-                + ak._util.exception_suffix(__file__)
-            )
-
-    out = apply(layout, 1, axis)
-
-    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+    # Finally, fall through to failure
+    else:
+        raise AssertionError(
+            "unrecognized layout: " + repr(layout) + ak._util.exception_suffix(__file__)
+        )
 
 
 def packed(array, highlevel=True, behavior=None):
@@ -2352,7 +2318,16 @@ def packed(array, highlevel=True, behavior=None):
 
     See also #ak.to_buffers.
     """
-    return _packed(array, highlevel=highlevel, behavior=behavior)
+
+    def _pack_all(self, layout, depth, user):
+        packed = _pack_layout(layout)
+        return self.generic_transform(packed, depth, user)
+
+    layout = ak.operations.convert.to_layout(
+        array, allow_record=True, allow_other=False
+    )
+    out = ak._util.recursively_transform(layout, _pack_all)
+    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 def local_index(array, axis=-1, highlevel=True, behavior=None):

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -185,17 +185,3 @@ def test_record():
     packed = ak.packed(first, highlevel=False)
     assert ak.to_list(packed) == ak.to_list(first)
     assert len(packed.array) == len(layout)
-
-
-def test_axis():
-    content_0 = ak.layout.NumpyArray(np.arange(10))
-
-    offsets_1 = ak.layout.Index64(np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
-    content_1 = ak.layout.ListOffsetArray64(offsets_1, content_0)
-
-    layout = ak.layout.RegularArray(content_1, 3)
-
-    packed = ak.operations.structure._packed(layout, axis=0, highlevel=False)
-    assert ak.to_list(layout) == ak.to_list(packed)
-
-    assert np.asarray(packed.content.content).tolist() == np.asarray(content_0).tolist()


### PR DESCRIPTION
This PR does two things:

## Support Explicit Recursive Transformers
The main reason for adding `pass_apply` to `recursively_apply`
https://github.com/scikit-hep/awkward-1.0/blob/d3be0b101efeaf9f5345dfcbb7e03adc3f42c6c2/src/awkward/_util.py#L1175-L1195

was to enable recursive layout replacement. Having looked at the implementation again, however, it still doesn't go far enough to support the kinds of recursion that motivated this PR; it is not convenient to either call `apply` or just the generic recursion routine. 

This PR moves the existing recursion logic into the free function `transform_child_layouts`. This reconstructs an existing layout, calling `transform` on each child layout to ensure that each level of the recursion may be overridden by the user.
The `recursively_apply` helper function is now written in terms of this new function:
https://github.com/scikit-hep/awkward-1.0/blob/6c7e0659c33038cf8b0574b7d5a973a8448165ed/src/awkward/_util.py#L1184-L1203 

The combination of `transform` and `transform_child_layouts` makes explicit the recursion that was previously handled by testing the return value from the `getfunction`. Long-term, we might remove `recursively_apply` in favour of this new approach. For now, however, this PR re-implements the former using the latter.

## Replace internal `_packed` implementation
Additionally, the `_packed` routine is replaced with `_pack_layout` which operates upon a single layout object. 
https://github.com/scikit-hep/awkward-1.0/blob/6c7e0659c33038cf8b0574b7d5a973a8448165ed/src/awkward/operations/structure.py#L2097-L2262

This is then recursively applied by `ak.packed` using a custom transformer:
https://github.com/scikit-hep/awkward-1.0/blob/6c7e0659c33038cf8b0574b7d5a973a8448165ed/src/awkward/operations/structure.py#L2318-L2323

Closes #969