### PR TITLE
Fixes #998 and #1000; argmax for ListOffsetArray with nonzero start. Also optimizes toListOffsetArray64(true).

### DIFF
--- a/tests/test_1000-fixes-argmax-for-ListOffsetArray-with-nonzero-start.py
+++ b/tests/test_1000-fixes-argmax-for-ListOffsetArray-with-nonzero-start.py
@@ -1,0 +1,72 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_mine():
+    array = ak.Array(
+        ak.layout.ListOffsetArray64(
+            ak.layout.Index64(np.array([1, 2, 4, 7], np.int64)),
+            ak.layout.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+            ),
+        )
+    )
+    assert (
+        ak.argmax(array, axis=-1).tolist()
+        == ak.argmax(ak.Array([[1.1], [2.2, 3.3], [4.4, 5.5, 6.6]]), axis=-1).tolist()
+    )
+
+
+def test_998():
+    array = ak.Array(
+        ak.layout.ListOffsetArray64(
+            ak.layout.Index64(np.array([1, 2, 4, 7], np.int64)),
+            ak.layout.NumpyArray(
+                np.r_[
+                    1.8125,
+                    0.8125,
+                    -0.9375,
+                    1.1875,
+                    -0.6875,
+                    1.3125,
+                    21.3125,
+                ]
+            ),
+        )
+    )
+
+    assert ak.to_list(ak.argmax(array, axis=-1)) == [0, 1, 2]
+
+
+def test_1000():
+    array = ak.Array(
+        ak.layout.ListOffsetArray64(
+            ak.layout.Index64(np.array([1, 3, 5], np.int64)),
+            ak.layout.ListOffsetArray64(
+                ak.layout.Index64(np.array([0, 3, 5, 8, 10, 12], np.int64)),
+                ak.layout.NumpyArray(
+                    np.r_[
+                        1.8125,
+                        0.81252,
+                        -0.937,
+                        6.0,
+                        -0.6875,
+                        1.3125,
+                        21.3125,
+                        4.0,
+                        9.8,
+                        2.2,
+                        33.0,
+                        44.6,
+                    ]
+                ),
+            ),
+        )
+    )
+
+    assert ak.to_list(ak.argmax(array, axis=1)) == [[0, 1, 1], [1, 1]]


### PR DESCRIPTION
@agoose77 Although there's probably a solution involving fixing kernels, the offsets would have to be rewritten to shift to zero anyway (because that's what the output of the reduction has), so we might as well just adjust it to start at zero preemptively.

The cost of `ListOffsetArray64::toListOffsetArray64(true)` (if `offsets_[0] != 0`, which is a trivial case) should only be the cost of rewriting the `offsets`. (Which itself [is auto-vectorizable](https://awkward-array.readthedocs.io/en/latest/_auto/kernels.html#awkward-listoffsetarray-compact-offsets) by a smart enough compiler.) It shouldn't be necessary to do anything with the `content` other than `content->getitem_range(offsets_[0], content->length())`, which is _O(1)_.

The old implementation of `toListOffsetArray64` was calling `broadcast_tooffsets64`, which is a general purpose function that doesn't assume that the given offsets will fit this array, but if we've just generated them and we're starting with a ListOffsetArray, then we know that they will fit (i.e. all nested lists have have compatible lengths). Optimizing this utility function probably has benefits across the codebase, though we don't have frequently-executed performance metrics to measure it.