### PR TITLE
Fix high-level ak.Array.__dir__ to include methods and properties of overridden classes.

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1134,7 +1134,8 @@ class Array(
         """
         return sorted(
             set(
-                dir(super(Array, self))
+                [x for x in dir(type(self)) if not x.startswith("_")]
+                + dir(super(Array, self))
                 + [
                     x
                     for x in self.layout.keys()
@@ -1853,7 +1854,8 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
         """
         return sorted(
             set(
-                dir(super(Record, self))
+                [x for x in dir(type(self)) if not x.startswith("_")]
+                + dir(super(Record, self))
                 + [
                     x
                     for x in self.layout.keys()

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -519,6 +519,9 @@ class Array(
         """
         return ak.operations.describe.fields(self)
 
+    def _ipython_key_completions_(self):
+        return ak.operations.describe.fields(self)
+
     @property
     def type(self):
         """
@@ -1723,6 +1726,9 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
 
         See also #ak.fields.
         """
+        return ak.operations.describe.fields(self)
+
+    def _ipython_key_completions_(self):
         return ak.operations.describe.fields(self)
 
     @property


### PR DESCRIPTION
@nsmith- This might have been preventing Jupyter from displaying custom methods and properties in tab-completion.

Let me know if you think this implementation is right. (I'm not including the underscored attributes of `type(self)` because this `__dir__` should be showing an object's attributes; it should not include class attributes like `__mro__`.)