### PR TITLE
Respect CMAKE_ARGS if set by the environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,10 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
         # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
         # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
         # from Python.
-        cmake_args = [
+        cmake_args = []
+        if "CMAKE_ARGS" in os.environ:
+            cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
+        cmake_args += [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}".format(extdir),
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
             "-DEXAMPLE_VERSION_INFO={}".format(self.distribution.get_version()),


### PR DESCRIPTION
Fix that was required in conda-forge for the latest release to be deployable for a cross-compiled apple silicon Python 3.9 binary: https://github.com/conda-forge/awkward-feedstock/pull/74

Failing CI log will be available from [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=375352&view=logs&jobId=253ea3ec-a032-5a61-0d20-dbf0bb326fc2&j=253ea3ec-a032-5a61-0d20-dbf0bb326fc2&t=8f279e6b-1d24-5e23-4618-cb474b6bf3b9) for a a week or so.

(The CI is still running in conda-forge but once it works I'll unmark as draft)