### PR TITLE
docs: touch up contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ We adhere to an 80-character line width, which is a [standard in the industry](h
 
 Unit tests do not need to adhere to the 80-character limit.
 
-we use several linters and reformatters; all are supported through a single interface with the [pre-commit](https://pre-commit.com) tool. Automatic reformatting will be applied to PRs automatically using [pre-commit.ci](https://pre-commit.ci), though running pre-commit locally is still recommended.
+We use several linters and reformatters; all are supported through a single interface with the [pre-commit](https://pre-commit.com) tool. Automatic reformatting will be applied to PRs automatically using [pre-commit.ci](https://pre-commit.ci), though running pre-commit locally is still recommended.
 
 ### Fully qualified names
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,9 +235,7 @@ We adhere to an 80-character line width, which is a [standard in the industry](h
 
 Unit tests do not need to adhere to the 80-character limit.
 
-We don't, however, use automated formatters like clang-format or black. Automated formatting can rearrange code into something that is, paradoxically, harder to read, undermining the human element in programming.
-
-We don't currently use linters like clang-tidy or flake8, but I'm open to it.
+we use several linters and reformatters; all are supported through a single interface with the [pre-commit](https://pre-commit.com) tool. Automatic reformatting will be applied to PRs automatically using [pre-commit.ci](https://pre-commit.ci), though running pre-commit locally is still recommended.
 
 ### Fully qualified names
 
@@ -275,7 +273,7 @@ We only supprt Python 2.7 as much as is practical. For example, we ignore compil
 
 Python 2.7 and 3.5 have unstable dict order, which excludes them both from some tests.
 
-Allowing Python 2.7 after it has been [fully and finally discontinued](https://mail.python.org/archives/list/python-dev@python.org/message/OFCIETIXLX34X7FVK5B5WPZH22HXV342/) may sound anachronistic, but some of our users depend on legacy codebases forcing them in Python 2, and Python 2 limits our adoption of new language features, keeping the code "simple, rather than smart."
+Allowing Python 2.7 after it has been [fully and finally discontinued](https://mail.python.org/archives/list/python-dev@python.org/message/OFCIETIXLX34X7FVK5B5WPZH22HXV342/) may sound anachronistic, but some of our users depend on legacy codebases forcing them in Python 2, so we support that for now.
 
 ### Third party dependencies
 


### PR DESCRIPTION
This corrects the outdated commend about formatting and linting.

It also removes something I found highly irritating - I'm sure you know what it
is :). Using new features in a language or a library does _not_ make your code
"less-simple" - it makes it harder to read and more complex because instead of
using a new feature that has a clear meaning that everyone can learn, it's
adding code unique to your library only every reader must parse to see what you
are doing. For example, take a few items from contextlib (which has had
fantastic improvements):

```python
with contextlib.redirect_stdout(sys.stderr):
    should_print_to_stderr_but_doesnt()

with contextlib.suppress(FileNotFoundError):
    os.remove('somefile.tmp')

with contextlib.ExitStack() as stack:
    stack.enter_context(context_manager_1())
    stack.enter_context(context_manager_2())
    stack.enter_context(context_manager_3())
```

I think you can read what those do without looking at the docs, and if you
can't, everyone knows how to get to the Python docs; finding local
documentation or reading the expanded try/catch or manually implemented
versions is much harder for readers. And it's easy to incorrectly implement;
for example, if `should_print_to_stderr_but_doesnt` throws an error, a hand
implementation might not restore the streams, causing important information
about what happened to be swallowed.

Also, why should someone upgrade awkward, then? Aren't older versions
"simpler", by this logic?

If/when you are ready to drop Python 2, remember that Python 2 _will_ keep
working! It will just pull older versions of awkward / uproot (as it already
does with NumPy, boost-histogram, and everything else). Binary distribution
will become much harder quite rapidly for Python 2 - pip, packaging, wheel, and
auditwheel have already dropped support, manylinux1 (the only remaining place
with Python 2) dies Jan 1, 2022, pybind11 drops support roughly Jan 1, 2022,
cibuildwheel drops it tomorrow, etc.

(PS: I originally did this with the GitHub interface and it committed to main
accidentally - immediately reverted, and making a proper PR. Huge apologies!).
