### PR TITLE
Bugfix: fix #973

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -571,9 +571,14 @@ def completely_flatten(array):
 
     elif isinstance(array, ak.layout.NumpyArray):
         if array.format.upper().startswith("M"):
-            return (ak.nplike.of(array).asarray(array.view_int64).view(array.format),)
+            return (
+                ak.nplike.of(array)
+                .asarray(array.view_int64)
+                .view(array.format)
+                .reshape(-1),
+            )
         else:
-            return (ak.nplike.of(array).asarray(array),)
+            return (ak.nplike.of(array).asarray(array).reshape(-1),)
 
     else:
         raise RuntimeError(

--- a/tests/test_0973-flatten-multidimensional-numpy-array.py
+++ b/tests/test_0973-flatten-multidimensional-numpy-array.py
@@ -1,0 +1,13 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.from_numpy(np.zeros((3, 3, 5)))
+    flattened = ak.flatten(array, axis=None)
+    assert flattened.ndim == 1


### PR DESCRIPTION
Fix #973 by calling `array.reshape(-1)` before returning from `ak._util.completely_flatten`