### PR TITLE
Fix: set `numpy_to_regular=True` in `broadcast_arrays`

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -1380,6 +1380,7 @@ def broadcast_arrays(*arrays, **kwargs):
         left_broadcast=left_broadcast,
         right_broadcast=right_broadcast,
         pass_depth=False,
+        numpy_to_regular=True,
     )
     assert isinstance(out, tuple)
     if highlevel:

--- a/tests/test_1017-numpyarray-broadcast.py
+++ b/tests/test_1017-numpyarray-broadcast.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    x = ak.layout.ListOffsetArray64(
+        ak.layout.Index64(np.array([0, 2, 2, 4, 6])),
+        ak.layout.NumpyArray(np.arange(8 * 8).reshape(8, -1)),
+    )
+    y = ak.layout.ListOffsetArray64(
+        ak.layout.Index64(np.array([0, 2, 2, 4, 6])), ak.layout.NumpyArray(np.arange(8))
+    )
+    u, v = ak.broadcast_arrays(x, y)
+    assert u.ndim == v.ndim


### PR DESCRIPTION
As discussed in #1017, the solution here is either to apply this PR, or to modify the `getfunction` to accept n-dim arrays. As the broadcasting routine performs such a conversion anyway (albeit after the getfunction is called), it seems reasonable to do so earlier.

Fixes #1017 