### PR TITLE
Bugfix: fix `ak.packed` for `RegularArray`s with `.size=0`

### DIFF
--- a/tests/test_1006-packed-regular-array-zero-size.py
+++ b/tests/test_1006-packed-regular-array-zero-size.py
@@ -1,0 +1,13 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.from_numpy(np.zeros((1, 0), dtype=np.int32), regulararray=True)
+    packed = ak.packed(array)
+    assert ak.to_list(packed) == [[]]


### PR DESCRIPTION
This also catches some places where the `identities` and `parameters` were not retained from the original layout

Fixes #1006 