### PR TITLE
Feat: add `name` parameter to `mixin_class`

### DIFF
--- a/tests/test_1030-mixin-class-name.py
+++ b/tests/test_1030-mixin-class-name.py
@@ -1,0 +1,31 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+behavior = {}
+
+
+@ak.mixin_class(behavior, "1030_point")
+class AVeryVeryVeryLargeClassName:
+    @property
+    def mag2(self):
+        return self.x ** 2 + self.y ** 2
+
+
+def test():
+    x = np.random.randint(0, 64, 128)
+    y = np.random.randint(0, 64, 128)
+
+    point_1030 = ak.zip({"x": x, "y": y}, behavior=behavior, with_name="1030_point")
+    assert isinstance(point_1030.mag2, ak.Array)
+
+    point = ak.zip(
+        {"x": x, "y": y}, behavior=behavior, with_name="AVeryVeryVeryLargeClassName"
+    )
+    with pytest.raises(AttributeError):
+        assert isinstance(point.mag2, ak.Array)

--- a/tests/test_1030-mixin-class-name.py
+++ b/tests/test_1030-mixin-class-name.py
@@ -11,7 +11,7 @@ behavior = {}
 
 
 @ak.mixin_class(behavior, "1030_point")
-class AVeryVeryVeryLargeClassName:
+class AVeryVeryVeryLargeClassName(object):
     @property
     def mag2(self):
         return self.x ** 2 + self.y ** 2


### PR DESCRIPTION
`ak.mixin_class` is very useful, but does not provide a straightforward way to specify the name of the behavior; it uses the name of the class by default.

The requirements of a behavior name and a Python class name are somewhat in conflict:
- Length
  - Python class names tend to be longer and descriptive
  - Behavior names tend to be short and concise
- Case
  - Python class names are usually CamelCase
  - Type strings tend to be lower case

This PR makes it easier to change the name used by `ak.mixin_class`.