### PR TITLE
Proposal to stop ak.broadcast_arrays at records.

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -1369,6 +1369,8 @@ def broadcast_arrays(*arrays, **kwargs):
     def getfunction(inputs):
         if all(isinstance(x, ak.layout.NumpyArray) for x in inputs):
             return lambda: tuple(inputs)
+        elif all(isinstance(x, ak.layout.RecordArray) for x in inputs):
+            return lambda: tuple(inputs)
         else:
             return None
 

--- a/tests/test_1040-proposal-to-stop-broadcast_arrays-at-records.py
+++ b/tests/test_1040-proposal-to-stop-broadcast_arrays-at-records.py
@@ -1,0 +1,32 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    assert [x.tolist() for x in ak.broadcast_arrays([1, 2, 3], [[], [1], [1, 2]])] == [
+        [[], [2], [3, 3]],
+        [[], [1], [1, 2]],
+    ]
+
+    assert [
+        x.tolist()
+        for x in ak.broadcast_arrays([1, 2, 3], [[], [{"x": 1}], [{"x": 1}, {"x": 2}]])
+    ] == [
+        [[], [{"x": 2}], [{"x": 3}, {"x": 3}]],
+        [[], [{"x": 1}], [{"x": 1}, {"x": 2}]],
+    ]
+
+    assert [
+        x.tolist()
+        for x in ak.broadcast_arrays(
+            [{"y": 1}, {"y": 2}, {"y": 3}], [[], [{"x": 1}], [{"x": 1}, {"x": 2}]]
+        )
+    ] == [
+        [[], [{"y": 2}], [{"y": 3}, {"y": 3}]],
+        [[], [{"x": 1}], [{"x": 1}, {"x": 2}]],
+    ]

--- a/tests/test_1040-proposal-to-stop-broadcast_arrays-at-records.py
+++ b/tests/test_1040-proposal-to-stop-broadcast_arrays-at-records.py
@@ -26,7 +26,7 @@ def test():
         for x in ak.broadcast_arrays(
             [1, 2, 3],
             [[], [{"x": 1}], [{"x": 1}, {"x": 2}]],
-            promote_scalar_to_record=False,
+            stop_at_record=True,
         )
     ] == [
         [[], [2], [3, 3]],

--- a/tests/test_1040-proposal-to-stop-broadcast_arrays-at-records.py
+++ b/tests/test_1040-proposal-to-stop-broadcast_arrays-at-records.py
@@ -24,6 +24,18 @@ def test():
     assert [
         x.tolist()
         for x in ak.broadcast_arrays(
+            [1, 2, 3],
+            [[], [{"x": 1}], [{"x": 1}, {"x": 2}]],
+            promote_scalar_to_record=False,
+        )
+    ] == [
+        [[], [2], [3, 3]],
+        [[], [{"x": 1}], [{"x": 1}, {"x": 2}]],
+    ]
+
+    assert [
+        x.tolist()
+        for x in ak.broadcast_arrays(
             [{"y": 1}, {"y": 2}, {"y": 3}], [[], [{"x": 1}], [{"x": 1}, {"x": 2}]]
         )
     ] == [


### PR DESCRIPTION
@agoose77 This is prompted by your question on Gitter:

> Hey @jpivarski , sorry for the visual noise - I've determined that you can't edit messages on Matrix once someone has replied to them (well, you can, but Gitter displays copied messages 🤮).
> 
> Should two arrays with different dimensions and record types be broadcastable?
> E.g.
> 
> ```
> >>> x.type
> 4056 * var * {"u": ?int64, "v": ?int64}
> >>> y.type
> 4056 * var * var * {"q": float64, "t": float64}
> >>> ak.broadcast_arrays(x, y)
> ValueError ...
> ```
> We currently require the record fields to match if we allow records to broadcast against one another.
> 
> This behavior initially surprised me - I expected the record-part to be irrelevant and successfully left-broadcast; the record is part of the type, and we allow different dtypes to broadcast:
> 
> ```
> >>> ak.broadcast_arrays(x.u, y.t)
> [<Array [[[66], [65]], ... 64], [68], [65]]] type='4056 * var * option[var * int64]'>,
>  <Array [[[32], [199]], ... [31], [275]]] type='4056 * var * option[var * float64]'>]
> ```
> However, I'm also not sure about the resulting type here - naively I'd expect the option to wrap the dtype, not the var dimension.
> 
> The broadcasting works if I use zip, because zip exits early from the broadcasting once the purelist_depth is 1 (i.e. it doesn't encounter the bare record).
> 
> ```
> >>> ak.zip((u, v)).type
> 4056 * var * var * ({"u": ?int64, "v": ?int64}, {"t": float64, "q": float64})
> ```
> Most likely I am missing something here, but perhaps you could shed some light on this? @jpivarski

What I've done here is to stop broadcasting at records when all inputs are records, so that non-records are still broadcasted into the fields of a record, but two records aren't broadcasted into each other (which is impossible, which is why you got the ValueError). Maybe the rule should be "any record" rather than "all records"? That's why this PR is a draft.

See tests/test_1040-proposal-to-stop-broadcast_arrays-at-records.py for examples.

Also note that this only affects `ak.broadcast_arrays`, not broadcasting in general.