### PR TITLE
fix: Unrestrict jaxlib upper bound and exclude jaxlib v0.1.68

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 autograd;python_version>="3.6"
 flake8
 jax>=0.2.7;python_version>="3.6" and sys_platform != "win32"
-jaxlib>=0.1.57,<0.1.68;python_version>="3.6" and sys_platform != "win32"
+jaxlib>=0.1.57,!=0.1.68;python_version>="3.6" and sys_platform != "win32"
 numba>=0.50.0;python_version>="3.6"
 numexpr;python_version>="3.6"
 pandas>=0.24.0;python_version>="3.6"


### PR DESCRIPTION
* Unrestrict the upper bound on jaxlib in dev requirements
   - Reverts PR #963
* Exclude jaxlib v0.1.68 from being installed in dev requirements
   - c.f. https://github.com/google/jax/issues/7128