### PR TITLE
Fix deprecation warning stack level

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -109,7 +109,7 @@ after the first `import awkward` or use `@pytest.mark.filterwarnings("error:::aw
 Issue: {3}.""".format(
         version, date, will_be, message
     )
-    warnings.warn(warning, category)
+    warnings.warn(warning, category, stacklevel=3)
 
 
 # Sentinel object for catching pass-through values

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -96,7 +96,7 @@ def deprecate(
     date=None,
     will_be="an error",
     category=DeprecationWarning,
-    stacklevel=1,
+    stacklevel=2,
 ):
     if date is None:
         date = ""
@@ -114,7 +114,7 @@ after the first `import awkward` or use `@pytest.mark.filterwarnings("error:::aw
 Issue: {3}.""".format(
         version, date, will_be, message
     )
-    warnings.warn(warning, category, stacklevel=stacklevel + 2)
+    warnings.warn(warning, category, stacklevel=stacklevel + 1)
 
 
 # Sentinel object for catching pass-through values

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -91,7 +91,12 @@ warnings.filterwarnings("default", module="awkward.*")
 
 
 def deprecate(
-    message, version, date=None, will_be="an error", category=DeprecationWarning
+    message,
+    version,
+    date=None,
+    will_be="an error",
+    category=DeprecationWarning,
+    stacklevel=1,
 ):
     if date is None:
         date = ""
@@ -109,7 +114,7 @@ after the first `import awkward` or use `@pytest.mark.filterwarnings("error:::aw
 Issue: {3}.""".format(
         version, date, will_be, message
     )
-    warnings.warn(warning, category, stacklevel=3)
+    warnings.warn(warning, category, stacklevel=stacklevel + 2)
 
 
 # Sentinel object for catching pass-through values


### PR DESCRIPTION
The current warning(s) emitted by `deprecate` (currently only used in `fill_none`) are not too helpful since they show a [position](https://github.com/scikit-hep/awkward-1.0/blob/69b66fce097d3daf978eac7aa95c7ccd85b1e5bb/src/awkward/_util.py#L112) in the `deprecate` helper function.

By using the `stacklevel` parameter of [`warnings.warn`](https://docs.python.org/3/library/warnings.html#warnings.warn) we can adjust this to show the line where the (marked as deprecated) function was called from i.e. usually somewhere in the users code.