### PR TITLE
Bugfix: fix `awkward_NumpyArray_reduce_adjust_starts_64` 

### DIFF
--- a/src/cpu-kernels/awkward_NumpyArray_reduce_adjust_starts_64.cpp
+++ b/src/cpu-kernels/awkward_NumpyArray_reduce_adjust_starts_64.cpp
@@ -9,12 +9,16 @@ ERROR awkward_NumpyArray_reduce_adjust_starts_64(
   int64_t outlength,
   const int64_t* parents,
   const int64_t* starts) {
-  for (int64_t k = 0;  k < outlength;  k++) {
-    int64_t i = toptr[k];
-    if (i >= 0) {
-      int64_t parent = parents[i];
-      int64_t start = starts[parent];
-      toptr[k] += -start;
+
+  if (outlength > 0) {
+    int64_t origin = starts[parents[toptr[0]]];
+    for (int64_t k = 0;  k < outlength;  k++) {
+      int64_t i = toptr[k];
+      if (i >= 0) {
+        int64_t parent = parents[i];
+        int64_t start = starts[parent];
+        toptr[k] += -(start - origin);
+      }
     }
   }
   return success();

--- a/tests/test_0998-argmax-numpy-array-offset.py
+++ b/tests/test_0998-argmax-numpy-array-offset.py
@@ -30,5 +30,5 @@ def test_argmax():
 
 
 def test_argmin():
-    i = ak.argmax(array, axis=-1)
-    assert ak.to_list(i.layout.content) == [0, 1, 2]
+    i = ak.argmin(array, axis=-1)
+    assert ak.to_list(i.layout.content) == [0, 0, 0]

--- a/tests/test_0998-argmax-numpy-array-offset.py
+++ b/tests/test_0998-argmax-numpy-array-offset.py
@@ -1,0 +1,34 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+array = ak.Array(
+    ak.layout.ListOffsetArray64(
+        ak.layout.Index64(np.r_[1, 2, 4, 7]),
+        ak.layout.NumpyArray(
+            np.r_[
+                1.8125,
+                0.8125,
+                -0.9375,
+                1.1875,
+                -0.6875,
+                1.3125,
+                21.3125,
+            ]
+        ),
+    )
+)
+
+
+def test_argmax():
+    i = ak.argmax(array, axis=-1)
+    assert ak.to_list(i.layout.content) == [0, 1, 2]
+
+
+def test_argmin():
+    i = ak.argmax(array, axis=-1)
+    assert ak.to_list(i.layout.content) == [0, 1, 2]


### PR DESCRIPTION
This PR intends to solve #998 by fixing `awkward_NumpyArray_reduce_adjust_starts_64`. With these changes, the adjusted positions are now valid for `ListOffsetArray`s with non-zero `offsets[0]`.

This is my first time working with the kernels, and whilst I think I have a handle on what is going on (see #998), I would appreciate a look over by the reviewers.

Fixes #998