### PR TITLE
Bugfix: do not use `regular_to_jagged` in `ak.zip`

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -477,6 +477,7 @@ def zip(
     with_name=None,
     highlevel=True,
     behavior=None,
+    right_broadcast=False,
 ):
     """
     Args:
@@ -496,6 +497,8 @@ def zip(
             a low-level #ak.layout.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
+        right_broadcast (bool): If True, follow rules for implicit
+            right-broadcasting, as described in #ak.broadcast_arrays.
 
     Combines `arrays` into a single structure as the fields of a collection
     of records or the slots of a collection of tuples. If the `arrays` have
@@ -639,9 +642,8 @@ def zip(
         layouts,
         getfunction,
         behavior,
-        right_broadcast=False,
+        right_broadcast=right_broadcast,
         pass_depth=True,
-        regular_to_jagged=True,
     )
     assert isinstance(out, tuple) and len(out) == 1
     out = out[0]

--- a/tests/test_1012-zip-regular-arrays.py
+++ b/tests/test_1012-zip-regular-arrays.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    parameters = ak.from_numpy(np.arange(3 * 3).reshape(-1, 3), regulararray=True)
+    array = ak.zip((parameters, parameters))
+    assert array.layout.purelist_isregular
+
+    assert ak.to_list(array) == [
+        [(0, 0), (1, 1), (2, 2)],
+        [(3, 3), (4, 4), (5, 5)],
+        [(6, 6), (7, 7), (8, 8)],
+    ]


### PR DESCRIPTION
This fixes #1012 which was introduced by 585ca1a0d0c6f8d8473c3f177f7ccf8546cea9a6. Instead, we just use `right_broadcast=False`, and allow the user to override this value with a parameter.