### PR TITLE
Bugfix: support multidimensional NumPy mask arrays in `ak.mask`

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -179,6 +179,7 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
         [layoutarray, layoutmask],
         getfunction,
         behavior,
+        numpy_to_regular=True,
         right_broadcast=False,
         pass_depth=False,
     )

--- a/tests/test_0975-mask-multidimensional-numpy-array.py
+++ b/tests/test_0975-mask-multidimensional-numpy-array.py
@@ -1,0 +1,22 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array(
+        ak.layout.RegularArray(
+            ak.layout.NumpyArray(np.r_[1, 2, 3, 4, 5, 6, 7, 8, 9]), 3
+        )
+    )
+    mask = ak.Array(
+        ak.layout.NumpyArray(
+            np.array([[True, True, True], [True, True, False], [True, False, True]])
+        )
+    )
+
+    ak.mask(array, mask)

--- a/tests/test_0975-mask-multidimensional-numpy-array.py
+++ b/tests/test_0975-mask-multidimensional-numpy-array.py
@@ -19,4 +19,4 @@ def test():
         )
     )
 
-    ak.mask(array, mask)
+    assert ak.mask(array, mask).to_list() == [[1, 2, 3], [4, 5, None], [7, None, 9]]


### PR DESCRIPTION
Fixes #975