### PR TITLE
Extend arrayclass to depend on number of dimensions.

### DIFF
--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -105,6 +105,11 @@ namespace awkward {
     virtual const std::string
       purelist_parameter(const std::string& key) const = 0;
 
+    /// @brief The parameter associated with `key` n levels of list
+    /// dimensions deep.
+    virtual const std::string
+      nlist_parameter(const std::string& key, int64_t n) const = 0;
+
     /// @brief Returns `true` if the parameter associated with `key` exists
     /// and is equal to `value`; `false` otherwise.
     ///
@@ -558,6 +563,11 @@ namespace awkward {
     /// RecordArray.
     virtual const std::string
       purelist_parameter(const std::string& key) const;
+
+    /// @brief The parameter associated with `key` n levels of list
+    /// dimensions deep.
+    virtual const std::string
+      nlist_parameter(const std::string& key, int64_t n) const;
 
     /// @brief Returns `true` if all nested lists down to the first RecordArray
     /// are RegularArray nodes; `false` otherwise.

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -59,6 +59,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -53,6 +53,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -39,6 +39,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -47,6 +47,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 
@@ -128,6 +131,9 @@ namespace awkward {
 
     const std::string
       purelist_parameter(const std::string& key) const override;
+
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
 
     bool
       purelist_isregular() const override;

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -49,6 +49,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -45,6 +45,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -65,6 +65,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/RawArray.h
+++ b/include/awkward/array/RawArray.h
@@ -85,6 +85,16 @@ namespace awkward {
       return parameter(key);
     }
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override {
+      if (n == 0) {
+        return parameter(key);
+      }
+      else {
+        return "null";
+      }
+    }
+
     bool
       purelist_isregular() const override {
       return true;

--- a/include/awkward/array/RecordArray.h
+++ b/include/awkward/array/RecordArray.h
@@ -58,6 +58,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -45,6 +45,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -57,6 +57,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -45,6 +45,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/include/awkward/array/VirtualArray.h
+++ b/include/awkward/array/VirtualArray.h
@@ -50,6 +50,9 @@ namespace awkward {
     const std::string
       purelist_parameter(const std::string& key) const override;
 
+    const std::string
+      nlist_parameter(const std::string& key, int64_t n) const override;
+
     bool
       purelist_isregular() const override;
 

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -914,6 +914,11 @@ namespace awkward {
     return form(false).get()->purelist_parameter(key);
   }
 
+  const std::string
+  Content::nlist_parameter(const std::string& key, int64_t n) const {
+    return form(false).get()->nlist_parameter(key, n);
+  }
+
   bool
   Content::purelist_isregular() const {
     return form(true).get()->purelist_isregular();

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -120,6 +120,20 @@ namespace awkward {
     }
   }
 
+  const std::string
+  BitMaskedForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      std::string out = parameter(key);
+      if (out == std::string("null")) {
+        return content_.get()->nlist_parameter(key, n);
+      }
+      return out;
+    }
+    else {
+      return content_.get()->nlist_parameter(key, n);
+    }
+  }
+
   bool
   BitMaskedForm::purelist_isregular() const {
     return content_.get()->purelist_isregular();

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -112,6 +112,20 @@ namespace awkward {
     }
   }
 
+  const std::string
+  ByteMaskedForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      std::string out = parameter(key);
+      if (out == std::string("null")) {
+        return content_.get()->nlist_parameter(key, n);
+      }
+      return out;
+    }
+    else {
+      return content_.get()->nlist_parameter(key, n);
+    }
+  }
+
   bool
   ByteMaskedForm::purelist_isregular() const {
     return content_.get()->purelist_isregular();

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -63,6 +63,16 @@ namespace awkward {
     return parameter(key);
   }
 
+  const std::string
+  EmptyForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      return parameter(key);
+    }
+    else {
+      return "null";
+    }
+  }
+
   bool
   EmptyForm::purelist_isregular() const {
     return true;

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -129,6 +129,20 @@ namespace awkward {
     }
   }
 
+  const std::string
+  IndexedForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      std::string out = parameter(key);
+      if (out == std::string("null")) {
+        return content_.get()->nlist_parameter(key, n);
+      }
+      return out;
+    }
+    else {
+      return content_.get()->nlist_parameter(key, n);
+    }
+  }
+
   bool
   IndexedForm::purelist_isregular() const {
     return content_.get()->purelist_isregular();
@@ -372,6 +386,20 @@ namespace awkward {
     }
     else {
       return out;
+    }
+  }
+
+  const std::string
+  IndexedOptionForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      std::string out = parameter(key);
+      if (out == std::string("null")) {
+        return content_.get()->nlist_parameter(key, n);
+      }
+      return out;
+    }
+    else {
+      return content_.get()->nlist_parameter(key, n);
     }
   }
 

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -125,6 +125,16 @@ namespace awkward {
     }
   }
 
+  const std::string
+  ListForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      return parameter(key);
+    }
+    else {
+      return content_.get()->nlist_parameter(key, n - 1);
+    }
+  }
+
   bool
   ListForm::purelist_isregular() const {
     return false;

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -115,6 +115,16 @@ namespace awkward {
     }
   }
 
