### PR TITLE
Fix: add utility to check whether a string is a filepath

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import re
 import sys
 import os
+import os.path
 import warnings
 import itertools
 import numbers
@@ -39,6 +40,13 @@ kMaxUInt32 = 4294967295  # 2**32 - 1
 kMaxInt64 = 9223372036854775806  # 2**63 - 2: see below
 kSliceNone = kMaxInt64 + 1  # for Slice::none()
 kMaxLevels = 48
+
+
+def is_file_path(x):
+    try:
+        return os.path.isfile(x)
+    except OSError:
+        return False
 
 
 def isint(x):

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -45,7 +45,7 @@ kMaxLevels = 48
 def is_file_path(x):
     try:
         return os.path.isfile(x)
-    except OSError:
+    except ValueError:
         return False
 
 

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -1075,7 +1075,7 @@ def from_json(
 
     is_path, source = ak._util.regularize_path(source)
 
-    if os.path.isfile(source):
+    if ak._util.is_file_path(source):
         layout = ak._ext.fromjsonfile(
             source,
             nan_string=nan_string,

--- a/tests/test_1084-from-json-win-path.py
+++ b/tests/test_1084-from-json-win-path.py
@@ -7,13 +7,13 @@ import urllib.request
 import urllib.error
 
 
-@pytest.mark.skipif(not ak._util.win, reason="requires Windows")
+@pytest.mark.skipif(ak._util.win, reason="requires Windows")
 def test():
-    url = "https://raw.githubusercontent.com/Chicago/osd-bike-routes/5f556dc/data/Bikeroutes.geojson"
+    url = "https://raw.githubusercontent.com/Chicago/osd-biske-routes/5f556dc/data/Bikeroutes.geojson"
     try:
         bikeroutes_json = urllib.request.urlopen(url).read()
     except urllib.error.URLError:
-        pytest.skip(reason="couldn't download sample dataset")
+        pytest.skip(msg="couldn't download sample dataset")
 
     # This shouldn't fail (see #1084)
     ak.from_json(bikeroutes_json)

--- a/tests/test_1084-from-json-win-path.py
+++ b/tests/test_1084-from-json-win-path.py
@@ -9,7 +9,7 @@ import urllib.error
 
 @pytest.mark.skipif(not ak._util.win, reason="requires Windows")
 def test():
-    url = "https://raw.githubusercontent.com/Chicago/osd-bike-routes/master/data/Bikeroutes.geojson"
+    url = "https://raw.githubusercontent.com/Chicago/osd-bike-routes/5f556dc/data/Bikeroutes.geojson"
     try:
         bikeroutes_json = urllib.request.urlopen(url).read()
     except urllib.error.URLError:

--- a/tests/test_1084-from-json-win-path.py
+++ b/tests/test_1084-from-json-win-path.py
@@ -1,9 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import absolute_import
 
-import urllib.request
-import urllib.error
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
@@ -13,6 +10,8 @@ import awkward as ak  # noqa: F401
 def test():
     if not ak._util.py27:
         # Python 2.7 has differently named urllib libraries
+        import urllib.request
+        import urllib.error
 
         url = "https://raw.githubusercontent.com/Chicago/osd-bike-routes/5f556dc/data/Bikeroutes.geojson"
         try:

--- a/tests/test_1084-from-json-win-path.py
+++ b/tests/test_1084-from-json-win-path.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import absolute_import
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+import urllib.request
+import urllib.error
+
+
+@pytest.mark.skipif(not ak._util.win, reason="requires Windows")
+def test():
+    url = "https://raw.githubusercontent.com/Chicago/osd-bike-routes/master/data/Bikeroutes.geojson"
+    try:
+        bikeroutes_json = urllib.request.urlopen(url).read()
+    except urllib.error.URLError:
+        pytest.skip(reason="couldn't download sample dataset")
+
+    # This shouldn't fail (see #1084)
+    ak.from_json(bikeroutes_json)

--- a/tests/test_1084-from-json-win-path.py
+++ b/tests/test_1084-from-json-win-path.py
@@ -7,9 +7,9 @@ import urllib.request
 import urllib.error
 
 
-@pytest.mark.skipif(ak._util.win, reason="requires Windows")
+@pytest.mark.skipif(not ak._util.win, reason="requires Windows")
 def test():
-    url = "https://raw.githubusercontent.com/Chicago/osd-biske-routes/5f556dc/data/Bikeroutes.geojson"
+    url = "https://raw.githubusercontent.com/Chicago/osd-bike-routes/5f556dc/data/Bikeroutes.geojson"
     try:
         bikeroutes_json = urllib.request.urlopen(url).read()
     except urllib.error.URLError:

--- a/tests/test_1084-from-json-win-path.py
+++ b/tests/test_1084-from-json-win-path.py
@@ -1,19 +1,24 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import absolute_import
-import pytest  # noqa: F401
-import numpy as np  # noqa: F401
-import awkward as ak  # noqa: F401
+
 import urllib.request
 import urllib.error
 
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
 
-@pytest.mark.skipif(not ak._util.win, reason="requires Windows")
+
+@pytest.mark.skipif(not ak._util.win, reason="need Windows to test this case")
 def test():
-    url = "https://raw.githubusercontent.com/Chicago/osd-bike-routes/5f556dc/data/Bikeroutes.geojson"
-    try:
-        bikeroutes_json = urllib.request.urlopen(url).read()
-    except urllib.error.URLError:
-        pytest.skip(msg="couldn't download sample dataset")
+    if not ak._util.py27:
+        # Python 2.7 has differently named urllib libraries
 
-    # This shouldn't fail (see #1084)
-    ak.from_json(bikeroutes_json)
+        url = "https://raw.githubusercontent.com/Chicago/osd-bike-routes/5f556dc/data/Bikeroutes.geojson"
+        try:
+            bikeroutes_json = urllib.request.urlopen(url).read()
+        except urllib.error.URLError:
+            pytest.skip(msg="couldn't download sample dataset")
+
+        # This shouldn't fail (see #1084)
+        ak.from_json(bikeroutes_json)


### PR DESCRIPTION
I didn't follow the `isint` / `isstr` convention: I think we should rename those in a subsequent PR