### PR TITLE
Optimizing common take operations

### DIFF
--- a/src/cpu-kernels/awkward_ListArray_getitem_jagged_apply.cpp
+++ b/src/cpu-kernels/awkward_ListArray_getitem_jagged_apply.cpp
@@ -38,19 +38,19 @@ ERROR awkward_ListArray_getitem_jagged_apply(
       }
       int64_t count = stop - start;
       for (int64_t j = slicestart;  j < slicestop;  j++) {
-        int64_t index = (int64_t)sliceindex[j];
+        int64_t index = (int64_t) sliceindex[j];
+        if (index < -count || index >= count) {
+          return failure("index out of range", i, index, FILENAME(__LINE__));
+        }
         if (index < 0) {
           index += count;
-        }
-        if (!(0 <= index  &&  index < count)) {
-          return failure("index out of range", i, (int64_t)sliceindex[j], FILENAME(__LINE__));
         }
         tocarry[k] = start + index;
         k++;
       }
     }
-    tooffsets[i + 1] = (T)k;
   }
+  tooffsets[sliceouterlen] = (T)k;
   return success();
 }
 ERROR awkward_ListArray32_getitem_jagged_apply_64(

--- a/src/cpu-kernels/awkward_NumpyArray_getitem_next_null.cpp
+++ b/src/cpu-kernels/awkward_NumpyArray_getitem_next_null.cpp
@@ -11,8 +11,34 @@ ERROR awkward_NumpyArray_getitem_next_null(
   int64_t len,
   int64_t stride,
   const T* pos) {
-  for (int64_t i = 0;  i < len;  i++) {
-    std::memcpy(&toptr[i*stride], &fromptr[pos[i]*stride], (size_t)stride);
+  uint8_t* end = toptr + len*stride;
+  switch (stride) {
+    case 1:
+        while (toptr != end) *(toptr++) = fromptr[*(pos++)*stride];
+        break;
+    case 2:
+        while (toptr != end) {
+            std::memcpy(toptr, &fromptr[*(pos++)*stride], 2);
+            toptr += 2;
+        }
+        break;
+    case 4:
+        while (toptr != end) {
+            std::memcpy(toptr, &fromptr[*(pos++)*stride], 4);
+            toptr += 4;
+        }
+        break;
+    case 8:
+        while (toptr != end) {
+            std::memcpy(toptr, &fromptr[*(pos++)*stride], 8);
+            toptr += 8;
+        }
+        break;
+    default:
+      while (toptr != end) {
+          std::memcpy(toptr, &fromptr[*(pos++)*stride], (size_t)stride);
+          toptr += stride;
+      }
   }
   return success();
 }

--- a/src/cpu-kernels/awkward_regularize_arrayslice.cpp
+++ b/src/cpu-kernels/awkward_regularize_arrayslice.cpp
@@ -10,12 +10,11 @@ ERROR awkward_regularize_arrayslice(
   int64_t lenflathead,
   int64_t length) {
   for (int64_t i = 0;  i < lenflathead;  i++) {
-    T original = flatheadptr[i];
+    if (flatheadptr[i] < -length  ||  flatheadptr[i] >= length) {
+      return failure("index out of range", kSliceNone, flatheadptr[i], FILENAME(__LINE__));
+    }
     if (flatheadptr[i] < 0) {
       flatheadptr[i] += length;
-    }
-    if (flatheadptr[i] < 0  ||  flatheadptr[i] >= length) {
-      return failure("index out of range", kSliceNone, original, FILENAME(__LINE__));
     }
   }
   return success();

--- a/src/cpu-kernels/awkward_slicearray_ravel.cpp
+++ b/src/cpu-kernels/awkward_slicearray_ravel.cpp
@@ -12,8 +12,15 @@ ERROR awkward_slicearray_ravel(
   const int64_t* shape,
   const int64_t* strides) {
   if (ndim == 1) {
-    for (T i = 0;  i < shape[0];  i++) {
-      toptr[i] = fromptr[i*strides[0]];
+    if ( strides[0] == 1 ) {
+      std::memcpy(toptr, fromptr, shape[0]*sizeof(T));
+    }
+    else {
+      T* end = toptr + shape[0];
+      while (toptr != end) {
+        *(toptr++) = *fromptr;
+        fromptr += strides[0];
+      }
     }
   }
   else {

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -4705,7 +4705,7 @@ namespace awkward {
 
     if (advanced.is_empty_advanced()) {
       NumpyArray out = [&]() {
-        if ( carry.length() == 1 and carry.getitem_at(0) == 0 and nexthead.get() == nullptr ) {
+        if ( carry.length() == 1 && carry.getitem_at(0) == 0 && nexthead.get() == nullptr ) {
           // specialization for "trivial take" (i.e. this array is wrapped in length-1 array)
           return next.getitem_next(nexthead,
                                    nexttail,

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -4704,26 +4704,40 @@ namespace awkward {
     util::handle_error(err1, classname(), identities_.get());
 
     if (advanced.is_empty_advanced()) {
-      Index64 nextcarry(carry.length()*flathead.length());
-      Index64 nextadvanced(carry.length()*flathead.length());
-      struct Error err2 = kernel::NumpyArray_getitem_next_array_64(
-        kernel::lib::cpu,   // DERIVE
-        nextcarry.data(),
-        nextadvanced.data(),
-        carry.data(),
-        flathead.data(),
-        carry.length(),
-        flathead.length(),
-        shape_[1]);   // because this is contiguous
-      util::handle_error(err2, classname(), identities_.get());
+      NumpyArray out = [&]() {
+        if ( carry.length() == 1 and carry.getitem_at(0) == 0 and nexthead.get() == nullptr ) {
+          // specialization for "trivial take" (i.e. this array is wrapped in length-1 array)
+          return next.getitem_next(nexthead,
+                                   nexttail,
+                                   flathead,
+                                   advanced,  // this is a dummy variable now
+                                   length*flathead.length(),
+                                   next.strides_[0],
+                                   false);
+        }
+        else {
+          Index64 nextcarry(carry.length()*flathead.length());
+          Index64 nextadvanced(carry.length()*flathead.length());
+          struct Error err2 = kernel::NumpyArray_getitem_next_array_64(
+            kernel::lib::cpu,   // DERIVE
+            nextcarry.data(),
+            nextadvanced.data(),
+            carry.data(),
+            flathead.data(),
+            carry.length(),
+            flathead.length(),
+            shape_[1]);   // because this is contiguous
+          util::handle_error(err2, classname(), identities_.get());
 
-      NumpyArray out = next.getitem_next(nexthead,
-                                         nexttail,
-                                         nextcarry,
-                                         nextadvanced,
-                                         length*flathead.length(),
-                                         next.strides_[0],
-                                         false);
+          return next.getitem_next(nexthead,
+                                   nexttail,
+                                   nextcarry,
+                                   nextadvanced,
+                                   length*flathead.length(),
+                                   next.strides_[0],
+                                   false);
+        }
+      }();
 
       std::vector<ssize_t> outshape = { (ssize_t)length };
       std::vector<int64_t> arrayshape = array.shape();


### PR DESCRIPTION
The kernel `awkward_NumpyArray_getitem_next_null` was #2 in a profile of the [ADL benchmark](https://github.com/nsmith-/coffea-benchmarks/blob/master/coffea-adl-benchmarks.ipynb) after decompression.

I decided to compare the performance of a basic take operation to numpy, compiling awkward on my machine (Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz) with `python localbuild.py --release` (which, according to the internet, means CMake will use -O3 with clang, but not sure about `-march` setting) and then running the following ipython script:
```python
import numpy as np
import awkward as ak

np.random.seed(42)
n = np.random.poisson(5, size=100_000)
a = np.arange(n.sum(), dtype="f4")

x = ak.unflatten(a, n)
i0, _, _ = ak.unzip(ak.argcombinations(x, 3))

xoffsets = np.array(x.layout.offsets)
ioffsets = np.array(i0.layout.offsets)
icontent = np.array(ak.flatten(i0))

def take_ak():
    x[i0]


def take_np():
    iflat = np.repeat(xoffsets[:-1], np.diff(ioffsets)) + icontent
    a[iflat]

%timeit take_ak()
%timeit take_np()
```
I get
```
28.7 ms ± 3.67 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
11.9 ms ± 193 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
Using Instruments to sample 1000 `take_ak` calls, the heaviest functions are (omitting the stack parents for clarity) the kernels:
```
Time  % Self-time symbol
8.45 s   31.1%	8.45 s	 	        awkward_NumpyArray_getitem_next_null_64
1.94 s    7.1%	1.94 s	 	        awkward_carry_arange64
8.39 s   30.9%	8.39 s	 	       awkward_NumpyArray_getitem_next_null_64
3.90 s   14.3%	3.90 s	 	       awkward_ListArray64_getitem_jagged_apply_64
```
So I started with `awkward_NumpyArray_getitem_next_null_64`. This is doing the same thing as numpy's [mapiter_trivial_get](https://github.com/numpy/numpy/blob/7311af8238e5a3643acf9d7614ea64e56ad55078/numpy/core/src/multiarray/lowlevel_strided_loops.c.src#L1448), but much slower. Clearly numpy has implemented a lot of magic there. The relevant lines in awkward are https://github.com/scikit-hep/awkward-1.0/blob/f250c34279476ae545e1cd629b97a4013a71ca17/src/cpu-kernels/awkward_NumpyArray_getitem_next_null.cpp#L14-L16 
Putting the following functions into [compiler explorer](https://godbolt.org/z/5xh1Mqsqd)
```cpp
#include <cstring>
#include <cstdint>

void foo(uint8_t* toptr, uint8_t* fromptr, int64_t* pos, int64_t len, int64_t stride) {
  for (int64_t i = 0;  i < len;  i++) {
    std::memcpy(&toptr[i*stride], &fromptr[pos[i]*stride], (size_t)stride);
  }
}

void bar(uint8_t* toptr, uint8_t* fromptr, int64_t* pos, int64_t len) {
  for (int64_t i = 0;  i < len;  i++) {
    std::memcpy(&toptr[i*4], &fromptr[pos[i]*4], 4);
  }
}
```
it is apparent that most compilers can specialize on fixed strides to emit much more optimized code. It looks like the numpy tricks of casting to the dtype, copying, and casting back emits the same assembly as the fixed-size `std::memcpy`, so I think it is probably most of the magic in the numpy implementation. That's what's in https://github.com/scikit-hep/awkward-1.0/commit/4ce4b4d0d667990a996bd9a5c9236ffa84326f32 After that commit, the test script result is
```
11.7 ms ± 179 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
11.8 ms ± 153 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
and the statistical profile shows
```
1.95 s   15.4%	1.95 s	 	         awkward_NumpyArray_getitem_next_null_64
1.94 s   15.4%	1.94 s	 	        awkward_carry_arange64
4.06 s   32.2%	0 s	 	       awkward_ListArray64_getitem_jagged_apply_64
1.82 s   14.4%	1.82 s	 	        awkward_NumpyArray_getitem_next_null_64
```
Further improvement here could come from finding ways to skip validity checks in `awkward_NumpyArray_getitem_next_null_64`.

I also looked at the flat take operation, i.e.
```python
# continuing from above
xflat = ak.flatten(x)
iflat = np.repeat(xoffsets[:-1], np.diff(ioffsets)) + icontent

def take_ak():
    xflat[iflat]
```
Here there are a different set of kernels:
```
3.86 s   32.5%	3.86 s	 	    awkward_NumpyArray_getitem_next_array_64
2.58 s   21.7%	0 s	 	     awkward_slicearray_ravel_64
1.43 s   12.0%	1.43 s	 	     awkward_NumpyArray_getitem_next_null_64
1.42 s   11.9%	1.42 s	 	    awkward_regularize_arrayslice_64
```
The leading kernel, after some thought, can be completely optimized away in any case where the outer dimension is the length-1 wrapper artificially put around `iflat` for sake of convenience in the library code. This is https://github.com/scikit-hep/awkward-1.0/commit/254ddf6e1f41e4add5a17af53312a395c78eb25e In the same cases, `awkward_slicearray_ravel_64` is effectively a `memcpy` operation, as the stride is 1. Letting `std::memcpy` do it improves performance a lot, as done in https://github.com/scikit-hep/awkward-1.0/commit/eb968ef35d1c35d63000fbc1da50d10b65481d0e After these changes, we have for the same test
```
2.40 s   35.1%	0 s	 	     awkward_slicearray_ravel_64
1.92 s   28.1%	1.92 s	 	     awkward_NumpyArray_getitem_next_null_64
1.64 s   24.0%	1.64 s	 	    awkward_regularize_arrayslice_64
```
Ah! it didn't do anything! Ok, what happened is I was originally testing with CMake `RelWithDbgInfo` rather than `Release` and for that it seems `-O2` is [what is used in gcc/clang](https://stackoverflow.com/questions/48754619/what-are-cmake-build-type-debug-release-relwithdebinfo-and-minsizerel). I guess that wasn't enough to get the compiler to do the same memory copy optimization?

The last commit attempts to improve the validity checking in `awkward_regularize_arrayslice_64` and a similar kernel in the ListArray case by reordering two branch points to not be dependent, which I thought might help with pipelining. Amusingly, once again it showed better performance under `RelWithDbgInfo` but same performance under `Release`.

A significant source of improvement would be to add flags to some kernels to omit bounds checks if the indexers are known to be safe (e.g. when generated by awkward itself, as is the case for combinations). That's a more involved project so I didn't pursue it. Perhaps with awkward2 refactor this will be more straightforward.