+  const std::string
+  ListOffsetForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      return parameter(key);
+    }
+    else {
+      return content_.get()->nlist_parameter(key, n - 1);
+    }
+  }
+
   bool
   ListOffsetForm::purelist_isregular() const {
     return false;

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -193,6 +193,16 @@ namespace awkward {
     return parameter(key);
   }
 
+  const std::string
+  NumpyForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      return parameter(key);
+    }
+    else {
+      return "null";
+    }
+  }
+
   bool
   NumpyForm::purelist_isregular() const {
     return true;

--- a/src/libawkward/array/RecordArray.cpp
+++ b/src/libawkward/array/RecordArray.cpp
@@ -159,6 +159,16 @@ namespace awkward {
     return parameter(key);
   }
 
+  const std::string
+  RecordForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      return parameter(key);
+    }
+    else {
+      return "null";
+    }
+  }
+
   bool
   RecordForm::purelist_isregular() const {
     return true;

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -102,6 +102,16 @@ namespace awkward {
     }
   }
 
+  const std::string
+  RegularForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      return parameter(key);
+    }
+    else {
+      return content_.get()->nlist_parameter(key, n - 1);
+    }
+  }
+
   bool
   RegularForm::purelist_isregular() const {
     return content_.get()->purelist_isregular();

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -142,6 +142,40 @@ namespace awkward {
     }
   }
 
+  const std::string
+  UnionForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      std::string out = parameter(key);
+      if (out == std::string("null")) {
+        if (contents_.empty()) {
+          return "null";
+        }
+        out = contents_[0].get()->nlist_parameter(key, n);
+        for (size_t i = 1;  i < contents_.size();  i++) {
+          if (!util::json_equals(out, contents_[i].get()->nlist_parameter(key, n))) {
+            return "null";
+          }
+        }
+        return out;
+      }
+      else {
+        return out;
+      }
+    }
+    else {
+      if (contents_.empty()) {
+        return "null";
+      }
+      std::string out = contents_[0].get()->nlist_parameter(key, n);
+      for (size_t i = 1;  i < contents_.size();  i++) {
+        if (!util::json_equals(out, contents_[i].get()->nlist_parameter(key, n))) {
+          return "null";
+        }
+      }
+      return out;
+    }
+  }
+
   bool
   UnionForm::purelist_isregular() const {
     for (auto content : contents_) {

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -87,6 +87,20 @@ namespace awkward {
     }
   }
 
+  const std::string
+  UnmaskedForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      std::string out = parameter(key);
+      if (out == std::string("null")) {
+        return content_.get()->nlist_parameter(key, n);
+      }
+      return out;
+    }
+    else {
+      return content_.get()->nlist_parameter(key, n);
+    }
+  }
+
   bool
   UnmaskedForm::purelist_isregular() const {
     return content_.get()->purelist_isregular();

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -105,6 +105,28 @@ namespace awkward {
     }
   }
 
+  const std::string
+  VirtualForm::nlist_parameter(const std::string& key, int64_t n) const {
+    if (n == 0) {
+      std::string out = parameter(key);
+      if (out == std::string("null")) {
+        if (form_.get() == nullptr) {
+          return out;
+        }
+        return form_.get()->nlist_parameter(key, n);
+      }
+      else {
+        return out;
+      }
+    }
+    else {
+      if (form_.get() == nullptr) {
+        return "null";
+      }
+      return form_.get()->nlist_parameter(key, n);
+    }
+  }
+
   bool
   VirtualForm::purelist_isregular() const {
     if (form_.get() == nullptr) {

--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -1258,6 +1258,16 @@ purelist_parameter(const T& self, const std::string& key) {
 }
 
 template <typename T>
+py::object
+nlist_parameter(const T& self, const std::string& key, int64_t n) {
+  std::string cppvalue = self.nlist_parameter(key, n);
+  py::str pyvalue(PyUnicode_DecodeUTF8(cppvalue.data(),
+                                       cppvalue.length(),
+                                       "surrogateescape"));
+  return py::module::import("json").attr("loads")(pyvalue);
+}
+
+template <typename T>
 void
 setparameters(T& self, const py::object& parameters) {
   self.setparameters(dict2parameters(parameters));
@@ -1303,6 +1313,7 @@ content_methods(py::class_<T, std::shared_ptr<T>, ak::Content>& x) {
           .def("withparameter", &withparameter<T>)
           .def("parameter", &parameter<T>)
           .def("purelist_parameter", &purelist_parameter<T>)
+          .def("nlist_parameter", &nlist_parameter<T>)
           .def("type",
                [](const T& self,
                   const std::map<std::string, std::string>& typestrs)


### PR DESCRIPTION
@agoose77 I didn't want #1038 to have to wait for v2, so I wrote `nlist_parameter` to demonstrate how `purelist_parameter` can be generalized. This method is like `purelist_parameter` except that it will only report the parameter at a given depth. Unlike `purelist_parameter`, it "looks through" nodes at a higher depth than the one specified and like `purelist_parameter`, it will take the first node that has the requested parameter _at_ the specified depth.

Now that I look at the original problem, you also want "depth greater than or equal to," but that would be a simple modification of this method: after `n` reaches `0`, it can switch over to `purelist_parameter` to keep going. The main thing about these methods is that they encode the knowledge that ListArray, ListOffsetArray, and RegularArray are dimensions, RecordArrays are terminal, UnionArrays require agreement among all of their branches, and everything else is a non-dimension node.

You can use this PR as a base for solving #1038 or as an example of how a method _like_ `purelist_parameter` is implemented, since it's illustrated in the diff of this first commit. Whatever you come up with can easily be ported to v2.