### PR TITLE
Bugfix: support empty buffers in `from_buffers`

### DIFF
--- a/tests/test_1007-from_buffers-empty-ndarray.py
+++ b/tests/test_1007-from_buffers-empty-ndarray.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.from_numpy(np.zeros((3, 0), dtype=np.int32))
+    buffs = ak.to_buffers(array)
+    new_array = ak.from_buffers(*buffs)
+
+    assert ak.to_list(new_array) == [[], [], []]


### PR DESCRIPTION
`ak.from_buffers` fails to reconstruct an array when the `NumpyForm` has a zero itemsize. This PR fixes this by only performing a length check if itemsize` is nonzero, and taking the leading dimension from the given `length`.

Fixes #1007