### PR TITLE
Try fixing the search box by upgrading sphinx-rtd-theme.

### DIFF
--- a/docs-sphinx/requirements.txt
+++ b/docs-sphinx/requirements.txt
@@ -3,3 +3,4 @@ PyYAML
 black
 pycparser
 lark-parser
+sphinx-rtd-theme>=0.5,<1.0


### PR DESCRIPTION
The search box works when I build the docs using sphinx_rtd_theme==0.5.2 (the [latest non-1.0 release](https://github.com/readthedocs/sphinx_rtd_theme/releases)), but it doesn't on readthedocs.org, which uses sphinx_rtd_theme 0.4.3. @tacaswell has pointed out that https://github.com/matplotlib/matplotlib/pull/19279 was a necessary fix in Matplotlib, but this is the same change as https://github.com/readthedocs/sphinx_rtd_theme/commit/24f8e31c5b77131a25e6ed99533a4bbca969b2f0, which was [merged into sphinx_rtd_theme 0.5.1](https://github.com/readthedocs/sphinx_rtd_theme/compare/0.5.0...0.5.1#diff-500f053fcaf0bb11ee9ff8302134207002fdf56a7aedc9f26fa0a86e79540790).

Ideally, upgrading readthedocs.org's sphinx_rtd_theme should fix it without having to edit templates.