### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/dev/generate-kernel-signatures.py
+++ b/dev/generate-kernel-signatures.py
@@ -14,7 +14,7 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 def reproducible_datetime():
 
     build_date = datetime.datetime.utcfromtimestamp(
-        int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+        int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
     )
     return build_date.isoformat().replace("T", " AT ")[:22]
 

--- a/dev/generate-kernel-signatures.py
+++ b/dev/generate-kernel-signatures.py
@@ -4,10 +4,19 @@ from __future__ import absolute_import
 
 import os
 import datetime
+import time
 
 import yaml
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def reproducible_datetime():
+
+    build_date = datetime.datetime.utcfromtimestamp(
+        int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+    )
+    return build_date.isoformat().replace("T", " AT ")[:22]
 
 
 def type_to_ctype(typename):
@@ -49,7 +58,7 @@ def include_kernels_h(specification):
 extern "C" {{
 
 """.format(
-                datetime.datetime.now().isoformat().replace("T", " AT ")[:22]
+                reproducible_datetime()
             )
         )
         for spec in specification["kernels"]:
@@ -169,7 +178,7 @@ class ERROR(Structure):
 def by_signature(lib):
     out = {{}}
 """.format(
-                datetime.datetime.now().isoformat().replace("T", " AT ")[:22]
+                reproducible_datetime()
             )
         )
 


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This PR was done while working on reproducible builds for openSUSE.