### PR TITLE
C++ refactoring: Make the commented-out code in v2 a better guide.

### DIFF
--- a/src/awkward/_v2/_connect/numba/__init__.py
+++ b/src/awkward/_v2/_connect/numba/__init__.py
@@ -97,7 +97,7 @@
 #     if not isinstance(fromtype, numba.types.Integer):
 #         raise AssertionError(
 #             "unrecognized integer type: {0}".format(repr(fromtype))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     if fromtype.bitwidth < totype.bitwidth:

--- a/src/awkward/_v2/_connect/numba/__init__.py
+++ b/src/awkward/_v2/_connect/numba/__init__.py
@@ -38,31 +38,31 @@
 
 # def register():
 #     import numba
-#     import awkward._connect._numba.arrayview
-#     import awkward._connect._numba.layout
-#     import awkward._connect._numba.builder
+#     import awkward._v2._connect.numba.arrayview
+#     import awkward._v2._connect.numba.layout
+#     import awkward._v2._connect.numba.builder
 
 #     if hasattr(ak.numba, "ArrayViewType"):
 #         return
 
 #     n = ak.numba
-#     n.ArrayViewType = awkward._connect._numba.arrayview.ArrayViewType
-#     n.ArrayViewModel = awkward._connect._numba.arrayview.ArrayViewModel
-#     n.RecordViewType = awkward._connect._numba.arrayview.RecordViewType
-#     n.RecordViewModel = awkward._connect._numba.arrayview.RecordViewModel
-#     n.ContentType = awkward._connect._numba.layout.ContentType
-#     n.NumpyArrayType = awkward._connect._numba.layout.NumpyArrayType
-#     n.RegularArrayType = awkward._connect._numba.layout.RegularArrayType
-#     n.ListArrayType = awkward._connect._numba.layout.ListArrayType
-#     n.IndexedArrayType = awkward._connect._numba.layout.IndexedArrayType
-#     n.IndexedOptionArrayType = awkward._connect._numba.layout.IndexedOptionArrayType
-#     n.ByteMaskedArrayType = awkward._connect._numba.layout.ByteMaskedArrayType
-#     n.BitMaskedArrayType = awkward._connect._numba.layout.BitMaskedArrayType
-#     n.UnmaskedArrayType = awkward._connect._numba.layout.UnmaskedArrayType
-#     n.RecordArrayType = awkward._connect._numba.layout.RecordArrayType
-#     n.UnionArrayType = awkward._connect._numba.layout.UnionArrayType
-#     n.ArrayBuilderType = awkward._connect._numba.builder.ArrayBuilderType
-#     n.ArrayBuilderModel = awkward._connect._numba.builder.ArrayBuilderModel
+#     n.ArrayViewType = awkward._v2._connect.numba.arrayview.ArrayViewType
+#     n.ArrayViewModel = awkward._v2._connect.numba.arrayview.ArrayViewModel
+#     n.RecordViewType = awkward._v2._connect.numba.arrayview.RecordViewType
+#     n.RecordViewModel = awkward._v2._connect.numba.arrayview.RecordViewModel
+#     n.ContentType = awkward._v2._connect.numba.layout.ContentType
+#     n.NumpyArrayType = awkward._v2._connect.numba.layout.NumpyArrayType
+#     n.RegularArrayType = awkward._v2._connect.numba.layout.RegularArrayType
+#     n.ListArrayType = awkward._v2._connect.numba.layout.ListArrayType
+#     n.IndexedArrayType = awkward._v2._connect.numba.layout.IndexedArrayType
+#     n.IndexedOptionArrayType = awkward._v2._connect.numba.layout.IndexedOptionArrayType
+#     n.ByteMaskedArrayType = awkward._v2._connect.numba.layout.ByteMaskedArrayType
+#     n.BitMaskedArrayType = awkward._v2._connect.numba.layout.BitMaskedArrayType
+#     n.UnmaskedArrayType = awkward._v2._connect.numba.layout.UnmaskedArrayType
+#     n.RecordArrayType = awkward._v2._connect.numba.layout.RecordArrayType
+#     n.UnionArrayType = awkward._v2._connect.numba.layout.UnionArrayType
+#     n.ArrayBuilderType = awkward._v2._connect.numba.builder.ArrayBuilderType
+#     n.ArrayBuilderModel = awkward._v2._connect.numba.builder.ArrayBuilderModel
 
 #     @numba.extending.typeof_impl.register(ak.highlevel.Array)
 #     def typeof_Array(obj, c):

--- a/src/awkward/_v2/_connect/numba/__init__.py
+++ b/src/awkward/_v2/_connect/numba/__init__.py
@@ -64,15 +64,15 @@
 #     n.ArrayBuilderType = awkward._v2._connect.numba.builder.ArrayBuilderType
 #     n.ArrayBuilderModel = awkward._v2._connect.numba.builder.ArrayBuilderModel
 
-#     @numba.extending.typeof_impl.register(ak.highlevel.Array)
+#     @numba.extending.typeof_impl.register(ak._v2.highlevel.Array)
 #     def typeof_Array(obj, c):
 #         return obj.numba_type
 
-#     @numba.extending.typeof_impl.register(ak.highlevel.Record)
+#     @numba.extending.typeof_impl.register(ak._v2.highlevel.Record)
 #     def typeof_Record(obj, c):
 #         return obj.numba_type
 
-#     @numba.extending.typeof_impl.register(ak.highlevel.ArrayBuilder)
+#     @numba.extending.typeof_impl.register(ak._v2.highlevel.ArrayBuilder)
 #     def typeof_ArrayBuilder(obj, c):
 #         return obj.numba_type
 

--- a/src/awkward/_v2/_connect/numba/__init__.py
+++ b/src/awkward/_v2/_connect/numba/__init__.py
@@ -97,7 +97,7 @@
 #     if not isinstance(fromtype, numba.types.Integer):
 #         raise AssertionError(
 #             "unrecognized integer type: {0}".format(repr(fromtype))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     if fromtype.bitwidth < totype.bitwidth:

--- a/src/awkward/_v2/_connect/numba/arrayview.py
+++ b/src/awkward/_v2/_connect/numba/arrayview.py
@@ -223,7 +223,7 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Content or Form type: {0}".format(type(layout))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 
@@ -264,7 +264,7 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Form type: {0}".format(type(form))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 
@@ -337,7 +337,7 @@
 #                     raise ValueError(
 #                         "partitioned arrays can only be used in Numba if all "
 #                         "partitions have the same numba_type"
-#                         + ak._v2._util.exception_suffix(__file__)
+#
 #                     )
 #             return PartitionedView(
 #                 ak._connect._numba.layout.typeof(part),
@@ -589,7 +589,7 @@
 #                 raise TypeError(
 #                     "only an integer, start:stop range, or a *constant* "
 #                     "field name string may be used as ak.Array "
-#                     "slices in compiled code" + ak._v2._util.exception_suffix(__file__)
+#                     "slices in compiled code"
 #                 )
 
 
@@ -879,7 +879,7 @@
 #                 raise TypeError(
 #                     "only a *constant* field name string may be used as "
 #                     "ak.Record slices in compiled code"
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 
@@ -1513,7 +1513,7 @@
 #                 raise TypeError(
 #                     "only an integer, start:stop range, or a *constant* "
 #                     "field name string may be used as ak.Array "
-#                     "slices in compiled code" + ak._v2._util.exception_suffix(__file__)
+#                     "slices in compiled code"
 #                 )
 
 

--- a/src/awkward/_v2/_connect/numba/arrayview.py
+++ b/src/awkward/_v2/_connect/numba/arrayview.py
@@ -78,22 +78,22 @@
 
 
 # def tolookup(layout, positions, sharedptrs, arrays):
-#     if isinstance(layout, ak.layout.NumpyArray):
+#     if isinstance(layout, ak._v2.contents.NumpyArray):
 #         return ak._connect._numba.layout.NumpyArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.NumpyForm):
+#     elif isinstance(layout, ak._v2.forms.NumpyForm):
 #         return ak._connect._numba.layout.NumpyArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.layout.RegularArray):
+#     elif isinstance(layout, ak._v2.contents.RegularArray):
 #         return ak._connect._numba.layout.RegularArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.RegularForm):
+#     elif isinstance(layout, ak._v2.forms.RegularForm):
 #         return ak._connect._numba.layout.RegularArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
@@ -101,19 +101,19 @@
 #     elif isinstance(
 #         layout,
 #         (
-#             ak.layout.ListArray32,
-#             ak.layout.ListArrayU32,
-#             ak.layout.ListArray64,
-#             ak.layout.ListOffsetArray32,
-#             ak.layout.ListOffsetArrayU32,
-#             ak.layout.ListOffsetArray64,
+#             ak._v2.contents.ListArray32,
+#             ak._v2.contents.ListArrayU32,
+#             ak._v2.contents.ListArray64,
+#             ak._v2.contents.ListOffsetArray32,
+#             ak._v2.contents.ListOffsetArrayU32,
+#             ak._v2.contents.ListOffsetArray64,
 #         ),
 #     ):
 #         return ak._connect._numba.layout.ListArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, (ak.forms.ListForm, ak.forms.ListOffsetForm)):
+#     elif isinstance(layout, (ak._v2.forms.ListForm, ak._v2.forms.ListOffsetForm)):
 #         return ak._connect._numba.layout.ListArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
@@ -121,74 +121,74 @@
 #     elif isinstance(
 #         layout,
 #         (
-#             ak.layout.IndexedArray32,
-#             ak.layout.IndexedArrayU32,
-#             ak.layout.IndexedArray64,
+#             ak._v2.contents.IndexedArray32,
+#             ak._v2.contents.IndexedArrayU32,
+#             ak._v2.contents.IndexedArray64,
 #         ),
 #     ):
 #         return ak._connect._numba.layout.IndexedArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.IndexedForm):
+#     elif isinstance(layout, ak._v2.forms.IndexedForm):
 #         return ak._connect._numba.layout.IndexedArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(
 #         layout,
-#         (ak.layout.IndexedOptionArray32, ak.layout.IndexedOptionArray64),
+#         (ak._v2.contents.IndexedOptionArray32, ak._v2.contents.IndexedOptionArray64),
 #     ):
 #         return ak._connect._numba.layout.IndexedOptionArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.IndexedOptionForm):
+#     elif isinstance(layout, ak._v2.forms.IndexedOptionForm):
 #         return ak._connect._numba.layout.IndexedOptionArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.layout.ByteMaskedArray):
+#     elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
 #         return ak._connect._numba.layout.ByteMaskedArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.ByteMaskedForm):
+#     elif isinstance(layout, ak._v2.forms.ByteMaskedForm):
 #         return ak._connect._numba.layout.ByteMaskedArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.layout.BitMaskedArray):
+#     elif isinstance(layout, ak._v2.contents.BitMaskedArray):
 #         return ak._connect._numba.layout.BitMaskedArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.BitMaskedForm):
+#     elif isinstance(layout, ak._v2.forms.BitMaskedForm):
 #         return ak._connect._numba.layout.BitMaskedArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.layout.UnmaskedArray):
+#     elif isinstance(layout, ak._v2.contents.UnmaskedArray):
 #         return ak._connect._numba.layout.UnmaskedArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.UnmaskedForm):
+#     elif isinstance(layout, ak._v2.forms.UnmaskedForm):
 #         return ak._connect._numba.layout.UnmaskedArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.layout.RecordArray):
+#     elif isinstance(layout, ak._v2.contents.RecordArray):
 #         return ak._connect._numba.layout.RecordArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.RecordForm):
+#     elif isinstance(layout, ak._v2.forms.RecordForm):
 #         return ak._connect._numba.layout.RecordArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.layout.Record):
+#     elif isinstance(layout, ak._v2.contents.Record):
 #         return ak._connect._numba.layout.RecordType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
@@ -196,26 +196,26 @@
 #     elif isinstance(
 #         layout,
 #         (
-#             ak.layout.UnionArray8_32,
-#             ak.layout.UnionArray8_U32,
-#             ak.layout.UnionArray8_64,
+#             ak._v2.contents.UnionArray8_32,
+#             ak._v2.contents.UnionArray8_U32,
+#             ak._v2.contents.UnionArray8_64,
 #         ),
 #     ):
 #         return ak._connect._numba.layout.UnionArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.UnionForm):
+#     elif isinstance(layout, ak._v2.forms.UnionForm):
 #         return ak._connect._numba.layout.UnionArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.layout.VirtualArray):
+#     elif isinstance(layout, ak._v2.contents.VirtualArray):
 #         return ak._connect._numba.layout.VirtualArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
-#     elif isinstance(layout, ak.forms.VirtualForm):
+#     elif isinstance(layout, ak._v2.forms.VirtualForm):
 #         return ak._connect._numba.layout.VirtualArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
@@ -228,37 +228,37 @@
 
 
 # def tonumbatype(form):
-#     if isinstance(form, ak.forms.NumpyForm):
+#     if isinstance(form, ak._v2.forms.NumpyForm):
 #         return ak._connect._numba.layout.NumpyArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.RegularForm):
+#     elif isinstance(form, ak._v2.forms.RegularForm):
 #         return ak._connect._numba.layout.RegularArrayType.from_form(form)
 
-#     elif isinstance(form, (ak.forms.ListForm, ak.forms.ListOffsetForm)):
+#     elif isinstance(form, (ak._v2.forms.ListForm, ak._v2.forms.ListOffsetForm)):
 #         return ak._connect._numba.layout.ListArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.IndexedForm):
+#     elif isinstance(form, ak._v2.forms.IndexedForm):
 #         return ak._connect._numba.layout.IndexedArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.IndexedOptionForm):
+#     elif isinstance(form, ak._v2.forms.IndexedOptionForm):
 #         return ak._connect._numba.layout.IndexedOptionArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.ByteMaskedForm):
+#     elif isinstance(form, ak._v2.forms.ByteMaskedForm):
 #         return ak._connect._numba.layout.ByteMaskedArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.BitMaskedForm):
+#     elif isinstance(form, ak._v2.forms.BitMaskedForm):
 #         return ak._connect._numba.layout.BitMaskedArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.UnmaskedForm):
+#     elif isinstance(form, ak._v2.forms.UnmaskedForm):
 #         return ak._connect._numba.layout.UnmaskedArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.RecordForm):
+#     elif isinstance(form, ak._v2.forms.RecordForm):
 #         return ak._connect._numba.layout.RecordArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.UnionForm):
+#     elif isinstance(form, ak._v2.forms.UnionForm):
 #         return ak._connect._numba.layout.UnionArrayType.from_form(form)
 
-#     elif isinstance(form, ak.forms.VirtualForm):
+#     elif isinstance(form, ak._v2.forms.VirtualForm):
 #         return ak._connect._numba.layout.VirtualArrayType.from_form(form)
 
 #     else:
@@ -320,8 +320,8 @@
 #             allow_other=False,
 #             numpytype=(np.number, bool, np.bool_),
 #         )
-#         while isinstance(layout, ak.layout.VirtualArray) and isinstance(
-#             layout.generator, ak.layout.SliceGenerator
+#         while isinstance(layout, ak._v2.contents.VirtualArray) and isinstance(
+#             layout.generator, ak._v2.contents.SliceGenerator
 #         ):
 #             layout = layout.array
 #         layout = ak.operations.convert.regularize_numpyarray(
@@ -747,7 +747,7 @@
 #             allow_other=False,
 #             numpytype=(np.number, bool, np.bool_),
 #         )
-#         assert isinstance(layout, ak.layout.Record)
+#         assert isinstance(layout, ak._v2.contents.Record)
 #         arraylayout = layout.array
 #         return RecordView(
 #             ArrayView(
@@ -769,7 +769,7 @@
 #     def torecord(self):
 #         arraylayout = self.arrayview.toarray().layout
 #         return ak._util.wrap(
-#             ak.layout.Record(arraylayout, self.at), self.arrayview.behavior
+#             ak._v2.contents.Record(arraylayout, self.at), self.arrayview.behavior
 #         )
 
 

--- a/src/awkward/_v2/_connect/numba/arrayview.py
+++ b/src/awkward/_v2/_connect/numba/arrayview.py
@@ -314,7 +314,7 @@
 #     @classmethod
 #     def fromarray(cls, array):
 #         behavior = ak._v2._util.behaviorof(array)
-#         layout = ak.operations.convert.to_layout(
+#         layout = ak._v2.operations.convert.to_layout(
 #             array,
 #             allow_record=False,
 #             allow_other=False,
@@ -324,7 +324,7 @@
 #             layout.generator, ak._v2.contents.SliceGenerator
 #         ):
 #             layout = layout.array
-#         layout = ak.operations.convert.regularize_numpyarray(
+#         layout = ak._v2.operations.convert.regularize_numpyarray(  # NOTE: NumpyArray has a .toRegularArray; use this instead
 #             layout, allow_empty=False, highlevel=False
 #         )
 
@@ -741,7 +741,7 @@
 #     @classmethod
 #     def fromrecord(cls, record):
 #         behavior = ak._v2._util.behaviorof(record)
-#         layout = ak.operations.convert.to_layout(
+#         layout = ak._v2.operations.convert.to_layout(
 #             record,
 #             allow_record=True,
 #             allow_other=False,

--- a/src/awkward/_v2/_connect/numba/arrayview.py
+++ b/src/awkward/_v2/_connect/numba/arrayview.py
@@ -79,22 +79,22 @@
 
 # def tolookup(layout, positions, sharedptrs, arrays):
 #     if isinstance(layout, ak._v2.contents.NumpyArray):
-#         return ak._connect._numba.layout.NumpyArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.NumpyArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.NumpyForm):
-#         return ak._connect._numba.layout.NumpyArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.NumpyArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.contents.RegularArray):
-#         return ak._connect._numba.layout.RegularArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.RegularArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.RegularForm):
-#         return ak._connect._numba.layout.RegularArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.RegularArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
@@ -109,12 +109,12 @@
 #             ak._v2.contents.ListOffsetArray64,
 #         ),
 #     ):
-#         return ak._connect._numba.layout.ListArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.ListArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, (ak._v2.forms.ListForm, ak._v2.forms.ListOffsetForm)):
-#         return ak._connect._numba.layout.ListArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.ListArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
@@ -126,12 +126,12 @@
 #             ak._v2.contents.IndexedArray64,
 #         ),
 #     ):
-#         return ak._connect._numba.layout.IndexedArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.IndexedArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.IndexedForm):
-#         return ak._connect._numba.layout.IndexedArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.IndexedArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
@@ -139,57 +139,57 @@
 #         layout,
 #         (ak._v2.contents.IndexedOptionArray32, ak._v2.contents.IndexedOptionArray64),
 #     ):
-#         return ak._connect._numba.layout.IndexedOptionArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.IndexedOptionArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.IndexedOptionForm):
-#         return ak._connect._numba.layout.IndexedOptionArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.IndexedOptionArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
-#         return ak._connect._numba.layout.ByteMaskedArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.ByteMaskedArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.ByteMaskedForm):
-#         return ak._connect._numba.layout.ByteMaskedArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.ByteMaskedArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.contents.BitMaskedArray):
-#         return ak._connect._numba.layout.BitMaskedArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.BitMaskedArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.BitMaskedForm):
-#         return ak._connect._numba.layout.BitMaskedArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.BitMaskedArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.contents.UnmaskedArray):
-#         return ak._connect._numba.layout.UnmaskedArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.UnmaskedArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.UnmaskedForm):
-#         return ak._connect._numba.layout.UnmaskedArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.UnmaskedArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.contents.RecordArray):
-#         return ak._connect._numba.layout.RecordArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.RecordArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.RecordForm):
-#         return ak._connect._numba.layout.RecordArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.RecordArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.contents.Record):
-#         return ak._connect._numba.layout.RecordType.tolookup(
+#         return ak._v2._connect.numba.layout.RecordType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
@@ -201,22 +201,22 @@
 #             ak._v2.contents.UnionArray8_64,
 #         ),
 #     ):
-#         return ak._connect._numba.layout.UnionArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.UnionArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.UnionForm):
-#         return ak._connect._numba.layout.UnionArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.UnionArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.contents.VirtualArray):
-#         return ak._connect._numba.layout.VirtualArrayType.tolookup(
+#         return ak._v2._connect.numba.layout.VirtualArrayType.tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
 #     elif isinstance(layout, ak._v2.forms.VirtualForm):
-#         return ak._connect._numba.layout.VirtualArrayType.form_tolookup(
+#         return ak._v2._connect.numba.layout.VirtualArrayType.form_tolookup(
 #             layout, positions, sharedptrs, arrays
 #         )
 
@@ -229,37 +229,37 @@
 
 # def tonumbatype(form):
 #     if isinstance(form, ak._v2.forms.NumpyForm):
-#         return ak._connect._numba.layout.NumpyArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.NumpyArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.RegularForm):
-#         return ak._connect._numba.layout.RegularArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.RegularArrayType.from_form(form)
 
 #     elif isinstance(form, (ak._v2.forms.ListForm, ak._v2.forms.ListOffsetForm)):
-#         return ak._connect._numba.layout.ListArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.ListArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.IndexedForm):
-#         return ak._connect._numba.layout.IndexedArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.IndexedArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.IndexedOptionForm):
-#         return ak._connect._numba.layout.IndexedOptionArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.IndexedOptionArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.ByteMaskedForm):
-#         return ak._connect._numba.layout.ByteMaskedArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.ByteMaskedArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.BitMaskedForm):
-#         return ak._connect._numba.layout.BitMaskedArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.BitMaskedArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.UnmaskedForm):
-#         return ak._connect._numba.layout.UnmaskedArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.UnmaskedArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.RecordForm):
-#         return ak._connect._numba.layout.RecordArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.RecordArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.UnionForm):
-#         return ak._connect._numba.layout.UnionArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.UnionArrayType.from_form(form)
 
 #     elif isinstance(form, ak._v2.forms.VirtualForm):
-#         return ak._connect._numba.layout.VirtualArrayType.from_form(form)
+#         return ak._v2._connect.numba.layout.VirtualArrayType.from_form(form)
 
 #     else:
 #         raise AssertionError(
@@ -332,15 +332,15 @@
 #             numba_type = None
 #             for part in layout.partitions:
 #                 if numba_type is None:
-#                     numba_type = ak._connect._numba.layout.typeof(part)
-#                 elif numba_type != ak._connect._numba.layout.typeof(part):
+#                     numba_type = ak._v2._connect.numba.layout.typeof(part)
+#                 elif numba_type != ak._v2._connect.numba.layout.typeof(part):
 #                     raise ValueError(
 #                         "partitioned arrays can only be used in Numba if all "
 #                         "partitions have the same numba_type"
 #
 #                     )
 #             return PartitionedView(
-#                 ak._connect._numba.layout.typeof(part),
+#                 ak._v2._connect.numba.layout.typeof(part),
 #                 behavior,
 #                 [Lookup(x) for x in layout.partitions],
 #                 ak.nplike.of(layout).asarray(layout.stops, dtype=np.intp),
@@ -351,7 +351,7 @@
 
 #         else:
 #             return ArrayView(
-#                 ak._connect._numba.layout.typeof(layout),
+#                 ak._v2._connect.numba.layout.typeof(layout),
 #                 behavior,
 #                 Lookup(layout),
 #                 0,
@@ -392,7 +392,7 @@
 #         super(ArrayViewType, self).__init__(
 #             name="ak.ArrayView({0}, {1}, {2})".format(
 #                 type.name,
-#                 ak._connect._numba.repr_behavior(behavior),
+#                 ak._v2._connect.numba.repr_behavior(behavior),
 #                 repr(fields),
 #             )
 #         )
@@ -751,7 +751,7 @@
 #         arraylayout = layout.array
 #         return RecordView(
 #             ArrayView(
-#                 ak._connect._numba.layout.typeof(arraylayout),
+#                 ak._v2._connect.numba.layout.typeof(arraylayout),
 #                 behavior,
 #                 Lookup(arraylayout),
 #                 0,
@@ -1052,7 +1052,7 @@
 #                 name = "x"
 #                 indent = indent + "    "
 
-#             if isinstance(arraytype, ak._connect._numba.layout.RecordArrayType):
+#             if isinstance(arraytype, ak._v2._connect.numba.layout.RecordArrayType):
 #                 if arraytype.is_tuple:
 #                     for fi, ft in enumerate(arraytype.contenttypes):
 #                         add_statement(indent, name + "[" + repr(fi) + "]", ft, False)
@@ -1190,7 +1190,7 @@
 #     def typer(arrayview):
 #         if (
 #             isinstance(arrayview, ArrayViewType)
-#             and isinstance(arrayview.type, ak._connect._numba.layout.NumpyArrayType)
+#             and isinstance(arrayview.type, ak._v2._connect.numba.layout.NumpyArrayType)
 #             and arrayview.type.ndim == 1
 #             and arrayview.type.inner_dtype in array_supported
 #         ):
@@ -1204,16 +1204,16 @@
 #     rettype, (viewtype,) = sig.return_type, sig.args
 #     (viewval,) = args
 #     viewproxy = context.make_helper(builder, viewtype, viewval)
-#     assert isinstance(viewtype.type, ak._connect._numba.layout.NumpyArrayType)
+#     assert isinstance(viewtype.type, ak._v2._connect.numba.layout.NumpyArrayType)
 
-#     whichpos = ak._connect._numba.layout.posat(
+#     whichpos = ak._v2._connect.numba.layout.posat(
 #         context, builder, viewproxy.pos, viewtype.type.ARRAY
 #     )
-#     arrayptr = ak._connect._numba.layout.getat(
+#     arrayptr = ak._v2._connect.numba.layout.getat(
 #         context, builder, viewproxy.arrayptrs, whichpos
 #     )
 
-#     bitwidth = ak._connect._numba.layout.type_bitwidth(rettype.dtype)
+#     bitwidth = ak._v2._connect.numba.layout.type_bitwidth(rettype.dtype)
 #     itemsize = context.get_constant(numba.intp, bitwidth // 8)
 
 #     data = numba.core.cgutils.pointer_add(
@@ -1309,7 +1309,7 @@
 #         super(PartitionedViewType, self).__init__(
 #             name="ak.PartitionedView({0}, {1}, {2})".format(
 #                 type.name,
-#                 ak._connect._numba.repr_behavior(behavior),
+#                 ak._v2._connect.numba.repr_behavior(behavior),
 #                 repr(fields),
 #             )
 #         )

--- a/src/awkward/_v2/_connect/numba/arrayview.py
+++ b/src/awkward/_v2/_connect/numba/arrayview.py
@@ -223,7 +223,7 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Content or Form type: {0}".format(type(layout))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 
@@ -264,7 +264,7 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Form type: {0}".format(type(form))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 
@@ -313,7 +313,7 @@
 # class ArrayView(object):
 #     @classmethod
 #     def fromarray(cls, array):
-#         behavior = ak._util.behaviorof(array)
+#         behavior = ak._v2._util.behaviorof(array)
 #         layout = ak.operations.convert.to_layout(
 #             array,
 #             allow_record=False,
@@ -337,7 +337,7 @@
 #                     raise ValueError(
 #                         "partitioned arrays can only be used in Numba if all "
 #                         "partitions have the same numba_type"
-#                         + ak._util.exception_suffix(__file__)
+#                         + ak._v2._util.exception_suffix(__file__)
 #                     )
 #             return PartitionedView(
 #                 ak._connect._numba.layout.typeof(part),
@@ -372,7 +372,7 @@
 #     def toarray(self):
 #         layout = self.type.tolayout(self.lookup, self.pos, self.fields)
 #         sliced = layout.getitem_range_nowrap(self.start, self.stop)
-#         return ak._util.wrap(sliced, self.behavior)
+#         return ak._v2._util.wrap(sliced, self.behavior)
 
 
 # @numba.extending.typeof_impl.register(ArrayView)
@@ -589,7 +589,7 @@
 #                 raise TypeError(
 #                     "only an integer, start:stop range, or a *constant* "
 #                     "field name string may be used as ak.Array "
-#                     "slices in compiled code" + ak._util.exception_suffix(__file__)
+#                     "slices in compiled code" + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 
@@ -740,7 +740,7 @@
 # class RecordView(object):
 #     @classmethod
 #     def fromrecord(cls, record):
-#         behavior = ak._util.behaviorof(record)
+#         behavior = ak._v2._util.behaviorof(record)
 #         layout = ak.operations.convert.to_layout(
 #             record,
 #             allow_record=True,
@@ -768,7 +768,7 @@
 
 #     def torecord(self):
 #         arraylayout = self.arrayview.toarray().layout
-#         return ak._util.wrap(
+#         return ak._v2._util.wrap(
 #             ak._v2.contents.Record(arraylayout, self.at), self.arrayview.behavior
 #         )
 
@@ -879,7 +879,7 @@
 #                 raise TypeError(
 #                     "only a *constant* field name string may be used as "
 #                     "ak.Record slices in compiled code"
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 
@@ -899,7 +899,7 @@
 #     key = RecordViewType
 
 #     def generic_resolve(self, recordviewtype, attr):
-#         for methodname, typer, lower in ak._util.numba_methods(
+#         for methodname, typer, lower in ak._v2._util.numba_methods(
 #             recordviewtype.arrayviewtype.type, recordviewtype.arrayviewtype.behavior
 #         ):
 #             if attr == methodname:
@@ -927,7 +927,7 @@
 
 #                 return numba.types.BoundFunction(type_method, recordviewtype)
 
-#         for attrname, typer, _ in ak._util.numba_attrs(
+#         for attrname, typer, _ in ak._v2._util.numba_attrs(
 #             recordviewtype.arrayviewtype.type, recordviewtype.arrayviewtype.behavior
 #         ):
 #             if attr == attrname:
@@ -939,7 +939,7 @@
 
 # @numba.extending.lower_getattr_generic(RecordViewType)
 # def lower_getattr_generic_record(context, builder, recordviewtype, recordviewval, attr):
-#     for attrname, typer, lower in ak._util.numba_attrs(
+#     for attrname, typer, lower in ak._v2._util.numba_attrs(
 #         recordviewtype.arrayviewtype.type, recordviewtype.arrayviewtype.behavior
 #     ):
 #         if attr == attrname:
@@ -964,7 +964,7 @@
 #                     left = args[0].arrayviewtype.type
 #                     behavior = args[0].arrayviewtype.behavior
 
-#                     for typer, lower in ak._util.numba_unaryops(
+#                     for typer, lower in ak._v2._util.numba_unaryops(
 #                         unaryop, left, behavior
 #                     ):
 #                         numba.extending.lower_builtin(unaryop, *args)(lower)
@@ -1000,7 +1000,7 @@
 #                         behavior = args[1].arrayviewtype.behavior
 
 #                 if left is not None or right is not None:
-#                     for typer, lower in ak._util.numba_binops(
+#                     for typer, lower in ak._v2._util.numba_binops(
 #                         binop, left, right, behavior
 #                     ):
 #                         numba.extending.lower_builtin(binop, *args)(lower)
@@ -1292,7 +1292,7 @@
 
 #             partition_start = partition_stop
 
-#         return ak._util.wrap(
+#         return ak._v2._util.wrap(
 #             ak.partition.IrregularlyPartitionedArray(output), self.behavior
 #         )
 
@@ -1513,7 +1513,7 @@
 #                 raise TypeError(
 #                     "only an integer, start:stop range, or a *constant* "
 #                     "field name string may be used as ak.Array "
-#                     "slices in compiled code" + ak._util.exception_suffix(__file__)
+#                     "slices in compiled code" + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 

--- a/src/awkward/_v2/_connect/numba/arrayview.py
+++ b/src/awkward/_v2/_connect/numba/arrayview.py
@@ -328,7 +328,7 @@
 #             layout, allow_empty=False, highlevel=False
 #         )
 
-#         if isinstance(layout, ak.partition.PartitionedArray):
+#         if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             numba_type = None
 #             for part in layout.partitions:
 #                 if numba_type is None:
@@ -1293,7 +1293,7 @@
 #             partition_start = partition_stop
 
 #         return ak._v2._util.wrap(
-#             ak.partition.IrregularlyPartitionedArray(output), self.behavior
+#             ak.partition.IrregularlyPartitionedArray(output), self.behavior   # NO PARTITIONED ARRAY
 #         )
 
 
@@ -1390,7 +1390,7 @@
 
 
 # @numba.extending.unbox(PartitionedViewType)
-# def unbox_PartitionedArray(partviewtype, arrayobj, c):
+# def unbox_PartitionedArray(partviewtype, arrayobj, c):   # NO PARTITIONED ARRAY
 #     partview_obj = c.pyapi.object_getattr_string(arrayobj, "_numbaview")
 #     out = unbox_PartitionedView(partviewtype, partview_obj, c)
 #     c.pyapi.decref(partview_obj)
@@ -1430,7 +1430,7 @@
 
 
 # @numba.extending.box(PartitionedViewType)
-# def box_PartitionedArray(partviewtype, partviewval, c):
+# def box_PartitionedArray(partviewtype, partviewval, c):   # NO PARTITIONED ARRAY
 #     arrayview_obj = box_PartitionedView(partviewtype, partviewval, c)
 #     out = c.pyapi.call_method(arrayview_obj, "toarray", ())
 #     c.pyapi.decref(arrayview_obj)

--- a/src/awkward/_v2/_connect/numba/builder.py
+++ b/src/awkward/_v2/_connect/numba/builder.py
@@ -77,7 +77,7 @@
 # @numba.extending.box(ArrayBuilderType)
 # def box_ArrayBuilder(arraybuildertype, arraybuilderval, c):
 #     ArrayBuilder_obj = c.pyapi.unserialize(
-#         c.pyapi.serialize_object(ak.highlevel.ArrayBuilder)
+#         c.pyapi.serialize_object(ak._v2.highlevel.ArrayBuilder)
 #     )
 #     behavior_obj = c.pyapi.unserialize(
 #         c.pyapi.serialize_object(arraybuildertype.behavior)
@@ -351,7 +351,7 @@
 #                         isinstance(key, tuple)
 #                         and len(key) == 3
 #                         and key[0] == "__numba_lower__"
-#                         and key[1] == ak.highlevel.ArrayBuilder.append
+#                         and key[1] == ak._v2.highlevel.ArrayBuilder.append
 #                         and (
 #                             args[0] == key[2]
 #                             or (

--- a/src/awkward/_v2/_connect/numba/builder.py
+++ b/src/awkward/_v2/_connect/numba/builder.py
@@ -31,7 +31,7 @@
 #     def __init__(self, behavior):
 #         super(ArrayBuilderType, self).__init__(
 #             name="ak.ArrayBuilderType({0})".format(
-#                 ak._connect._numba.repr_behavior(behavior)
+#                 ak._v2._connect.numba.repr_behavior(behavior)
 #             )
 #         )
 #         self.behavior = behavior
@@ -135,7 +135,7 @@
 #         ak._libawkward.ArrayBuilder_length,
 #         (proxyin.rawptr, result),
 #     )
-#     return ak._connect._numba.castint(
+#     return ak._v2._connect.numba.castint(
 #         context, builder, numba.int64, numba.intp, builder.load(result)
 #     )
 
@@ -312,8 +312,8 @@
 #             and isinstance(
 #                 args[0],
 #                 (
-#                     ak._connect._numba.arrayview.ArrayViewType,
-#                     ak._connect._numba.arrayview.RecordViewType,
+#                     ak._v2._connect.numba.arrayview.ArrayViewType,
+#                     ak._v2._connect.numba.arrayview.RecordViewType,
 #                     numba.types.Boolean,
 #                     numba.types.Integer,
 #                     numba.types.Float,
@@ -340,7 +340,7 @@
 #         elif (
 #             len(args) == 2
 #             and len(kwargs) == 0
-#             and isinstance(args[0], ak._connect._numba.arrayview.ArrayViewType)
+#             and isinstance(args[0], ak._v2._connect.numba.arrayview.ArrayViewType)
 #             and isinstance(args[1], numba.types.Integer)
 #         ):
 #             return numba.types.none(args[0], args[1])
@@ -374,7 +374,7 @@
 #         if (
 #             len(args) == 1
 #             and len(kwargs) == 0
-#             and isinstance(args[0], ak._connect._numba.arrayview.ArrayViewType)
+#             and isinstance(args[0], ak._v2._connect.numba.arrayview.ArrayViewType)
 #         ):
 #             return numba.types.none(args[0])
 #         else:
@@ -417,7 +417,7 @@
 #     arraybuildertype, xtype = sig.args
 #     arraybuilderval, xval = args
 #     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-#     x = ak._connect._numba.castint(context, builder, xtype, numba.int64, xval)
+#     x = ak._v2._connect.numba.castint(context, builder, xtype, numba.int64, xval)
 #     call(context, builder, ak._libawkward.ArrayBuilder_integer, (proxyin.rawptr, x))
 #     return context.get_dummy_value()
 
@@ -465,7 +465,7 @@
 #     arraybuildertype, numfieldstype = sig.args
 #     arraybuilderval, numfieldsval = args
 #     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-#     numfields = ak._connect._numba.castint(
+#     numfields = ak._v2._connect.numba.castint(
 #         context, builder, numfieldstype, numba.int64, numfieldsval
 #     )
 #     call(
@@ -482,7 +482,7 @@
 #     arraybuildertype, indextype = sig.args
 #     arraybuilderval, indexval = args
 #     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
-#     index = ak._connect._numba.castint(
+#     index = ak._v2._connect.numba.castint(
 #         context, builder, indextype, numba.int64, indexval
 #     )
 #     call(
@@ -561,7 +561,7 @@
 # @numba.extending.lower_builtin(
 #     "append",
 #     ArrayBuilderType,
-#     ak._connect._numba.arrayview.ArrayViewType,
+#     ak._v2._connect.numba.arrayview.ArrayViewType,
 #     numba.types.Integer,
 # )
 # def lower_append_array_at(context, builder, sig, args):
@@ -569,12 +569,12 @@
 #     arraybuilderval, viewval, atval = args
 
 #     viewproxy = context.make_helper(builder, viewtype, viewval)
-#     atval = ak._connect._numba.layout.regularize_atval(
+#     atval = ak._v2._connect.numba.layout.regularize_atval(
 #         context, builder, viewproxy, attype, atval, True, True
 #     )
-#     atval = ak._connect._numba.castint(context, builder, numba.intp, numba.int64, atval)
+#     atval = ak._v2._connect.numba.castint(context, builder, numba.intp, numba.int64, atval)
 
-#     sharedptr = ak._connect._numba.layout.getat(
+#     sharedptr = ak._v2._connect.numba.layout.getat(
 #         context, builder, viewproxy.sharedptrs, viewproxy.pos
 #     )
 
@@ -593,7 +593,7 @@
 
 
 # @numba.extending.lower_builtin(
-#     "append", ArrayBuilderType, ak._connect._numba.arrayview.ArrayViewType
+#     "append", ArrayBuilderType, ak._v2._connect.numba.arrayview.ArrayViewType
 # )
 # def lower_append_array(context, builder, sig, args):
 #     arraybuildertype, viewtype = sig.args
@@ -610,7 +610,7 @@
 
 
 # @numba.extending.lower_builtin(
-#     "append", ArrayBuilderType, ak._connect._numba.arrayview.RecordViewType
+#     "append", ArrayBuilderType, ak._v2._connect.numba.arrayview.RecordViewType
 # )
 # def lower_append_record(context, builder, sig, args):
 #     arraybuildertype, recordviewtype = sig.args
@@ -621,11 +621,11 @@
 #     arrayviewproxy = context.make_helper(
 #         builder, recordviewtype.arrayviewtype, recordviewproxy.arrayview
 #     )
-#     atval = ak._connect._numba.castint(
+#     atval = ak._v2._connect.numba.castint(
 #         context, builder, numba.intp, numba.int64, recordviewproxy.at
 #     )
 
-#     sharedptr = ak._connect._numba.layout.getat(
+#     sharedptr = ak._v2._connect.numba.layout.getat(
 #         context, builder, arrayviewproxy.sharedptrs, arrayviewproxy.pos
 #     )
 
@@ -713,7 +713,7 @@
 
 
 # @numba.extending.lower_builtin(
-#     "extend", ArrayBuilderType, ak._connect._numba.arrayview.ArrayViewType
+#     "extend", ArrayBuilderType, ak._v2._connect.numba.arrayview.ArrayViewType
 # )
 # def lower_extend_array(context, builder, sig, args):
 #     arraybuildertype, viewtype = sig.args
@@ -721,13 +721,13 @@
 
 #     viewproxy = context.make_helper(builder, viewtype, viewval)
 
-#     sharedptr = ak._connect._numba.layout.getat(
+#     sharedptr = ak._v2._connect.numba.layout.getat(
 #         context, builder, viewproxy.sharedptrs, viewproxy.pos
 #     )
 
 #     proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
 #     with numba.core.cgutils.for_range(builder, viewproxy.stop, viewproxy.start) as loop:
-#         atval = ak._connect._numba.castint(
+#         atval = ak._v2._connect.numba.castint(
 #             context, builder, numba.intp, numba.int64, loop.index
 #         )
 #         call(

--- a/src/awkward/_v2/_connect/numba/builder.py
+++ b/src/awkward/_v2/_connect/numba/builder.py
@@ -151,7 +151,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.clear"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("null")
@@ -161,7 +161,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.null"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("boolean")
@@ -175,7 +175,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.boolean"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("integer")
@@ -189,7 +189,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.integer"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("real")
@@ -203,7 +203,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.real"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("begin_list")
@@ -213,7 +213,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.begin_list"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("end_list")
@@ -223,7 +223,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.end_list"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("begin_tuple")
@@ -237,7 +237,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.begin_tuple"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("index")
@@ -251,7 +251,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.index"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("end_tuple")
@@ -261,7 +261,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.end_tuple"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("begin_record")
@@ -277,7 +277,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.begin_record"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("field")
@@ -291,7 +291,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.field"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("end_record")
@@ -301,7 +301,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.end_record"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("append")
@@ -366,7 +366,7 @@
 
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.append"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     @numba.core.typing.templates.bound_function("extend")
@@ -380,7 +380,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.extend"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 
@@ -691,7 +691,7 @@
 #                 )
 #             else:
 #                 raise AssertionError(
-#                     repr(opttype.type) + ak._v2._util.exception_suffix(__file__)
+#                     repr(opttype.type)
 #                 )
 
 #         with is_not_valid:

--- a/src/awkward/_v2/_connect/numba/builder.py
+++ b/src/awkward/_v2/_connect/numba/builder.py
@@ -151,7 +151,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.clear"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("null")
@@ -161,7 +161,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.null"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("boolean")
@@ -175,7 +175,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.boolean"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("integer")
@@ -189,7 +189,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.integer"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("real")
@@ -203,7 +203,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.real"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("begin_list")
@@ -213,7 +213,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.begin_list"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("end_list")
@@ -223,7 +223,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.end_list"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("begin_tuple")
@@ -237,7 +237,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.begin_tuple"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("index")
@@ -251,7 +251,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.index"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("end_tuple")
@@ -261,7 +261,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.end_tuple"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("begin_record")
@@ -277,7 +277,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.begin_record"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("field")
@@ -291,7 +291,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.field"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("end_record")
@@ -301,7 +301,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number of arguments for ArrayBuilder.end_record"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("append")
@@ -366,7 +366,7 @@
 
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.append"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @numba.core.typing.templates.bound_function("extend")
@@ -380,7 +380,7 @@
 #         else:
 #             raise TypeError(
 #                 "wrong number or types of arguments for ArrayBuilder.extend"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 
@@ -691,7 +691,7 @@
 #                 )
 #             else:
 #                 raise AssertionError(
-#                     repr(opttype.type) + ak._util.exception_suffix(__file__)
+#                     repr(opttype.type) + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #         with is_not_valid:

--- a/src/awkward/_v2/_connect/numba/layout.py
+++ b/src/awkward/_v2/_connect/numba/layout.py
@@ -326,11 +326,11 @@
 #             return typer(viewtype)
 
 #     def getitem_range(self, viewtype):
-#         return ak._connect._numba.arrayview.wrap(self, viewtype, None)
+#         return ak._v2._connect.numba.arrayview.wrap(self, viewtype, None)
 
 #     def getitem_field(self, viewtype, key):
 #         if self.has_field(key):
-#             return ak._connect._numba.arrayview.wrap(
+#             return ak._v2._connect.numba.arrayview.wrap(
 #                 self, viewtype, viewtype.fields + (key,)
 #             )
 #         else:
@@ -469,7 +469,7 @@
 
 
 # def regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkbounds):
-#     atval = ak._connect._numba.castint(context, builder, attype, numba.intp, atval)
+#     atval = ak._v2._connect.numba.castint(context, builder, attype, numba.intp, atval)
 
 #     if not attype.signed:
 #         wrapneg = False
@@ -498,7 +498,7 @@
 #                     builder, ValueError, ("slice index out of bounds",)
 #                 )
 
-#     return ak._connect._numba.castint(context, builder, atval.type, numba.intp, atval)
+#     return ak._v2._connect.numba.castint(context, builder, atval.type, numba.intp, atval)
 
 
 # class NumpyArrayType(ContentType):
@@ -655,7 +655,7 @@
 #         sharedptrs[-1] = layout._persistent_shared_ptr
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             layout.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -667,7 +667,7 @@
 #         sharedptrs[-1] = 0
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             form.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -675,7 +675,7 @@
 #     @classmethod
 #     def from_form(cls, form):
 #         return RegularArrayType(
-#             ak._connect._numba.arrayview.tonumbatype(form.content),
+#             ak._v2._connect.numba.arrayview.tonumbatype(form.content),
 #             form.size,
 #             cls.from_form_identities(form),
 #             form.parameters,
@@ -711,7 +711,7 @@
 #         return self.contenttype.has_field(key)
 
 #     def getitem_at(self, viewtype):
-#         return ak._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+#         return ak._v2._connect.numba.arrayview.wrap(self.contenttype, viewtype, None)
 
 #     def lower_getitem_at(
 #         self,
@@ -804,7 +804,7 @@
 #         arrays.append(stops)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             layout.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -822,7 +822,7 @@
 #         arrays.append(0)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             form.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -833,7 +833,7 @@
 #             cls.from_form_index(
 #                 form.starts if isinstance(form, ak.forms.ListForm) else form.offsets
 #             ),
-#             ak._connect._numba.arrayview.tonumbatype(form.content),
+#             ak._v2._connect.numba.arrayview.tonumbatype(form.content),
 #             cls.from_form_identities(form),
 #             form.parameters,
 #         )
@@ -917,7 +917,7 @@
 #         return self.contenttype.has_field(key)
 
 #     def getitem_at(self, viewtype):
-#         return ak._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+#         return ak._v2._connect.numba.arrayview.wrap(self.contenttype, viewtype, None)
 
 #     def lower_getitem_at(
 #         self,
@@ -955,10 +955,10 @@
 
 #         proxyout = context.make_helper(builder, rettype)
 #         proxyout.pos = nextpos
-#         proxyout.start = ak._connect._numba.castint(
+#         proxyout.start = ak._v2._connect.numba.castint(
 #             context, builder, self.indextype.dtype, numba.intp, start
 #         )
-#         proxyout.stop = ak._connect._numba.castint(
+#         proxyout.stop = ak._v2._connect.numba.castint(
 #             context, builder, self.indextype.dtype, numba.intp, stop
 #         )
 #         proxyout.arrayptrs = viewproxy.arrayptrs
@@ -998,7 +998,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             layout.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1013,7 +1013,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             form.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1022,7 +1022,7 @@
 #     def from_form(cls, form):
 #         return IndexedArrayType(
 #             cls.from_form_index(form.index),
-#             ak._connect._numba.arrayview.tonumbatype(form.content),
+#             ak._v2._connect.numba.arrayview.tonumbatype(form.content),
 #             cls.from_form_identities(form),
 #             form.parameters,
 #         )
@@ -1080,7 +1080,7 @@
 #         return self.contenttype.has_field(key)
 
 #     def getitem_at(self, viewtype):
-#         viewtype = ak._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+#         viewtype = ak._v2._connect.numba.arrayview.wrap(self.contenttype, viewtype, None)
 #         return self.contenttype.getitem_at_check(viewtype)
 
 #     def lower_getitem_at(
@@ -1110,14 +1110,14 @@
 #             context, builder, indexptr, indexarraypos, rettype=self.indextype.dtype
 #         )
 
-#         nextviewtype = ak._connect._numba.arrayview.wrap(
+#         nextviewtype = ak._v2._connect.numba.arrayview.wrap(
 #             self.contenttype, viewtype, None
 #         )
 #         proxynext = context.make_helper(builder, nextviewtype)
 #         proxynext.pos = nextpos
 #         proxynext.start = context.get_constant(numba.intp, 0)
 #         proxynext.stop = builder.add(
-#             ak._connect._numba.castint(
+#             ak._v2._connect.numba.castint(
 #                 context, builder, self.indextype.dtype, numba.intp, nextat
 #             ),
 #             context.get_constant(numba.intp, 1),
@@ -1171,7 +1171,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             layout.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1186,7 +1186,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             form.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1195,7 +1195,7 @@
 #     def from_form(cls, form):
 #         return IndexedOptionArrayType(
 #             cls.from_form_index(form.index),
-#             ak._connect._numba.arrayview.tonumbatype(form.content),
+#             ak._v2._connect.numba.arrayview.tonumbatype(form.content),
 #             cls.from_form_identities(form),
 #             form.parameters,
 #         )
@@ -1251,7 +1251,7 @@
 #         return self.contenttype.has_field(key)
 
 #     def getitem_at(self, viewtype):
-#         viewtype = ak._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+#         viewtype = ak._v2._connect.numba.arrayview.wrap(self.contenttype, viewtype, None)
 #         return numba.types.optional(self.contenttype.getitem_at_check(viewtype))
 
 #     def lower_getitem_at(
@@ -1293,14 +1293,14 @@
 #                 output.data = numba.core.cgutils.get_null_value(output.data.type)
 
 #             with isvalid:
-#                 nextviewtype = ak._connect._numba.arrayview.wrap(
+#                 nextviewtype = ak._v2._connect.numba.arrayview.wrap(
 #                     self.contenttype, viewtype, None
 #                 )
 #                 proxynext = context.make_helper(builder, nextviewtype)
 #                 proxynext.pos = nextpos
 #                 proxynext.start = context.get_constant(numba.intp, 0)
 #                 proxynext.stop = builder.add(
-#                     ak._connect._numba.castint(
+#                     ak._v2._connect.numba.castint(
 #                         context, builder, self.indextype.dtype, numba.intp, nextat
 #                     ),
 #                     context.get_constant(numba.intp, 1),
@@ -1359,7 +1359,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             layout.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1374,7 +1374,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             form.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1383,7 +1383,7 @@
 #     def from_form(cls, form):
 #         return ByteMaskedArrayType(
 #             cls.from_form_index(form.mask),
-#             ak._connect._numba.arrayview.tonumbatype(form.content),
+#             ak._v2._connect.numba.arrayview.tonumbatype(form.content),
 #             form.valid_when,
 #             cls.from_form_identities(form),
 #             form.parameters,
@@ -1432,7 +1432,7 @@
 #         return self.contenttype.has_field(key)
 
 #     def getitem_at(self, viewtype):
-#         viewtype = ak._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+#         viewtype = ak._v2._connect.numba.arrayview.wrap(self.contenttype, viewtype, None)
 #         return numba.types.optional(self.contenttype.getitem_at_check(viewtype))
 
 #     def lower_getitem_at(
@@ -1472,7 +1472,7 @@
 #             )
 #         ) as (isvalid, isnone):
 #             with isvalid:
-#                 nextviewtype = ak._connect._numba.arrayview.wrap(
+#                 nextviewtype = ak._v2._connect.numba.arrayview.wrap(
 #                     self.contenttype, viewtype, None
 #                 )
 #                 proxynext = context.make_helper(builder, nextviewtype)
@@ -1537,7 +1537,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             layout.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1552,7 +1552,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             form.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1561,7 +1561,7 @@
 #     def from_form(cls, form):
 #         return BitMaskedArrayType(
 #             cls.from_form_index(form.mask),
-#             ak._connect._numba.arrayview.tonumbatype(form.content),
+#             ak._v2._connect.numba.arrayview.tonumbatype(form.content),
 #             form.valid_when,
 #             form.lsb_order,
 #             cls.from_form_identities(form),
@@ -1620,7 +1620,7 @@
 #         return self.contenttype.has_field(key)
 
 #     def getitem_at(self, viewtype):
-#         viewtype = ak._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+#         viewtype = ak._v2._connect.numba.arrayview.wrap(self.contenttype, viewtype, None)
 #         return numba.types.optional(self.contenttype.getitem_at_check(viewtype))
 
 #     def lower_getitem_at(
@@ -1643,7 +1643,7 @@
 #             context, builder, viewproxy, attype, atval, wrapneg, checkbounds
 #         )
 #         bitatval = builder.sdiv(atval, context.get_constant(numba.intp, 8))
-#         shiftval = ak._connect._numba.castint(
+#         shiftval = ak._v2._connect.numba.castint(
 #             context,
 #             builder,
 #             numba.intp,
@@ -1678,7 +1678,7 @@
 #             )
 #         ) as (isvalid, isnone):
 #             with isvalid:
-#                 nextviewtype = ak._connect._numba.arrayview.wrap(
+#                 nextviewtype = ak._v2._connect.numba.arrayview.wrap(
 #                     self.contenttype, viewtype, None
 #                 )
 #                 proxynext = context.make_helper(builder, nextviewtype)
@@ -1739,7 +1739,7 @@
 #         sharedptrs[-1] = layout._persistent_shared_ptr
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             layout.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1751,7 +1751,7 @@
 #         sharedptrs[-1] = 0
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.CONTENT] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
 #             form.content, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -1759,7 +1759,7 @@
 #     @classmethod
 #     def from_form(cls, form):
 #         return UnmaskedArrayType(
-#             ak._connect._numba.arrayview.tonumbatype(form.content),
+#             ak._v2._connect.numba.arrayview.tonumbatype(form.content),
 #             cls.from_form_identities(form),
 #             form.parameters,
 #         )
@@ -1793,7 +1793,7 @@
 #         return self.contenttype.has_field(key)
 
 #     def getitem_at(self, viewtype):
-#         viewtype = ak._connect._numba.arrayview.wrap(self.contenttype, viewtype, None)
+#         viewtype = ak._v2._connect.numba.arrayview.wrap(self.contenttype, viewtype, None)
 #         return numba.types.optional(self.contenttype.getitem_at_check(viewtype))
 
 #     def lower_getitem_at(
@@ -1818,7 +1818,7 @@
 
 #         output = context.make_helper(builder, rettype)
 
-#         nextviewtype = ak._connect._numba.arrayview.wrap(
+#         nextviewtype = ak._v2._connect.numba.arrayview.wrap(
 #             self.contenttype, viewtype, None
 #         )
 #         proxynext = context.make_helper(builder, nextviewtype)
@@ -1876,7 +1876,7 @@
 #         positions.extend([None] * layout.numfields)
 #         sharedptrs.extend([None] * layout.numfields)
 #         for i, content in enumerate(layout.contents):
-#             positions[pos + cls.CONTENTS + i] = ak._connect._numba.arrayview.tolookup(
+#             positions[pos + cls.CONTENTS + i] = ak._v2._connect.numba.arrayview.tolookup(
 #                 content, positions, sharedptrs, arrays
 #             )
 #         return pos
@@ -1892,14 +1892,14 @@
 #             for i, (_, content) in enumerate(form.contents.items()):
 #                 positions[
 #                     pos + cls.CONTENTS + i
-#                 ] = ak._connect._numba.arrayview.tolookup(
+#                 ] = ak._v2._connect.numba.arrayview.tolookup(
 #                     content, positions, sharedptrs, arrays
 #                 )
 #         else:
 #             for i, (_, content) in enumerate(form.contents.items()):
 #                 positions[
 #                     pos + cls.CONTENTS + i
-#                 ] = ak._connect._numba.arrayview.tolookup(
+#                 ] = ak._v2._connect.numba.arrayview.tolookup(
 #                     content, positions, sharedptrs, arrays
 #                 )
 #         return pos
@@ -1910,11 +1910,11 @@
 #         if form.istuple:
 #             recordlookup = None
 #             for x in form.contents.values():
-#                 contents.append(ak._connect._numba.arrayview.tonumbatype(x))
+#                 contents.append(ak._v2._connect.numba.arrayview.tonumbatype(x))
 #         else:
 #             recordlookup = []
 #             for n, x in form.contents.items():
-#                 contents.append(ak._connect._numba.arrayview.tonumbatype(x))
+#                 contents.append(ak._v2._connect.numba.arrayview.tonumbatype(x))
 #                 recordlookup.append(n)
 
 #         return RecordArrayType(
@@ -2002,7 +2002,7 @@
 
 #     def getitem_at_check(self, viewtype):
 #         out = self.getitem_at(viewtype)
-#         if isinstance(out, ak._connect._numba.arrayview.RecordViewType):
+#         if isinstance(out, ak._v2._connect.numba.arrayview.RecordViewType):
 #             typer = ak._v2._util.numba_record_typer(
 #                 out.arrayviewtype.type, out.arrayviewtype.behavior
 #             )
@@ -2012,7 +2012,7 @@
 
 #     def getitem_at(self, viewtype):
 #         if len(viewtype.fields) == 0:
-#             return ak._connect._numba.arrayview.RecordViewType(viewtype)
+#             return ak._v2._connect.numba.arrayview.RecordViewType(viewtype)
 #         else:
 #             key = viewtype.fields[0]
 #             index = self.fieldindex(key)
@@ -2033,7 +2033,7 @@
 #
 #                     )
 #             contenttype = self.contenttypes[index]
-#             subviewtype = ak._connect._numba.arrayview.wrap(
+#             subviewtype = ak._v2._connect.numba.arrayview.wrap(
 #                 contenttype, viewtype, viewtype.fields[1:]
 #             )
 #             return contenttype.getitem_at_check(subviewtype)
@@ -2056,7 +2056,7 @@
 #
 #                 )
 #         contenttype = self.contenttypes[index]
-#         subviewtype = ak._connect._numba.arrayview.wrap(contenttype, viewtype, None)
+#         subviewtype = ak._v2._connect.numba.arrayview.wrap(contenttype, viewtype, None)
 #         return contenttype.getitem_range(subviewtype)
 
 #     def getitem_field_record(self, recordviewtype, key):
@@ -2077,7 +2077,7 @@
 #
 #                 )
 #         contenttype = self.contenttypes[index]
-#         subviewtype = ak._connect._numba.arrayview.wrap(
+#         subviewtype = ak._v2._connect.numba.arrayview.wrap(
 #             contenttype, recordviewtype, None
 #         )
 #         return contenttype.getitem_at_check(subviewtype)
@@ -2108,7 +2108,7 @@
 #             checkbounds,
 #         )
 #         baretype = self.getitem_at(viewtype)
-#         if isinstance(baretype, ak._connect._numba.arrayview.RecordViewType):
+#         if isinstance(baretype, ak._v2._connect.numba.arrayview.RecordViewType):
 #             lower = ak._v2._util.numba_record_lower(
 #                 baretype.arrayviewtype.type, baretype.arrayviewtype.behavior
 #             )
@@ -2135,7 +2135,7 @@
 
 #         if len(viewtype.fields) == 0:
 #             proxyout = context.make_helper(
-#                 builder, ak._connect._numba.arrayview.RecordViewType(viewtype)
+#                 builder, ak._v2._connect.numba.arrayview.RecordViewType(viewtype)
 #             )
 #             proxyout.arrayview = viewval
 #             proxyout.at = atval
@@ -2148,7 +2148,7 @@
 #             whichpos = posat(context, builder, viewproxy.pos, self.CONTENTS + index)
 #             nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-#             nextviewtype = ak._connect._numba.arrayview.wrap(
+#             nextviewtype = ak._v2._connect.numba.arrayview.wrap(
 #                 contenttype, viewtype, viewtype.fields[1:]
 #             )
 #             proxynext = context.make_helper(builder, nextviewtype)
@@ -2220,7 +2220,7 @@
 #         proxynext.sharedptrs = arrayviewproxy.sharedptrs
 #         proxynext.pylookup = arrayviewproxy.pylookup
 
-#         nextviewtype = ak._connect._numba.arrayview.wrap(
+#         nextviewtype = ak._v2._connect.numba.arrayview.wrap(
 #             contenttype, arrayviewtype, None
 #         )
 
@@ -2280,7 +2280,7 @@
 #         positions.extend([None] * layout.numcontents)
 #         sharedptrs.extend([None] * layout.numcontents)
 #         for i, content in enumerate(layout.contents):
-#             positions[pos + cls.CONTENTS + i] = ak._connect._numba.arrayview.tolookup(
+#             positions[pos + cls.CONTENTS + i] = ak._v2._connect.numba.arrayview.tolookup(
 #                 content, positions, sharedptrs, arrays
 #             )
 #         return pos
@@ -2299,7 +2299,7 @@
 #         positions.extend([None] * form.numcontents)
 #         sharedptrs.extend([None] * form.numcontents)
 #         for i, content in enumerate(form.contents):
-#             positions[pos + cls.CONTENTS + i] = ak._connect._numba.arrayview.tolookup(
+#             positions[pos + cls.CONTENTS + i] = ak._v2._connect.numba.arrayview.tolookup(
 #                 content, positions, sharedptrs, arrays
 #             )
 #         return pos
@@ -2308,7 +2308,7 @@
 #     def from_form(cls, form):
 #         contents = []
 #         for x in form.contents:
-#             contents.append(ak._connect._numba.arrayview.tonumbatype(x))
+#             contents.append(ak._v2._connect.numba.arrayview.tonumbatype(x))
 
 #         return UnionArrayType(
 #             cls.from_form_index(form.tags),
@@ -2506,7 +2506,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.ARRAY] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.ARRAY] = ak._v2._connect.numba.arrayview.tolookup(
 #             layout.form.form, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -2525,7 +2525,7 @@
 #         sharedptrs.append(None)
 #         positions.append(None)
 #         sharedptrs.append(None)
-#         positions[pos + cls.ARRAY] = ak._connect._numba.arrayview.tolookup(
+#         positions[pos + cls.ARRAY] = ak._v2._connect.numba.arrayview.tolookup(
 #             form.form, positions, sharedptrs, arrays
 #         )
 #         return pos
@@ -2657,8 +2657,8 @@
 
 #         def wrap(out):
 #             if isinstance(out, ak.forms.Form):
-#                 numbatype = ak._connect._numba.arrayview.tonumbatype(out)
-#                 return ak._connect._numba.arrayview.wrap(numbatype, viewtype, None)
+#                 numbatype = ak._v2._connect.numba.arrayview.tonumbatype(out)
+#                 return ak._v2._connect.numba.arrayview.wrap(numbatype, viewtype, None)
 #             else:
 #                 return out
 
@@ -2691,7 +2691,7 @@
 #         )
 #         sharedptr = getat(context, builder, viewproxy.sharedptrs, arraypos)
 
-#         numbatype = ak._connect._numba.arrayview.tonumbatype(self.generator_form)
+#         numbatype = ak._v2._connect.numba.arrayview.tonumbatype(self.generator_form)
 
 #         with builder.if_then(
 #             builder.icmp_signed("==", sharedptr, context.get_constant(numba.intp, 0)),
@@ -2757,7 +2757,7 @@
 #         whichpos = posat(context, builder, viewproxy.pos, self.ARRAY)
 #         nextpos = getat(context, builder, viewproxy.arrayptrs, whichpos)
 
-#         nextviewtype = ak._connect._numba.arrayview.wrap(numbatype, viewtype, None)
+#         nextviewtype = ak._v2._connect.numba.arrayview.wrap(numbatype, viewtype, None)
 #         proxynext = context.make_helper(builder, nextviewtype)
 #         proxynext.pos = nextpos
 #         proxynext.start = viewproxy.start

--- a/src/awkward/_v2/_connect/numba/layout.py
+++ b/src/awkward/_v2/_connect/numba/layout.py
@@ -237,11 +237,11 @@
 #     if obj.form.form is None:
 #         raise ValueError(
 #             "VirtualArrays without a known 'form' can't be used in Numba"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 #     if obj.form.has_identities:
 #         raise NotImplementedError(
-#             "TODO: identities in VirtualArray" + ak._util.exception_suffix(__file__)
+#             "TODO: identities in VirtualArray" + ak._v2._util.exception_suffix(__file__)
 #         )
 #     return VirtualArrayType(obj.form.form, numba.none, obj.parameters)
 
@@ -273,7 +273,7 @@
 #             return numba.none
 #         else:
 #             raise NotImplementedError(
-#                 "TODO: identities in VirtualArray" + ak._util.exception_suffix(__file__)
+#                 "TODO: identities in VirtualArray" + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @classmethod
@@ -291,7 +291,7 @@
 #         else:
 #             raise AssertionError(
 #                 "unrecognized Form index type: {0}".format(index_string)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def form_fill_identities(self, pos, layout, lookup):
@@ -315,11 +315,11 @@
 #         else:
 #             raise AssertionError(
 #                 "no Index* type for array: {0}".format(arraytype)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def getitem_at_check(self, viewtype):
-#         typer = ak._util.numba_array_typer(viewtype.type, viewtype.behavior)
+#         typer = ak._v2._util.numba_array_typer(viewtype.type, viewtype.behavior)
 #         if typer is None:
 #             return self.getitem_at(viewtype)
 #         else:
@@ -336,7 +336,7 @@
 #         else:
 #             raise TypeError(
 #                 "array does not have a field with key {0}".format(repr(key))
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def lower_getitem_at_check(
@@ -352,7 +352,7 @@
 #         wrapneg,
 #         checkbounds,
 #     ):
-#         lower = ak._util.numba_array_lower(viewtype.type, viewtype.behavior)
+#         lower = ak._v2._util.numba_array_lower(viewtype.type, viewtype.behavior)
 #         if lower is not None:
 #             atval = regularize_atval(
 #                 context, builder, viewproxy, attype, atval, wrapneg, checkbounds
@@ -523,7 +523,7 @@
 #             raise NotImplementedError(
 #                 "NumpyForm is multidimensional; TODO: convert to RegularForm,"
 #                 " just as NumpyArrays are converted to RegularArrays"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         pos = len(positions)
 #         cls.form_tolookup_identities(form, positions, sharedptrs, arrays)
@@ -539,7 +539,7 @@
 #             raise NotImplementedError(
 #                 "NumpyForm is multidimensional; TODO: convert to RegularForm,"
 #                 " just as NumpyArrays are converted to RegularArrays"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         if form.primitive == "float64":
 #             arraytype = numba.types.Array(numba.float64, 1, "A")
@@ -566,7 +566,7 @@
 #         else:
 #             raise ValueError(
 #                 "unrecognized NumpyForm.primitive type: {0}".format(form.primitive)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         return NumpyArrayType(
 #             arraytype, cls.from_form_identities(form), form.parameters
@@ -898,7 +898,7 @@
 #         else:
 #             raise AssertionError(
 #                 "no ListArray* type for array: {0}".format(self.indextype)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def tolayout(self, lookup, pos, fields):
@@ -1064,7 +1064,7 @@
 #         else:
 #             raise AssertionError(
 #                 "no IndexedArray* type for array: {0}".format(self.indextype)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def tolayout(self, lookup, pos, fields):
@@ -1235,7 +1235,7 @@
 #         else:
 #             raise AssertionError(
 #                 "no IndexedOptionArray* type for array: {0}".format(self.indextype)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def tolayout(self, lookup, pos, fields):
@@ -2003,7 +2003,7 @@
 #     def getitem_at_check(self, viewtype):
 #         out = self.getitem_at(viewtype)
 #         if isinstance(out, ak._connect._numba.arrayview.RecordViewType):
-#             typer = ak._util.numba_record_typer(
+#             typer = ak._v2._util.numba_record_typer(
 #                 out.arrayviewtype.type, out.arrayviewtype.behavior
 #             )
 #             if typer is not None:
@@ -2022,7 +2022,7 @@
 #                         "no field {0} in tuples with {1} fields".format(
 #                             repr(key), len(self.contenttypes)
 #                         )
-#                         + ak._util.exception_suffix(__file__)
+#                         + ak._v2._util.exception_suffix(__file__)
 #                     )
 #                 else:
 #                     raise ValueError(
@@ -2030,7 +2030,7 @@
 #                         "fields: [{1}]".format(
 #                             repr(key), ", ".join(repr(x) for x in self.recordlookup)
 #                         )
-#                         + ak._util.exception_suffix(__file__)
+#                         + ak._v2._util.exception_suffix(__file__)
 #                     )
 #             contenttype = self.contenttypes[index]
 #             subviewtype = ak._connect._numba.arrayview.wrap(
@@ -2046,14 +2046,14 @@
 #                     "no field {0} in tuples with {1} fields".format(
 #                         repr(key), len(self.contenttypes)
 #                     )
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             else:
 #                 raise ValueError(
 #                     "no field {0} in records with fields: [{1}]".format(
 #                         repr(key), ", ".join(repr(x) for x in self.recordlookup)
 #                     )
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #         contenttype = self.contenttypes[index]
 #         subviewtype = ak._connect._numba.arrayview.wrap(contenttype, viewtype, None)
@@ -2067,14 +2067,14 @@
 #                     "no field {0} in tuple with {1} fields".format(
 #                         repr(key), len(self.contenttypes)
 #                     )
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             else:
 #                 raise ValueError(
 #                     "no field {0} in record with fields: [{1}]".format(
 #                         repr(key), ", ".join(repr(x) for x in self.recordlookup)
 #                     )
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #         contenttype = self.contenttypes[index]
 #         subviewtype = ak._connect._numba.arrayview.wrap(
@@ -2109,7 +2109,7 @@
 #         )
 #         baretype = self.getitem_at(viewtype)
 #         if isinstance(baretype, ak._connect._numba.arrayview.RecordViewType):
-#             lower = ak._util.numba_record_lower(
+#             lower = ak._v2._util.numba_record_lower(
 #                 baretype.arrayviewtype.type, baretype.arrayviewtype.behavior
 #             )
 #             if lower is not None:
@@ -2365,12 +2365,12 @@
 #             else:
 #                 raise AssertionError(
 #                     "no UnionArray* type for index array: {0}".format(self.indextype)
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #         else:
 #             raise AssertionError(
 #                 "no UnionArray* type for tags array: {0}".format(self.tagstype)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def tolayout(self, lookup, pos, fields):
@@ -2393,21 +2393,21 @@
 #         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
 #             raise TypeError(
 #                 "union types cannot be accessed in Numba"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def getitem_range(self, viewtype):
 #         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
 #             raise TypeError(
 #                 "union types cannot be accessed in Numba"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def getitem_field(self, viewtype, key):
 #         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
 #             raise TypeError(
 #                 "union types cannot be accessed in Numba"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     def lower_getitem_at(
@@ -2426,7 +2426,7 @@
 #         raise NotImplementedError(
 #             type(self).__name__
 #             + ".lower_getitem_at not implemented"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     def lower_getitem_range(
@@ -2444,14 +2444,14 @@
 #         raise NotImplementedError(
 #             type(self).__name__
 #             + ".lower_getitem_range not implemented"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     def lower_getitem_field(self, context, builder, viewtype, viewval, viewproxy, key):
 #         raise NotImplementedError(
 #             type(self).__name__
 #             + ".lower_getitem_field not implemented"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     @property
@@ -2496,7 +2496,7 @@
 #         if layout.form is None:
 #             raise ValueError(
 #                 "VirtualArrays without a known 'form' can't be used in Numba"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         pyptr = ctypes.py_object(layout)
 #         ctypes.pythonapi.Py_IncRef(pyptr)
@@ -2519,7 +2519,7 @@
 #         if form.form is None:
 #             raise ValueError(
 #                 "VirtualArrays without a known 'form' can't be used in Numba"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         positions.append(0)
 #         sharedptrs.append(None)
@@ -2535,7 +2535,7 @@
 #         if form.form is None:
 #             raise ValueError(
 #                 "VirtualArrays without a known 'form' can't be used in Numba "
-#                 "(including nested)" + ak._util.exception_suffix(__file__)
+#                 "(including nested)" + ak._v2._util.exception_suffix(__file__)
 #             )
 #         return VirtualArrayType(
 #             form.form, cls.from_form_identities(form), form.parameters
@@ -2545,7 +2545,7 @@
 #         if generator_form is None:
 #             raise ValueError(
 #                 "VirtualArrays without a known 'form' can't be used in Numba"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         super(VirtualArrayType, self).__init__(
 #             name="ak.VirtualArrayType({0}, {1}, {2})".format(
@@ -2609,7 +2609,7 @@
 #                         "unrecognized NumpyForm.primitive type: {0}".format(
 #                             form.primitive
 #                         )
-#                         + ak._util.exception_suffix(__file__)
+#                         + ak._v2._util.exception_suffix(__file__)
 #                     )
 
 #             elif isinstance(
@@ -2643,7 +2643,7 @@
 #             elif isinstance(form, ak.forms.UnionForm):
 #                 raise TypeError(
 #                     "union types cannot be accessed in Numba"
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #             elif isinstance(form, ak.forms.VirtualForm):
@@ -2652,7 +2652,7 @@
 #             else:
 #                 raise AssertionError(
 #                     "unrecognized Form type: {0}".format(type(form))
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #         def wrap(out):
@@ -2839,7 +2839,7 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Form type: {0}".format(type(form))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 
@@ -2881,7 +2881,7 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Form type: {0}".format(type(form))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 
@@ -2925,5 +2925,5 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Form type: {0}".format(type(form))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )

--- a/src/awkward/_v2/_connect/numba/layout.py
+++ b/src/awkward/_v2/_connect/numba/layout.py
@@ -13,33 +13,33 @@
 # numpy = ak.nplike.Numpy.instance()
 
 
-# @numba.extending.typeof_impl.register(ak.layout.NumpyArray)
-# @numba.extending.typeof_impl.register(ak.layout.RegularArray)
-# @numba.extending.typeof_impl.register(ak.layout.ListArray32)
-# @numba.extending.typeof_impl.register(ak.layout.ListArrayU32)
-# @numba.extending.typeof_impl.register(ak.layout.ListArray64)
-# @numba.extending.typeof_impl.register(ak.layout.ListOffsetArray32)
-# @numba.extending.typeof_impl.register(ak.layout.ListOffsetArrayU32)
-# @numba.extending.typeof_impl.register(ak.layout.ListOffsetArray64)
-# @numba.extending.typeof_impl.register(ak.layout.IndexedArray32)
-# @numba.extending.typeof_impl.register(ak.layout.IndexedArrayU32)
-# @numba.extending.typeof_impl.register(ak.layout.IndexedArray64)
-# @numba.extending.typeof_impl.register(ak.layout.IndexedOptionArray32)
-# @numba.extending.typeof_impl.register(ak.layout.IndexedOptionArray64)
-# @numba.extending.typeof_impl.register(ak.layout.ByteMaskedArray)
-# @numba.extending.typeof_impl.register(ak.layout.BitMaskedArray)
-# @numba.extending.typeof_impl.register(ak.layout.UnmaskedArray)
-# @numba.extending.typeof_impl.register(ak.layout.RecordArray)
-# @numba.extending.typeof_impl.register(ak.layout.UnionArray8_32)
-# @numba.extending.typeof_impl.register(ak.layout.UnionArray8_U32)
-# @numba.extending.typeof_impl.register(ak.layout.UnionArray8_64)
-# @numba.extending.typeof_impl.register(ak.layout.VirtualArray)
-# @numba.extending.typeof_impl.register(ak.layout.Index8)
-# @numba.extending.typeof_impl.register(ak.layout.IndexU8)
-# @numba.extending.typeof_impl.register(ak.layout.Index32)
-# @numba.extending.typeof_impl.register(ak.layout.IndexU32)
-# @numba.extending.typeof_impl.register(ak.layout.Index64)
-# @numba.extending.typeof_impl.register(ak.layout.Record)
+# @numba.extending.typeof_impl.register(ak._v2.contents.NumpyArray)
+# @numba.extending.typeof_impl.register(ak._v2.contents.RegularArray)
+# @numba.extending.typeof_impl.register(ak._v2.contents.ListArray32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.ListArrayU32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.ListArray64)
+# @numba.extending.typeof_impl.register(ak._v2.contents.ListOffsetArray32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.ListOffsetArrayU32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.ListOffsetArray64)
+# @numba.extending.typeof_impl.register(ak._v2.contents.IndexedArray32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.IndexedArrayU32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.IndexedArray64)
+# @numba.extending.typeof_impl.register(ak._v2.contents.IndexedOptionArray32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.IndexedOptionArray64)
+# @numba.extending.typeof_impl.register(ak._v2.contents.ByteMaskedArray)
+# @numba.extending.typeof_impl.register(ak._v2.contents.BitMaskedArray)
+# @numba.extending.typeof_impl.register(ak._v2.contents.UnmaskedArray)
+# @numba.extending.typeof_impl.register(ak._v2.contents.RecordArray)
+# @numba.extending.typeof_impl.register(ak._v2.contents.UnionArray8_32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.UnionArray8_U32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.UnionArray8_64)
+# @numba.extending.typeof_impl.register(ak._v2.contents.VirtualArray)
+# @numba.extending.typeof_impl.register(ak._v2.contents.Index8)
+# @numba.extending.typeof_impl.register(ak._v2.contents.IndexU8)
+# @numba.extending.typeof_impl.register(ak._v2.contents.Index32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.IndexU32)
+# @numba.extending.typeof_impl.register(ak._v2.contents.Index64)
+# @numba.extending.typeof_impl.register(ak._v2.record.Record)
 # def fake_typeof(obj, c):
 #     raise TypeError(
 #         "{0} objects cannot be passed directly into Numba-compiled functions; "
@@ -50,21 +50,21 @@
 
 
 # def typeof(obj):
-#     if isinstance(obj, ak.layout.NumpyArray):
+#     if isinstance(obj, ak._v2.contents.NumpyArray):
 #         return typeof_NumpyArray(obj)
 
-#     elif isinstance(obj, ak.layout.RegularArray):
+#     elif isinstance(obj, ak._v2.contents.RegularArray):
 #         return typeof_RegularArray(obj)
 
 #     elif isinstance(
 #         obj,
 #         (
-#             ak.layout.ListArray32,
-#             ak.layout.ListArrayU32,
-#             ak.layout.ListArray64,
-#             ak.layout.ListOffsetArray32,
-#             ak.layout.ListOffsetArrayU32,
-#             ak.layout.ListOffsetArray64,
+#             ak._v2.contents.ListArray32,
+#             ak._v2.contents.ListArrayU32,
+#             ak._v2.contents.ListArray64,
+#             ak._v2.contents.ListOffsetArray32,
+#             ak._v2.contents.ListOffsetArrayU32,
+#             ak._v2.contents.ListOffsetArray64,
 #         ),
 #     ):
 #         return typeof_ListArray(obj)
@@ -72,9 +72,9 @@
 #     elif isinstance(
 #         obj,
 #         (
-#             ak.layout.IndexedArray32,
-#             ak.layout.IndexedArrayU32,
-#             ak.layout.IndexedArray64,
+#             ak._v2.contents.IndexedArray32,
+#             ak._v2.contents.IndexedArrayU32,
+#             ak._v2.contents.IndexedArray64,
 #         ),
 #     ):
 #         return typeof_IndexedArray(obj)
@@ -82,42 +82,42 @@
 #     elif isinstance(
 #         obj,
 #         (
-#             ak.layout.IndexedOptionArray32,
-#             ak.layout.IndexedOptionArray64,
+#             ak._v2.contents.IndexedOptionArray32,
+#             ak._v2.contents.IndexedOptionArray64,
 #         ),
 #     ):
 #         return typeof_IndexedOptionArray(obj)
 
-#     elif isinstance(obj, ak.layout.ByteMaskedArray):
+#     elif isinstance(obj, ak._v2.contents.ByteMaskedArray):
 #         return typeof_ByteMaskedArray(obj)
 
-#     elif isinstance(obj, ak.layout.BitMaskedArray):
+#     elif isinstance(obj, ak._v2.contents.BitMaskedArray):
 #         return typeof_BitMaskedArray(obj)
 
-#     elif isinstance(obj, ak.layout.UnmaskedArray):
+#     elif isinstance(obj, ak._v2.contents.UnmaskedArray):
 #         return typeof_UnmaskedArray(obj)
 
-#     elif isinstance(obj, ak.layout.RecordArray):
+#     elif isinstance(obj, ak._v2.contents.RecordArray):
 #         return typeof_RecordArray(obj)
 
 #     elif isinstance(
 #         obj,
 #         (
-#             ak.layout.UnionArray8_32,
-#             ak.layout.UnionArray8_U32,
-#             ak.layout.UnionArray8_64,
+#             ak._v2.contents.UnionArray8_32,
+#             ak._v2.contents.UnionArray8_U32,
+#             ak._v2.contents.UnionArray8_64,
 #         ),
 #     ):
 #         return typeof_UnionArray(obj)
 
-#     elif isinstance(obj, ak.layout.VirtualArray):
+#     elif isinstance(obj, ak._v2.contents.VirtualArray):
 #         return typeof_VirtualArray(obj)
 
 #     elif isinstance(
 #         obj,
 #         (
-#             ak.layout.Identities32,
-#             ak.layout.Identities64,
+#             ak._v2.identifier.Identifier32,
+#             ak._v2.identifier.Identifier64,
 #         ),
 #     ):
 #         raise NotImplementedError(
@@ -127,11 +127,11 @@
 #     elif isinstance(
 #         obj,
 #         (
-#             ak.layout.Index8,
-#             ak.layout.IndexU8,
-#             ak.layout.Index32,
-#             ak.layout.IndexU32,
-#             ak.layout.Index64,
+#             ak._v2.index.Index8,
+#             ak._v2.index.IndexU8,
+#             ak._v2.index.Index32,
+#             ak._v2.index.IndexU32,
+#             ak._v2.index.Index64,
 #         ),
 #     ):
 #         raise RuntimeError(
@@ -303,15 +303,15 @@
 
 #     def IndexOf(self, arraytype):
 #         if arraytype.dtype.bitwidth == 8 and arraytype.dtype.signed:
-#             return ak.layout.Index8
+#             return ak._v2.index.Index8
 #         elif arraytype.dtype.bitwidth == 8:
-#             return ak.layout.IndexU8
+#             return ak._v2.index.IndexU8
 #         elif arraytype.dtype.bitwidth == 32 and arraytype.dtype.signed:
-#             return ak.layout.Index32
+#             return ak._v2.index.Index32
 #         elif arraytype.dtype.bitwidth == 32:
-#             return ak.layout.IndexU32
+#             return ak._v2.index.IndexU32
 #         elif arraytype.dtype.bitwidth == 64 and arraytype.dtype.signed:
-#             return ak.layout.Index64
+#             return ak._v2.index.Index64
 #         else:
 #             raise AssertionError(
 #                 "no Index* type for array: {0}".format(arraytype)
@@ -596,7 +596,7 @@
 
 #     def tolayout(self, lookup, pos, fields):
 #         assert fields == ()
-#         return ak.layout.NumpyArray(
+#         return ak._v2.contents.NumpyArray(
 #             lookup.original_positions[pos + self.ARRAY], parameters=self.parameters
 #         )
 
@@ -705,7 +705,7 @@
 #         content = self.contenttype.tolayout(
 #             lookup, lookup.positions[pos + self.CONTENT], fields
 #         )
-#         return ak.layout.RegularArray(content, self.size, 0, parameters=self.parameters)
+#         return ak._v2.contents.RegularArray(content, self.size, 0, parameters=self.parameters)
 
 #     def has_field(self, key):
 #         return self.contenttype.has_field(key)
@@ -774,9 +774,9 @@
 #         if isinstance(
 #             layout,
 #             (
-#                 ak.layout.ListArray32,
-#                 ak.layout.ListArrayU32,
-#                 ak.layout.ListArray64,
+#                 ak._v2.contents.ListArray32,
+#                 ak._v2.contents.ListArrayU32,
+#                 ak._v2.contents.ListArray64,
 #             ),
 #         ):
 #             starts = ak.nplike.of(layout.starts).asarray(layout.starts)
@@ -784,9 +784,9 @@
 #         elif isinstance(
 #             layout,
 #             (
-#                 ak.layout.ListOffsetArray32,
-#                 ak.layout.ListOffsetArrayU32,
-#                 ak.layout.ListOffsetArray64,
+#                 ak._v2.contents.ListOffsetArray32,
+#                 ak._v2.contents.ListOffsetArrayU32,
+#                 ak._v2.contents.ListOffsetArray64,
 #             ),
 #         ):
 #             offsets = ak.nplike.of(layout.offsets).asarray(layout.offsets)
@@ -860,9 +860,9 @@
 #         if isinstance(
 #             layout,
 #             (
-#                 ak.layout.ListArray32,
-#                 ak.layout.ListArrayU32,
-#                 ak.layout.ListArray64,
+#                 ak._v2.contents.ListArray32,
+#                 ak._v2.contents.ListArrayU32,
+#                 ak._v2.contents.ListArray64,
 #             ),
 #         ):
 #             starts = ak.nplike.of(layout.starts).asarray(layout.starts)
@@ -870,9 +870,9 @@
 #         elif isinstance(
 #             layout,
 #             (
-#                 ak.layout.ListOffsetArray32,
-#                 ak.layout.ListOffsetArrayU32,
-#                 ak.layout.ListOffsetArray64,
+#                 ak._v2.contents.ListOffsetArray32,
+#                 ak._v2.contents.ListOffsetArrayU32,
+#                 ak._v2.contents.ListOffsetArray64,
 #             ),
 #         ):
 #             offsets = ak.nplike.of(layout.offsets).asarray(layout.offsets)
@@ -890,11 +890,11 @@
 
 #     def ListArrayOf(self):
 #         if self.indextype.dtype.bitwidth == 32 and self.indextype.dtype.signed:
-#             return ak.layout.ListArray32
+#             return ak._v2.contents.ListArray32
 #         elif self.indextype.dtype.bitwidth == 32:
-#             return ak.layout.ListArrayU32
+#             return ak._v2.contents.ListArrayU32
 #         elif self.indextype.dtype.bitwidth == 64 and self.indextype.dtype.signed:
-#             return ak.layout.ListArray64
+#             return ak._v2.contents.ListArray64
 #         else:
 #             raise AssertionError(
 #                 "no ListArray* type for array: {0}".format(self.indextype)
@@ -1056,11 +1056,11 @@
 
 #     def IndexedArrayOf(self):
 #         if self.indextype.dtype.bitwidth == 32 and self.indextype.dtype.signed:
-#             return ak.layout.IndexedArray32
+#             return ak._v2.contents.IndexedArray32
 #         elif self.indextype.dtype.bitwidth == 32:
-#             return ak.layout.IndexedArrayU32
+#             return ak._v2.contents.IndexedArrayU32
 #         elif self.indextype.dtype.bitwidth == 64 and self.indextype.dtype.signed:
-#             return ak.layout.IndexedArray64
+#             return ak._v2.contents.IndexedArray64
 #         else:
 #             raise AssertionError(
 #                 "no IndexedArray* type for array: {0}".format(self.indextype)
@@ -1229,9 +1229,9 @@
 
 #     def IndexedOptionArrayOf(self):
 #         if self.indextype.dtype.bitwidth == 32 and self.indextype.dtype.signed:
-#             return ak.layout.IndexedOptionArray32
+#             return ak._v2.contents.IndexedOptionArray32
 #         elif self.indextype.dtype.bitwidth == 64 and self.indextype.dtype.signed:
-#             return ak.layout.IndexedOptionArray64
+#             return ak._v2.contents.IndexedOptionArray64
 #         else:
 #             raise AssertionError(
 #                 "no IndexedOptionArray* type for array: {0}".format(self.indextype)
@@ -1424,7 +1424,7 @@
 #         content = self.contenttype.tolayout(
 #             lookup, lookup.positions[pos + self.CONTENT], fields
 #         )
-#         return ak.layout.ByteMaskedArray(
+#         return ak._v2.contents.ByteMaskedArray(
 #             mask, content, self.valid_when, parameters=self.parameters
 #         )
 
@@ -1607,7 +1607,7 @@
 #         content = self.contenttype.tolayout(
 #             lookup, lookup.positions[pos + self.CONTENT], fields
 #         )
-#         return ak.layout.BitMaskedArray(
+#         return ak._v2.contents.BitMaskedArray(
 #             mask,
 #             content,
 #             self.valid_when,
@@ -1787,7 +1787,7 @@
 #         content = self.contenttype.tolayout(
 #             lookup, lookup.positions[pos + self.CONTENT], fields
 #         )
-#         return ak.layout.UnmaskedArray(content, parameters=self.parameters)
+#         return ak._v2.contents.UnmaskedArray(content, parameters=self.parameters)
 
 #     def has_field(self, key):
 #         return self.contenttype.has_field(key)
@@ -1986,14 +1986,14 @@
 #                 contents.append(layout)
 
 #             if len(contents) == 0:
-#                 return ak.layout.RecordArray(
+#                 return ak._v2.contents.RecordArray(
 #                     contents,
 #                     self.recordlookup,
 #                     np.iinfo(np.int64).max,
 #                     parameters=self.parameters,
 #                 )
 #             else:
-#                 return ak.layout.RecordArray(
+#                 return ak._v2.contents.RecordArray(
 #                     contents, self.recordlookup, parameters=self.parameters
 #                 )
 
@@ -2357,11 +2357,11 @@
 #     def UnionArrayOf(self):
 #         if self.tagstype.dtype.bitwidth == 8 and self.tagstype.dtype.signed:
 #             if self.indextype.dtype.bitwidth == 32 and self.indextype.dtype.signed:
-#                 return ak.layout.UnionArray8_32
+#                 return ak._v2.contents.UnionArray8_32
 #             elif self.indextype.dtype.bitwidth == 32:
-#                 return ak.layout.UnionArray8_U32
+#                 return ak._v2.contents.UnionArray8_U32
 #             elif self.indextype.dtype.bitwidth == 64 and self.indextype.dtype.signed:
-#                 return ak.layout.UnionArray8_64
+#                 return ak._v2.contents.UnionArray8_64
 #             else:
 #                 raise AssertionError(
 #                     "no UnionArray* type for index array: {0}".format(self.indextype)

--- a/src/awkward/_v2/_connect/numba/layout.py
+++ b/src/awkward/_v2/_connect/numba/layout.py
@@ -237,11 +237,11 @@
 #     if obj.form.form is None:
 #         raise ValueError(
 #             "VirtualArrays without a known 'form' can't be used in Numba"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 #     if obj.form.has_identities:
 #         raise NotImplementedError(
-#             "TODO: identities in VirtualArray" + ak._v2._util.exception_suffix(__file__)
+#             "TODO: identities in VirtualArray"
 #         )
 #     return VirtualArrayType(obj.form.form, numba.none, obj.parameters)
 
@@ -273,7 +273,7 @@
 #             return numba.none
 #         else:
 #             raise NotImplementedError(
-#                 "TODO: identities in VirtualArray" + ak._v2._util.exception_suffix(__file__)
+#                 "TODO: identities in VirtualArray"
 #             )
 
 #     @classmethod
@@ -291,7 +291,7 @@
 #         else:
 #             raise AssertionError(
 #                 "unrecognized Form index type: {0}".format(index_string)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def form_fill_identities(self, pos, layout, lookup):
@@ -315,7 +315,7 @@
 #         else:
 #             raise AssertionError(
 #                 "no Index* type for array: {0}".format(arraytype)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def getitem_at_check(self, viewtype):
@@ -336,7 +336,7 @@
 #         else:
 #             raise TypeError(
 #                 "array does not have a field with key {0}".format(repr(key))
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def lower_getitem_at_check(
@@ -523,7 +523,7 @@
 #             raise NotImplementedError(
 #                 "NumpyForm is multidimensional; TODO: convert to RegularForm,"
 #                 " just as NumpyArrays are converted to RegularArrays"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         pos = len(positions)
 #         cls.form_tolookup_identities(form, positions, sharedptrs, arrays)
@@ -539,7 +539,7 @@
 #             raise NotImplementedError(
 #                 "NumpyForm is multidimensional; TODO: convert to RegularForm,"
 #                 " just as NumpyArrays are converted to RegularArrays"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         if form.primitive == "float64":
 #             arraytype = numba.types.Array(numba.float64, 1, "A")
@@ -566,7 +566,7 @@
 #         else:
 #             raise ValueError(
 #                 "unrecognized NumpyForm.primitive type: {0}".format(form.primitive)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         return NumpyArrayType(
 #             arraytype, cls.from_form_identities(form), form.parameters
@@ -898,7 +898,7 @@
 #         else:
 #             raise AssertionError(
 #                 "no ListArray* type for array: {0}".format(self.indextype)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def tolayout(self, lookup, pos, fields):
@@ -1064,7 +1064,7 @@
 #         else:
 #             raise AssertionError(
 #                 "no IndexedArray* type for array: {0}".format(self.indextype)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def tolayout(self, lookup, pos, fields):
@@ -1235,7 +1235,7 @@
 #         else:
 #             raise AssertionError(
 #                 "no IndexedOptionArray* type for array: {0}".format(self.indextype)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def tolayout(self, lookup, pos, fields):
@@ -2022,7 +2022,7 @@
 #                         "no field {0} in tuples with {1} fields".format(
 #                             repr(key), len(self.contenttypes)
 #                         )
-#                         + ak._v2._util.exception_suffix(__file__)
+#
 #                     )
 #                 else:
 #                     raise ValueError(
@@ -2030,7 +2030,7 @@
 #                         "fields: [{1}]".format(
 #                             repr(key), ", ".join(repr(x) for x in self.recordlookup)
 #                         )
-#                         + ak._v2._util.exception_suffix(__file__)
+#
 #                     )
 #             contenttype = self.contenttypes[index]
 #             subviewtype = ak._connect._numba.arrayview.wrap(
@@ -2046,14 +2046,14 @@
 #                     "no field {0} in tuples with {1} fields".format(
 #                         repr(key), len(self.contenttypes)
 #                     )
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #             else:
 #                 raise ValueError(
 #                     "no field {0} in records with fields: [{1}]".format(
 #                         repr(key), ", ".join(repr(x) for x in self.recordlookup)
 #                     )
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #         contenttype = self.contenttypes[index]
 #         subviewtype = ak._connect._numba.arrayview.wrap(contenttype, viewtype, None)
@@ -2067,14 +2067,14 @@
 #                     "no field {0} in tuple with {1} fields".format(
 #                         repr(key), len(self.contenttypes)
 #                     )
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #             else:
 #                 raise ValueError(
 #                     "no field {0} in record with fields: [{1}]".format(
 #                         repr(key), ", ".join(repr(x) for x in self.recordlookup)
 #                     )
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #         contenttype = self.contenttypes[index]
 #         subviewtype = ak._connect._numba.arrayview.wrap(
@@ -2365,12 +2365,12 @@
 #             else:
 #                 raise AssertionError(
 #                     "no UnionArray* type for index array: {0}".format(self.indextype)
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #         else:
 #             raise AssertionError(
 #                 "no UnionArray* type for tags array: {0}".format(self.tagstype)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def tolayout(self, lookup, pos, fields):
@@ -2393,21 +2393,21 @@
 #         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
 #             raise TypeError(
 #                 "union types cannot be accessed in Numba"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def getitem_range(self, viewtype):
 #         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
 #             raise TypeError(
 #                 "union types cannot be accessed in Numba"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def getitem_field(self, viewtype, key):
 #         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
 #             raise TypeError(
 #                 "union types cannot be accessed in Numba"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     def lower_getitem_at(
@@ -2426,7 +2426,7 @@
 #         raise NotImplementedError(
 #             type(self).__name__
 #             + ".lower_getitem_at not implemented"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     def lower_getitem_range(
@@ -2444,14 +2444,14 @@
 #         raise NotImplementedError(
 #             type(self).__name__
 #             + ".lower_getitem_range not implemented"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     def lower_getitem_field(self, context, builder, viewtype, viewval, viewproxy, key):
 #         raise NotImplementedError(
 #             type(self).__name__
 #             + ".lower_getitem_field not implemented"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     @property
@@ -2496,7 +2496,7 @@
 #         if layout.form is None:
 #             raise ValueError(
 #                 "VirtualArrays without a known 'form' can't be used in Numba"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         pyptr = ctypes.py_object(layout)
 #         ctypes.pythonapi.Py_IncRef(pyptr)
@@ -2519,7 +2519,7 @@
 #         if form.form is None:
 #             raise ValueError(
 #                 "VirtualArrays without a known 'form' can't be used in Numba"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         positions.append(0)
 #         sharedptrs.append(None)
@@ -2535,7 +2535,7 @@
 #         if form.form is None:
 #             raise ValueError(
 #                 "VirtualArrays without a known 'form' can't be used in Numba "
-#                 "(including nested)" + ak._v2._util.exception_suffix(__file__)
+#                 "(including nested)"
 #             )
 #         return VirtualArrayType(
 #             form.form, cls.from_form_identities(form), form.parameters
@@ -2545,7 +2545,7 @@
 #         if generator_form is None:
 #             raise ValueError(
 #                 "VirtualArrays without a known 'form' can't be used in Numba"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         super(VirtualArrayType, self).__init__(
 #             name="ak.VirtualArrayType({0}, {1}, {2})".format(
@@ -2609,7 +2609,7 @@
 #                         "unrecognized NumpyForm.primitive type: {0}".format(
 #                             form.primitive
 #                         )
-#                         + ak._v2._util.exception_suffix(__file__)
+#
 #                     )
 
 #             elif isinstance(
@@ -2643,7 +2643,7 @@
 #             elif isinstance(form, ak.forms.UnionForm):
 #                 raise TypeError(
 #                     "union types cannot be accessed in Numba"
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #             elif isinstance(form, ak.forms.VirtualForm):
@@ -2652,7 +2652,7 @@
 #             else:
 #                 raise AssertionError(
 #                     "unrecognized Form type: {0}".format(type(form))
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #         def wrap(out):
@@ -2839,7 +2839,7 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Form type: {0}".format(type(form))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 
@@ -2881,7 +2881,7 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Form type: {0}".format(type(form))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 
@@ -2925,5 +2925,5 @@
 #     else:
 #         raise AssertionError(
 #             "unrecognized Form type: {0}".format(type(form))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )

--- a/src/awkward/_v2/_connect/numexpr.py
+++ b/src/awkward/_v2/_connect/numexpr.py
@@ -91,11 +91,11 @@
 
 #     def getfunction(inputs):
 #         if all(
-#             isinstance(x, ak.layout.NumpyArray) or not isinstance(x, ak.layout.Content)
+#             isinstance(x, ak._v2.contents.NumpyArray) or not isinstance(x, ak._v2.contents.Content)
 #             for x in inputs
 #         ):
 #             return lambda: (
-#                 ak.layout.NumpyArray(
+#                 ak._v2.contents.NumpyArray(
 #                     numexpr.evaluate(
 #                         expression,
 #                         dict(zip(names, inputs)),
@@ -140,11 +140,11 @@
 
 #     def getfunction(inputs):
 #         if all(
-#             isinstance(x, ak.layout.NumpyArray) or not isinstance(x, ak.layout.Content)
+#             isinstance(x, ak._v2.contents.NumpyArray) or not isinstance(x, ak._v2.contents.Content)
 #             for x in inputs
 #         ):
 #             return lambda: (
-#                 ak.layout.NumpyArray(numexpr.re_evaluate(dict(zip(names, inputs)))),
+#                 ak._v2.contents.NumpyArray(numexpr.re_evaluate(dict(zip(names, inputs)))),
 #             )
 #         else:
 #             return None

--- a/src/awkward/_v2/_connect/numexpr.py
+++ b/src/awkward/_v2/_connect/numexpr.py
@@ -109,12 +109,12 @@
 #         else:
 #             return None
 
-#     behavior = ak._util.behaviorof(*arrays)
-#     out = ak._util.broadcast_and_apply(
+#     behavior = ak._v2._util.behaviorof(*arrays)
+#     out = ak._v2._util.broadcast_and_apply(
 #         arrays, getfunction, behavior, allow_records=False, pass_depth=False
 #     )
 #     assert isinstance(out, tuple) and len(out) == 1
-#     return ak._util.wrap(out[0], behavior)
+#     return ak._v2._util.wrap(out[0], behavior)
 
 
 # evaluate.evaluate = evaluate
@@ -128,7 +128,7 @@
 #     except KeyError:
 #         raise RuntimeError(
 #             "not a previous evaluate() execution found"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 #     names = numexpr.necompiler._numexpr_last["argnames"]
 #     arguments = getArguments(names, local_dict)
@@ -149,12 +149,12 @@
 #         else:
 #             return None
 
-#     behavior = ak._util.behaviorof(*arrays)
-#     out = ak._util.broadcast_and_apply(
+#     behavior = ak._v2._util.behaviorof(*arrays)
+#     out = ak._v2._util.broadcast_and_apply(
 #         arrays, getfunction, behavior, allow_records=False, pass_depth=False
 #     )
 #     assert isinstance(out, tuple) and len(out) == 1
-#     return ak._util.wrap(out[0], behavior)
+#     return ak._v2._util.wrap(out[0], behavior)
 
 
 # ak.numexpr = types.ModuleType("numexpr")

--- a/src/awkward/_v2/_connect/numexpr.py
+++ b/src/awkward/_v2/_connect/numexpr.py
@@ -85,7 +85,7 @@
 #     arguments = getArguments(names, local_dict, global_dict)
 
 #     arrays = [
-#         ak.operations.convert.to_layout(x, allow_record=True, allow_other=True)
+#         ak._v2.operations.convert.to_layout(x, allow_record=True, allow_other=True)
 #         for x in arguments
 #     ]
 
@@ -134,7 +134,7 @@
 #     arguments = getArguments(names, local_dict)
 
 #     arrays = [
-#         ak.operations.convert.to_layout(x, allow_record=True, allow_other=True)
+#         ak._v2.operations.convert.to_layout(x, allow_record=True, allow_other=True)
 #         for x in arguments
 #     ]
 

--- a/src/awkward/_v2/_connect/numexpr.py
+++ b/src/awkward/_v2/_connect/numexpr.py
@@ -128,7 +128,7 @@
 #     except KeyError:
 #         raise RuntimeError(
 #             "not a previous evaluate() execution found"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 #     names = numexpr.necompiler._numexpr_last["argnames"]
 #     arguments = getArguments(names, local_dict)

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -200,7 +200,7 @@ import numpy
 #                 isinstance(x, ak._v2.contents.NumpyArray)
 #                 and not (x.format.upper().startswith("M"))
 #             )
-#             or not isinstance(x, (ak._v2.contents.Content, ak.partition.PartitionedArray))
+#             or not isinstance(x, (ak._v2.contents.Content, ak.partition.PartitionedArray))   # NO PARTITIONED ARRAY
 #             for x in inputs
 #         ):
 #             nplike = ak.nplike.of(*inputs)

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -10,7 +10,7 @@ import numpy
 
 
 # def convert_to_array(layout, args, kwargs):
-#     out = ak.operations.convert.to_numpy(layout, allow_missing=False)
+#     out = ak._v2.operations.convert.to_numpy(layout, allow_missing=False)
 #     if args == () and kwargs == {}:
 #         return out
 #     else:
@@ -75,7 +75,7 @@ import numpy
 #         if cast_fcn is not None:
 #             x = cast_fcn(x)
 #         nextinputs.append(
-#             ak.operations.convert.to_layout(x, allow_record=True, allow_other=True)
+#             ak._v2.operations.convert.to_layout(x, allow_record=True, allow_other=True)
 #         )
 #     inputs = nextinputs
 
@@ -207,7 +207,7 @@ import numpy
 #             result = getattr(ufunc, method)(
 #                 *[nplike.asarray(x) for x in inputs], **kwargs
 #             )
-#             return lambda: (ak.operations.convert.from_numpy(result, highlevel=False),)
+#             return lambda: (ak._v2.operations.convert.from_numpy(result, highlevel=False),)
 #         elif all(
 #             isinstance(x, ak._v2.contents.NumpyArray) and (x.format.upper().startswith("M"))
 #             for x in inputs
@@ -216,7 +216,7 @@ import numpy
 #             result = getattr(ufunc, method)(
 #                 *[nplike.asarray(x.view_int64).view(x.format) for x in inputs], **kwargs
 #             )
-#             return lambda: (ak.operations.convert.from_numpy(result, highlevel=False),)
+#             return lambda: (ak._v2.operations.convert.from_numpy(result, highlevel=False),)
 
 #         for x in inputs:
 #             if isinstance(x, ak._v2.contents.Content):

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -67,11 +67,11 @@ import numpy
 #     if method != "__call__" or len(inputs) == 0 or "out" in kwargs:
 #         return NotImplemented
 
-#     behavior = ak._util.behaviorof(*inputs)
+#     behavior = ak._v2._util.behaviorof(*inputs)
 
 #     nextinputs = []
 #     for x in inputs:
-#         cast_fcn = ak._util.custom_cast(x, behavior)
+#         cast_fcn = ak._v2._util.custom_cast(x, behavior)
 #         if cast_fcn is not None:
 #             x = cast_fcn(x)
 #         nextinputs.append(
@@ -81,7 +81,7 @@ import numpy
 
 #     def adjust(custom, inputs, kwargs):
 #         args = [
-#             ak._util.wrap(x, behavior)
+#             ak._v2._util.wrap(x, behavior)
 #             if isinstance(x, (ak._v2.contents.Content, ak._v2.record.Record))
 #             else x
 #             for x in inputs
@@ -97,7 +97,7 @@ import numpy
 
 #     def adjust_apply_ufunc(apply_ufunc, ufunc, method, inputs, kwargs):
 #         nextinputs = [
-#             ak._util.wrap(x, behavior)
+#             ak._v2._util.wrap(x, behavior)
 #             if isinstance(x, (ak._v2.contents.Content, ak._v2.record.Record))
 #             else x
 #             for x in inputs
@@ -184,7 +184,7 @@ import numpy
 #             else:
 #                 signature.append(type(x))
 
-#         custom = ak._util.overload(behavior, signature)
+#         custom = ak._v2._util.overload(behavior, signature)
 #         if custom is not None:
 #             return lambda: adjust(custom, inputs, kwargs)
 
@@ -220,7 +220,7 @@ import numpy
 
 #         for x in inputs:
 #             if isinstance(x, ak._v2.contents.Content):
-#                 chained_behavior = ak._util.Behavior(ak.behavior, behavior)
+#                 chained_behavior = ak._v2._util.Behavior(ak.behavior, behavior)
 #                 apply_ufunc = chained_behavior[numpy.ufunc, x.parameter("__array__")]
 #                 if apply_ufunc is not None:
 #                     out = adjust_apply_ufunc(apply_ufunc, ufunc, method, inputs, kwargs)
@@ -254,16 +254,16 @@ import numpy
 #                     ufunc.__name__,
 #                     ", ".join(custom_types),
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         return None
 
-#     out = ak._util.broadcast_and_apply(
+#     out = ak._v2._util.broadcast_and_apply(
 #         inputs, getfunction, behavior, allow_records=False, pass_depth=False
 #     )
 #     assert isinstance(out, tuple) and len(out) == 1
-#     return ak._util.wrap(out[0], behavior)
+#     return ak._v2._util.wrap(out[0], behavior)
 
 
 # def matmul_for_numba(lefts, rights, dtype):
@@ -347,7 +347,7 @@ import numpy
 
 # def getfunction_matmul(inputs):
 #     inputs = [
-#         ak._util.recursively_apply(
+#         ak._v2._util.recursively_apply(
 #             x, (lambda _: _), pass_depth=False, numpy_to_regular=True
 #         )
 #         if isinstance(x, (ak._v2.contents.Content, ak._v2.record.Record))
@@ -356,8 +356,8 @@ import numpy
 #     ]
 
 #     if len(inputs) == 2 and all(
-#         isinstance(x, ak._util.listtypes)
-#         and isinstance(x.content, ak._util.listtypes)
+#         isinstance(x, ak._v2._util.listtypes)
+#         and isinstance(x.content, ak._v2._util.listtypes)
 #         and isinstance(x.content.content, ak._v2.contents.NumpyArray)
 #         for x in inputs
 #     ):

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -27,8 +27,8 @@ import numpy
 #             ak.Array,
 #             ak.Record,
 #             ak.ArrayBuilder,
-#             ak.layout.Content,
-#             ak.layout.Record,
+#             ak._v2.contents.Content,
+#             ak._v2.record.Record,
 #             ak.layout.ArrayBuilder,
 #             ak.layout.LayoutBuilder32,
 #             ak.layout.LayoutBuilder64,
@@ -82,7 +82,7 @@ import numpy
 #     def adjust(custom, inputs, kwargs):
 #         args = [
 #             ak._util.wrap(x, behavior)
-#             if isinstance(x, (ak.layout.Content, ak.layout.Record))
+#             if isinstance(x, (ak._v2.contents.Content, ak._v2.record.Record))
 #             else x
 #             for x in inputs
 #         ]
@@ -98,7 +98,7 @@ import numpy
 #     def adjust_apply_ufunc(apply_ufunc, ufunc, method, inputs, kwargs):
 #         nextinputs = [
 #             ak._util.wrap(x, behavior)
-#             if isinstance(x, (ak.layout.Content, ak.layout.Record))
+#             if isinstance(x, (ak._v2.contents.Content, ak._v2.record.Record))
 #             else x
 #             for x in inputs
 #         ]
@@ -120,13 +120,13 @@ import numpy
 
 #     def is_fully_regular(layout):
 #         if (
-#             isinstance(layout, ak.layout.RegularArray)
+#             isinstance(layout, ak._v2.contents.RegularArray)
 #             and layout.parameter("__record__") is None
 #             and layout.parameter("__array__") is None
 #         ):
-#             if isinstance(layout.content, ak.layout.NumpyArray):
+#             if isinstance(layout.content, ak._v2.contents.NumpyArray):
 #                 return True
-#             elif isinstance(layout.content, ak.layout.RegularArray):
+#             elif isinstance(layout.content, ak._v2.contents.RegularArray):
 #                 return is_fully_regular(layout.content)
 #             else:
 #                 return False
@@ -139,13 +139,13 @@ import numpy
 #         else:
 #             shape = [len(layout)]
 #             node = layout
-#             while isinstance(node, ak.layout.RegularArray):
+#             while isinstance(node, ak._v2.contents.RegularArray):
 #                 shape.append(node.size)
 #                 node = node.content
 #             if node.format.upper().startswith("M"):
 #                 nparray = ak.nplike.of(node).asarray(node.view_int64).view(node.format)
 #                 nparray = nparray.reshape(tuple(shape) + nparray.shape[1:])
-#                 return ak.layout.NumpyArray(
+#                 return ak._v2.contents.NumpyArray(
 #                     nparray,
 #                     node.identities,
 #                     node.parameters,
@@ -153,7 +153,7 @@ import numpy
 #             else:
 #                 nparray = ak.nplike.of(node).asarray(node)
 #                 nparray = nparray.reshape(tuple(shape) + nparray.shape[1:])
-#                 return ak.layout.NumpyArray(
+#                 return ak._v2.contents.NumpyArray(
 #                     nparray,
 #                     node.identities,
 #                     node.parameters,
@@ -162,14 +162,14 @@ import numpy
 #     def getfunction(inputs):
 #         signature = [ufunc]
 #         for x in inputs:
-#             if isinstance(x, ak.layout.Content):
+#             if isinstance(x, ak._v2.contents.Content):
 #                 record = x.parameter("__record__")
 #                 array = x.parameter("__array__")
 #                 if record is not None:
 #                     signature.append(record)
 #                 elif array is not None:
 #                     signature.append(array)
-#                 elif isinstance(x, ak.layout.NumpyArray):
+#                 elif isinstance(x, ak._v2.contents.NumpyArray):
 #                     if x.format.upper().startswith("M"):
 #                         signature.append(
 #                             ak.nplike.of(x)
@@ -197,10 +197,10 @@ import numpy
 
 #         if all(
 #             (
-#                 isinstance(x, ak.layout.NumpyArray)
+#                 isinstance(x, ak._v2.contents.NumpyArray)
 #                 and not (x.format.upper().startswith("M"))
 #             )
-#             or not isinstance(x, (ak.layout.Content, ak.partition.PartitionedArray))
+#             or not isinstance(x, (ak._v2.contents.Content, ak.partition.PartitionedArray))
 #             for x in inputs
 #         ):
 #             nplike = ak.nplike.of(*inputs)
@@ -209,7 +209,7 @@ import numpy
 #             )
 #             return lambda: (ak.operations.convert.from_numpy(result, highlevel=False),)
 #         elif all(
-#             isinstance(x, ak.layout.NumpyArray) and (x.format.upper().startswith("M"))
+#             isinstance(x, ak._v2.contents.NumpyArray) and (x.format.upper().startswith("M"))
 #             for x in inputs
 #         ):
 #             nplike = ak.nplike.of(*inputs)
@@ -219,7 +219,7 @@ import numpy
 #             return lambda: (ak.operations.convert.from_numpy(result, highlevel=False),)
 
 #         for x in inputs:
-#             if isinstance(x, ak.layout.Content):
+#             if isinstance(x, ak._v2.contents.Content):
 #                 chained_behavior = ak._util.Behavior(ak.behavior, behavior)
 #                 apply_ufunc = chained_behavior[numpy.ufunc, x.parameter("__array__")]
 #                 if apply_ufunc is not None:
@@ -236,11 +236,11 @@ import numpy
 #             x.parameter("__array__") is not None
 #             or x.parameter("__record__") is not None
 #             for x in inputs
-#             if isinstance(x, ak.layout.Content)
+#             if isinstance(x, ak._v2.contents.Content)
 #         ):
 #             custom_types = []
 #             for x in inputs:
-#                 if isinstance(x, ak.layout.Content):
+#                 if isinstance(x, ak._v2.contents.Content):
 #                     if x.parameter("__array__") is not None:
 #                         custom_types.append(x.parameter("__array__"))
 #                     elif x.parameter("__record__") is not None:
@@ -350,7 +350,7 @@ import numpy
 #         ak._util.recursively_apply(
 #             x, (lambda _: _), pass_depth=False, numpy_to_regular=True
 #         )
-#         if isinstance(x, (ak.layout.Content, ak.layout.Record))
+#         if isinstance(x, (ak._v2.contents.Content, ak._v2.record.Record))
 #         else x
 #         for x in inputs
 #     ]
@@ -358,7 +358,7 @@ import numpy
 #     if len(inputs) == 2 and all(
 #         isinstance(x, ak._util.listtypes)
 #         and isinstance(x.content, ak._util.listtypes)
-#         and isinstance(x.content.content, ak.layout.NumpyArray)
+#         and isinstance(x.content.content, ak._v2.contents.NumpyArray)
 #         for x in inputs
 #     ):
 #         ak._connect._numba.register_and_check()
@@ -374,11 +374,11 @@ import numpy
 #         outer, inner, content = matmul_for_numba.numbafied(lefts, rights, dtype)
 
 #         return lambda: (
-#             ak.layout.ListOffsetArray64(
-#                 ak.layout.Index64(outer),
-#                 ak.layout.ListOffsetArray64(
-#                     ak.layout.Index64(inner),
-#                     ak.layout.NumpyArray(content),
+#             ak._v2.contents.ListOffsetArray64(
+#                 ak._v2.index.Index64(outer),
+#                 ak._v2.contents.ListOffsetArray64(
+#                     ak._v2.index.Index64(inner),
+#                     ak._v2.contents.NumpyArray(content),
 #                 ),
 #             ),
 #         )

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -254,7 +254,7 @@ import numpy
 #                     ufunc.__name__,
 #                     ", ".join(custom_types),
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         return None

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -361,7 +361,7 @@ import numpy
 #         and isinstance(x.content.content, ak._v2.contents.NumpyArray)
 #         for x in inputs
 #     ):
-#         ak._connect._numba.register_and_check()
+#         ak._v2._connect.numba.register_and_check()
 #         import numba
 
 #         if matmul_for_numba.numbafied is None:

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -91,7 +91,7 @@ import numpy
 #             out = (out,)
 
 #         return tuple(
-#             x.layout if isinstance(x, (ak.highlevel.Array, ak.highlevel.Record)) else x
+#             x.layout if isinstance(x, (ak._v2.highlevel.Array, ak._v2.highlevel.Record)) else x
 #             for x in out
 #         )
 
@@ -112,7 +112,7 @@ import numpy
 #                 out = (out,)
 #             out = tuple(
 #                 x.layout
-#                 if isinstance(x, (ak.highlevel.Array, ak.highlevel.Record))
+#                 if isinstance(x, (ak._v2.highlevel.Array, ak._v2.highlevel.Record))
 #                 else x
 #                 for x in out
 #             )
@@ -367,8 +367,8 @@ import numpy
 #         if matmul_for_numba.numbafied is None:
 #             matmul_for_numba.numbafied = numba.njit(matmul_for_numba)
 
-#         lefts = ak.highlevel.Array(inputs[0])
-#         rights = ak.highlevel.Array(inputs[1])
+#         lefts = ak._v2.highlevel.Array(inputs[0])
+#         rights = ak._v2.highlevel.Array(inputs[1])
 #         dtype = numpy.asarray(lefts[0:0, 0:0, 0:0] + rights[0:0, 0:0, 0:0]).dtype
 
 #         outer, inner, content = matmul_for_numba.numbafied(lefts, rights, dtype)

--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -102,46 +102,46 @@ def isstr(x):
 #     pass
 
 
-# virtualtypes = (ak.layout.VirtualArray,)
+# virtualtypes = (ak._v2.contents.VirtualArray,)
 
-# unknowntypes = (ak.layout.EmptyArray,)
+# unknowntypes = (ak._v2.contents.EmptyArray,)
 
 # indexedtypes = (
-#     ak.layout.IndexedArray32,
-#     ak.layout.IndexedArrayU32,
-#     ak.layout.IndexedArray64,
+#     ak._v2.contents.IndexedArray32,
+#     ak._v2.contents.IndexedArrayU32,
+#     ak._v2.contents.IndexedArray64,
 # )
 
 # uniontypes = (
-#     ak.layout.UnionArray8_32,
-#     ak.layout.UnionArray8_U32,
-#     ak.layout.UnionArray8_64,
+#     ak._v2.contents.UnionArray8_32,
+#     ak._v2.contents.UnionArray8_U32,
+#     ak._v2.contents.UnionArray8_64,
 # )
 
 # indexedoptiontypes = (
-#     ak.layout.IndexedOptionArray32,
-#     ak.layout.IndexedOptionArray64,
+#     ak._v2.contents.IndexedOptionArray32,
+#     ak._v2.contents.IndexedOptionArray64,
 # )
 
 # optiontypes = (
-#     ak.layout.IndexedOptionArray32,
-#     ak.layout.IndexedOptionArray64,
-#     ak.layout.ByteMaskedArray,
-#     ak.layout.BitMaskedArray,
-#     ak.layout.UnmaskedArray,
+#     ak._v2.contents.IndexedOptionArray32,
+#     ak._v2.contents.IndexedOptionArray64,
+#     ak._v2.contents.ByteMaskedArray,
+#     ak._v2.contents.BitMaskedArray,
+#     ak._v2.contents.UnmaskedArray,
 # )
 
 # listtypes = (
-#     ak.layout.RegularArray,
-#     ak.layout.ListArray32,
-#     ak.layout.ListArrayU32,
-#     ak.layout.ListArray64,
-#     ak.layout.ListOffsetArray32,
-#     ak.layout.ListOffsetArrayU32,
-#     ak.layout.ListOffsetArray64,
+#     ak._v2.contents.RegularArray,
+#     ak._v2.contents.ListArray32,
+#     ak._v2.contents.ListArrayU32,
+#     ak._v2.contents.ListArray64,
+#     ak._v2.contents.ListOffsetArray32,
+#     ak._v2.contents.ListOffsetArrayU32,
+#     ak._v2.contents.ListOffsetArray64,
 # )
 
-# recordtypes = (ak.layout.RecordArray,)
+# recordtypes = (ak._v2.contents.RecordArray,)
 
 
 # def regularize_path(path):
@@ -570,7 +570,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             out.extend(completely_flatten(array.field(i)))
 #         return tuple(out)
 
-#     elif isinstance(array, ak.layout.NumpyArray):
+#     elif isinstance(array, ak._v2.contents.NumpyArray):
 #         if array.format.upper().startswith("M"):
 #             return (
 #                 ak.nplike.of(array)
@@ -619,9 +619,9 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             if isinstance(
 #                 x,
 #                 (
-#                     ak.layout.ListOffsetArray32,
-#                     ak.layout.ListOffsetArrayU32,
-#                     ak.layout.ListOffsetArray64,
+#                     ak._v2.contents.ListOffsetArray32,
+#                     ak._v2.contents.ListOffsetArrayU32,
+#                     ak._v2.contents.ListOffsetArray64,
 #                 ),
 #             ):
 #                 if offsets is None:
@@ -631,9 +631,9 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             elif isinstance(
 #                 x,
 #                 (
-#                     ak.layout.ListArray32,
-#                     ak.layout.ListArrayU32,
-#                     ak.layout.ListArray64,
+#                     ak._v2.contents.ListArray32,
+#                     ak._v2.contents.ListArrayU32,
+#                     ak._v2.contents.ListArray64,
 #                 ),
 #             ):
 #                 starts = nplike.asarray(x.starts)
@@ -651,7 +651,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     len(stops) != 0 and offsets[-1] != stops[-1]
 #                 ):
 #                     return False
-#             elif isinstance(x, ak.layout.RegularArray):
+#             elif isinstance(x, ak._v2.contents.RegularArray):
 #                 if x.size == 0:
 #                     my_offsets = nplike.empty(0, dtype=np.int64)
 #                 else:
@@ -660,7 +660,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     offsets = my_offsets
 #                 elif not nplike.array_equal(offsets, my_offsets):
 #                     return False
-#             elif isinstance(x, ak.layout.Content):
+#             elif isinstance(x, ak._v2.contents.Content):
 #                 return False
 #         else:
 #             return True
@@ -670,14 +670,14 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 
 #         if numpy_to_regular:
 #             inputs = [
-#                 x.toRegularArray() if isinstance(x, ak.layout.NumpyArray) else x
+#                 x.toRegularArray() if isinstance(x, ak._v2.contents.NumpyArray) else x
 #                 for x in inputs
 #             ]
 
 #         if regular_to_jagged:
 #             inputs = [
 #                 x.toListOffsetArray64(False)
-#                 if isinstance(x, ak.layout.RegularArray)
+#                 if isinstance(x, ak._v2.contents.RegularArray)
 #                 else x
 #                 for x in inputs
 #             ]
@@ -685,23 +685,23 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #         # handle implicit right-broadcasting (i.e. NumPy-like)
 #         if right_broadcast and any(isinstance(x, listtypes) for x in inputs):
 #             maxdepth = max(
-#                 x.purelist_depth for x in inputs if isinstance(x, ak.layout.Content)
+#                 x.purelist_depth for x in inputs if isinstance(x, ak._v2.contents.Content)
 #             )
 
 #             if maxdepth > 0 and all(
-#                 x.purelist_isregular for x in inputs if isinstance(x, ak.layout.Content)
+#                 x.purelist_isregular for x in inputs if isinstance(x, ak._v2.contents.Content)
 #             ):
 #                 nextinputs = []
 #                 for obj in inputs:
-#                     if isinstance(obj, ak.layout.Content):
+#                     if isinstance(obj, ak._v2.contents.Content):
 #                         while obj.purelist_depth < maxdepth:
-#                             obj = ak.layout.RegularArray(obj, 1, len(obj))
+#                             obj = ak._v2.contents.RegularArray(obj, 1, len(obj))
 #                     nextinputs.append(obj)
 #                 if any(x is not y for x, y in zip(inputs, nextinputs)):
 #                     return apply(nextinputs, depth, user)
 
 #         # now all lengths must agree
-#         checklength([x for x in inputs if isinstance(x, ak.layout.Content)])
+#         checklength([x for x in inputs if isinstance(x, ak._v2.contents.Content)])
 
 #         args = ()
 #         if pass_depth:
@@ -730,16 +730,16 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             for x in inputs:
 #                 if isinstance(x, unknowntypes):
 #                     nextinputs.append(
-#                         ak.layout.NumpyArray(nplike.array([], dtype=np.bool_))
+#                         ak._v2.contents.NumpyArray(nplike.array([], dtype=np.bool_))
 #                     )
 #                 else:
 #                     nextinputs.append(x)
 #             return apply(nextinputs, depth, user)
 
-#         elif any(isinstance(x, ak.layout.NumpyArray) and x.ndim > 1 for x in inputs):
+#         elif any(isinstance(x, ak._v2.contents.NumpyArray) and x.ndim > 1 for x in inputs):
 #             nextinputs = []
 #             for x in inputs:
-#                 if isinstance(x, ak.layout.NumpyArray) and x.ndim > 1:
+#                 if isinstance(x, ak._v2.contents.NumpyArray) and x.ndim > 1:
 #                     nextinputs.append(x.toRegularArray())
 #                 else:
 #                     nextinputs.append(x)
@@ -798,7 +798,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     if isinstance(x, uniontypes):
 #                         nextinputs.append(x[mask].project(combo[str(i)]))
 #                         i += 1
-#                     elif isinstance(x, ak.layout.Content):
+#                     elif isinstance(x, ak._v2.contents.Content):
 #                         nextinputs.append(x[mask])
 #                     else:
 #                         nextinputs.append(x)
@@ -810,10 +810,10 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 
 #             assert numoutputs is not None
 
-#             tags = ak.layout.Index8(tags)
-#             index = ak.layout.Index64(index)
+#             tags = ak._v2.contents.Index8(tags)
+#             index = ak._v2.contents.Index64(index)
 #             return tuple(
-#                 ak.layout.UnionArray8_64(
+#                 ak._v2.contents.UnionArray8_64(
 #                     tags, index, [x[i] for x in outcontents]
 #                 ).simplify()
 #                 for i in range(numoutputs)
@@ -829,24 +829,24 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     else:
 #                         nplike.bitwise_or(mask, m, out=mask)
 
-#             nextmask = ak.layout.Index8(mask.view(np.int8))
+#             nextmask = ak._v2.contents.Index8(mask.view(np.int8))
 #             index = nplike.full(len(mask), -1, dtype=np.int64)
 #             index[~mask] = nplike.arange(
 #                 len(mask) - nplike.count_nonzero(mask), dtype=np.int64
 #             )
-#             index = ak.layout.Index64(index)
+#             index = ak._v2.contents.Index64(index)
 #             if any(not isinstance(x, optiontypes) for x in inputs):
 #                 nextindex = nplike.arange(len(mask), dtype=np.int64)
 #                 nextindex[mask] = -1
-#                 nextindex = ak.layout.Index64(nextindex)
+#                 nextindex = ak._v2.contents.Index64(nextindex)
 
 #             nextinputs = []
 #             for x in inputs:
 #                 if isinstance(x, optiontypes):
 #                     nextinputs.append(x.project(nextmask))
-#                 elif isinstance(x, ak.layout.Content):
+#                 elif isinstance(x, ak._v2.contents.Content):
 #                     nextinputs.append(
-#                         ak.layout.IndexedOptionArray64(nextindex, x).project(nextmask)
+#                         ak._v2.contents.IndexedOptionArray64(nextindex, x).project(nextmask)
 #                     )
 #                 else:
 #                     nextinputs.append(x)
@@ -854,31 +854,31 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             outcontent = apply(nextinputs, depth, user)
 #             assert isinstance(outcontent, tuple)
 #             return tuple(
-#                 ak.layout.IndexedOptionArray64(index, x).simplify() for x in outcontent
+#                 ak._v2.contents.IndexedOptionArray64(index, x).simplify() for x in outcontent
 #             )
 
 #         elif any(isinstance(x, listtypes) for x in inputs):
 #             if all(
-#                 isinstance(x, ak.layout.RegularArray) or not isinstance(x, listtypes)
+#                 isinstance(x, ak._v2.contents.RegularArray) or not isinstance(x, listtypes)
 #                 for x in inputs
 #             ):
 #                 maxsize = max(
-#                     [x.size for x in inputs if isinstance(x, ak.layout.RegularArray)]
+#                     [x.size for x in inputs if isinstance(x, ak._v2.contents.RegularArray)]
 #                 )
 #                 for x in inputs:
-#                     if isinstance(x, ak.layout.RegularArray):
+#                     if isinstance(x, ak._v2.contents.RegularArray):
 #                         if maxsize > 1 and x.size == 1:
-#                             tmpindex = ak.layout.Index64(
+#                             tmpindex = ak._v2.contents.Index64(
 #                                 nplike.repeat(
 #                                     nplike.arange(len(x), dtype=np.int64), maxsize
 #                                 )
 #                             )
 #                 nextinputs = []
 #                 for x in inputs:
-#                     if isinstance(x, ak.layout.RegularArray):
+#                     if isinstance(x, ak._v2.contents.RegularArray):
 #                         if maxsize > 1 and x.size == 1:
 #                             nextinputs.append(
-#                                 ak.layout.IndexedArray64(
+#                                 ak._v2.contents.IndexedArray64(
 #                                     tmpindex, x.content[: len(x) * x.size]
 #                                 ).project()
 #                             )
@@ -896,19 +896,19 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                         nextinputs.append(x)
 
 #                 maxlen = max(
-#                     [len(x) for x in nextinputs if isinstance(x, ak.layout.Content)]
+#                     [len(x) for x in nextinputs if isinstance(x, ak._v2.contents.Content)]
 #                 )
 #                 outcontent = apply(nextinputs, depth + 1, user)
 #                 assert isinstance(outcontent, tuple)
 
 #                 return tuple(
-#                     ak.layout.RegularArray(x, maxsize, maxlen) for x in outcontent
+#                     ak._v2.contents.RegularArray(x, maxsize, maxlen) for x in outcontent
 #                 )
 
 #             elif not all_same_offsets(nplike, inputs):
 #                 fcns = [
 #                     custom_broadcast(x, behavior)
-#                     if isinstance(x, ak.layout.Content)
+#                     if isinstance(x, ak._v2.contents.Content)
 #                     else None
 #                     for x in inputs
 #                 ]
@@ -917,7 +917,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                 for x, fcn in zip(inputs, fcns):
 #                     if (
 #                         isinstance(x, listtypes)
-#                         and not isinstance(x, ak.layout.RegularArray)
+#                         and not isinstance(x, ak._v2.contents.RegularArray)
 #                         and fcn is None
 #                     ):
 #                         first = x
@@ -927,7 +927,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     secondround = True
 #                     for x in inputs:
 #                         if isinstance(x, listtypes) and not isinstance(
-#                             x, ak.layout.RegularArray
+#                             x, ak._v2.contents.RegularArray
 #                         ):
 #                             first = x
 #                             break
@@ -941,9 +941,9 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     elif isinstance(x, listtypes):
 #                         nextinputs.append(x.broadcast_tooffsets64(offsets).content)
 #                     # handle implicit left-broadcasting (unlike NumPy)
-#                     elif left_broadcast and isinstance(x, ak.layout.Content):
+#                     elif left_broadcast and isinstance(x, ak._v2.contents.Content):
 #                         nextinputs.append(
-#                             ak.layout.RegularArray(x, 1, len(x))
+#                             ak._v2.contents.RegularArray(x, 1, len(x))
 #                             .broadcast_tooffsets64(offsets)
 #                             .content
 #                         )
@@ -954,7 +954,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                 assert isinstance(outcontent, tuple)
 
 #                 return tuple(
-#                     ak.layout.ListOffsetArray64(offsets, x) for x in outcontent
+#                     ak._v2.contents.ListOffsetArray64(offsets, x) for x in outcontent
 #                 )
 
 #             else:
@@ -965,9 +965,9 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     if isinstance(
 #                         x,
 #                         (
-#                             ak.layout.ListOffsetArray32,
-#                             ak.layout.ListOffsetArrayU32,
-#                             ak.layout.ListOffsetArray64,
+#                             ak._v2.contents.ListOffsetArray32,
+#                             ak._v2.contents.ListOffsetArrayU32,
+#                             ak._v2.contents.ListOffsetArray64,
 #                         ),
 #                     ):
 #                         offsets = x.offsets
@@ -977,9 +977,9 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     elif isinstance(
 #                         x,
 #                         (
-#                             ak.layout.ListArray32,
-#                             ak.layout.ListArrayU32,
-#                             ak.layout.ListArray64,
+#                             ak._v2.contents.ListArray32,
+#                             ak._v2.contents.ListArrayU32,
+#                             ak._v2.contents.ListArray64,
 #                         ),
 #                     ):
 #                         starts, stops = x.starts, x.stops
@@ -994,29 +994,29 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 
 #                 outcontent = apply(nextinputs, depth + 1, user)
 
-#                 if isinstance(offsets, ak.layout.Index32):
+#                 if isinstance(offsets, ak._v2.contents.Index32):
 #                     return tuple(
-#                         ak.layout.ListOffsetArray32(offsets, x) for x in outcontent
+#                         ak._v2.contents.ListOffsetArray32(offsets, x) for x in outcontent
 #                     )
-#                 elif isinstance(offsets, ak.layout.IndexU32):
+#                 elif isinstance(offsets, ak._v2.contents.IndexU32):
 #                     return tuple(
-#                         ak.layout.ListOffsetArrayU32(offsets, x) for x in outcontent
+#                         ak._v2.contents.ListOffsetArrayU32(offsets, x) for x in outcontent
 #                     )
-#                 elif isinstance(offsets, ak.layout.Index64):
+#                 elif isinstance(offsets, ak._v2.contents.Index64):
 #                     return tuple(
-#                         ak.layout.ListOffsetArray64(offsets, x) for x in outcontent
+#                         ak._v2.contents.ListOffsetArray64(offsets, x) for x in outcontent
 #                     )
-#                 elif isinstance(starts, ak.layout.Index32):
+#                 elif isinstance(starts, ak._v2.contents.Index32):
 #                     return tuple(
-#                         ak.layout.ListArray32(starts, stops, x) for x in outcontent
+#                         ak._v2.contents.ListArray32(starts, stops, x) for x in outcontent
 #                     )
-#                 elif isinstance(starts, ak.layout.IndexU32):
+#                 elif isinstance(starts, ak._v2.contents.IndexU32):
 #                     return tuple(
-#                         ak.layout.ListArrayU32(starts, stops, x) for x in outcontent
+#                         ak._v2.contents.ListArrayU32(starts, stops, x) for x in outcontent
 #                     )
-#                 elif isinstance(starts, ak.layout.Index64):
+#                 elif isinstance(starts, ak._v2.contents.Index64):
 #                     return tuple(
-#                         ak.layout.ListArray64(starts, stops, x) for x in outcontent
+#                         ak._v2.contents.ListArray64(starts, stops, x) for x in outcontent
 #                     )
 #                 else:
 #                     raise AssertionError(
@@ -1077,7 +1077,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     assert numoutputs == len(outcontents[-1])
 #                 numoutputs = len(outcontents[-1])
 #             return tuple(
-#                 ak.layout.RecordArray(
+#                 ak._v2.contents.RecordArray(
 #                     [x[i] for x in outcontents], None if istuple else keys, length
 #                 )
 #                 for i in range(numoutputs)
@@ -1093,7 +1093,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #         purelist_isregular = True
 #         purelist_depths = set()
 #         for x in inputs:
-#             if isinstance(x, (ak.layout.Content, ak.partition.PartitionedArray)):
+#             if isinstance(x, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
 #                 if not x.purelist_isregular:
 #                     purelist_isregular = False
 #                     break
@@ -1144,19 +1144,19 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 # def broadcast_pack(inputs, isscalar):
 #     maxlen = -1
 #     for x in inputs:
-#         if isinstance(x, ak.layout.Content):
+#         if isinstance(x, ak._v2.contents.Content):
 #             maxlen = max(maxlen, len(x))
 #     if maxlen < 0:
 #         maxlen = 1
 
 #     nextinputs = []
 #     for x in inputs:
-#         if isinstance(x, ak.layout.Record):
+#         if isinstance(x, ak._v2.record.Record):
 #             index = ak.nplike.of(*inputs).full(maxlen, x.at, dtype=np.int64)
-#             nextinputs.append(ak.layout.RegularArray(x.array[index], maxlen, 1))
+#             nextinputs.append(ak._v2.contents.RegularArray(x.array[index], maxlen, 1))
 #             isscalar.append(True)
-#         elif isinstance(x, ak.layout.Content):
-#             nextinputs.append(ak.layout.RegularArray(x, len(x), 1))
+#         elif isinstance(x, ak._v2.contents.Content):
+#             nextinputs.append(ak._v2.contents.RegularArray(x, len(x), 1))
 #             isscalar.append(False)
 #         else:
 #             nextinputs.append(x)
@@ -1188,7 +1188,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #     numpy_to_regular=False,
 # ):
 #     def transform(layout, depth, user):
-#         if numpy_to_regular and isinstance(layout, ak.layout.NumpyArray):
+#         if numpy_to_regular and isinstance(layout, ak._v2.contents.NumpyArray):
 #             layout = layout.toRegularArray()
 
 #         args = ()
@@ -1216,22 +1216,22 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #         for x in layout.partitions:
 #             recursive_walk(x, apply, args, depth, materialize)
 
-#     elif isinstance(layout, ak.layout.NumpyArray):
+#     elif isinstance(layout, ak._v2.contents.NumpyArray):
 #         pass
 
-#     elif isinstance(layout, ak.layout.EmptyArray):
+#     elif isinstance(layout, ak._v2.contents.EmptyArray):
 #         pass
 
 #     elif isinstance(
 #         layout,
 #         (
-#             ak.layout.RegularArray,
-#             ak.layout.ListArray32,
-#             ak.layout.ListArrayU32,
-#             ak.layout.ListArray64,
-#             ak.layout.ListOffsetArray32,
-#             ak.layout.ListOffsetArrayU32,
-#             ak.layout.ListOffsetArray64,
+#             ak._v2.contents.RegularArray,
+#             ak._v2.contents.ListArray32,
+#             ak._v2.contents.ListArrayU32,
+#             ak._v2.contents.ListArray64,
+#             ak._v2.contents.ListOffsetArray32,
+#             ak._v2.contents.ListOffsetArrayU32,
+#             ak._v2.contents.ListOffsetArray64,
 #         ),
 #     ):
 #         recursive_walk(layout.content, apply, args, depth + 1, materialize)
@@ -1239,14 +1239,14 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #     elif isinstance(
 #         layout,
 #         (
-#             ak.layout.IndexedArray32,
-#             ak.layout.IndexedArrayU32,
-#             ak.layout.IndexedArray64,
-#             ak.layout.IndexedOptionArray32,
-#             ak.layout.IndexedOptionArray64,
-#             ak.layout.ByteMaskedArray,
-#             ak.layout.BitMaskedArray,
-#             ak.layout.UnmaskedArray,
+#             ak._v2.contents.IndexedArray32,
+#             ak._v2.contents.IndexedArrayU32,
+#             ak._v2.contents.IndexedArray64,
+#             ak._v2.contents.IndexedOptionArray32,
+#             ak._v2.contents.IndexedOptionArray64,
+#             ak._v2.contents.ByteMaskedArray,
+#             ak._v2.contents.BitMaskedArray,
+#             ak._v2.contents.UnmaskedArray,
 #         ),
 #     ):
 #         recursive_walk(layout.content, apply, args, depth, materialize)
@@ -1254,19 +1254,19 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #     elif isinstance(
 #         layout,
 #         (
-#             ak.layout.RecordArray,
-#             ak.layout.UnionArray8_32,
-#             ak.layout.UnionArray8_U32,
-#             ak.layout.UnionArray8_64,
+#             ak._v2.contents.RecordArray,
+#             ak._v2.contents.UnionArray8_32,
+#             ak._v2.contents.UnionArray8_U32,
+#             ak._v2.contents.UnionArray8_64,
 #         ),
 #     ):
 #         for x in layout.contents:
 #             recursive_walk(x, apply, args, depth, materialize)
 
-#     elif isinstance(layout, ak.layout.Record):
+#     elif isinstance(layout, ak._v2.record.Record):
 #         recursive_walk(layout.array, apply, args, depth, materialize)
 
-#     elif isinstance(layout, ak.layout.VirtualArray):
+#     elif isinstance(layout, ak._v2.contents.VirtualArray):
 #         if materialize:
 #             recursive_walk(layout.array, apply, args, depth, materialize)
 
@@ -1284,22 +1284,22 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             [transform(x, depth, user) for x in layout.partitions]
 #         )
 
-#     elif isinstance(layout, ak.layout.NumpyArray):
+#     elif isinstance(layout, ak._v2.contents.NumpyArray):
 #         if keep_parameters:
 #             return layout
 #         else:
-#             return ak.layout.NumpyArray(
+#             return ak._v2.contents.NumpyArray(
 #                 ak.nplike.of(layout).asarray(layout), layout.identities, None
 #             )
 
-#     elif isinstance(layout, ak.layout.EmptyArray):
+#     elif isinstance(layout, ak._v2.contents.EmptyArray):
 #         if keep_parameters:
 #             return layout
 #         else:
-#             return ak.layout.EmptyArray(layout.identities, None)
+#             return ak._v2.contents.EmptyArray(layout.identities, None)
 
-#     elif isinstance(layout, ak.layout.RegularArray):
-#         return ak.layout.RegularArray(
+#     elif isinstance(layout, ak._v2.contents.RegularArray):
+#         return ak._v2.contents.RegularArray(
 #             transform(layout.content, depth + 1, user),
 #             layout.size,
 #             len(layout),
@@ -1307,8 +1307,8 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.ListArray32):
-#         return ak.layout.ListArray32(
+#     elif isinstance(layout, ak._v2.contents.ListArray32):
+#         return ak._v2.contents.ListArray32(
 #             layout.starts,
 #             layout.stops,
 #             transform(layout.content, depth + 1, user),
@@ -1316,8 +1316,8 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.ListArrayU32):
-#         return ak.layout.ListArrayU32(
+#     elif isinstance(layout, ak._v2.contents.ListArrayU32):
+#         return ak._v2.contents.ListArrayU32(
 #             layout.starts,
 #             layout.stops,
 #             transform(layout.content, depth + 1, user),
@@ -1325,8 +1325,8 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.ListArray64):
-#         return ak.layout.ListArray64(
+#     elif isinstance(layout, ak._v2.contents.ListArray64):
+#         return ak._v2.contents.ListArray64(
 #             layout.starts,
 #             layout.stops,
 #             transform(layout.content, depth + 1, user),
@@ -1334,72 +1334,72 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.ListOffsetArray32):
-#         return ak.layout.ListOffsetArray32(
+#     elif isinstance(layout, ak._v2.contents.ListOffsetArray32):
+#         return ak._v2.contents.ListOffsetArray32(
 #             layout.offsets,
 #             transform(layout.content, depth + 1, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.ListOffsetArrayU32):
-#         return ak.layout.ListOffsetArrayU32(
+#     elif isinstance(layout, ak._v2.contents.ListOffsetArrayU32):
+#         return ak._v2.contents.ListOffsetArrayU32(
 #             layout.offsets,
 #             transform(layout.content, depth + 1, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.ListOffsetArray64):
-#         return ak.layout.ListOffsetArray64(
+#     elif isinstance(layout, ak._v2.contents.ListOffsetArray64):
+#         return ak._v2.contents.ListOffsetArray64(
 #             layout.offsets,
 #             transform(layout.content, depth + 1, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.IndexedArray32):
-#         return ak.layout.IndexedArray32(
+#     elif isinstance(layout, ak._v2.contents.IndexedArray32):
+#         return ak._v2.contents.IndexedArray32(
 #             layout.index,
 #             transform(layout.content, depth, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.IndexedArrayU32):
-#         return ak.layout.IndexedArrayU32(
+#     elif isinstance(layout, ak._v2.contents.IndexedArrayU32):
+#         return ak._v2.contents.IndexedArrayU32(
 #             layout.index,
 #             transform(layout.content, depth, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.IndexedArray64):
-#         return ak.layout.IndexedArray64(
+#     elif isinstance(layout, ak._v2.contents.IndexedArray64):
+#         return ak._v2.contents.IndexedArray64(
 #             layout.index,
 #             transform(layout.content, depth, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.IndexedOptionArray32):
-#         return ak.layout.IndexedOptionArray32(
+#     elif isinstance(layout, ak._v2.contents.IndexedOptionArray32):
+#         return ak._v2.contents.IndexedOptionArray32(
 #             layout.index,
 #             transform(layout.content, depth, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.IndexedOptionArray64):
-#         return ak.layout.IndexedOptionArray64(
+#     elif isinstance(layout, ak._v2.contents.IndexedOptionArray64):
+#         return ak._v2.contents.IndexedOptionArray64(
 #             layout.index,
 #             transform(layout.content, depth, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.ByteMaskedArray):
-#         return ak.layout.ByteMaskedArray(
+#     elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
+#         return ak._v2.contents.ByteMaskedArray(
 #             layout.mask,
 #             transform(layout.content, depth, user),
 #             layout.valid_when,
@@ -1407,8 +1407,8 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.BitMaskedArray):
-#         return ak.layout.BitMaskedArray(
+#     elif isinstance(layout, ak._v2.contents.BitMaskedArray):
+#         return ak._v2.contents.BitMaskedArray(
 #             layout.mask,
 #             transform(layout.content, depth, user),
 #             layout.valid_when,
@@ -1418,15 +1418,15 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.UnmaskedArray):
-#         return ak.layout.UnmaskedArray(
+#     elif isinstance(layout, ak._v2.contents.UnmaskedArray):
+#         return ak._v2.contents.UnmaskedArray(
 #             transform(layout.content, depth, user),
 #             layout.identities,
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.RecordArray):
-#         return ak.layout.RecordArray(
+#     elif isinstance(layout, ak._v2.contents.RecordArray):
+#         return ak._v2.contents.RecordArray(
 #             [transform(x, depth, user) for x in layout.contents],
 #             layout.recordlookup,
 #             len(layout),
@@ -1434,14 +1434,14 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.Record):
-#         return ak.layout.Record(
+#     elif isinstance(layout, ak._v2.record.Record):
+#         return ak._v2.record.Record(
 #             transform(layout.array, depth, user),
 #             layout.at,
 #         )
 
-#     elif isinstance(layout, ak.layout.UnionArray8_32):
-#         return ak.layout.UnionArray8_32(
+#     elif isinstance(layout, ak._v2.contents.UnionArray8_32):
+#         return ak._v2.contents.UnionArray8_32(
 #             layout.tags,
 #             layout.index,
 #             [transform(x, depth, user) for x in layout.contents],
@@ -1449,8 +1449,8 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.UnionArray8_U32):
-#         return ak.layout.UnionArray8_U32(
+#     elif isinstance(layout, ak._v2.contents.UnionArray8_U32):
+#         return ak._v2.contents.UnionArray8_U32(
 #             layout.tags,
 #             layout.index,
 #             [transform(x, depth, user) for x in layout.contents],
@@ -1458,8 +1458,8 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.UnionArray8_64):
-#         return ak.layout.UnionArray8_64(
+#     elif isinstance(layout, ak._v2.contents.UnionArray8_64):
+#         return ak._v2.contents.UnionArray8_64(
 #             layout.tags,
 #             layout.index,
 #             [transform(x, depth, user) for x in layout.contents],
@@ -1467,7 +1467,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             layout.parameters if keep_parameters else None,
 #         )
 
-#     elif isinstance(layout, ak.layout.VirtualArray):
+#     elif isinstance(layout, ak._v2.contents.VirtualArray):
 #         return transform(layout.array, depth, user)
 
 #     else:
@@ -1503,7 +1503,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                 if "__repr__" in type(y).__dict__:
 #                     yield space + repr(y)
 #                     done = True
-#         if wrap and isinstance(x, ak.layout.Record):
+#         if wrap and isinstance(x, ak._v2.record.Record):
 #             cls = recordclass(x, behavior)
 #             if cls is not ak._v2.highlevel.Record:
 #                 y = cls(x, behavior=behavior)
@@ -1521,7 +1521,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     sp = ", "
 #                 if brackets:
 #                     yield "]"
-#             elif isinstance(x, ak.layout.Record) and x.istuple:
+#             elif isinstance(x, ak._v2.record.Record) and x.istuple:
 #                 yield space + "("
 #                 sp = ""
 #                 for i in range(x.numfields):
@@ -1531,7 +1531,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                         key = ""
 #                     sp = ", "
 #                 yield ")"
-#             elif isinstance(x, ak.layout.Record):
+#             elif isinstance(x, ak._v2.record.Record):
 #                 yield space + "{"
 #                 sp = ""
 #                 for k in x.keys():
@@ -1563,7 +1563,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                 if "__repr__" in type(y).__dict__:
 #                     yield repr(y) + space
 #                     done = True
-#         if wrap and isinstance(x, ak.layout.Record):
+#         if wrap and isinstance(x, ak._v2.record.Record):
 #             cls = recordclass(x, behavior)
 #             if cls is not ak._v2.highlevel.Record:
 #                 y = cls(x, behavior=behavior)
@@ -1581,7 +1581,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     sp = ", "
 #                 if brackets:
 #                     yield "["
-#             elif isinstance(x, ak.layout.Record) and x.istuple:
+#             elif isinstance(x, ak._v2.record.Record) and x.istuple:
 #                 yield ")" + space
 #                 for i in range(x.numfields - 1, -1, -1):
 #                     last = None
@@ -1594,7 +1594,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     if i != 0:
 #                         yield ", "
 #                 yield "("
-#             elif isinstance(x, ak.layout.Record):
+#             elif isinstance(x, ak._v2.record.Record):
 #                 yield "}" + space
 #                 keys = x.keys()
 #                 for i in range(len(keys) - 1, -1, -1):
@@ -1704,12 +1704,12 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 
 
 # def make_union(tags, index, contents, identities, parameters):
-#     if isinstance(index, ak.layout.Index32):
-#         return ak.layout.UnionArray8_32(tags, index, contents, identities, parameters)
-#     elif isinstance(index, ak.layout.IndexU32):
-#         return ak.layout.UnionArray8_U32(tags, index, contents, identities, parameters)
-#     elif isinstance(index, ak.layout.Index64):
-#         return ak.layout.UnionArray8_64(tags, index, contents, identities, parameters)
+#     if isinstance(index, ak._v2.contents.Index32):
+#         return ak._v2.contents.UnionArray8_32(tags, index, contents, identities, parameters)
+#     elif isinstance(index, ak._v2.contents.IndexU32):
+#         return ak._v2.contents.UnionArray8_U32(tags, index, contents, identities, parameters)
+#     elif isinstance(index, ak._v2.contents.Index64):
+#         return ak._v2.contents.UnionArray8_64(tags, index, contents, identities, parameters)
 #     else:
 #         raise AssertionError(index)
 
@@ -1734,7 +1734,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #         else:
 #             contents.append(layout)
 
-#     if not any(isinstance(x, ak.layout.RecordArray) for x in contents):
+#     if not any(isinstance(x, ak._v2.contents.RecordArray) for x in contents):
 #         return make_union(
 #             unionarray.tags,
 #             unionarray.index,
@@ -1747,7 +1747,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #         seen = set()
 #         all_names = []
 #         for layout in contents:
-#             if isinstance(layout, ak.layout.RecordArray):
+#             if isinstance(layout, ak._v2.contents.RecordArray):
 #                 for key in layout.keys():
 #                     if key not in seen:
 #                         seen.add(key)
@@ -1757,16 +1757,16 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     seen.add(anonymous)
 #                     all_names.append(anonymous)
 
-#         missingarray = ak.layout.IndexedOptionArray64(
-#             ak.layout.Index64(nplike.full(len(unionarray), -1, dtype=np.int64)),
-#             ak.layout.EmptyArray(),
+#         missingarray = ak._v2.contents.IndexedOptionArray64(
+#             ak._v2.contents.Index64(nplike.full(len(unionarray), -1, dtype=np.int64)),
+#             ak._v2.contents.EmptyArray(),
 #         )
 
 #         all_fields = []
 #         for name in all_names:
 #             union_contents = []
 #             for layout in contents:
-#                 if isinstance(layout, ak.layout.RecordArray):
+#                 if isinstance(layout, ak._v2.contents.RecordArray):
 #                     for key in layout.keys():
 #                         if name == key:
 #                             union_contents.append(layout.field(key))
@@ -1789,7 +1789,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                 ).simplify()
 #             )
 
-#         return ak.layout.RecordArray(all_fields, all_names, len(unionarray))
+#         return ak._v2.contents.RecordArray(all_fields, all_names, len(unionarray))
 
 
 # def adjust_old_pickle(form, container, num_partitions, behavior):

--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -523,7 +523,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 
 #     if attempt is None:
 #         raise ValueError(
-#             "key {0} not found in record".format(repr(key)) + exception_suffix(__file__)
+#             "key {0} not found in record".format(repr(key))
 #         )
 #     else:
 #         return attempt
@@ -584,7 +584,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #     else:
 #         raise RuntimeError(
 #             "cannot completely flatten: {0}".format(type(array))
-#             + exception_suffix(__file__)
+#
 #         )
 
 
@@ -610,7 +610,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                     "length {3}".format(
 #                         type(inputs[0]).__name__, length, type(x).__name__, len(x)
 #                     )
-#                     + exception_suffix(__file__)
+#
 #                 )
 
 #     def all_same_offsets(nplike, inputs):
@@ -770,7 +770,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                             "with UnionArray of length {1}".format(
 #                                 length, len(tagslist[-1])
 #                             )
-#                             + exception_suffix(__file__)
+#
 #                         )
 
 #             combos = nplike.stack(tagslist, axis=-1)
@@ -890,7 +890,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                                 "{0} with RegularArray of size {1}".format(
 #                                     x.size, maxsize
 #                                 )
-#                                 + exception_suffix(__file__)
+#
 #                             )
 #                     else:
 #                         nextinputs.append(x)
@@ -1023,14 +1023,14 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                         "unexpected offsets, starts: {0} {1}".format(
 #                             type(offsets), type(starts)
 #                         )
-#                         + exception_suffix(__file__)
+#
 #                     )
 
 #         elif any(isinstance(x, recordtypes) for x in inputs):
 #             if not allow_records:
 #                 raise ValueError(
 #                     "cannot broadcast records in this type of operation"
-#                     + exception_suffix(__file__)
+#
 #                 )
 
 #             keys = None
@@ -1046,7 +1046,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                             "match:\n    {0}\n    {1}".format(
 #                                 ", ".join(sorted(keys)), ", ".join(sorted(x.keys()))
 #                             )
-#                             + exception_suffix(__file__)
+#
 #                         )
 #                     if length is None:
 #                         length = len(x)
@@ -1054,7 +1054,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #                         raise ValueError(
 #                             "cannot broadcast RecordArray of length {0} "
 #                             "with RecordArray of length {1}".format(length, len(x))
-#                             + exception_suffix(__file__)
+#
 #                         )
 #                     if not x.istuple:
 #                         istuple = False
@@ -1086,7 +1086,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #         else:
 #             raise ValueError(
 #                 "cannot broadcast: {0}".format(", ".join(repr(type(x)) for x in inputs))
-#                 + exception_suffix(__file__)
+#
 #             )
 
 #     if any(isinstance(x, ak.partition.PartitionedArray) for x in inputs):
@@ -1273,7 +1273,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #     else:
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(layout))
-#             + exception_suffix(__file__)
+#
 #         )
 
 
@@ -1473,7 +1473,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #     else:
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(layout))
-#             + exception_suffix(__file__)
+#
 #         )
 
 

--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -533,7 +533,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 
 
 # def completely_flatten(array):
-#     if isinstance(array, ak.partition.PartitionedArray):
+#     if isinstance(array, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         out = []
 #         for partition in array.partitions:
 #             for outi in completely_flatten(partition):
@@ -1089,11 +1089,11 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #
 #             )
 
-#     if any(isinstance(x, ak.partition.PartitionedArray) for x in inputs):
+#     if any(isinstance(x, ak.partition.PartitionedArray) for x in inputs):   # NO PARTITIONED ARRAY
 #         purelist_isregular = True
 #         purelist_depths = set()
 #         for x in inputs:
-#             if isinstance(x, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
+#             if isinstance(x, (ak._v2.contents.Content, ak.partition.PartitionedArray)):   # NO PARTITIONED ARRAY
 #                 if not x.purelist_isregular:
 #                     purelist_isregular = False
 #                     break
@@ -1102,7 +1102,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #         if purelist_isregular and len(purelist_depths) > 1:
 #             nextinputs = []
 #             for x in inputs:
-#                 if isinstance(x, ak.partition.PartitionedArray):
+#                 if isinstance(x, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                     nextinputs.append(x.toContent())
 #                 else:
 #                     nextinputs.append(x)
@@ -1115,7 +1115,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #         else:
 #             sample = None
 #             for x in inputs:
-#                 if isinstance(x, ak.partition.PartitionedArray):
+#                 if isinstance(x, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                     sample = x
 #                     break
 #             nextinputs = ak.partition.partition_as(sample, inputs)
@@ -1130,7 +1130,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             out = ()
 #             for i in range(len(part)):
 #                 out = out + (
-#                     ak.partition.IrregularlyPartitionedArray([x[i] for x in outputs]),
+#                     ak.partition.IrregularlyPartitionedArray([x[i] for x in outputs]),   # NO PARTITIONED ARRAY
 #                 )
 #             return out
 
@@ -1212,7 +1212,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 # def recursive_walk(layout, apply, args=(), depth=1, materialize=False):
 #     apply(layout, depth, *args)
 
-#     if isinstance(layout, ak.partition.PartitionedArray):
+#     if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         for x in layout.partitions:
 #             recursive_walk(x, apply, args, depth, materialize)
 
@@ -1279,8 +1279,8 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 
 # def transform_child_layouts(transform, layout, depth, user=None, keep_parameters=True):
 #     # the rest of this is one switch statement
-#     if isinstance(layout, ak.partition.PartitionedArray):
-#         return ak.partition.IrregularlyPartitionedArray(
+#     if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
+#         return ak.partition.IrregularlyPartitionedArray(   # NO PARTITIONED ARRAY
 #             [transform(x, depth, user) for x in layout.partitions]
 #         )
 

--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -1727,7 +1727,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             contents.append(union_to_record(layout, anonymous))
 #         elif isinstance(layout, optiontypes):
 #             contents.append(
-#                 ak.operations.structure.fill_none(
+#                 ak._v2.operations.structure.fill_none(
 #                     layout, np.nan, axis=0, highlevel=False
 #                 )
 #             )
@@ -1806,7 +1806,7 @@ def wrap(content, behavior=None, highlevel=True, like=None):
 #             else:
 #                 return "{form_key}-{attribute}-part{partition}".format(**v)
 
-#     return ak.operations.convert.from_buffers(
+#     return ak._v2.operations.convert.from_buffers(
 #         form,
 #         None,
 #         container,

--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -407,7 +407,7 @@ def recordclass(layout, behavior):
 #     behavior = Behavior(ak.behavior, behavior)
 #     done = False
 
-#     if isinstance(left, ak._connect._numba.layout.ContentType):
+#     if isinstance(left, ak._v2._connect.numba.layout.ContentType):
 #         left = left.parameters.get("__record__")
 #         if not (isinstance(left, str) or (py27 and isinstance(left, unicode))):
 #             done = True
@@ -429,12 +429,12 @@ def recordclass(layout, behavior):
 #     behavior = Behavior(ak.behavior, behavior)
 #     done = False
 
-#     if isinstance(left, ak._connect._numba.layout.ContentType):
+#     if isinstance(left, ak._v2._connect.numba.layout.ContentType):
 #         left = left.parameters.get("__record__")
 #         if not (isinstance(left, str) or (py27 and isinstance(left, unicode))):
 #             done = True
 
-#     if isinstance(right, ak._connect._numba.layout.ContentType):
+#     if isinstance(right, ak._v2._connect.numba.layout.ContentType):
 #         right = right.parameters.get("__record__")
 #         if not isinstance(right, str) and not (py27 and isinstance(right, unicode)):
 #             done = True

--- a/src/awkward/_v2/behaviors/categorical.py
+++ b/src/awkward/_v2/behaviors/categorical.py
@@ -69,14 +69,14 @@
 #     one_content = ak._v2._util.wrap(one.content, behavior)
 #     two_content = ak._v2._util.wrap(two.content, behavior)
 
-#     if len(one_content) == len(two_content) and ak.operations.reducers.all(
+#     if len(one_content) == len(two_content) and ak._v2.operations.reducers.all(
 #         one_content == two_content, axis=None
 #     ):
 #         one_mapped = one_index
 
 #     else:
-#         one_list = ak.operations.convert.to_list(one_content)
-#         two_list = ak.operations.convert.to_list(two_content)
+#         one_list = ak._v2.operations.convert.to_list(one_content)
+#         two_list = ak._v2.operations.convert.to_list(two_content)
 #         one_hashable = [_hashable(x) for x in one_list]
 #         two_hashable = [_hashable(x) for x in two_list]
 #         two_lookup = {x: i for i, x in enumerate(two_hashable)}
@@ -126,7 +126,7 @@
 #     See also #ak.categories, #ak.to_categorical, #ak.from_categorical.
 #     """
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     return layout.purelist_parameter("__array__") == "categorical"
@@ -156,7 +156,7 @@
 #         else:
 #             return None
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
@@ -254,7 +254,7 @@
 #                 content = layout
 #                 cls = ak._v2.contents.IndexedArray64
 
-#             content_list = ak.operations.convert.to_list(content)
+#             content_list = ak._v2.operations.convert.to_list(content)
 #             hashable = [_hashable(x) for x in content_list]
 
 #             lookup = {}
@@ -293,7 +293,7 @@
 #         else:
 #             return None
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
@@ -323,7 +323,7 @@
 
 #     def getfunction(layout):
 #         if layout.parameter("__array__") == "categorical":
-#             out = ak.operations.structure.with_parameter(
+#             out = ak._v2.operations.structure.with_parameter(
 #                 layout, "__array__", None, highlevel=False
 #             )
 #             return lambda: out
@@ -331,7 +331,7 @@
 #         else:
 #             return None
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)

--- a/src/awkward/_v2/behaviors/categorical.py
+++ b/src/awkward/_v2/behaviors/categorical.py
@@ -55,19 +55,19 @@
 
 
 # def _categorical_equal(one, two):
-#     behavior = ak._util.behaviorof(one, two)
+#     behavior = ak._v2._util.behaviorof(one, two)
 
 #     one, two = one.layout, two.layout
 
-#     assert isinstance(one, ak._util.indexedtypes + ak._util.indexedoptiontypes)
-#     assert isinstance(two, ak._util.indexedtypes + ak._util.indexedoptiontypes)
+#     assert isinstance(one, ak._v2._util.indexedtypes + ak._v2._util.indexedoptiontypes)
+#     assert isinstance(two, ak._v2._util.indexedtypes + ak._v2._util.indexedoptiontypes)
 #     assert one.parameter("__array__") == "categorical"
 #     assert two.parameter("__array__") == "categorical"
 
 #     one_index = ak.nplike.numpy.asarray(one.index)
 #     two_index = ak.nplike.numpy.asarray(two.index)
-#     one_content = ak._util.wrap(one.content, behavior)
-#     two_content = ak._util.wrap(two.content, behavior)
+#     one_content = ak._v2._util.wrap(one.content, behavior)
+#     two_content = ak._v2._util.wrap(two.content, behavior)
 
 #     if len(one_content) == len(two_content) and ak.operations.reducers.all(
 #         one_content == two_content, axis=None
@@ -89,7 +89,7 @@
 #         one_mapped = one_to_two[one_index]
 
 #     out = one_mapped == two_index
-#     return ak._util.wrap(ak._v2.contents.NumpyArray(out), ak._util.behaviorof(one, two))
+#     return ak._v2._util.wrap(ak._v2.contents.NumpyArray(out), ak._v2._util.behaviorof(one, two))
 
 
 # ak.behavior[ak.nplike.numpy.equal, "categorical", "categorical"] = _categorical_equal
@@ -99,10 +99,10 @@
 #     nextinputs = []
 #     for x in inputs:
 #         if isinstance(x, ak.highlevel.Array) and isinstance(
-#             x.layout, ak._util.indexedtypes
+#             x.layout, ak._v2._util.indexedtypes
 #         ):
 #             nextinputs.append(
-#                 ak.highlevel.Array(x.layout.project(), behavior=ak._util.behaviorof(x))
+#                 ak.highlevel.Array(x.layout.project(), behavior=ak._v2._util.behaviorof(x))
 #             )
 #         else:
 #             nextinputs.append(x)
@@ -159,12 +159,12 @@
 #     layout = ak.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
-#     ak._util.recursively_apply(layout, getfunction, pass_depth=False)
+#     ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
 
 #     if output[0] is None:
 #         return None
 #     elif highlevel:
-#         return ak._util.wrap(output[0], ak._util.behaviorof(array))
+#         return ak._v2._util.wrap(output[0], ak._v2._util.behaviorof(array))
 #     else:
 #         return output[0]
 
@@ -238,16 +238,16 @@
 
 #     def getfunction(layout):
 #         if layout.purelist_depth == 1:
-#             if isinstance(layout, ak._util.optiontypes):
+#             if isinstance(layout, ak._v2._util.optiontypes):
 #                 layout = layout.simplify()
 
-#             if isinstance(layout, ak._util.indexedoptiontypes):
+#             if isinstance(layout, ak._v2._util.indexedoptiontypes):
 #                 content = layout.content
 #                 cls = ak._v2.contents.IndexedOptionArray64
-#             elif isinstance(layout, ak._util.indexedtypes):
+#             elif isinstance(layout, ak._v2._util.indexedtypes):
 #                 content = layout.content
 #                 cls = ak._v2.contents.IndexedArray64
-#             elif isinstance(layout, ak._util.optiontypes):
+#             elif isinstance(layout, ak._v2._util.optiontypes):
 #                 content = layout.content
 #                 cls = ak._v2.contents.IndexedOptionArray64
 #             else:
@@ -269,17 +269,17 @@
 #                     lookup[x] = j = len(lookup)
 #                     mapping[i] = j
 
-#             if isinstance(layout, ak._util.indexedoptiontypes):
+#             if isinstance(layout, ak._v2._util.indexedoptiontypes):
 #                 original_index = ak.nplike.numpy.asarray(layout.index)
 #                 index = mapping[original_index]
 #                 index[original_index < 0] = -1
 #                 index = ak._v2.index.Index64(index)
 
-#             elif isinstance(layout, ak._util.indexedtypes):
+#             elif isinstance(layout, ak._v2._util.indexedtypes):
 #                 original_index = ak.nplike.numpy.asarray(layout.index)
 #                 index = ak._v2.index.Index64(mapping[original_index])
 
-#             elif isinstance(layout, ak._util.optiontypes):
+#             elif isinstance(layout, ak._v2._util.optiontypes):
 #                 mask = ak.nplike.numpy.asarray(layout.bytemask())
 #                 mapping[mask.view(np.bool_)] = -1
 #                 index = ak._v2.index.Index64(mapping)
@@ -296,9 +296,9 @@
 #     layout = ak.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
-#     out = ak._util.recursively_apply(layout, getfunction, pass_depth=False)
+#     out = ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
 #     if highlevel:
-#         return ak._util.wrap(out, ak._util.behaviorof(array))
+#         return ak._v2._util.wrap(out, ak._v2._util.behaviorof(array))
 #     else:
 #         return out
 
@@ -334,9 +334,9 @@
 #     layout = ak.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
-#     out = ak._util.recursively_apply(layout, getfunction, pass_depth=False)
+#     out = ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
 #     if highlevel:
-#         return ak._util.wrap(out, ak._util.behaviorof(array))
+#         return ak._v2._util.wrap(out, ak._v2._util.behaviorof(array))
 #     else:
 #         return out
 

--- a/src/awkward/_v2/behaviors/categorical.py
+++ b/src/awkward/_v2/behaviors/categorical.py
@@ -89,7 +89,7 @@
 #         one_mapped = one_to_two[one_index]
 
 #     out = one_mapped == two_index
-#     return ak._util.wrap(ak.layout.NumpyArray(out), ak._util.behaviorof(one, two))
+#     return ak._util.wrap(ak._v2.contents.NumpyArray(out), ak._util.behaviorof(one, two))
 
 
 # ak.behavior[ak.nplike.numpy.equal, "categorical", "categorical"] = _categorical_equal
@@ -243,16 +243,16 @@
 
 #             if isinstance(layout, ak._util.indexedoptiontypes):
 #                 content = layout.content
-#                 cls = ak.layout.IndexedOptionArray64
+#                 cls = ak._v2.contents.IndexedOptionArray64
 #             elif isinstance(layout, ak._util.indexedtypes):
 #                 content = layout.content
-#                 cls = ak.layout.IndexedArray64
+#                 cls = ak._v2.contents.IndexedArray64
 #             elif isinstance(layout, ak._util.optiontypes):
 #                 content = layout.content
-#                 cls = ak.layout.IndexedOptionArray64
+#                 cls = ak._v2.contents.IndexedOptionArray64
 #             else:
 #                 content = layout
-#                 cls = ak.layout.IndexedArray64
+#                 cls = ak._v2.contents.IndexedArray64
 
 #             content_list = ak.operations.convert.to_list(content)
 #             hashable = [_hashable(x) for x in content_list]
@@ -273,19 +273,19 @@
 #                 original_index = ak.nplike.numpy.asarray(layout.index)
 #                 index = mapping[original_index]
 #                 index[original_index < 0] = -1
-#                 index = ak.layout.Index64(index)
+#                 index = ak._v2.index.Index64(index)
 
 #             elif isinstance(layout, ak._util.indexedtypes):
 #                 original_index = ak.nplike.numpy.asarray(layout.index)
-#                 index = ak.layout.Index64(mapping[original_index])
+#                 index = ak._v2.index.Index64(mapping[original_index])
 
 #             elif isinstance(layout, ak._util.optiontypes):
 #                 mask = ak.nplike.numpy.asarray(layout.bytemask())
 #                 mapping[mask.view(np.bool_)] = -1
-#                 index = ak.layout.Index64(mapping)
+#                 index = ak._v2.index.Index64(mapping)
 
 #             else:
-#                 index = ak.layout.Index64(mapping)
+#                 index = ak._v2.index.Index64(mapping)
 
 #             out = cls(index, content[is_first], parameters={"__array__": "categorical"})
 #             return lambda: out

--- a/src/awkward/_v2/behaviors/categorical.py
+++ b/src/awkward/_v2/behaviors/categorical.py
@@ -7,7 +7,7 @@
 # np = ak.nplike.NumpyMetadata.instance()
 
 
-# class CategoricalBehavior(ak.highlevel.Array):
+# class CategoricalBehavior(ak._v2.highlevel.Array):
 #     __name__ = "Array"
 
 
@@ -98,11 +98,11 @@
 # def _apply_ufunc(ufunc, method, inputs, kwargs):
 #     nextinputs = []
 #     for x in inputs:
-#         if isinstance(x, ak.highlevel.Array) and isinstance(
+#         if isinstance(x, ak._v2.highlevel.Array) and isinstance(
 #             x.layout, ak._v2._util.indexedtypes
 #         ):
 #             nextinputs.append(
-#                 ak.highlevel.Array(x.layout.project(), behavior=ak._v2._util.behaviorof(x))
+#                 ak._v2.highlevel.Array(x.layout.project(), behavior=ak._v2._util.behaviorof(x))
 #             )
 #         else:
 #             nextinputs.append(x)

--- a/src/awkward/_v2/behaviors/mixins.py
+++ b/src/awkward/_v2/behaviors/mixins.py
@@ -32,14 +32,14 @@
 
 #         record = type(
 #             cls_name + "Record",
-#             (cls, ak.highlevel.Record),
+#             (cls, ak._v2.highlevel.Record),
 #             {"__module__": cls.__module__},
 #         )
 #         setattr(sys.modules[cls.__module__], cls_name + "Record", record)
 #         registry[behavior_name] = record
 #         array = type(
 #             cls_name + "Array",
-#             (cls, ak.highlevel.Array),
+#             (cls, ak._v2.highlevel.Array),
 #             {"__module__": cls.__module__},
 #         )
 #         setattr(sys.modules[cls.__module__], cls_name + "Array", array)

--- a/src/awkward/_v2/behaviors/mixins.py
+++ b/src/awkward/_v2/behaviors/mixins.py
@@ -85,7 +85,7 @@
 #         if not isinstance(rhs, (set, type(None))):
 #             raise ValueError(
 #                 "expected a set of right-hand-side argument types"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         if transpose and rhs is not None:
 

--- a/src/awkward/_v2/behaviors/mixins.py
+++ b/src/awkward/_v2/behaviors/mixins.py
@@ -85,7 +85,7 @@
 #         if not isinstance(rhs, (set, type(None))):
 #             raise ValueError(
 #                 "expected a set of right-hand-side argument types"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         if transpose and rhs is not None:
 

--- a/src/awkward/_v2/behaviors/string.py
+++ b/src/awkward/_v2/behaviors/string.py
@@ -189,45 +189,45 @@ class CharBehavior(Array):
 #     import numba
 #     import llvmlite.llvmpy.core
 
-#     whichpos = ak._connect._numba.layout.posat(
+#     whichpos = ak._v2._connect.numba.layout.posat(
 #         context, builder, viewproxy.pos, viewtype.type.CONTENT
 #     )
-#     nextpos = ak._connect._numba.layout.getat(
+#     nextpos = ak._v2._connect.numba.layout.getat(
 #         context, builder, viewproxy.arrayptrs, whichpos
 #     )
 
-#     whichnextpos = ak._connect._numba.layout.posat(
+#     whichnextpos = ak._v2._connect.numba.layout.posat(
 #         context, builder, nextpos, viewtype.type.contenttype.ARRAY
 #     )
 
-#     startspos = ak._connect._numba.layout.posat(
+#     startspos = ak._v2._connect.numba.layout.posat(
 #         context, builder, viewproxy.pos, viewtype.type.STARTS
 #     )
-#     startsptr = ak._connect._numba.layout.getat(
+#     startsptr = ak._v2._connect.numba.layout.getat(
 #         context, builder, viewproxy.arrayptrs, startspos
 #     )
 #     startsarraypos = builder.add(viewproxy.start, atval)
-#     start = ak._connect._numba.layout.getat(
+#     start = ak._v2._connect.numba.layout.getat(
 #         context, builder, startsptr, startsarraypos, viewtype.type.indextype.dtype
 #     )
 
-#     stopspos = ak._connect._numba.layout.posat(
+#     stopspos = ak._v2._connect.numba.layout.posat(
 #         context, builder, viewproxy.pos, viewtype.type.STOPS
 #     )
-#     stopsptr = ak._connect._numba.layout.getat(
+#     stopsptr = ak._v2._connect.numba.layout.getat(
 #         context, builder, viewproxy.arrayptrs, stopspos
 #     )
 #     stopsarraypos = builder.add(viewproxy.start, atval)
-#     stop = ak._connect._numba.layout.getat(
+#     stop = ak._v2._connect.numba.layout.getat(
 #         context, builder, stopsptr, stopsarraypos, viewtype.type.indextype.dtype
 #     )
 
-#     baseptr = ak._connect._numba.layout.getat(
+#     baseptr = ak._v2._connect.numba.layout.getat(
 #         context, builder, viewproxy.arrayptrs, whichnextpos
 #     )
 #     rawptr = builder.add(
 #         baseptr,
-#         ak._connect._numba.castint(
+#         ak._v2._connect.numba.castint(
 #             context, builder, viewtype.type.indextype.dtype, numba.intp, start
 #         ),
 #     )
@@ -238,7 +238,7 @@ class CharBehavior(Array):
 #         ),
 #     )
 #     strsize = builder.sub(stop, start)
-#     strsize_cast = ak._connect._numba.castint(
+#     strsize_cast = ak._v2._connect.numba.castint(
 #         context, builder, viewtype.type.indextype.dtype, numba.intp, strsize
 #     )
 

--- a/src/awkward/_v2/behaviors/string.py
+++ b/src/awkward/_v2/behaviors/string.py
@@ -100,7 +100,7 @@ class CharBehavior(Array):
 # ak.behavior["__typestr__", "char"] = "char"
 
 
-# class ByteStringBehavior(ak.highlevel.Array):
+# class ByteStringBehavior(ak._v2.highlevel.Array):
 #     __name__ = "Array"
 
 #     def __iter__(self):
@@ -108,7 +108,7 @@ class CharBehavior(Array):
 #             yield x.__bytes__()
 
 
-# class StringBehavior(ak.highlevel.Array):
+# class StringBehavior(ak._v2.highlevel.Array):
 #     __name__ = "Array"
 
 #     def __iter__(self):

--- a/src/awkward/_v2/behaviors/string.py
+++ b/src/awkward/_v2/behaviors/string.py
@@ -124,7 +124,7 @@ class CharBehavior(Array):
 
 # def _string_equal(one, two):
 #     nplike = ak.nplike.of(one, two)
-#     behavior = ak._util.behaviorof(one, two)
+#     behavior = ak._v2._util.behaviorof(one, two)
 
 #     one, two = ak.without_parameters(one).layout, ak.without_parameters(two).layout
 
@@ -147,7 +147,7 @@ class CharBehavior(Array):
 #         # update same-length strings with a verdict about their characters
 #         out[possible] = reduced
 
-#     return ak._util.wrap(ak._v2.contents.NumpyArray(out), behavior)
+#     return ak._v2._util.wrap(ak._v2.contents.NumpyArray(out), behavior)
 
 
 # def _string_notequal(one, two):
@@ -164,7 +164,7 @@ class CharBehavior(Array):
 #     nplike = ak.nplike.of(offsets)
 #     offsets = nplike.asarray(offsets)
 #     counts = offsets[1:] - offsets[:-1]
-#     if ak._util.win or ak._util.bits32:
+#     if ak._v2._util.win or ak._v2._util.bits32:
 #         counts = counts.astype(np.int32)
 #     parents = nplike.repeat(nplike.arange(len(counts), dtype=counts.dtype), counts)
 #     return ak._v2.contents.IndexedArray64(ak._v2.index.Index64(parents), layout).project()

--- a/src/awkward/_v2/behaviors/string.py
+++ b/src/awkward/_v2/behaviors/string.py
@@ -147,7 +147,7 @@ class CharBehavior(Array):
 #         # update same-length strings with a verdict about their characters
 #         out[possible] = reduced
 
-#     return ak._util.wrap(ak.layout.NumpyArray(out), behavior)
+#     return ak._util.wrap(ak._v2.contents.NumpyArray(out), behavior)
 
 
 # def _string_notequal(one, two):
@@ -167,7 +167,7 @@ class CharBehavior(Array):
 #     if ak._util.win or ak._util.bits32:
 #         counts = counts.astype(np.int32)
 #     parents = nplike.repeat(nplike.arange(len(counts), dtype=counts.dtype), counts)
-#     return ak.layout.IndexedArray64(ak.layout.Index64(parents), layout).project()
+#     return ak._v2.contents.IndexedArray64(ak._v2.index.Index64(parents), layout).project()
 
 
 # ak.behavior["__broadcast__", "bytestring"] = _string_broadcast

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -54,7 +54,7 @@ _dir_pattern = re.compile(r"^[a-zA-Z_]\w*$")
 
 
 # def _suffix(array):
-#     out = ak.operations.convert.kernels(array)
+#     out = ak._v2.operations.convert.kernels(array)
 #     if out is None or out == "cpu":
 #         return ""
 #     else:
@@ -248,7 +248,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             layout = ak._v2.operations.convert.from_cupy(data, highlevel=False)
 
         elif ak._v2._util.in_module(data, "pyarrow"):
-            layout = ak.operations.convert.from_arrow(data, highlevel=False)
+            layout = ak._v2.operations.convert.from_arrow(data, highlevel=False)
 
         elif isinstance(data, dict):
             fields = []
@@ -417,7 +417,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #             return "<{0}.mask{1} {2} type={3}>".format(name, suffix, value, typestr)
 
     #         def __getitem__(self, where):
-    #             return ak.operations.structure.mask(self._array, where, self._valid_when)
+    #             return ak._v2.operations.structure.mask(self._array, where, self._valid_when)
 
     #     @property
     #     def mask(self, valid_when=True):
@@ -1396,8 +1396,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #         return numba.typeof(self._numbaview)
 
     #     def __getstate__(self):
-    #         packed = ak.operations.structure.packed(self.layout, highlevel=False)
-    #         form, length, container = ak.operations.convert.to_buffers(packed)
+    #         packed = ak._v2.operations.structure.packed(self.layout, highlevel=False)
+    #         form, length, container = ak._v2.operations.convert.to_buffers(packed)
     #         if self._behavior is ak.behavior:
     #             behavior = None
     #         else:
@@ -1412,7 +1412,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #             )
     #         else:
     #             form, length, container, behavior = state
-    #             layout = ak.operations.convert.from_buffers(
+    #             layout = ak._v2.operations.convert.from_buffers(
     #                 form, length, container, highlevel=False, behavior=behavior
     #             )
     #         if self.__class__ is Array:
@@ -1493,10 +1493,10 @@ class Record(NDArrayOperatorsMixin):
             layout = data._layout
 
         elif isinstance(data, str):
-            layout = ak.operations.convert.from_json(data, highlevel=False)
+            layout = ak._v2.operations.convert.from_json(data, highlevel=False)
 
         elif isinstance(data, dict):
-            layout = ak.operations.convert.from_iter([data], highlevel=False)[0]
+            layout = ak._v2.operations.convert.from_iter([data], highlevel=False)[0]
 
         elif isinstance(data, Iterable):
             raise TypeError(
@@ -1980,8 +1980,8 @@ class Record(NDArrayOperatorsMixin):
     #         return numba.typeof(self._numbaview)
 
     #     def __getstate__(self):
-    #         packed = ak.operations.structure.packed(self._layout, highlevel=False)
-    #         form, length, container = ak.operations.convert.to_buffers(packed.array)
+    #         packed = ak._v2.operations.structure.packed(self._layout, highlevel=False)
+    #         form, length, container = ak._v2.operations.convert.to_buffers(packed.array)
     #         if self._behavior is ak.behavior:
     #             behavior = None
     #         else:
@@ -1996,7 +1996,7 @@ class Record(NDArrayOperatorsMixin):
     #             )
     #         else:
     #             form, length, container, behavior, at = state
-    #             layout = ak.operations.convert.from_buffers(
+    #             layout = ak._v2.operations.convert.from_buffers(
     #                 form, length, container, highlevel=False, behavior=behavior
     #             )
     #         layout = ak._v2.record.Record(layout, at)
@@ -2214,7 +2214,7 @@ class Record(NDArrayOperatorsMixin):
 #         The type of a #ak.layout.Content (from #ak.Array.layout) is not
 #         wrapped by an #ak.types.ArrayType.
 #         """
-#         return ak.operations.describe.type(self)
+#         return ak._v2.operations.describe.type(self)
 
 #     def __len__(self):
 #         """

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -64,7 +64,7 @@ _dir_pattern = re.compile(r"^[a-zA-Z_]\w*$")
 class Array(NDArrayOperatorsMixin, Iterable, Sized):
     u"""
     Args:
-        data (#ak.layout.Content, #ak.partition.PartitionedArray, #ak.Array, `np.ndarray`, `cp.ndarray`, `pyarrow.*`, str, dict, or iterable):
+        data (#ak.layout.Content, #ak.Array, `np.ndarray`, `cp.ndarray`, `pyarrow.*`, str, dict, or iterable):
             Data to wrap or convert into an array.
                - If a NumPy array, the regularity of its dimensions is preserved
                  and the data are viewed, not copied.

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -1999,7 +1999,7 @@ class Record(NDArrayOperatorsMixin):
     #             layout = ak.operations.convert.from_buffers(
     #                 form, length, container, highlevel=False, behavior=behavior
     #             )
-    #         layout = ak.layout.Record(layout, at)
+    #         layout = ak._v2.record.Record(layout, at)
     #         if self.__class__ is Record:
     #             self.__class__ = ak._util.recordclass(layout, behavior)
     #         self.layout = layout

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -395,7 +395,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #             suffix = _suffix(self)
     #             limit_value -= len(suffix)
 
-    #             value = ak._util.minimally_touching_string(
+    #             value = ak._v2._util.minimally_touching_string(
     #                 limit_value, self._array.layout, self._array._behavior
     #             )
 
@@ -406,7 +406,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #             limit_type = limit_total - (len(value) + len(name) + len("<.mask  type=>"))
     #             typestr = repr(
     #                 str(
-    #                     ak._util.highlevel_type(
+    #                     ak._v2._util.highlevel_type(
     #                         self._array.layout, self._array._behavior, True
     #                     )
     #                 )
@@ -1407,7 +1407,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #     def __setstate__(self, state):
     #         if isinstance(state[1], dict):
     #             form, container, num_partitions, behavior = state
-    #             layout = ak._util.adjust_old_pickle(
+    #             layout = ak._v2._util.adjust_old_pickle(
     #                 form, container, num_partitions, behavior
     #             )
     #         else:
@@ -1416,10 +1416,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #                 form, length, container, highlevel=False, behavior=behavior
     #             )
     #         if self.__class__ is Array:
-    #             self.__class__ = ak._util.arrayclass(layout, behavior)
+    #             self.__class__ = ak._v2._util.arrayclass(layout, behavior)
     #         self.layout = layout
     #         self.behavior = behavior
-    #         self._caches = ak._util.find_caches(self.layout)
+    #         self._caches = ak._v2._util.find_caches(self.layout)
 
     #     def __copy__(self):
     #         return Array(self.layout, behavior=self._behavior)
@@ -1438,7 +1438,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
 
 #     def __contains__(self, element):
-#         for test in ak._util.completely_flatten(self.layout):
+#         for test in ak._v2._util.completely_flatten(self.layout):
 #             if element in test:
 #                 return True
 #         return False
@@ -1991,7 +1991,7 @@ class Record(NDArrayOperatorsMixin):
     #     def __setstate__(self, state):
     #         if isinstance(state[1], dict):
     #             form, container, num_partitions, behavior, at = state
-    #             layout = ak._util.adjust_old_pickle(
+    #             layout = ak._v2._util.adjust_old_pickle(
     #                 form, container, num_partitions, behavior
     #             )
     #         else:
@@ -2001,10 +2001,10 @@ class Record(NDArrayOperatorsMixin):
     #             )
     #         layout = ak._v2.record.Record(layout, at)
     #         if self.__class__ is Record:
-    #             self.__class__ = ak._util.recordclass(layout, behavior)
+    #             self.__class__ = ak._v2._util.recordclass(layout, behavior)
     #         self.layout = layout
     #         self.behavior = behavior
-    #         self._caches = ak._util.find_caches(self.layout)
+    #         self._caches = ak._v2._util.find_caches(self.layout)
 
     #     def __copy__(self):
     #         return Record(self.layout, behavior=self._behavior)
@@ -2020,7 +2020,7 @@ class Record(NDArrayOperatorsMixin):
 
 
 #     def __contains__(self, element):
-#         for test in ak._util.completely_flatten(self.layout):
+#         for test in ak._v2._util.completely_flatten(self.layout):
 #             if element in test:
 #                 return True
 #         return False
@@ -2200,7 +2200,7 @@ class Record(NDArrayOperatorsMixin):
 #             self._behavior = behavior
 #         else:
 #             raise TypeError(
-#                 "behavior must be None or a dict" + ak._util.exception_suffix(__file__)
+#                 "behavior must be None or a dict" + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     @property
@@ -2232,12 +2232,12 @@ class Record(NDArrayOperatorsMixin):
 
 #         See #ak.Array.__getitem__ for a more complete description.
 #         """
-#         tmp = ak._util.wrap(self._layout[where], self._behavior)
+#         tmp = ak._v2._util.wrap(self._layout[where], self._behavior)
 
 #         if isinstance(tmp, ak.behaviors.string.ByteBehavior):
 #             return bytes(tmp)
 #         elif isinstance(tmp, ak.behaviors.string.CharBehavior):
-#             return ak._util.unicode(tmp) if ak._util.py27 else str(tmp)
+#             return ak._v2._util.unicode(tmp) if ak._v2._util.py27 else str(tmp)
 #         else:
 #             return tmp
 
@@ -2288,7 +2288,7 @@ class Record(NDArrayOperatorsMixin):
 #         value = self._str(limit_value=limit_value, snapshot=snapshot)
 
 #         limit_type = limit_total - len(value) - len("<ArrayBuilder  type=>")
-#         typestrs = ak._util.typestrs(self._behavior)
+#         typestrs = ak._v2._util.typestrs(self._behavior)
 #         typestr = repr(
 #             str(ak.types.ArrayType(snapshot._layout.type(typestrs), len(self)))
 #         )
@@ -2369,7 +2369,7 @@ class Record(NDArrayOperatorsMixin):
 #         buffers are deleted exactly once.
 #         """
 #         layout = self._layout.snapshot()
-#         return ak._util.wrap(layout, self._behavior)
+#         return ak._v2._util.wrap(layout, self._behavior)
 
 #     def null(self):
 #         """
@@ -2605,7 +2605,7 @@ class Record(NDArrayOperatorsMixin):
 #             else:
 #                 raise TypeError(
 #                     "'append' method can only be used with 'at' when "
-#                     "'obj' is an ak.Array" + ak._util.exception_suffix(__file__)
+#                     "'obj' is an ak.Array" + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #     def extend(self, obj):
@@ -2621,7 +2621,7 @@ class Record(NDArrayOperatorsMixin):
 #         else:
 #             raise TypeError(
 #                 "'extend' method requires an ak.Array"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     class _Nested(object):
@@ -2638,7 +2638,7 @@ class Record(NDArrayOperatorsMixin):
 #                 - len("<ArrayBuilder.  type=>")
 #                 - len(self._name)
 #             )
-#             typestrs = ak._util.typestrs(self._arraybuilder._behavior)
+#             typestrs = ak._v2._util.typestrs(self._arraybuilder._behavior)
 #             typestr = repr(
 #                 str(ak.types.ArrayType(snapshot._layout.type(typestrs), len(self)))
 #             )

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -2234,9 +2234,9 @@ class Record(NDArrayOperatorsMixin):
 #         """
 #         tmp = ak._v2._util.wrap(self._layout[where], self._behavior)
 
-#         if isinstance(tmp, ak.behaviors.string.ByteBehavior):
+#         if isinstance(tmp, ak._v2.behaviors.string.ByteBehavior):
 #             return bytes(tmp)
-#         elif isinstance(tmp, ak.behaviors.string.CharBehavior):
+#         elif isinstance(tmp, ak._v2.behaviors.string.CharBehavior):
 #             return ak._v2._util.unicode(tmp) if ak._v2._util.py27 else str(tmp)
 #         else:
 #             return tmp
@@ -2290,7 +2290,7 @@ class Record(NDArrayOperatorsMixin):
 #         limit_type = limit_total - len(value) - len("<ArrayBuilder  type=>")
 #         typestrs = ak._v2._util.typestrs(self._behavior)
 #         typestr = repr(
-#             str(ak.types.ArrayType(snapshot._layout.type(typestrs), len(self)))
+#             str(ak._v2.types.ArrayType(snapshot._layout.type(typestrs), len(self)))
 #         )
 #         if len(typestr) > limit_type:
 #             typestr = typestr[: (limit_type - 4)] + "..." + typestr[-1]
@@ -2640,7 +2640,7 @@ class Record(NDArrayOperatorsMixin):
 #             )
 #             typestrs = ak._v2._util.typestrs(self._arraybuilder._behavior)
 #             typestr = repr(
-#                 str(ak.types.ArrayType(snapshot._layout.type(typestrs), len(self)))
+#                 str(ak._v2.types.ArrayType(snapshot._layout.type(typestrs), len(self)))
 #             )
 #             if len(typestr) > limit_type:
 #                 typestr = typestr[: (limit_type - 4)] + "..." + typestr[-1]

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -2200,7 +2200,7 @@ class Record(NDArrayOperatorsMixin):
 #             self._behavior = behavior
 #         else:
 #             raise TypeError(
-#                 "behavior must be None or a dict" + ak._v2._util.exception_suffix(__file__)
+#                 "behavior must be None or a dict"
 #             )
 
 #     @property
@@ -2605,7 +2605,7 @@ class Record(NDArrayOperatorsMixin):
 #             else:
 #                 raise TypeError(
 #                     "'append' method can only be used with 'at' when "
-#                     "'obj' is an ak.Array" + ak._v2._util.exception_suffix(__file__)
+#                     "'obj' is an ak.Array"
 #                 )
 
 #     def extend(self, obj):
@@ -2621,7 +2621,7 @@ class Record(NDArrayOperatorsMixin):
 #         else:
 #             raise TypeError(
 #                 "'extend' method requires an ak.Array"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     class _Nested(object):

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -1291,7 +1291,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #         nested lists in a NumPy `"O"` array are severed from the array and
     #         cannot be sliced as dimensions.
     #         """
-    #         return ak._connect._numpy.convert_to_array(self.layout, args, kwargs)
+    #         return ak._v2._connect.numpy.convert_to_array(self.layout, args, kwargs)
 
     #     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
     #         """
@@ -1351,9 +1351,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #         See also #__array_function__.
     #         """
     #         if not hasattr(self, "_tracers"):
-    #             return ak._connect._numpy.array_ufunc(ufunc, method, inputs, kwargs)
+    #             return ak._v2._connect.numpy.array_ufunc(ufunc, method, inputs, kwargs)
     #         else:
-    #             return ak._connect._jax.jax_utils.array_ufunc(
+    #             return ak._v2._connect.jax.jax_utils.array_ufunc(
     #                 self, ufunc, method, inputs, kwargs
     #             )
 
@@ -1374,7 +1374,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
     #         See also #__array_ufunc__.
     #         """
-    #         return ak._connect._numpy.array_function(func, types, args, kwargs)
+    #         return ak._v2._connect.numpy.array_function(func, types, args, kwargs)
 
     #     @property
     #     def numba_type(self):
@@ -1386,11 +1386,11 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     #         See [Numba documentation](https://numba.pydata.org/numba-doc/dev/reference/types.html)
     #         on types and signatures.
     #         """
-    #         import awkward._connect._numba  # noqa: F401
+    #         import awkward._v2._connect.numba  # noqa: F401
 
-    #         ak._connect._numba.register_and_check()
+    #         ak._v2._connect.numba.register_and_check()
     #         if self._numbaview is None:
-    #             self._numbaview = ak._connect._numba.arrayview.ArrayView.fromarray(self)
+    #             self._numbaview = ak._v2._connect.numba.arrayview.ArrayView.fromarray(self)
     #         import numba
 
     #         return numba.typeof(self._numbaview)
@@ -1958,7 +1958,7 @@ class Record(NDArrayOperatorsMixin):
 
     #         See #ak.Array.__array_ufunc__ for a more complete description.
     #         """
-    #         return ak._connect._numpy.array_ufunc(ufunc, method, inputs, kwargs)
+    #         return ak._v2._connect.numpy.array_ufunc(ufunc, method, inputs, kwargs)
 
     #     @property
     #     def numba_type(self):
@@ -1970,11 +1970,11 @@ class Record(NDArrayOperatorsMixin):
     #         See [Numba documentation](https://numba.pydata.org/numba-doc/dev/reference/types.html)
     #         on types and signatures.
     #         """
-    #         import awkward._connect._numba  # noqa: F401
+    #         import awkward._v2._connect.numba  # noqa: F401
 
-    #         ak._connect._numba.register_and_check()
+    #         ak._v2._connect.numba.register_and_check()
     #         if self._numbaview is None:
-    #             self._numbaview = ak._connect._numba.arrayview.RecordView.fromrecord(self)
+    #             self._numbaview = ak._v2._connect.numba.arrayview.RecordView.fromrecord(self)
     #         import numba
 
     #         return numba.typeof(self._numbaview)
@@ -2305,7 +2305,7 @@ class Record(NDArrayOperatorsMixin):
 
 #         See #ak.Array.__array__ for a more complete description.
 #         """
-#         return ak._connect._numpy.convert_to_array(self.snapshot(), args, kwargs)
+#         return ak._v2._connect.numpy.convert_to_array(self.snapshot(), args, kwargs)
 
 #     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
 #         """
@@ -2315,7 +2315,7 @@ class Record(NDArrayOperatorsMixin):
 
 #         See #ak.Array.__array_ufunc__ for a more complete description.
 #         """
-#         return ak._connect._numpy.array_ufunc(ufunc, method, inputs, kwargs)
+#         return ak._v2._connect.numpy.array_ufunc(ufunc, method, inputs, kwargs)
 
 #     def __array_function__(self, func, types, args, kwargs):
 #         """
@@ -2324,7 +2324,7 @@ class Record(NDArrayOperatorsMixin):
 
 #         See #ak.ArrayBuilder.__array_ufunc__ for a more complete description.
 #         """
-#         return ak._connect._numpy.array_function(func, types, args, kwargs)
+#         return ak._v2._connect.numpy.array_function(func, types, args, kwargs)
 
 #     @property
 #     def numba_type(self):
@@ -2336,12 +2336,12 @@ class Record(NDArrayOperatorsMixin):
 #         See [Numba documentation](https://numba.pydata.org/numba-doc/dev/reference/types.html)
 #         on types and signatures.
 #         """
-#         import awkward._connect._numba
+#         import awkward._v2._connect.numba
 
-#         ak._connect._numba.register_and_check()
-#         import awkward._connect._numba.builder  # noqa: F401
+#         ak._v2._connect.numba.register_and_check()
+#         import awkward._v2._connect.numba.builder  # noqa: F401
 
-#         return ak._connect._numba.builder.ArrayBuilderType(self._behavior)
+#         return ak._v2._connect.numba.builder.ArrayBuilderType(self._behavior)
 
 #     def __bool__(self):
 #         if len(self) == 1:

--- a/src/awkward/_v2/operations/convert/from_arrow.py
+++ b/src/awkward/_v2/operations/convert/from_arrow.py
@@ -163,7 +163,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             else:
 #                 raise TypeError(
 #                     "unrecognized Arrow union array mode: {0}".format(repr(tpe.mode))
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #             mask = buffers.pop(0)
@@ -288,7 +288,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #         else:
 #             raise TypeError(
 #                 "unrecognized Arrow array type: {0}".format(repr(tpe))
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         # All 'no return yet' cases need to become option-type (even if the UnmaskedArray
@@ -369,7 +369,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #         else:
 #             raise TypeError(
 #                 "unrecognized Arrow type: {0}".format(type(obj))
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     return ak._v2._util.maybe_wrap(handle_arrow(array), behavior, highlevel)

--- a/src/awkward/_v2/operations/convert/from_arrow.py
+++ b/src/awkward/_v2/operations/convert/from_arrow.py
@@ -64,14 +64,14 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             index = popbuffers(array.indices, tpe.index_type, buffers)
 #             content = handle_arrow(array.dictionary)
 
-#             out = ak.layout.IndexedArray32(
-#                 ak.layout.Index32(index.content),
+#             out = ak._v2.contents.IndexedArray32(
+#                 ak._v2.index.Index32(index.content),
 #                 content,
 #                 parameters={"__array__": "categorical"},
 #             ).simplify()
 
-#             if isinstance(index, ak.layout.BitMaskedArray):
-#                 return ak.layout.BitMaskedArray(
+#             if isinstance(index, ak._v2.contents.BitMaskedArray):
+#                 return ak._v2.contents.BitMaskedArray(
 #                     index.mask,
 #                     out,
 #                     True,
@@ -111,38 +111,38 @@ def from_arrow(array, highlevel=True, behavior=None):
 #                         keys.append(tpe[i].name)
 #                 assert found
 
-#             out = ak.layout.RecordArray(child_arrays, keys, length=len(array))
+#             out = ak._v2.contents.RecordArray(child_arrays, keys, length=len(array))
 #             if mask is not None:
-#                 mask = ak.layout.IndexU8(numpy.frombuffer(mask, dtype=np.uint8))
-#                 return ak.layout.BitMaskedArray(mask, out, True, len(out), True)
+#                 mask = ak._v3.index.IndexU8(numpy.frombuffer(mask, dtype=np.uint8))
+#                 return ak._v2.contents.BitMaskedArray(mask, out, True, len(out), True)
 #             else:
-#                 return ak.layout.UnmaskedArray(out)
+#                 return ak._v2.contents.UnmaskedArray(out)
 #             # RETURNED because each field has already been offset-corrected.
 
 #         elif isinstance(tpe, pyarrow.lib.ListType):
 #             assert tpe.num_buffers == 2
 #             mask = buffers.pop(0)
-#             offsets = ak.layout.Index32(
+#             offsets = ak._v2.index.Index32(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.int32)
 #             )
 #             content = popbuffers(array.values, tpe.value_type, buffers)
 #             if not tpe.value_field.nullable:
 #                 content = content.content
 
-#             out = ak.layout.ListOffsetArray32(offsets, content)
+#             out = ak._v2.contents.ListOffsetArray32(offsets, content)
 #             # No return yet!
 
 #         elif isinstance(tpe, pyarrow.lib.LargeListType):
 #             assert tpe.num_buffers == 2
 #             mask = buffers.pop(0)
-#             offsets = ak.layout.Index64(
+#             offsets = ak._v2.index.Index64(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.int64)
 #             )
 #             content = popbuffers(array.values, tpe.value_type, buffers)
 #             if not tpe.value_field.nullable:
 #                 content = content.content
 
-#             out = ak.layout.ListOffsetArray64(offsets, content)
+#             out = ak._v2.contents.ListOffsetArray64(offsets, content)
 #             # No return yet!
 
 #         elif isinstance(tpe, pyarrow.lib.FixedSizeListType):
@@ -152,7 +152,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             if not tpe.value_field.nullable:
 #                 content = content.content
 
-#             out = ak.layout.RegularArray(content, tpe.list_size)
+#             out = ak._v2.contents.RegularArray(content, tpe.list_size)
 #             # No return yet!
 
 #         elif isinstance(tpe, pyarrow.lib.UnionType):
@@ -188,64 +188,64 @@ def from_arrow(array, highlevel=True, behavior=None):
 #                 if not tpe[i].nullable:
 #                     contents[i] = contents[i].content
 
-#             tags = ak.layout.Index8(tags)
-#             index = ak.layout.Index32(index)
-#             out = ak.layout.UnionArray8_32(tags, index, contents)
+#             tags = ak._v2.index.Index8(tags)
+#             index = ak._v2_index.Index32(index)
+#             out = ak._v2.contents.UnionArray8_32(tags, index, contents)
 #             # No return yet!
 
 #         elif tpe == pyarrow.string():
 #             assert tpe.num_buffers == 3
 #             mask = buffers.pop(0)
-#             offsets = ak.layout.Index32(
+#             offsets = ak._v2.index.Index32(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.int32)
 #             )
-#             contents = ak.layout.NumpyArray(
+#             contents = ak._v2.contents.NumpyArray(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.uint8)
 #             )
 #             contents.setparameter("__array__", "char")
-#             out = ak.layout.ListOffsetArray32(offsets, contents)
+#             out = ak._v2.contents.ListOffsetArray32(offsets, contents)
 #             out.setparameter("__array__", "string")
 #             # No return yet!
 
 #         elif tpe == pyarrow.large_string():
 #             assert tpe.num_buffers == 3
 #             mask = buffers.pop(0)
-#             offsets = ak.layout.Index64(
+#             offsets = ak._v2.index.Index64(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.int64)
 #             )
-#             contents = ak.layout.NumpyArray(
+#             contents = ak._v2.contents.NumpyArray(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.uint8)
 #             )
 #             contents.setparameter("__array__", "char")
-#             out = ak.layout.ListOffsetArray64(offsets, contents)
+#             out = ak._v2.contents.ListOffsetArray64(offsets, contents)
 #             out.setparameter("__array__", "string")
 #             # No return yet!
 
 #         elif tpe == pyarrow.binary():
 #             assert tpe.num_buffers == 3
 #             mask = buffers.pop(0)
-#             offsets = ak.layout.Index32(
+#             offsets = ak._v2.index.Index32(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.int32)
 #             )
-#             contents = ak.layout.NumpyArray(
+#             contents = ak._v2.contents.NumpyArray(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.uint8)
 #             )
 #             contents.setparameter("__array__", "byte")
-#             out = ak.layout.ListOffsetArray32(offsets, contents)
+#             out = ak._v2.contents.ListOffsetArray32(offsets, contents)
 #             out.setparameter("__array__", "bytestring")
 #             # No return yet!
 
 #         elif tpe == pyarrow.large_binary():
 #             assert tpe.num_buffers == 3
 #             mask = buffers.pop(0)
-#             offsets = ak.layout.Index64(
+#             offsets = ak._v2.index.Index64(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.int64)
 #             )
-#             contents = ak.layout.NumpyArray(
+#             contents = ak._v2.contents.NumpyArray(
 #                 numpy.frombuffer(buffers.pop(0), dtype=np.uint8)
 #             )
 #             contents.setparameter("__array__", "byte")
-#             out = ak.layout.ListOffsetArray64(offsets, contents)
+#             out = ak._v2.contents.ListOffsetArray64(offsets, contents)
 #             out.setparameter("__array__", "bytestring")
 #             # No return yet!
 
@@ -258,7 +258,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #                 .reshape(-1, 8)[:, ::-1]
 #                 .reshape(-1)
 #             )
-#             out = ak.layout.NumpyArray(as_bytes.view(np.bool_))
+#             out = ak._v2.contents.NumpyArray(as_bytes.view(np.bool_))
 #             # No return yet!
 
 #         elif isinstance(tpe, pyarrow.lib.DataType) and tpe.num_buffers == 1:
@@ -266,9 +266,9 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             mask = buffers.pop(0)
 #             assert tpe.num_fields == 0
 #             assert mask is None
-#             out = ak.layout.IndexedOptionArray64(
-#                 ak.layout.Index64(numpy.full(len(array), -1, dtype=np.int64)),
-#                 ak.layout.EmptyArray(),
+#             out = ak._v2.contents.IndexedOptionArray64(
+#                 ak._v2.index.Index64(numpy.full(len(array), -1, dtype=np.int64)),
+#                 ak._v2.contents.EmptyArray(),
 #             )
 #             # No return yet!
 
@@ -282,7 +282,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #                 data = numpy.frombuffer(data, dtype=np.int32).astype(np.int64)
 #             if dt is None:
 #                 dt = tpe.to_pandas_dtype()
-#             out = ak.layout.NumpyArray(numpy.frombuffer(data, dtype=dt))
+#             out = ak._v2.contents.NumpyArray(numpy.frombuffer(data, dtype=dt))
 #             # No return yet!
 
 #         else:
@@ -294,10 +294,10 @@ def from_arrow(array, highlevel=True, behavior=None):
 #         # All 'no return yet' cases need to become option-type (even if the UnmaskedArray
 #         # is just going to get stripped off in the recursive step that calls this one).
 #         if mask is not None:
-#             mask = ak.layout.IndexU8(numpy.frombuffer(mask, dtype=np.uint8))
-#             out = ak.layout.BitMaskedArray(mask, out, True, len(out), True)
+#             mask = ak._v2.index.IndexU8(numpy.frombuffer(mask, dtype=np.uint8))
+#             out = ak._v2.contents.BitMaskedArray(mask, out, True, len(out), True)
 #         else:
-#             out = ak.layout.UnmaskedArray(out)
+#             out = ak._v2.contents.UnmaskedArray(out)
 
 #         # All 'no return yet' cases need to be corrected for pyarrow's 'offset'.
 #         if array.offset == 0 and len(array) == len(out):
@@ -310,14 +310,14 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             buffers = obj.buffers()
 #             out = popbuffers(obj, obj.type, buffers)
 #             assert len(buffers) == 0
-#             if isinstance(out, ak.layout.UnmaskedArray):
+#             if isinstance(out, ak._v2.contents.UnmaskedArray):
 #                 return out.content
 #             else:
 #                 return out
 
 #         elif isinstance(obj, pyarrow.lib.ChunkedArray):
 #             layouts = [handle_arrow(x) for x in obj.chunks if len(x) > 0]
-#             if all(isinstance(x, ak.layout.UnmaskedArray) for x in layouts):
+#             if all(isinstance(x, ak._v2.contents.UnmaskedArray) for x in layouts):
 #                 layouts = [x.content for x in layouts]
 #             if len(layouts) == 1:
 #                 return layouts[0]
@@ -331,12 +331,12 @@ def from_arrow(array, highlevel=True, behavior=None):
 #                 if obj.schema.field(i).nullable and not isinstance(
 #                     layout, ak._util.optiontypes
 #                 ):
-#                     layout = ak.layout.UnmaskedArray(layout)
+#                     layout = ak._v2.contents.UnmaskedArray(layout)
 #                 child_array.append(layout)
 #             if pass_empty_field and list(obj.schema.names) == [""]:
 #                 return child_array[0]
 #             else:
-#                 return ak.layout.RecordArray(child_array, obj.schema.names)
+#                 return ak._v2.contents.RecordArray(child_array, obj.schema.names)
 
 #         elif isinstance(obj, pyarrow.lib.Table):
 #             batches = obj.combine_chunks().to_batches()

--- a/src/awkward/_v2/operations/convert/from_arrow.py
+++ b/src/awkward/_v2/operations/convert/from_arrow.py
@@ -163,7 +163,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             else:
 #                 raise TypeError(
 #                     "unrecognized Arrow union array mode: {0}".format(repr(tpe.mode))
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #             mask = buffers.pop(0)
@@ -288,7 +288,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #         else:
 #             raise TypeError(
 #                 "unrecognized Arrow array type: {0}".format(repr(tpe))
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         # All 'no return yet' cases need to become option-type (even if the UnmaskedArray
@@ -329,7 +329,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             for i in range(obj.num_columns):
 #                 layout = handle_arrow(obj.column(i))
 #                 if obj.schema.field(i).nullable and not isinstance(
-#                     layout, ak._util.optiontypes
+#                     layout, ak._v2._util.optiontypes
 #                 ):
 #                     layout = ak._v2.contents.UnmaskedArray(layout)
 #                 child_array.append(layout)
@@ -369,7 +369,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #         else:
 #             raise TypeError(
 #                 "unrecognized Arrow type: {0}".format(type(obj))
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
-#     return ak._util.maybe_wrap(handle_arrow(array), behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(handle_arrow(array), behavior, highlevel)

--- a/src/awkward/_v2/operations/convert/from_arrow.py
+++ b/src/awkward/_v2/operations/convert/from_arrow.py
@@ -322,7 +322,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             if len(layouts) == 1:
 #                 return layouts[0]
 #             else:
-#                 return ak.operations.structure.concatenate(layouts, highlevel=False)
+#                 return ak._v2.operations.structure.concatenate(layouts, highlevel=False)
 
 #         elif isinstance(obj, pyarrow.lib.RecordBatch):
 #             child_array = []
@@ -347,7 +347,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #                 return handle_arrow(batches[0])
 #             else:
 #                 arrays = [handle_arrow(batch) for batch in batches if len(batch) > 0]
-#                 return ak.operations.structure.concatenate(arrays, highlevel=False)
+#                 return ak._v2.operations.structure.concatenate(arrays, highlevel=False)
 
 #         elif (
 #             isinstance(obj, Iterable)
@@ -364,7 +364,7 @@ def from_arrow(array, highlevel=True, behavior=None):
 #             if len(chunks) == 1:
 #                 return chunks[0]
 #             else:
-#                 return ak.operations.structure.concatenate(chunks, highlevel=False)
+#                 return ak._v2.operations.structure.concatenate(chunks, highlevel=False)
 
 #         else:
 #             raise TypeError(

--- a/src/awkward/_v2/operations/convert/from_buffers.py
+++ b/src/awkward/_v2/operations/convert/from_buffers.py
@@ -82,7 +82,7 @@ def from_buffers(
 #     See #ak.to_buffers for examples.
 #     """
 
-#     if isinstance(form, str) or (ak._util.py27 and isinstance(form, ak._util.unicode)):
+#     if isinstance(form, str) or (ak._v2._util.py27 and isinstance(form, ak._v2._util.unicode)):
 #         form = ak.forms.Form.fromjson(form)
 #     elif isinstance(form, dict):
 #         form = ak.forms.Form.fromjson(json.dumps(form))
@@ -102,12 +102,12 @@ def from_buffers(
 #         form = _wrap_record_with_virtual(form)
 
 #         if lazy_cache == "new":
-#             hold_cache = ak._util.MappingProxy({})
+#             hold_cache = ak._v2._util.MappingProxy({})
 #             lazy_cache = ak._v2.contents.ArrayCache(hold_cache)
 #         elif lazy_cache is not None and not isinstance(
 #             lazy_cache, ak._v2.contents.ArrayCache
 #         ):
-#             hold_cache = ak._util.MappingProxy.maybe_wrap(lazy_cache)
+#             hold_cache = ak._v2._util.MappingProxy.maybe_wrap(lazy_cache)
 #             if not isinstance(hold_cache, MutableMapping):
 #                 raise TypeError("lazy_cache must be a MutableMapping")
 #             lazy_cache = ak._v2.contents.ArrayCache(hold_cache)
@@ -119,7 +119,7 @@ def from_buffers(
 #         if length is None:
 #             raise TypeError(
 #                 "length must be an integer or an iterable of integers"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         args = (form, container, str(partition_start), key_format, length)
@@ -168,10 +168,10 @@ def from_buffers(
 #         raise TypeError(
 #             "length must be an integer or an iterable of integers, not "
 #             + repr(length)
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
-#     return ak._util.maybe_wrap(out, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(out, behavior, highlevel)
 
 
 # _index_form_to_dtype = _index_form_to_index = _form_to_layout_class = None
@@ -234,7 +234,7 @@ def from_buffers(
 #     if form.has_identities:
 #         raise NotImplementedError(
 #             "ak.from_buffers for an array with Identities"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 #     else:
 #         identities = None
@@ -266,7 +266,7 @@ def from_buffers(
 #             raise ValueError(
 #                 "mask is too short for BitMaskedArray: content length "
 #                 "is {0}, mask length * 8 is {1}".format(length, len(mask) * 8)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         return ak._v2.contents.BitMaskedArray(
@@ -294,7 +294,7 @@ def from_buffers(
 #                 "mask is too short for ByteMaskedArray: expected {0}, mask length is {1}".format(
 #                     length, len(mask)
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         content = _form_to_layout(
@@ -317,7 +317,7 @@ def from_buffers(
 #                 "EmptyArray found in node with non-zero expected length: expected {0}".format(
 #                     length
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         return ak._v2.contents.EmptyArray(identities, parameters)
 
@@ -336,7 +336,7 @@ def from_buffers(
 #                 "index too short for IndexedArray: expected {0}, index length is {1}".format(
 #                     length, len(index)
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         content = _form_to_layout(
@@ -368,7 +368,7 @@ def from_buffers(
 #                 "index too short for IndexedOptionArray: expected {0}, index length is {1}".format(
 #                     length, len(index)
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         content = _form_to_layout(
@@ -406,14 +406,14 @@ def from_buffers(
 #                 "starts too short for ListArray: expected {0}, starts length is {1}".format(
 #                     length, len(starts)
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         elif length > len(stops):
 #             raise ValueError(
 #                 "stops too short for ListArray: expected {0}, stops length is {1}".format(
 #                     length, len(stops)
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         array_starts = numpy.asarray(starts)
@@ -452,7 +452,7 @@ def from_buffers(
 #                 "offsets too short for ListOffsetArray: expected {0}, offsets length - 1 is {1}".format(
 #                     length, len(offsets) - 1
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         content = _form_to_layout(
@@ -487,7 +487,7 @@ def from_buffers(
 #                 raise ValueError(
 #                     "buffer is too short for NumpyArray: expected {0}, buffer "
 #                     "has {1} items ({2} bytes)".format(length, actual, len(raw_array))
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #         # NumPy can only infer the length of the array from the buffer
@@ -539,7 +539,7 @@ def from_buffers(
 #                 "RecordArray length mismatch: expected {0}, minimum content is {1}".format(
 #                     length, minlength
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         return ak._v2.contents.RecordArray(
@@ -589,14 +589,14 @@ def from_buffers(
 #                 "tags too short for UnionArray: expected {0}, tags length is {1}".format(
 #                     length, len(tags)
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         elif length > len(index):
 #             raise ValueError(
 #                 "index too short for UnionArray: expected {0}, index length is {1}".format(
 #                     length, len(index)
 #                 )
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         array_tags = numpy.asarray(tags)
@@ -675,7 +675,7 @@ def from_buffers(
 #         raise AssertionError(
 #             "unexpected form node type: "
 #             + str(type(form))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 

--- a/src/awkward/_v2/operations/convert/from_buffers.py
+++ b/src/awkward/_v2/operations/convert/from_buffers.py
@@ -119,7 +119,7 @@ def from_buffers(
 #         if length is None:
 #             raise TypeError(
 #                 "length must be an integer or an iterable of integers"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         args = (form, container, str(partition_start), key_format, length)
@@ -168,7 +168,7 @@ def from_buffers(
 #         raise TypeError(
 #             "length must be an integer or an iterable of integers, not "
 #             + repr(length)
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     return ak._v2._util.maybe_wrap(out, behavior, highlevel)
@@ -234,7 +234,7 @@ def from_buffers(
 #     if form.has_identities:
 #         raise NotImplementedError(
 #             "ak.from_buffers for an array with Identities"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 #     else:
 #         identities = None
@@ -266,7 +266,7 @@ def from_buffers(
 #             raise ValueError(
 #                 "mask is too short for BitMaskedArray: content length "
 #                 "is {0}, mask length * 8 is {1}".format(length, len(mask) * 8)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         return ak._v2.contents.BitMaskedArray(
@@ -294,7 +294,7 @@ def from_buffers(
 #                 "mask is too short for ByteMaskedArray: expected {0}, mask length is {1}".format(
 #                     length, len(mask)
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         content = _form_to_layout(
@@ -317,7 +317,7 @@ def from_buffers(
 #                 "EmptyArray found in node with non-zero expected length: expected {0}".format(
 #                     length
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         return ak._v2.contents.EmptyArray(identities, parameters)
 
@@ -336,7 +336,7 @@ def from_buffers(
 #                 "index too short for IndexedArray: expected {0}, index length is {1}".format(
 #                     length, len(index)
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         content = _form_to_layout(
@@ -368,7 +368,7 @@ def from_buffers(
 #                 "index too short for IndexedOptionArray: expected {0}, index length is {1}".format(
 #                     length, len(index)
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         content = _form_to_layout(
@@ -406,14 +406,14 @@ def from_buffers(
 #                 "starts too short for ListArray: expected {0}, starts length is {1}".format(
 #                     length, len(starts)
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         elif length > len(stops):
 #             raise ValueError(
 #                 "stops too short for ListArray: expected {0}, stops length is {1}".format(
 #                     length, len(stops)
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         array_starts = numpy.asarray(starts)
@@ -452,7 +452,7 @@ def from_buffers(
 #                 "offsets too short for ListOffsetArray: expected {0}, offsets length - 1 is {1}".format(
 #                     length, len(offsets) - 1
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         content = _form_to_layout(
@@ -487,7 +487,7 @@ def from_buffers(
 #                 raise ValueError(
 #                     "buffer is too short for NumpyArray: expected {0}, buffer "
 #                     "has {1} items ({2} bytes)".format(length, actual, len(raw_array))
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #         # NumPy can only infer the length of the array from the buffer
@@ -539,7 +539,7 @@ def from_buffers(
 #                 "RecordArray length mismatch: expected {0}, minimum content is {1}".format(
 #                     length, minlength
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         return ak._v2.contents.RecordArray(
@@ -589,14 +589,14 @@ def from_buffers(
 #                 "tags too short for UnionArray: expected {0}, tags length is {1}".format(
 #                     length, len(tags)
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         elif length > len(index):
 #             raise ValueError(
 #                 "index too short for UnionArray: expected {0}, index length is {1}".format(
 #                     length, len(index)
 #                 )
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         array_tags = numpy.asarray(tags)
@@ -675,7 +675,7 @@ def from_buffers(
 #         raise AssertionError(
 #             "unexpected form node type: "
 #             + str(type(form))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 

--- a/src/awkward/_v2/operations/convert/from_buffers.py
+++ b/src/awkward/_v2/operations/convert/from_buffers.py
@@ -103,14 +103,14 @@ def from_buffers(
 
 #         if lazy_cache == "new":
 #             hold_cache = ak._util.MappingProxy({})
-#             lazy_cache = ak.layout.ArrayCache(hold_cache)
+#             lazy_cache = ak._v2.contents.ArrayCache(hold_cache)
 #         elif lazy_cache is not None and not isinstance(
-#             lazy_cache, ak.layout.ArrayCache
+#             lazy_cache, ak._v2.contents.ArrayCache
 #         ):
 #             hold_cache = ak._util.MappingProxy.maybe_wrap(lazy_cache)
 #             if not isinstance(hold_cache, MutableMapping):
 #                 raise TypeError("lazy_cache must be a MutableMapping")
-#             lazy_cache = ak.layout.ArrayCache(hold_cache)
+#             lazy_cache = ak._v2.contents.ArrayCache(hold_cache)
 
 #         if lazy_cache_key is None:
 #             lazy_cache_key = "ak.from_buffers:{0}".format(_from_buffers_key())
@@ -125,13 +125,13 @@ def from_buffers(
 #         args = (form, container, str(partition_start), key_format, length)
 
 #         if lazy:
-#             generator = ak.layout.ArrayGenerator(
+#             generator = ak._v2.contents.ArrayGenerator(
 #                 _form_to_layout,
 #                 args + (lazy_cache, lazy_cache_key),
 #                 form=form,
 #                 length=length,
 #             )
-#             out = ak.layout.VirtualArray(generator, lazy_cache, lazy_cache_key)
+#             out = ak._v2.contents.VirtualArray(generator, lazy_cache, lazy_cache_key)
 
 #         else:
 #             out = _form_to_layout(*(args + (None, None)))
@@ -146,7 +146,7 @@ def from_buffers(
 
 #             if lazy:
 #                 lazy_cache_key_part = "{0}[{1}]".format(lazy_cache_key, partnum)
-#                 generator = ak.layout.ArrayGenerator(
+#                 generator = ak._v2.contents.ArrayGenerator(
 #                     _form_to_layout,
 #                     args + (partlen, lazy_cache, lazy_cache_key_part),
 #                     form=form,
@@ -154,7 +154,7 @@ def from_buffers(
 #                 )
 
 #                 partitions.append(
-#                     ak.layout.VirtualArray(generator, lazy_cache, lazy_cache_key_part)
+#                     ak._v2.contents.VirtualArray(generator, lazy_cache, lazy_cache_key_part)
 #                 )
 #                 offsets.append(offsets[-1] + length[part])
 
@@ -207,28 +207,28 @@ def from_buffers(
 #         }
 
 #         _index_form_to_index = {
-#             "i8": ak.layout.Index8,
-#             "u8": ak.layout.IndexU8,
-#             "i32": ak.layout.Index32,
-#             "u32": ak.layout.IndexU32,
-#             "i64": ak.layout.Index64,
+#             "i8": ak._v2.index.Index8,
+#             "u8": ak._v2.index.IndexU8,
+#             "i32": ak._v2.index.Index32,
+#             "u32": ak._v2.index.IndexU32,
+#             "i64": ak._v2.index.Index64,
 #         }
 
 #         _form_to_layout_class = {
-#             (ak.forms.IndexedForm, "i32"): ak.layout.IndexedArray32,
-#             (ak.forms.IndexedForm, "u32"): ak.layout.IndexedArrayU32,
-#             (ak.forms.IndexedForm, "i64"): ak.layout.IndexedArray64,
-#             (ak.forms.IndexedOptionForm, "i32"): ak.layout.IndexedOptionArray32,
-#             (ak.forms.IndexedOptionForm, "i64"): ak.layout.IndexedOptionArray64,
-#             (ak.forms.ListForm, "i32"): ak.layout.ListArray32,
-#             (ak.forms.ListForm, "u32"): ak.layout.ListArrayU32,
-#             (ak.forms.ListForm, "i64"): ak.layout.ListArray64,
-#             (ak.forms.ListOffsetForm, "i32"): ak.layout.ListOffsetArray32,
-#             (ak.forms.ListOffsetForm, "u32"): ak.layout.ListOffsetArrayU32,
-#             (ak.forms.ListOffsetForm, "i64"): ak.layout.ListOffsetArray64,
-#             (ak.forms.UnionForm, "i32"): ak.layout.UnionArray8_32,
-#             (ak.forms.UnionForm, "u32"): ak.layout.UnionArray8_U32,
-#             (ak.forms.UnionForm, "i64"): ak.layout.UnionArray8_64,
+#             (ak.forms.IndexedForm, "i32"): ak._v2.contents.IndexedArray32,
+#             (ak.forms.IndexedForm, "u32"): ak._v2.contents.IndexedArrayU32,
+#             (ak.forms.IndexedForm, "i64"): ak._v2.contents.IndexedArray64,
+#             (ak.forms.IndexedOptionForm, "i32"): ak._v2.contents.IndexedOptionArray32,
+#             (ak.forms.IndexedOptionForm, "i64"): ak._v2.contents.IndexedOptionArray64,
+#             (ak.forms.ListForm, "i32"): ak._v2.contents.ListArray32,
+#             (ak.forms.ListForm, "u32"): ak._v2.contents.ListArrayU32,
+#             (ak.forms.ListForm, "i64"): ak._v2.contents.ListArray64,
+#             (ak.forms.ListOffsetForm, "i32"): ak._v2.contents.ListOffsetArray32,
+#             (ak.forms.ListOffsetForm, "u32"): ak._v2.contents.ListOffsetArrayU32,
+#             (ak.forms.ListOffsetForm, "i64"): ak._v2.contents.ListOffsetArray64,
+#             (ak.forms.UnionForm, "i32"): ak._v2.contents.UnionArray8_32,
+#             (ak.forms.UnionForm, "u32"): ak._v2.contents.UnionArray8_U32,
+#             (ak.forms.UnionForm, "i64"): ak._v2.contents.UnionArray8_64,
 #         }
 
 #     if form.has_identities:
@@ -269,7 +269,7 @@ def from_buffers(
 #                 + ak._util.exception_suffix(__file__)
 #             )
 
-#         return ak.layout.BitMaskedArray(
+#         return ak._v2.contents.BitMaskedArray(
 #             mask,
 #             content,
 #             form.valid_when,
@@ -307,7 +307,7 @@ def from_buffers(
 #             lazy_cache_key,
 #         )
 
-#         return ak.layout.ByteMaskedArray(
+#         return ak._v2.contents.ByteMaskedArray(
 #             mask, content, form.valid_when, identities, parameters
 #         )
 
@@ -319,7 +319,7 @@ def from_buffers(
 #                 )
 #                 + ak._util.exception_suffix(__file__)
 #             )
-#         return ak.layout.EmptyArray(identities, parameters)
+#         return ak._v2.contents.EmptyArray(identities, parameters)
 
 #     elif isinstance(form, ak.forms.IndexedForm):
 #         raw_index = _asbuf(
@@ -506,7 +506,7 @@ def from_buffers(
 
 #         array = raw_array.view(dtype).reshape(leading_shape + inner_shape)
 
-#         return ak.layout.NumpyArray(array, identities, parameters)
+#         return ak._v2.contents.NumpyArray(array, identities, parameters)
 
 #     elif isinstance(form, ak.forms.RecordForm):
 #         items = list(form.contents.items())
@@ -542,7 +542,7 @@ def from_buffers(
 #                 + ak._util.exception_suffix(__file__)
 #             )
 
-#         return ak.layout.RecordArray(
+#         return ak._v2.contents.RecordArray(
 #             contents,
 #             None if form.istuple else keys,
 #             length,
@@ -564,7 +564,7 @@ def from_buffers(
 #             lazy_cache_key,
 #         )
 
-#         return ak.layout.RegularArray(
+#         return ak._v2.contents.RegularArray(
 #             content, form.size, length, identities, parameters
 #         )
 
@@ -636,7 +636,7 @@ def from_buffers(
 #             lazy_cache_key,
 #         )
 
-#         return ak.layout.UnmaskedArray(content, identities, parameters)
+#         return ak._v2.contents.UnmaskedArray(content, identities, parameters)
 
 #     elif isinstance(form, ak.forms.VirtualForm):
 #         args = (
@@ -648,7 +648,7 @@ def from_buffers(
 #             lazy_cache,
 #             lazy_cache_key,
 #         )
-#         generator = ak.layout.ArrayGenerator(
+#         generator = ak._v2.contents.ArrayGenerator(
 #             _form_to_layout,
 #             args,
 #             form=form.form,
@@ -669,7 +669,7 @@ def from_buffers(
 #                 lazy_cache_key, node_cache_key, _from_buffers_key()
 #             )
 
-#         return ak.layout.VirtualArray(generator, lazy_cache, nested_cache_key)
+#         return ak._v2.contents.VirtualArray(generator, lazy_cache, nested_cache_key)
 
 #     else:
 #         raise AssertionError(

--- a/src/awkward/_v2/operations/convert/from_buffers.py
+++ b/src/awkward/_v2/operations/convert/from_buffers.py
@@ -162,7 +162,7 @@ def from_buffers(
 #                 partitions.append(_form_to_layout(*(args + (partlen, None, None))))
 #                 offsets.append(offsets[-1] + len(partitions[-1]))
 
-#         out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])
+#         out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])   # NO PARTITIONED ARRAY
 
 #     else:
 #         raise TypeError(

--- a/src/awkward/_v2/operations/convert/from_cupy.py
+++ b/src/awkward/_v2/operations/convert/from_cupy.py
@@ -37,16 +37,16 @@ def from_cupy(array, regulararray=False, highlevel=True, behavior=None):
 
 #     def recurse(array):
 #         if regulararray and len(array.shape) > 1:
-#             return ak.layout.RegularArray(
+#             return ak._v2.contents.RegularArray(
 #                 recurse(array.reshape((-1,) + array.shape[2:])),
 #                 array.shape[1],
 #                 array.shape[0],
 #             )
 
 #         if len(array.shape) == 0:
-#             data = ak.layout.NumpyArray.from_cupy(array.reshape(1))
+#             data = ak._v2.contents.NumpyArray.from_cupy(array.reshape(1))
 #         else:
-#             data = ak.layout.NumpyArray.from_cupy(array)
+#             data = ak._v2.contents.NumpyArray.from_cupy(array)
 
 #         return data
 

--- a/src/awkward/_v2/operations/convert/from_cupy.py
+++ b/src/awkward/_v2/operations/convert/from_cupy.py
@@ -52,4 +52,4 @@ def from_cupy(array, regulararray=False, highlevel=True, behavior=None):
 
 #     layout = recurse(array)
 
-#     return ak._util.maybe_wrap(layout, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(layout, behavior, highlevel)

--- a/src/awkward/_v2/operations/convert/from_iter.py
+++ b/src/awkward/_v2/operations/convert/from_iter.py
@@ -67,7 +67,7 @@ def from_iter(
 #         else:
 #             raise ValueError(
 #                 "cannot produce an array from a dict"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     out = ak.layout.ArrayBuilder(initial=initial, resize=resize)

--- a/src/awkward/_v2/operations/convert/from_iter.py
+++ b/src/awkward/_v2/operations/convert/from_iter.py
@@ -67,11 +67,11 @@ def from_iter(
 #         else:
 #             raise ValueError(
 #                 "cannot produce an array from a dict"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     out = ak.layout.ArrayBuilder(initial=initial, resize=resize)
 #     for x in iterable:
 #         out.fromiter(x)
 #     layout = out.snapshot()
-#     return ak._util.maybe_wrap(layout, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(layout, behavior, highlevel)

--- a/src/awkward/_v2/operations/convert/from_jax.py
+++ b/src/awkward/_v2/operations/convert/from_jax.py
@@ -37,16 +37,16 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
 
 #     def recurse(array):
 #         if regulararray and len(array.shape) > 1:
-#             return ak.layout.RegularArray(
+#             return ak._v2.contents.RegularArray(
 #                 recurse(array.reshape((-1,) + array.shape[2:])),
 #                 array.shape[1],
 #                 array.shape[0],
 #             )
 
 #         if len(array.shape) == 0:
-#             data = ak.layout.NumpyArray.from_jax(array.reshape(1))
+#             data = ak._v2.contents.NumpyArray.from_jax(array.reshape(1))
 #         else:
-#             data = ak.layout.NumpyArray.from_jax(array)
+#             data = ak._v2.contents.NumpyArray.from_jax(array)
 
 #         return data
 

--- a/src/awkward/_v2/operations/convert/from_jax.py
+++ b/src/awkward/_v2/operations/convert/from_jax.py
@@ -52,4 +52,4 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
 
 #     layout = recurse(array)
 
-#     return ak._util.maybe_wrap(layout, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(layout, behavior, highlevel)

--- a/src/awkward/_v2/operations/convert/from_json.py
+++ b/src/awkward/_v2/operations/convert/from_json.py
@@ -104,16 +104,16 @@ def from_json(  # note: move ability to read from file into from_json_file
 #         raise exc("file not found or not a regular file: {0}".format(source))
 
 #     def getfunction(recordnode):
-#         if isinstance(recordnode, ak.layout.RecordArray):
+#         if isinstance(recordnode, ak._v2.contents.RecordArray):
 #             keys = recordnode.keys()
 #             if complex_record_fields[0] in keys and complex_record_fields[1] in keys:
 #                 nplike = ak.nplike.of(recordnode)
 #                 real = recordnode[complex_record_fields[0]]
 #                 imag = recordnode[complex_record_fields[1]]
 #                 if (
-#                     isinstance(real, ak.layout.NumpyArray)
+#                     isinstance(real, ak._v2.contents.NumpyArray)
 #                     and len(real.shape) == 1
-#                     and isinstance(imag, ak.layout.NumpyArray)
+#                     and isinstance(imag, ak._v2.contents.NumpyArray)
 #                     and len(imag.shape) == 1
 #                 ):
 #                     return lambda: nplike.asarray(real) + nplike.asarray(imag) * 1j
@@ -122,7 +122,7 @@ def from_json(  # note: move ability to read from file into from_json_file
 #                         "Complex number fields must be numbers"
 #                         + ak._util.exception_suffix(__file__)
 #                     )
-#                 return lambda: ak.layout.NumpyArray(real + imag * 1j)
+#                 return lambda: ak._v2.contents.NumpyArray(real + imag * 1j)
 #             else:
 #                 return None
 #         else:

--- a/src/awkward/_v2/operations/convert/from_json.py
+++ b/src/awkward/_v2/operations/convert/from_json.py
@@ -120,7 +120,7 @@ def from_json(  # note: move ability to read from file into from_json_file
 #                 else:
 #                     raise ValueError(
 #                         "Complex number fields must be numbers"
-#                         + ak._v2._util.exception_suffix(__file__)
+#
 #                     )
 #                 return lambda: ak._v2.contents.NumpyArray(real + imag * 1j)
 #             else:

--- a/src/awkward/_v2/operations/convert/from_json.py
+++ b/src/awkward/_v2/operations/convert/from_json.py
@@ -71,9 +71,9 @@ def from_json(  # note: move ability to read from file into from_json_file
 #     ):
 #         complex_real_string, complex_imag_string = complex_record_fields
 
-#     is_path, source = ak._util.regularize_path(source)
+#     is_path, source = ak._v2._util.regularize_path(source)
 
-#     if ak._util.is_file_path(source):
+#     if ak._v2._util.is_file_path(source):
 #         layout = ak._ext.fromjsonfile(
 #             source,
 #             nan_string=nan_string,
@@ -97,7 +97,7 @@ def from_json(  # note: move ability to read from file into from_json_file
 #             buffersize=buffersize,
 #         )
 #     else:
-#         if ak._util.py27:
+#         if ak._v2._util.py27:
 #             exc = IOError
 #         else:
 #             exc = FileNotFoundError
@@ -120,7 +120,7 @@ def from_json(  # note: move ability to read from file into from_json_file
 #                 else:
 #                     raise ValueError(
 #                         "Complex number fields must be numbers"
-#                         + ak._util.exception_suffix(__file__)
+#                         + ak._v2._util.exception_suffix(__file__)
 #                     )
 #                 return lambda: ak._v2.contents.NumpyArray(real + imag * 1j)
 #             else:
@@ -129,6 +129,6 @@ def from_json(  # note: move ability to read from file into from_json_file
 #             return None
 
 #     if complex_imag_string is not None:
-#         layout = ak._util.recursively_apply(layout, getfunction, pass_depth=False)
+#         layout = ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
 
-#     return ak._util.maybe_wrap(layout, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(layout, behavior, highlevel)

--- a/src/awkward/_v2/operations/convert/from_numpy.py
+++ b/src/awkward/_v2/operations/convert/from_numpy.py
@@ -48,7 +48,7 @@ def from_numpy(
 
 #     def recurse(array, mask):
 #         if regulararray and len(array.shape) > 1:
-#             return ak.layout.RegularArray(
+#             return ak._v2.contents.RegularArray(
 #                 recurse(array.reshape((-1,) + array.shape[2:]), mask),
 #                 array.shape[1],
 #                 array.shape[0],
@@ -62,53 +62,53 @@ def from_numpy(
 #             itemsize = asbytes.dtype.itemsize
 #             starts = numpy.arange(0, len(asbytes) * itemsize, itemsize, dtype=np.int64)
 #             stops = starts + numpy.char.str_len(asbytes)
-#             data = ak.layout.ListArray64(
-#                 ak.layout.Index64(starts),
-#                 ak.layout.Index64(stops),
-#                 ak.layout.NumpyArray(
+#             data = ak._v2.contents.ListArray64(
+#                 ak._v2.index.Index64(starts),
+#                 ak._v2.index.Index64(stops),
+#                 ak._v2.contents.NumpyArray(
 #                     asbytes.view("u1"), parameters={"__array__": "byte"}
 #                 ),
 #                 parameters={"__array__": "bytestring"},
 #             )
 #             for i in range(len(array.shape) - 1, 0, -1):
-#                 data = ak.layout.RegularArray(data, array.shape[i], array.shape[i - 1])
+#                 data = ak._v2.contents.RegularArray(data, array.shape[i], array.shape[i - 1])
 #         elif array.dtype.kind == "U":
 #             asbytes = numpy.char.encode(array.reshape(-1), "utf-8", "surrogateescape")
 #             itemsize = asbytes.dtype.itemsize
 #             starts = numpy.arange(0, len(asbytes) * itemsize, itemsize, dtype=np.int64)
 #             stops = starts + numpy.char.str_len(asbytes)
-#             data = ak.layout.ListArray64(
-#                 ak.layout.Index64(starts),
-#                 ak.layout.Index64(stops),
-#                 ak.layout.NumpyArray(
+#             data = ak._v2.contents.ListArray64(
+#                 ak._v2.index.Index64(starts),
+#                 ak._v2.index.Index64(stops),
+#                 ak._v2.contents.NumpyArray(
 #                     asbytes.view("u1"), parameters={"__array__": "char"}
 #                 ),
 #                 parameters={"__array__": "string"},
 #             )
 #             for i in range(len(array.shape) - 1, 0, -1):
-#                 data = ak.layout.RegularArray(data, array.shape[i], array.shape[i - 1])
+#                 data = ak._v2.contents.RegularArray(data, array.shape[i], array.shape[i - 1])
 #         else:
-#             data = ak.layout.NumpyArray(array)
+#             data = ak._v2.contents.NumpyArray(array)
 
 #         if mask is None:
 #             return data
 #         elif mask is False or (isinstance(mask, np.bool_) and not mask):
 #             # NumPy's MaskedArray with mask == False is an UnmaskedArray
 #             if len(array.shape) == 1:
-#                 return ak.layout.UnmaskedArray(data)
+#                 return ak._v2.contents.UnmaskedArray(data)
 #             else:
 
 #                 def attach(x):
-#                     if isinstance(x, ak.layout.NumpyArray):
-#                         return ak.layout.UnmaskedArray(x)
+#                     if isinstance(x, ak._v2.contents.NumpyArray):
+#                         return ak._v2.contents.UnmaskedArray(x)
 #                     else:
-#                         return ak.layout.RegularArray(attach(x.content), x.size, len(x))
+#                         return ak._v2.contents.RegularArray(attach(x.content), x.size, len(x))
 
 #                 return attach(data.toRegularArray())
 #         else:
 #             # NumPy's MaskedArray is a ByteMaskedArray with valid_when=False
-#             return ak.layout.ByteMaskedArray(
-#                 ak.layout.Index8(mask), data, valid_when=False
+#             return ak._v2.contents.ByteMaskedArray(
+#                 ak._v2.index.Index8(mask), data, valid_when=False
 #             )
 
 #     if isinstance(array, numpy.ma.MaskedArray):
@@ -126,6 +126,6 @@ def from_numpy(
 #         contents = []
 #         for name in array.dtype.names:
 #             contents.append(recurse(array[name], mask))
-#         layout = ak.layout.RecordArray(contents, array.dtype.names)
+#         layout = ak._v2.contents.RecordArray(contents, array.dtype.names)
 
 #     return ak._util.maybe_wrap(layout, behavior, highlevel)

--- a/src/awkward/_v2/operations/convert/from_numpy.py
+++ b/src/awkward/_v2/operations/convert/from_numpy.py
@@ -128,4 +128,4 @@ def from_numpy(
 #             contents.append(recurse(array[name], mask))
 #         layout = ak._v2.contents.RecordArray(contents, array.dtype.names)
 
-#     return ak._util.maybe_wrap(layout, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(layout, behavior, highlevel)

--- a/src/awkward/_v2/operations/convert/to_arrow.py
+++ b/src/awkward/_v2/operations/convert/to_arrow.py
@@ -70,7 +70,7 @@ def to_arrow(
 #     layout = to_layout(array, allow_record=False, allow_other=False)
 
 #     def recurse(layout, mask, is_option):
-#         if isinstance(layout, ak.layout.NumpyArray):
+#         if isinstance(layout, ak._v2.contents.NumpyArray):
 #             numpy_arr = numpy.asarray(layout)
 #             length = len(numpy_arr)
 #             arrow_type = pyarrow.from_numpy_dtype(numpy_arr.dtype)
@@ -116,10 +116,10 @@ def to_arrow(
 #                     is_option,
 #                 )
 
-#         elif isinstance(layout, ak.layout.EmptyArray):
+#         elif isinstance(layout, ak._v2.contents.EmptyArray):
 #             return pyarrow.Array.from_buffers(pyarrow.null(), 0, [None])
 
-#         elif isinstance(layout, ak.layout.ListOffsetArray32):
+#         elif isinstance(layout, ak._v2.contents.ListOffsetArray32):
 #             offsets = numpy.asarray(layout.offsets, dtype=np.int32)
 
 #             if layout.parameter("__array__") == "bytestring":
@@ -187,7 +187,7 @@ def to_arrow(
 
 #         elif isinstance(
 #             layout,
-#             (ak.layout.ListOffsetArray64, ak.layout.ListOffsetArrayU32),
+#             (ak._v2.contents.ListOffsetArray64, ak._v2.contents.ListOffsetArrayU32),
 #         ):
 #             if layout.parameter("__array__") == "bytestring":
 #                 downsize = bytestring_to32
@@ -199,8 +199,8 @@ def to_arrow(
 #             offsets = numpy.asarray(layout.offsets)
 
 #             if downsize and offsets[-1] <= np.iinfo(np.int32).max:
-#                 small_layout = ak.layout.ListOffsetArray32(
-#                     ak.layout.Index32(offsets.astype(np.int32)),
+#                 small_layout = ak._v2.contents.ListOffsetArray32(
+#                     ak._v2.index.Index32(offsets.astype(np.int32)),
 #                     layout.content,
 #                     parameters=layout.parameters,
 #                 )
@@ -271,7 +271,7 @@ def to_arrow(
 #                 )
 #             return arrow_arr
 
-#         elif isinstance(layout, ak.layout.RegularArray):
+#         elif isinstance(layout, ak._v2.contents.RegularArray):
 #             return recurse(
 #                 layout.broadcast_tooffsets64(layout.compact_offsets64()),
 #                 mask,
@@ -281,9 +281,9 @@ def to_arrow(
 #         elif isinstance(
 #             layout,
 #             (
-#                 ak.layout.ListArray32,
-#                 ak.layout.ListArrayU32,
-#                 ak.layout.ListArray64,
+#                 ak._v2.contents.ListArray32,
+#                 ak._v2.contents.ListArrayU32,
+#                 ak._v2.contents.ListArray64,
 #             ),
 #         ):
 #             return recurse(
@@ -292,7 +292,7 @@ def to_arrow(
 #                 is_option,
 #             )
 
-#         elif isinstance(layout, ak.layout.RecordArray):
+#         elif isinstance(layout, ak._v2.contents.RecordArray):
 #             values = [
 #                 recurse(x[: len(layout)], mask, is_option) for x in layout.contents
 #             ]
@@ -320,9 +320,9 @@ def to_arrow(
 #         elif isinstance(
 #             layout,
 #             (
-#                 ak.layout.UnionArray8_32,
-#                 ak.layout.UnionArray8_64,
-#                 ak.layout.UnionArray8_U32,
+#                 ak._v2.contents.UnionArray8_32,
+#                 ak._v2.contents.UnionArray8_64,
+#                 ak._v2.contents.UnionArray8_U32,
 #             ),
 #         ):
 #             tags = numpy.asarray(layout.tags)
@@ -392,9 +392,9 @@ def to_arrow(
 #         elif isinstance(
 #             layout,
 #             (
-#                 ak.layout.IndexedArray32,
-#                 ak.layout.IndexedArrayU32,
-#                 ak.layout.IndexedArray64,
+#                 ak._v2.contents.IndexedArray32,
+#                 ak._v2.contents.IndexedArrayU32,
+#                 ak._v2.contents.IndexedArray64,
 #             ),
 #         ):
 #             index = numpy.asarray(layout.index)
@@ -424,7 +424,7 @@ def to_arrow(
 #                     else:
 #                         return pyarrow.array([None] * len(index)).cast(empty.type)
 
-#                 elif isinstance(layout_content, ak.layout.RecordArray):
+#                 elif isinstance(layout_content, ak._v2.contents.RecordArray):
 #                     values = [
 #                         recurse(x[: len(layout_content)][index], mask, is_option)
 #                         for x in layout_content.contents
@@ -462,7 +462,7 @@ def to_arrow(
 
 #         elif isinstance(
 #             layout,
-#             (ak.layout.IndexedOptionArray32, ak.layout.IndexedOptionArray64),
+#             (ak._v2.contents.IndexedOptionArray32, ak._v2.contents.IndexedOptionArray64),
 #         ):
 #             index = numpy.array(layout.index, copy=True)
 #             nulls = index < 0
@@ -497,13 +497,13 @@ def to_arrow(
 #                     this_bytemask.reshape(-1, 8)[:, ::-1].reshape(-1)
 #                 )
 
-#                 if isinstance(layout, ak.layout.IndexedOptionArray32):
-#                     next = ak.layout.IndexedArray32(
-#                         ak.layout.Index32(index), layout.content
+#                 if isinstance(layout, ak._v2.contents.IndexedOptionArray32):
+#                     next = ak._v2.contents.IndexedArray32(
+#                         ak._v2.index.Index32(index), layout.content
 #                     )
 #                 else:
-#                     next = ak.layout.IndexedArray64(
-#                         ak.layout.Index64(index), layout.content
+#                     next = ak._v2.contents.IndexedArray64(
+#                         ak._v2.index.Index64(index), layout.content
 #                     )
 
 #                 if mask is None:
@@ -511,7 +511,7 @@ def to_arrow(
 #                 else:
 #                     return recurse(next, mask & this_bitmask, True)
 
-#         elif isinstance(layout, ak.layout.BitMaskedArray):
+#         elif isinstance(layout, ak._v2.contents.BitMaskedArray):
 #             bitmask = numpy.asarray(layout.mask, dtype=np.uint8)
 
 #             if layout.lsb_order is False:
@@ -526,7 +526,7 @@ def to_arrow(
 #                 length=min(len(bitmask) * 8, len(layout.content))
 #             )
 
-#         elif isinstance(layout, ak.layout.ByteMaskedArray):
+#         elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
 #             mask = numpy.asarray(layout.mask, dtype=np.bool_) == layout.valid_when
 
 #             bytemask = numpy.zeros(
@@ -540,10 +540,10 @@ def to_arrow(
 #                 length=len(mask)
 #             )
 
-#         elif isinstance(layout, (ak.layout.UnmaskedArray)):
+#         elif isinstance(layout, (ak._v2.contents.UnmaskedArray)):
 #             return recurse(layout.content, None, True)
 
-#         elif isinstance(layout, (ak.layout.VirtualArray)):
+#         elif isinstance(layout, (ak._v2.contents.VirtualArray)):
 #             return recurse(layout.array, None, False)
 
 #         elif isinstance(layout, (ak.partition.PartitionedArray)):

--- a/src/awkward/_v2/operations/convert/to_arrow.py
+++ b/src/awkward/_v2/operations/convert/to_arrow.py
@@ -554,7 +554,7 @@ def to_arrow(
 #         else:
 #             raise TypeError(
 #                 "unrecognized array type: {0}".format(repr(layout))
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     return recurse(layout, None, False)

--- a/src/awkward/_v2/operations/convert/to_arrow.py
+++ b/src/awkward/_v2/operations/convert/to_arrow.py
@@ -166,7 +166,7 @@ def to_arrow(
 #             content_buffer = recurse(layout.content[: offsets[-1]], None, False)
 #             content_type = pyarrow.list_(content_buffer.type).value_field.with_nullable(
 #                 isinstance(
-#                     ak._v2.operations.describe.type(layout.content), ak.types.OptionType
+#                     ak._v2.operations.describe.type(layout.content), ak._v2.types.OptionType
 #                 )
 #             )
 #             if mask is None:
@@ -252,7 +252,7 @@ def to_arrow(
 #             content_buffer = recurse(layout.content[: offsets[-1]], None, False)
 #             content_type = pyarrow.list_(content_buffer.type).value_field.with_nullable(
 #                 isinstance(
-#                     ak._v2.operations.describe.type(layout.content), ak.types.OptionType
+#                     ak._v2.operations.describe.type(layout.content), ak._v2.types.OptionType
 #                 )
 #             )
 #             if mask is None:
@@ -302,7 +302,7 @@ def to_arrow(
 #             types = pyarrow.struct(
 #                 [
 #                     pyarrow.field(layout.key(i), values[i].type).with_nullable(
-#                         isinstance(ak._v2.operations.describe.type(x), ak.types.OptionType)
+#                         isinstance(ak._v2.operations.describe.type(x), ak._v2.types.OptionType)
 #                     )
 #                     for i, x in enumerate(layout.contents)
 #                 ]
@@ -370,7 +370,7 @@ def to_arrow(
 #                 [
 #                     pyarrow.field(str(i), values[i].type).with_nullable(
 #                         is_option
-#                         or isinstance(layout.content(i).type, ak.types.OptionType)
+#                         or isinstance(layout.content(i).type, ak._v2.types.OptionType)
 #                     )
 #                     for i in range(len(values))
 #                 ],
@@ -438,7 +438,7 @@ def to_arrow(
 #                                 layout_content.key(i), values[i].type
 #                             ).with_nullable(
 #                                 isinstance(
-#                                     ak._v2.operations.describe.type(x), ak.types.OptionType
+#                                     ak._v2.operations.describe.type(x), ak._v2.types.OptionType
 #                                 )
 #                             )
 #                             for i, x in enumerate(layout_content.contents)

--- a/src/awkward/_v2/operations/convert/to_arrow.py
+++ b/src/awkward/_v2/operations/convert/to_arrow.py
@@ -166,7 +166,7 @@ def to_arrow(
 #             content_buffer = recurse(layout.content[: offsets[-1]], None, False)
 #             content_type = pyarrow.list_(content_buffer.type).value_field.with_nullable(
 #                 isinstance(
-#                     ak.operations.describe.type(layout.content), ak.types.OptionType
+#                     ak._v2.operations.describe.type(layout.content), ak.types.OptionType
 #                 )
 #             )
 #             if mask is None:
@@ -252,7 +252,7 @@ def to_arrow(
 #             content_buffer = recurse(layout.content[: offsets[-1]], None, False)
 #             content_type = pyarrow.list_(content_buffer.type).value_field.with_nullable(
 #                 isinstance(
-#                     ak.operations.describe.type(layout.content), ak.types.OptionType
+#                     ak._v2.operations.describe.type(layout.content), ak.types.OptionType
 #                 )
 #             )
 #             if mask is None:
@@ -302,7 +302,7 @@ def to_arrow(
 #             types = pyarrow.struct(
 #                 [
 #                     pyarrow.field(layout.key(i), values[i].type).with_nullable(
-#                         isinstance(ak.operations.describe.type(x), ak.types.OptionType)
+#                         isinstance(ak._v2.operations.describe.type(x), ak.types.OptionType)
 #                     )
 #                     for i, x in enumerate(layout.contents)
 #                 ]
@@ -438,7 +438,7 @@ def to_arrow(
 #                                 layout_content.key(i), values[i].type
 #                             ).with_nullable(
 #                                 isinstance(
-#                                     ak.operations.describe.type(x), ak.types.OptionType
+#                                     ak._v2.operations.describe.type(x), ak.types.OptionType
 #                                 )
 #                             )
 #                             for i, x in enumerate(layout_content.contents)

--- a/src/awkward/_v2/operations/convert/to_arrow.py
+++ b/src/awkward/_v2/operations/convert/to_arrow.py
@@ -546,7 +546,7 @@ def to_arrow(
 #         elif isinstance(layout, (ak._v2.contents.VirtualArray)):
 #             return recurse(layout.array, None, False)
 
-#         elif isinstance(layout, (ak.partition.PartitionedArray)):
+#         elif isinstance(layout, (ak.partition.PartitionedArray)):   # NO PARTITIONED ARRAY
 #             return pyarrow.chunked_array(
 #                 [recurse(x, None, False) for x in layout.partitions]
 #             )

--- a/src/awkward/_v2/operations/convert/to_arrow.py
+++ b/src/awkward/_v2/operations/convert/to_arrow.py
@@ -554,7 +554,7 @@ def to_arrow(
 #         else:
 #             raise TypeError(
 #                 "unrecognized array type: {0}".format(repr(layout))
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     return recurse(layout, None, False)

--- a/src/awkward/_v2/operations/convert/to_arrow_table.py
+++ b/src/awkward/_v2/operations/convert/to_arrow_table.py
@@ -47,7 +47,7 @@ def to_arrow_table(
 #     layout = to_layout(array, allow_record=False, allow_other=False)
 
 #     if explode_records or isinstance(
-#         ak.operations.describe.type(layout), ak.types.RecordType
+#         ak._v2.operations.describe.type(layout), ak.types.RecordType
 #     ):
 #         names = layout.keys()
 #         contents = [layout[name] for name in names]
@@ -68,7 +68,7 @@ def to_arrow_table(
 #         )
 #         pa_fields.append(
 #             pyarrow.field(name, pa_arrays[-1].type).with_nullable(
-#                 isinstance(ak.operations.describe.type(content), ak.types.OptionType)
+#                 isinstance(ak._v2.operations.describe.type(content), ak.types.OptionType)
 #             )
 #         )
 

--- a/src/awkward/_v2/operations/convert/to_arrow_table.py
+++ b/src/awkward/_v2/operations/convert/to_arrow_table.py
@@ -47,7 +47,7 @@ def to_arrow_table(
 #     layout = to_layout(array, allow_record=False, allow_other=False)
 
 #     if explode_records or isinstance(
-#         ak._v2.operations.describe.type(layout), ak.types.RecordType
+#         ak._v2.operations.describe.type(layout), ak._v2.types.RecordType
 #     ):
 #         names = layout.keys()
 #         contents = [layout[name] for name in names]
@@ -68,7 +68,7 @@ def to_arrow_table(
 #         )
 #         pa_fields.append(
 #             pyarrow.field(name, pa_arrays[-1].type).with_nullable(
-#                 isinstance(ak._v2.operations.describe.type(content), ak.types.OptionType)
+#                 isinstance(ak._v2.operations.describe.type(content), ak._v2.types.OptionType)
 #             )
 #         )
 

--- a/src/awkward/_v2/operations/convert/to_buffers.py
+++ b/src/awkward/_v2/operations/convert/to_buffers.py
@@ -175,7 +175,7 @@ def to_buffers(
 #             raise AssertionError(
 #                 "unrecognized index: "
 #                 + repr(index)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     if isinstance(form_key, str):
@@ -212,7 +212,7 @@ def to_buffers(
 #         if has_identities:
 #             raise NotImplementedError(
 #                 "ak.to_buffers for an array with Identities"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         if isinstance(layout, ak._v2.contents.EmptyArray):
@@ -410,14 +410,14 @@ def to_buffers(
 #                 raise ValueError(
 #                     "unrecognized value for 'virtual': "
 #                     + str(virtual)
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #         else:
 #             raise AssertionError(
 #                 "unrecognized layout node type: "
 #                 + str(type(layout))
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     layout = to_layout(array, allow_record=False, allow_other=False)
@@ -445,7 +445,7 @@ def to_buffers(
 #                         f.tojson(True, False),
 #                         form.tojson(True, False),
 #                     )
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #             length.append(len(content))
 

--- a/src/awkward/_v2/operations/convert/to_buffers.py
+++ b/src/awkward/_v2/operations/convert/to_buffers.py
@@ -161,15 +161,15 @@ def to_buffers(
 #         container = {}
 
 #     def index_form(index):
-#         if isinstance(index, ak.layout.Index64):
+#         if isinstance(index, ak._v2.index.Index64):
 #             return "i64"
-#         elif isinstance(index, ak.layout.Index32):
+#         elif isinstance(index, ak._v2.index.Index32):
 #             return "i32"
-#         elif isinstance(index, ak.layout.IndexU32):
+#         elif isinstance(index, ak._v2.index.IndexU32):
 #             return "u32"
-#         elif isinstance(index, ak.layout.Index8):
+#         elif isinstance(index, ak._v2.index.Index8):
 #             return "i8"
-#         elif isinstance(index, ak.layout.IndexU8):
+#         elif isinstance(index, ak._v2.index.IndexU8):
 #             return "u8"
 #         else:
 #             raise AssertionError(
@@ -215,7 +215,7 @@ def to_buffers(
 #                 + ak._util.exception_suffix(__file__)
 #             )
 
-#         if isinstance(layout, ak.layout.EmptyArray):
+#         if isinstance(layout, ak._v2.contents.EmptyArray):
 #             fk = form_key(id=str(key_index))
 #             key = key_format(form_key=fk, attribute="data", partition=str(part))
 #             container[key] = little_endian(numpy.asarray(layout))
@@ -224,9 +224,9 @@ def to_buffers(
 #         elif isinstance(
 #             layout,
 #             (
-#                 ak.layout.IndexedArray32,
-#                 ak.layout.IndexedArrayU32,
-#                 ak.layout.IndexedArray64,
+#                 ak._v2.contents.IndexedArray32,
+#                 ak._v2.contents.IndexedArrayU32,
+#                 ak._v2.contents.IndexedArray64,
 #             ),
 #         ):
 #             fk = form_key(id=str(key_index), layout=layout)
@@ -241,7 +241,7 @@ def to_buffers(
 #             )
 
 #         elif isinstance(
-#             layout, (ak.layout.IndexedOptionArray32, ak.layout.IndexedOptionArray64)
+#             layout, (ak._v2.contents.IndexedOptionArray32, ak._v2.contents.IndexedOptionArray64)
 #         ):
 #             fk = form_key(id=str(key_index), layout=layout)
 #             key = key_format(form_key=fk, attribute="index", partition=str(part))
@@ -254,7 +254,7 @@ def to_buffers(
 #                 fk,
 #             )
 
-#         elif isinstance(layout, ak.layout.ByteMaskedArray):
+#         elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
 #             fk = form_key(id=str(key_index), layout=layout)
 #             key = key_format(form_key=fk, attribute="mask", partition=str(part))
 #             container[key] = little_endian(numpy.asarray(layout.mask))
@@ -267,7 +267,7 @@ def to_buffers(
 #                 fk,
 #             )
 
-#         elif isinstance(layout, ak.layout.BitMaskedArray):
+#         elif isinstance(layout, ak._v2.contents.BitMaskedArray):
 #             fk = form_key(id=str(key_index), layout=layout)
 #             key = key_format(form_key=fk, attribute="mask", partition=str(part))
 #             container[key] = little_endian(numpy.asarray(layout.mask))
@@ -281,7 +281,7 @@ def to_buffers(
 #                 fk,
 #             )
 
-#         elif isinstance(layout, ak.layout.UnmaskedArray):
+#         elif isinstance(layout, ak._v2.contents.UnmaskedArray):
 #             return ak.forms.UnmaskedForm(
 #                 fill(layout.content, part),
 #                 has_identities,
@@ -291,7 +291,7 @@ def to_buffers(
 
 #         elif isinstance(
 #             layout,
-#             (ak.layout.ListArray32, ak.layout.ListArrayU32, ak.layout.ListArray64),
+#             (ak._v2.contents.ListArray32, ak._v2.contents.ListArrayU32, ak._v2.contents.ListArray64),
 #         ):
 #             fk = form_key(id=str(key_index), layout=layout)
 #             key = key_format(form_key=fk, attribute="starts", partition=str(part))
@@ -310,9 +310,9 @@ def to_buffers(
 #         elif isinstance(
 #             layout,
 #             (
-#                 ak.layout.ListOffsetArray32,
-#                 ak.layout.ListOffsetArrayU32,
-#                 ak.layout.ListOffsetArray64,
+#                 ak._v2.contents.ListOffsetArray32,
+#                 ak._v2.contents.ListOffsetArrayU32,
+#                 ak._v2.contents.ListOffsetArray64,
 #             ),
 #         ):
 #             fk = form_key(id=str(key_index), layout=layout)
@@ -326,7 +326,7 @@ def to_buffers(
 #                 fk,
 #             )
 
-#         elif isinstance(layout, ak.layout.NumpyArray):
+#         elif isinstance(layout, ak._v2.contents.NumpyArray):
 #             fk = form_key(id=str(key_index), layout=layout)
 #             key = key_format(form_key=fk, attribute="data", partition=str(part))
 #             array = numpy.asarray(layout)
@@ -341,7 +341,7 @@ def to_buffers(
 #                 fk,
 #             )
 
-#         elif isinstance(layout, ak.layout.RecordArray):
+#         elif isinstance(layout, ak._v2.contents.RecordArray):
 #             if layout.istuple:
 #                 forms = [fill(x, part) for x in layout.contents]
 #                 keys = None
@@ -360,7 +360,7 @@ def to_buffers(
 #                 form_key(id=str(key_index), layout=layout),
 #             )
 
-#         elif isinstance(layout, ak.layout.RegularArray):
+#         elif isinstance(layout, ak._v2.contents.RegularArray):
 #             return ak.forms.RegularForm(
 #                 fill(layout.content, part),
 #                 layout.size,
@@ -372,9 +372,9 @@ def to_buffers(
 #         elif isinstance(
 #             layout,
 #             (
-#                 ak.layout.UnionArray8_32,
-#                 ak.layout.UnionArray8_U32,
-#                 ak.layout.UnionArray8_64,
+#                 ak._v2.contents.UnionArray8_32,
+#                 ak._v2.contents.UnionArray8_U32,
+#                 ak._v2.contents.UnionArray8_64,
 #             ),
 #         ):
 #             forms = []
@@ -395,7 +395,7 @@ def to_buffers(
 #                 fk,
 #             )
 
-#         elif isinstance(layout, ak.layout.VirtualArray):
+#         elif isinstance(layout, ak._v2.contents.VirtualArray):
 #             if virtual == "materialize":
 #                 return fill(layout.array, part)
 #             elif virtual == "pass":

--- a/src/awkward/_v2/operations/convert/to_buffers.py
+++ b/src/awkward/_v2/operations/convert/to_buffers.py
@@ -175,7 +175,7 @@ def to_buffers(
 #             raise AssertionError(
 #                 "unrecognized index: "
 #                 + repr(index)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     if isinstance(form_key, str):
@@ -212,7 +212,7 @@ def to_buffers(
 #         if has_identities:
 #             raise NotImplementedError(
 #                 "ak.to_buffers for an array with Identities"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         if isinstance(layout, ak._v2.contents.EmptyArray):
@@ -410,14 +410,14 @@ def to_buffers(
 #                 raise ValueError(
 #                     "unrecognized value for 'virtual': "
 #                     + str(virtual)
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #         else:
 #             raise AssertionError(
 #                 "unrecognized layout node type: "
 #                 + str(type(layout))
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     layout = to_layout(array, allow_record=False, allow_other=False)
@@ -445,7 +445,7 @@ def to_buffers(
 #                         f.tojson(True, False),
 #                         form.tojson(True, False),
 #                     )
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             length.append(len(content))
 

--- a/src/awkward/_v2/operations/convert/to_buffers.py
+++ b/src/awkward/_v2/operations/convert/to_buffers.py
@@ -422,7 +422,7 @@ def to_buffers(
 
 #     layout = to_layout(array, allow_record=False, allow_other=False)
 
-#     if isinstance(layout, ak.partition.PartitionedArray):
+#     if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         form = None
 #         length = []
 #         for part, content in enumerate(layout.partitions):

--- a/src/awkward/_v2/operations/convert/to_cupy.py
+++ b/src/awkward/_v2/operations/convert/to_cupy.py
@@ -60,7 +60,7 @@ def to_cupy(array):
 #
 #         )
 
-#     elif isinstance(array, ak.partition.PartitionedArray):
+#     elif isinstance(array, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         return cupy.concatenate([to_cupy(x) for x in array.partitions])
 
 #     elif isinstance(array, ak._v2._util.virtualtypes):

--- a/src/awkward/_v2/operations/convert/to_cupy.py
+++ b/src/awkward/_v2/operations/convert/to_cupy.py
@@ -42,7 +42,7 @@ def to_cupy(array):
 #     elif isinstance(array, ak.highlevel.Record):
 #         raise ValueError(
 #             "CuPy does not support record structures"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, ak.highlevel.ArrayBuilder):
@@ -57,7 +57,7 @@ def to_cupy(array):
 #     ):
 #         raise ValueError(
 #             "CuPy does not support arrays of strings"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, ak.partition.PartitionedArray):
@@ -94,7 +94,7 @@ def to_cupy(array):
 #         if mask0.any():
 #             raise ValueError(
 #                 "CuPy does not support masked arrays"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         else:
 #             return content
@@ -111,7 +111,7 @@ def to_cupy(array):
 #     elif isinstance(array, ak._v2._util.recordtypes):
 #         raise ValueError(
 #             "CuPy does not support record structures"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, ak._v2.contents.NumpyArray):
@@ -120,7 +120,7 @@ def to_cupy(array):
 #     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, Iterable):
@@ -129,5 +129,5 @@ def to_cupy(array):
 #     else:
 #         raise ValueError(
 #             "cannot convert {0} into cp.ndarray".format(array)
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )

--- a/src/awkward/_v2/operations/convert/to_cupy.py
+++ b/src/awkward/_v2/operations/convert/to_cupy.py
@@ -36,16 +36,16 @@ def to_cupy(array):
 #     elif isinstance(array, np.ndarray):
 #         return cupy.asarray(array)
 
-#     elif isinstance(array, ak.highlevel.Array):
+#     elif isinstance(array, ak._v2.highlevel.Array):
 #         return to_cupy(array.layout)
 
-#     elif isinstance(array, ak.highlevel.Record):
+#     elif isinstance(array, ak._v2.highlevel.Record):
 #         raise ValueError(
 #             "CuPy does not support record structures"
 #
 #         )
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         return to_cupy(array.snapshot().layout)
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):

--- a/src/awkward/_v2/operations/convert/to_cupy.py
+++ b/src/awkward/_v2/operations/convert/to_cupy.py
@@ -82,7 +82,7 @@ def to_cupy(array):
 #             out[mask] = content
 #         return out
 
-#     elif isinstance(array, ak.layout.UnmaskedArray):
+#     elif isinstance(array, ak._v2.contents.UnmaskedArray):
 #         return to_cupy(array.content)
 
 #     elif isinstance(array, ak._util.optiontypes):
@@ -99,7 +99,7 @@ def to_cupy(array):
 #         else:
 #             return content
 
-#     elif isinstance(array, ak.layout.RegularArray):
+#     elif isinstance(array, ak._v2.contents.RegularArray):
 #         out = to_cupy(array.content)
 #         head, tail = out.shape[0], out.shape[1:]
 #         shape = (head // array.size, array.size) + tail
@@ -114,10 +114,10 @@ def to_cupy(array):
 #             + ak._util.exception_suffix(__file__)
 #         )
 
-#     elif isinstance(array, ak.layout.NumpyArray):
+#     elif isinstance(array, ak._v2.contents.NumpyArray):
 #         return array.to_cupy()
 
-#     elif isinstance(array, ak.layout.Content):
+#     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
 #             + ak._util.exception_suffix(__file__)

--- a/src/awkward/_v2/operations/convert/to_cupy.py
+++ b/src/awkward/_v2/operations/convert/to_cupy.py
@@ -52,8 +52,8 @@ def to_cupy(array):
 #         return to_cupy(array.snapshot())
 
 #     elif (
-#         ak.operations.describe.parameters(array).get("__array__") == "bytestring"
-#         or ak.operations.describe.parameters(array).get("__array__") == "string"
+#         ak._v2.operations.describe.parameters(array).get("__array__") == "bytestring"
+#         or ak._v2.operations.describe.parameters(array).get("__array__") == "string"
 #     ):
 #         raise ValueError(
 #             "CuPy does not support arrays of strings"

--- a/src/awkward/_v2/operations/convert/to_cupy.py
+++ b/src/awkward/_v2/operations/convert/to_cupy.py
@@ -42,7 +42,7 @@ def to_cupy(array):
 #     elif isinstance(array, ak.highlevel.Record):
 #         raise ValueError(
 #             "CuPy does not support record structures"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, ak.highlevel.ArrayBuilder):
@@ -57,22 +57,22 @@ def to_cupy(array):
 #     ):
 #         raise ValueError(
 #             "CuPy does not support arrays of strings"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, ak.partition.PartitionedArray):
 #         return cupy.concatenate([to_cupy(x) for x in array.partitions])
 
-#     elif isinstance(array, ak._util.virtualtypes):
+#     elif isinstance(array, ak._v2._util.virtualtypes):
 #         return to_cupy(array.array)
 
-#     elif isinstance(array, ak._util.unknowntypes):
+#     elif isinstance(array, ak._v2._util.unknowntypes):
 #         return cupy.array([])
 
-#     elif isinstance(array, ak._util.indexedtypes):
+#     elif isinstance(array, ak._v2._util.indexedtypes):
 #         return to_cupy(array.project())
 
-#     elif isinstance(array, ak._util.uniontypes):
+#     elif isinstance(array, ak._v2._util.uniontypes):
 #         contents = [to_cupy(array.project(i)) for i in range(array.numcontents)]
 #         out = cupy.concatenate(contents)
 
@@ -85,7 +85,7 @@ def to_cupy(array):
 #     elif isinstance(array, ak._v2.contents.UnmaskedArray):
 #         return to_cupy(array.content)
 
-#     elif isinstance(array, ak._util.optiontypes):
+#     elif isinstance(array, ak._v2._util.optiontypes):
 #         content = to_cupy(array.project())
 
 #         shape = list(content.shape)
@@ -94,7 +94,7 @@ def to_cupy(array):
 #         if mask0.any():
 #             raise ValueError(
 #                 "CuPy does not support masked arrays"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         else:
 #             return content
@@ -105,13 +105,13 @@ def to_cupy(array):
 #         shape = (head // array.size, array.size) + tail
 #         return out[: shape[0] * array.size].reshape(shape)
 
-#     elif isinstance(array, ak._util.listtypes):
+#     elif isinstance(array, ak._v2._util.listtypes):
 #         return to_cupy(array.toRegularArray())
 
-#     elif isinstance(array, ak._util.recordtypes):
+#     elif isinstance(array, ak._v2._util.recordtypes):
 #         raise ValueError(
 #             "CuPy does not support record structures"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, ak._v2.contents.NumpyArray):
@@ -120,7 +120,7 @@ def to_cupy(array):
 #     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, Iterable):
@@ -129,5 +129,5 @@ def to_cupy(array):
 #     else:
 #         raise ValueError(
 #             "cannot convert {0} into cp.ndarray".format(array)
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )

--- a/src/awkward/_v2/operations/convert/to_jax.py
+++ b/src/awkward/_v2/operations/convert/to_jax.py
@@ -67,7 +67,7 @@ def to_jax(array):
 #
 #         )
 
-#     elif isinstance(array, ak.partition.PartitionedArray):
+#     elif isinstance(array, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         return jax.numpy.concatenate([to_jax(x) for x in array.partitions])
 
 #     elif isinstance(array, ak._v2._util.virtualtypes):

--- a/src/awkward/_v2/operations/convert/to_jax.py
+++ b/src/awkward/_v2/operations/convert/to_jax.py
@@ -49,7 +49,7 @@ def to_jax(array):
 #     elif isinstance(array, ak.highlevel.Record):
 #         raise ValueError(
 #             "JAX does not support record structures"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, ak.highlevel.ArrayBuilder):
@@ -64,34 +64,34 @@ def to_jax(array):
 #     ):
 #         raise ValueError(
 #             "JAX does not support arrays of strings"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, ak.partition.PartitionedArray):
 #         return jax.numpy.concatenate([to_jax(x) for x in array.partitions])
 
-#     elif isinstance(array, ak._util.virtualtypes):
+#     elif isinstance(array, ak._v2._util.virtualtypes):
 #         return to_jax(array.array)
 
-#     elif isinstance(array, ak._util.unknowntypes):
+#     elif isinstance(array, ak._v2._util.unknowntypes):
 #         return jax.numpy.array([])
 
-#     elif isinstance(array, ak._util.indexedtypes):
+#     elif isinstance(array, ak._v2._util.indexedtypes):
 #         return to_jax(array.project())
 
-#     elif isinstance(array, ak._util.uniontypes):
+#     elif isinstance(array, ak._v2._util.uniontypes):
 #         array = array.simplify()
-#         if isinstance(array, ak._util.uniontypes):
+#         if isinstance(array, ak._v2._util.uniontypes):
 #             raise ValueError(
 #                 "cannot convert {0} into jax.numpy.array".format(array)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         return to_jax(array)
 
 #     elif isinstance(array, ak._v2.contents.UnmaskedArray):
 #         return to_jax(array.content)
 
-#     elif isinstance(array, ak._util.optiontypes):
+#     elif isinstance(array, ak._v2._util.optiontypes):
 #         content = to_jax(array.project())
 
 #         shape = list(content.shape)
@@ -100,7 +100,7 @@ def to_jax(array):
 #         if mask0.any():
 #             raise ValueError(
 #                 "JAX does not support masked arrays"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         else:
 #             return content
@@ -111,13 +111,13 @@ def to_jax(array):
 #         shape = (head // array.size, array.size) + tail
 #         return out[: shape[0] * array.size].reshape(shape)
 
-#     elif isinstance(array, ak._util.listtypes):
+#     elif isinstance(array, ak._v2._util.listtypes):
 #         return to_jax(array.toRegularArray())
 
-#     elif isinstance(array, ak._util.recordtypes):
+#     elif isinstance(array, ak._v2._util.recordtypes):
 #         raise ValueError(
 #             "JAX does not support record structures"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, ak._v2.contents.NumpyArray):
@@ -126,7 +126,7 @@ def to_jax(array):
 #     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, Iterable):
@@ -135,5 +135,5 @@ def to_jax(array):
 #     else:
 #         raise ValueError(
 #             "cannot convert {0} into jax.numpy.array".format(array)
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )

--- a/src/awkward/_v2/operations/convert/to_jax.py
+++ b/src/awkward/_v2/operations/convert/to_jax.py
@@ -49,7 +49,7 @@ def to_jax(array):
 #     elif isinstance(array, ak.highlevel.Record):
 #         raise ValueError(
 #             "JAX does not support record structures"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, ak.highlevel.ArrayBuilder):
@@ -64,7 +64,7 @@ def to_jax(array):
 #     ):
 #         raise ValueError(
 #             "JAX does not support arrays of strings"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, ak.partition.PartitionedArray):
@@ -84,7 +84,7 @@ def to_jax(array):
 #         if isinstance(array, ak._v2._util.uniontypes):
 #             raise ValueError(
 #                 "cannot convert {0} into jax.numpy.array".format(array)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         return to_jax(array)
 
@@ -100,7 +100,7 @@ def to_jax(array):
 #         if mask0.any():
 #             raise ValueError(
 #                 "JAX does not support masked arrays"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         else:
 #             return content
@@ -117,7 +117,7 @@ def to_jax(array):
 #     elif isinstance(array, ak._v2._util.recordtypes):
 #         raise ValueError(
 #             "JAX does not support record structures"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, ak._v2.contents.NumpyArray):
@@ -126,7 +126,7 @@ def to_jax(array):
 #     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, Iterable):
@@ -135,5 +135,5 @@ def to_jax(array):
 #     else:
 #         raise ValueError(
 #             "cannot convert {0} into jax.numpy.array".format(array)
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )

--- a/src/awkward/_v2/operations/convert/to_jax.py
+++ b/src/awkward/_v2/operations/convert/to_jax.py
@@ -88,7 +88,7 @@ def to_jax(array):
 #             )
 #         return to_jax(array)
 
-#     elif isinstance(array, ak.layout.UnmaskedArray):
+#     elif isinstance(array, ak._v2.contents.UnmaskedArray):
 #         return to_jax(array.content)
 
 #     elif isinstance(array, ak._util.optiontypes):
@@ -105,7 +105,7 @@ def to_jax(array):
 #         else:
 #             return content
 
-#     elif isinstance(array, ak.layout.RegularArray):
+#     elif isinstance(array, ak._v2.contents.RegularArray):
 #         out = to_jax(array.content)
 #         head, tail = out.shape[0], out.shape[1:]
 #         shape = (head // array.size, array.size) + tail
@@ -120,10 +120,10 @@ def to_jax(array):
 #             + ak._util.exception_suffix(__file__)
 #         )
 
-#     elif isinstance(array, ak.layout.NumpyArray):
+#     elif isinstance(array, ak._v2.contents.NumpyArray):
 #         return array.to_jax()
 
-#     elif isinstance(array, ak.layout.Content):
+#     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
 #             + ak._util.exception_suffix(__file__)

--- a/src/awkward/_v2/operations/convert/to_jax.py
+++ b/src/awkward/_v2/operations/convert/to_jax.py
@@ -59,8 +59,8 @@ def to_jax(array):
 #         return to_jax(array.snapshot())
 
 #     elif (
-#         ak.operations.describe.parameters(array).get("__array__") == "bytestring"
-#         or ak.operations.describe.parameters(array).get("__array__") == "string"
+#         ak._v2.operations.describe.parameters(array).get("__array__") == "bytestring"
+#         or ak._v2.operations.describe.parameters(array).get("__array__") == "string"
 #     ):
 #         raise ValueError(
 #             "JAX does not support arrays of strings"

--- a/src/awkward/_v2/operations/convert/to_jax.py
+++ b/src/awkward/_v2/operations/convert/to_jax.py
@@ -43,16 +43,16 @@ def to_jax(array):
 #     elif isinstance(array, np.ndarray):
 #         return jax.numpy.asarray(array)
 
-#     elif isinstance(array, ak.highlevel.Array):
+#     elif isinstance(array, ak._v2.highlevel.Array):
 #         return to_jax(array.layout)
 
-#     elif isinstance(array, ak.highlevel.Record):
+#     elif isinstance(array, ak._v2.highlevel.Record):
 #         raise ValueError(
 #             "JAX does not support record structures"
 #
 #         )
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         return to_jax(array.snapshot().layout)
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):

--- a/src/awkward/_v2/operations/convert/to_json.py
+++ b/src/awkward/_v2/operations/convert/to_json.py
@@ -74,13 +74,13 @@ def to_json(
 #     elif isinstance(array, np.ndarray):
 #         out = ak._v2.contents.NumpyArray(array)
 
-#     elif isinstance(array, ak.highlevel.Array):
+#     elif isinstance(array, ak._v2.highlevel.Array):
 #         out = array.layout
 
-#     elif isinstance(array, ak.highlevel.Record):
+#     elif isinstance(array, ak._v2.highlevel.Record):
 #         out = array.layout
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         out = array.snapshot().layout
 
 #     elif isinstance(array, ak._v2.record.Record):

--- a/src/awkward/_v2/operations/convert/to_json.py
+++ b/src/awkward/_v2/operations/convert/to_json.py
@@ -98,7 +98,7 @@ def to_json(
 #     else:
 #         raise TypeError(
 #             "unrecognized array type: {0}".format(repr(array))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     if complex_record_fields is None:

--- a/src/awkward/_v2/operations/convert/to_json.py
+++ b/src/awkward/_v2/operations/convert/to_json.py
@@ -89,7 +89,7 @@ def to_json(
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         out = array.snapshot()
 
-#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
+#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):   # NO PARTITIONED ARRAY
 #         out = array
 
 #     elif isinstance(array, ak._v2.contents.Content):

--- a/src/awkward/_v2/operations/convert/to_json.py
+++ b/src/awkward/_v2/operations/convert/to_json.py
@@ -72,7 +72,7 @@ def to_json(
 #         return json.dumps(array)
 
 #     elif isinstance(array, np.ndarray):
-#         out = ak.layout.NumpyArray(array)
+#         out = ak._v2.contents.NumpyArray(array)
 
 #     elif isinstance(array, ak.highlevel.Array):
 #         out = array.layout
@@ -83,13 +83,13 @@ def to_json(
 #     elif isinstance(array, ak.highlevel.ArrayBuilder):
 #         out = array.snapshot().layout
 
-#     elif isinstance(array, ak.layout.Record):
+#     elif isinstance(array, ak._v2.record.Record):
 #         out = array
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         out = array.snapshot()
 
-#     elif isinstance(array, (ak.layout.Content, ak.partition.PartitionedArray)):
+#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
 #         out = array
 
 #     elif isinstance(array, ak._v2.contents.Content):

--- a/src/awkward/_v2/operations/convert/to_json.py
+++ b/src/awkward/_v2/operations/convert/to_json.py
@@ -68,7 +68,7 @@ def to_json(
 #     elif isinstance(array, bytes):
 #         return json.dumps(array.decode("utf-8", "surrogateescape"))
 
-#     elif ak._util.py27 and isinstance(array, ak._util.unicode):
+#     elif ak._v2._util.py27 and isinstance(array, ak._v2._util.unicode):
 #         return json.dumps(array)
 
 #     elif isinstance(array, np.ndarray):
@@ -98,7 +98,7 @@ def to_json(
 #     else:
 #         raise TypeError(
 #             "unrecognized array type: {0}".format(repr(array))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     if complex_record_fields is None:

--- a/src/awkward/_v2/operations/convert/to_layout.py
+++ b/src/awkward/_v2/operations/convert/to_layout.py
@@ -56,7 +56,7 @@ def to_layout(
 #         if not issubclass(array.dtype.type, numpytype):
 #             raise ValueError(
 #                 "NumPy {0} not allowed".format(repr(array.dtype))
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         return from_numpy(array, regulararray=True, recordarray=True, highlevel=False)
 
@@ -66,7 +66,7 @@ def to_layout(
 #         return from_cupy(array, regulararray=True, highlevel=False)
 
 #     elif isinstance(array, (str, bytes)) or (
-#         ak._util.py27 and isinstance(array, ak._util.unicode)
+#         ak._v2._util.py27 and isinstance(array, ak._v2._util.unicode)
 #     ):
 #         return from_iter([array], highlevel=False)
 
@@ -76,7 +76,7 @@ def to_layout(
 #     elif not allow_other:
 #         raise TypeError(
 #             "{0} cannot be converted into an Awkward Array".format(array)
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     else:

--- a/src/awkward/_v2/operations/convert/to_layout.py
+++ b/src/awkward/_v2/operations/convert/to_layout.py
@@ -46,7 +46,7 @@ def to_layout(
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         return array.snapshot()
 
-#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
+#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):   # NO PARTITIONED ARRAY
 #         return array
 
 #     elif allow_record and isinstance(array, ak._v2.record.Record):

--- a/src/awkward/_v2/operations/convert/to_layout.py
+++ b/src/awkward/_v2/operations/convert/to_layout.py
@@ -46,10 +46,10 @@ def to_layout(
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         return array.snapshot()
 
-#     elif isinstance(array, (ak.layout.Content, ak.partition.PartitionedArray)):
+#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
 #         return array
 
-#     elif allow_record and isinstance(array, ak.layout.Record):
+#     elif allow_record and isinstance(array, ak._v2.record.Record):
 #         return array
 
 #     elif isinstance(array, (np.ndarray, numpy.ma.MaskedArray)):

--- a/src/awkward/_v2/operations/convert/to_layout.py
+++ b/src/awkward/_v2/operations/convert/to_layout.py
@@ -56,7 +56,7 @@ def to_layout(
 #         if not issubclass(array.dtype.type, numpytype):
 #             raise ValueError(
 #                 "NumPy {0} not allowed".format(repr(array.dtype))
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         return from_numpy(array, regulararray=True, recordarray=True, highlevel=False)
 
@@ -76,7 +76,7 @@ def to_layout(
 #     elif not allow_other:
 #         raise TypeError(
 #             "{0} cannot be converted into an Awkward Array".format(array)
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     else:

--- a/src/awkward/_v2/operations/convert/to_layout.py
+++ b/src/awkward/_v2/operations/convert/to_layout.py
@@ -34,13 +34,13 @@ def to_layout(
 #     This function is usually used to sanitize inputs for other functions; it
 #     would rarely be used in a data analysis.
 #     """
-#     if isinstance(array, ak.highlevel.Array):
+#     if isinstance(array, ak._v2.highlevel.Array):
 #         return array.layout
 
-#     elif allow_record and isinstance(array, ak.highlevel.Record):
+#     elif allow_record and isinstance(array, ak._v2.highlevel.Record):
 #         return array.layout
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         return array.snapshot().layout
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):

--- a/src/awkward/_v2/operations/convert/to_list.py
+++ b/src/awkward/_v2/operations/convert/to_list.py
@@ -132,5 +132,5 @@ def to_list(array):
 #     else:
 #         raise TypeError(
 #             "unrecognized array type: {0}".format(type(array))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )

--- a/src/awkward/_v2/operations/convert/to_list.py
+++ b/src/awkward/_v2/operations/convert/to_list.py
@@ -62,10 +62,10 @@ def to_list(array):
 #     elif isinstance(array, ak.behaviors.string.CharBehavior):
 #         return array.__str__()
 
-#     elif ak.operations.describe.parameters(array).get("__array__") == "byte":
+#     elif ak._v2.operations.describe.parameters(array).get("__array__") == "byte":
 #         return ak.behaviors.string.CharBehavior(array).__bytes__()
 
-#     elif ak.operations.describe.parameters(array).get("__array__") == "char":
+#     elif ak._v2.operations.describe.parameters(array).get("__array__") == "char":
 #         return ak.behaviors.string.CharBehavior(array).__str__()
 
 #     elif isinstance(array, np.datetime64) or isinstance(array, np.timedelta64):

--- a/src/awkward/_v2/operations/convert/to_list.py
+++ b/src/awkward/_v2/operations/convert/to_list.py
@@ -80,16 +80,16 @@ def to_list(array):
 #     elif isinstance(array, ak.highlevel.ArrayBuilder):
 #         return to_list(array.snapshot())
 
-#     elif isinstance(array, ak.layout.Record) and array.istuple:
+#     elif isinstance(array, ak._v2.record.Record) and array.istuple:
 #         return tuple(to_list(x) for x in array.fields())
 
-#     elif isinstance(array, ak.layout.Record):
+#     elif isinstance(array, ak._v2.record.Record):
 #         return {n: to_list(x) for n, x in array.fielditems()}
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         return [to_list(x) for x in array.snapshot()]
 
-#     elif isinstance(array, ak.layout.NumpyArray):
+#     elif isinstance(array, ak._v2.contents.NumpyArray):
 #         if array.format.upper().startswith("M"):
 #             return (
 #                 [
@@ -106,7 +106,7 @@ def to_list(array):
 #         else:
 #             return ak.nplike.of(array).asarray(array).tolist()
 
-#     elif isinstance(array, (ak.layout.Content, ak.partition.PartitionedArray)):
+#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
 #         return [to_list(x) for x in array]
 
 #     elif isinstance(array, ak._v2.contents.Content):

--- a/src/awkward/_v2/operations/convert/to_list.py
+++ b/src/awkward/_v2/operations/convert/to_list.py
@@ -71,13 +71,13 @@ def to_list(array):
 #     elif isinstance(array, np.datetime64) or isinstance(array, np.timedelta64):
 #         return array
 
-#     elif isinstance(array, ak.highlevel.Array):
+#     elif isinstance(array, ak._v2.highlevel.Array):
 #         return [to_list(x) for x in array]
 
-#     elif isinstance(array, ak.highlevel.Record):
+#     elif isinstance(array, ak._v2.highlevel.Record):
 #         return to_list(array.layout)
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         return to_list(array.snapshot())
 
 #     elif isinstance(array, ak._v2.record.Record) and array.istuple:

--- a/src/awkward/_v2/operations/convert/to_list.py
+++ b/src/awkward/_v2/operations/convert/to_list.py
@@ -56,17 +56,17 @@ def to_list(array):
 #     elif isinstance(array, np.ndarray):
 #         return array.tolist()
 
-#     elif isinstance(array, ak.behaviors.string.ByteBehavior):
+#     elif isinstance(array, ak._v2.behaviors.string.ByteBehavior):
 #         return array.__bytes__()
 
-#     elif isinstance(array, ak.behaviors.string.CharBehavior):
+#     elif isinstance(array, ak._v2.behaviors.string.CharBehavior):
 #         return array.__str__()
 
 #     elif ak._v2.operations.describe.parameters(array).get("__array__") == "byte":
-#         return ak.behaviors.string.CharBehavior(array).__bytes__()
+#         return ak._v2.behaviors.string.CharBehavior(array).__bytes__()
 
 #     elif ak._v2.operations.describe.parameters(array).get("__array__") == "char":
-#         return ak.behaviors.string.CharBehavior(array).__str__()
+#         return ak._v2.behaviors.string.CharBehavior(array).__str__()
 
 #     elif isinstance(array, np.datetime64) or isinstance(array, np.timedelta64):
 #         return array

--- a/src/awkward/_v2/operations/convert/to_list.py
+++ b/src/awkward/_v2/operations/convert/to_list.py
@@ -106,7 +106,7 @@ def to_list(array):
 #         else:
 #             return ak.nplike.of(array).asarray(array).tolist()
 
-#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
+#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):   # NO PARTITIONED ARRAY
 #         return [to_list(x) for x in array]
 
 #     elif isinstance(array, ak._v2.contents.Content):

--- a/src/awkward/_v2/operations/convert/to_list.py
+++ b/src/awkward/_v2/operations/convert/to_list.py
@@ -50,7 +50,7 @@ def to_list(array):
 #     elif array is None or isinstance(array, (bool, str, bytes, numbers.Number)):
 #         return array
 
-#     elif ak._util.py27 and isinstance(array, ak._util.unicode):
+#     elif ak._v2._util.py27 and isinstance(array, ak._v2._util.unicode):
 #         return array
 
 #     elif isinstance(array, np.ndarray):
@@ -132,5 +132,5 @@ def to_list(array):
 #     else:
 #         raise TypeError(
 #             "unrecognized array type: {0}".format(type(array))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )

--- a/src/awkward/_v2/operations/convert/to_numpy.py
+++ b/src/awkward/_v2/operations/convert/to_numpy.py
@@ -39,7 +39,7 @@ def to_numpy(array, allow_missing=True):
 #     if isinstance(array, (bool, str, bytes, numbers.Number)):
 #         return numpy.array([array])[0]
 
-#     elif ak._util.py27 and isinstance(array, ak._util.unicode):
+#     elif ak._v2._util.py27 and isinstance(array, ak._v2._util.unicode):
 #         return numpy.array([array])[0]
 
 #     elif isinstance(array, np.ndarray):
@@ -87,16 +87,16 @@ def to_numpy(array, allow_missing=True):
 #         else:
 #             return numpy.concatenate(tocat)
 
-#     elif isinstance(array, ak._util.virtualtypes):
+#     elif isinstance(array, ak._v2._util.virtualtypes):
 #         return to_numpy(array.array, allow_missing=True)
 
-#     elif isinstance(array, ak._util.unknowntypes):
+#     elif isinstance(array, ak._v2._util.unknowntypes):
 #         return numpy.array([])
 
-#     elif isinstance(array, ak._util.indexedtypes):
+#     elif isinstance(array, ak._v2._util.indexedtypes):
 #         return to_numpy(array.project(), allow_missing=allow_missing)
 
-#     elif isinstance(array, ak._util.uniontypes):
+#     elif isinstance(array, ak._v2._util.uniontypes):
 #         contents = [
 #             to_numpy(array.project(i), allow_missing=allow_missing)
 #             for i in range(array.numcontents)
@@ -108,7 +108,7 @@ def to_numpy(array, allow_missing=True):
 #             except Exception:
 #                 raise ValueError(
 #                     "cannot convert {0} into numpy.ma.MaskedArray".format(array)
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #         else:
 #             try:
@@ -116,7 +116,7 @@ def to_numpy(array, allow_missing=True):
 #             except Exception:
 #                 raise ValueError(
 #                     "cannot convert {0} into np.ndarray".format(array)
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #         tags = numpy.asarray(array.tags)
@@ -132,7 +132,7 @@ def to_numpy(array, allow_missing=True):
 #         else:
 #             return content
 
-#     elif isinstance(array, ak._util.optiontypes):
+#     elif isinstance(array, ak._v2._util.optiontypes):
 #         content = to_numpy(array.project(), allow_missing=allow_missing)
 
 #         shape = list(content.shape)
@@ -156,7 +156,7 @@ def to_numpy(array, allow_missing=True):
 #                     "ak.to_numpy cannot convert 'None' values to "
 #                     "np.ma.MaskedArray unless the "
 #                     "'allow_missing' parameter is set to True"
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #         else:
 #             if allow_missing:
@@ -173,10 +173,10 @@ def to_numpy(array, allow_missing=True):
 #             shape = (head // array.size, array.size) + tail
 #         return out[: shape[0] * array.size].reshape(shape)
 
-#     elif isinstance(array, ak._util.listtypes):
+#     elif isinstance(array, ak._v2._util.listtypes):
 #         return to_numpy(array.toRegularArray(), allow_missing=allow_missing)
 
-#     elif isinstance(array, ak._util.recordtypes):
+#     elif isinstance(array, ak._v2._util.recordtypes):
 #         if array.numfields == 0:
 #             return numpy.empty(len(array), dtype=[])
 #         contents = [
@@ -186,7 +186,7 @@ def to_numpy(array, allow_missing=True):
 #         if any(len(x.shape) != 1 for x in contents):
 #             raise ValueError(
 #                 "cannot convert {0} into np.ndarray".format(array)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         out = numpy.empty(
 #             len(contents[0]),
@@ -219,7 +219,7 @@ def to_numpy(array, allow_missing=True):
 #     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif isinstance(array, Iterable):
@@ -228,5 +228,5 @@ def to_numpy(array, allow_missing=True):
 #     else:
 #         raise ValueError(
 #             "cannot convert {0} into np.ndarray".format(array)
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )

--- a/src/awkward/_v2/operations/convert/to_numpy.py
+++ b/src/awkward/_v2/operations/convert/to_numpy.py
@@ -58,7 +58,7 @@ def to_numpy(array, allow_missing=True):
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         return to_numpy(array.snapshot(), allow_missing=allow_missing)
 
-#     elif ak.operations.describe.parameters(array).get("__array__") == "bytestring":
+#     elif ak._v2.operations.describe.parameters(array).get("__array__") == "bytestring":
 #         return numpy.array(
 #             [
 #                 ak.behaviors.string.ByteBehavior(array[i]).__bytes__()
@@ -66,7 +66,7 @@ def to_numpy(array, allow_missing=True):
 #             ]
 #         )
 
-#     elif ak.operations.describe.parameters(array).get("__array__") == "string":
+#     elif ak._v2.operations.describe.parameters(array).get("__array__") == "string":
 #         return numpy.array(
 #             [
 #                 ak.behaviors.string.CharBehavior(array[i]).__str__()
@@ -75,8 +75,8 @@ def to_numpy(array, allow_missing=True):
 #         )
 
 #     elif (
-#         str(ak.operations.describe.type(array)) == "datetime64"
-#         or str(ak.operations.describe.type(array)) == "timedelta64"
+#         str(ak._v2.operations.describe.type(array)) == "datetime64"
+#         or str(ak._v2.operations.describe.type(array)) == "timedelta64"
 #     ):
 #         return array
 

--- a/src/awkward/_v2/operations/convert/to_numpy.py
+++ b/src/awkward/_v2/operations/convert/to_numpy.py
@@ -108,7 +108,7 @@ def to_numpy(array, allow_missing=True):
 #             except Exception:
 #                 raise ValueError(
 #                     "cannot convert {0} into numpy.ma.MaskedArray".format(array)
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #         else:
 #             try:
@@ -116,7 +116,7 @@ def to_numpy(array, allow_missing=True):
 #             except Exception:
 #                 raise ValueError(
 #                     "cannot convert {0} into np.ndarray".format(array)
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #         tags = numpy.asarray(array.tags)
@@ -156,7 +156,7 @@ def to_numpy(array, allow_missing=True):
 #                     "ak.to_numpy cannot convert 'None' values to "
 #                     "np.ma.MaskedArray unless the "
 #                     "'allow_missing' parameter is set to True"
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #         else:
 #             if allow_missing:
@@ -186,7 +186,7 @@ def to_numpy(array, allow_missing=True):
 #         if any(len(x.shape) != 1 for x in contents):
 #             raise ValueError(
 #                 "cannot convert {0} into np.ndarray".format(array)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         out = numpy.empty(
 #             len(contents[0]),
@@ -219,7 +219,7 @@ def to_numpy(array, allow_missing=True):
 #     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif isinstance(array, Iterable):
@@ -228,5 +228,5 @@ def to_numpy(array, allow_missing=True):
 #     else:
 #         raise ValueError(
 #             "cannot convert {0} into np.ndarray".format(array)
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )

--- a/src/awkward/_v2/operations/convert/to_numpy.py
+++ b/src/awkward/_v2/operations/convert/to_numpy.py
@@ -61,7 +61,7 @@ def to_numpy(array, allow_missing=True):
 #     elif ak._v2.operations.describe.parameters(array).get("__array__") == "bytestring":
 #         return numpy.array(
 #             [
-#                 ak.behaviors.string.ByteBehavior(array[i]).__bytes__()
+#                 ak._v2.behaviors.string.ByteBehavior(array[i]).__bytes__()
 #                 for i in range(len(array))
 #             ]
 #         )
@@ -69,7 +69,7 @@ def to_numpy(array, allow_missing=True):
 #     elif ak._v2.operations.describe.parameters(array).get("__array__") == "string":
 #         return numpy.array(
 #             [
-#                 ak.behaviors.string.CharBehavior(array[i]).__str__()
+#                 ak._v2.behaviors.string.CharBehavior(array[i]).__str__()
 #                 for i in range(len(array))
 #             ]
 #         )

--- a/src/awkward/_v2/operations/convert/to_numpy.py
+++ b/src/awkward/_v2/operations/convert/to_numpy.py
@@ -45,14 +45,14 @@ def to_numpy(array, allow_missing=True):
 #     elif isinstance(array, np.ndarray):
 #         return array
 
-#     elif isinstance(array, ak.highlevel.Array):
+#     elif isinstance(array, ak._v2.highlevel.Array):
 #         return to_numpy(array.layout, allow_missing=allow_missing)
 
-#     elif isinstance(array, ak.highlevel.Record):
+#     elif isinstance(array, ak._v2.highlevel.Record):
 #         out = array.layout
 #         return to_numpy(out.array[out.at : out.at + 1], allow_missing=allow_missing)[0]
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         return to_numpy(array.snapshot().layout, allow_missing=allow_missing)
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):

--- a/src/awkward/_v2/operations/convert/to_numpy.py
+++ b/src/awkward/_v2/operations/convert/to_numpy.py
@@ -80,7 +80,7 @@ def to_numpy(array, allow_missing=True):
 #     ):
 #         return array
 
-#     elif isinstance(array, ak.partition.PartitionedArray):
+#     elif isinstance(array, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         tocat = [to_numpy(x, allow_missing=allow_missing) for x in array.partitions]
 #         if any(isinstance(x, numpy.ma.MaskedArray) for x in tocat):
 #             return numpy.ma.concatenate(tocat)

--- a/src/awkward/_v2/operations/convert/to_numpy.py
+++ b/src/awkward/_v2/operations/convert/to_numpy.py
@@ -125,7 +125,7 @@ def to_numpy(array, allow_missing=True):
 #             out[mask] = content
 #         return out
 
-#     elif isinstance(array, ak.layout.UnmaskedArray):
+#     elif isinstance(array, ak._v2.contents.UnmaskedArray):
 #         content = to_numpy(array.content, allow_missing=allow_missing)
 #         if allow_missing:
 #             return numpy.ma.MaskedArray(content)
@@ -164,7 +164,7 @@ def to_numpy(array, allow_missing=True):
 #             else:
 #                 return content
 
-#     elif isinstance(array, ak.layout.RegularArray):
+#     elif isinstance(array, ak._v2.contents.RegularArray):
 #         out = to_numpy(array.content, allow_missing=allow_missing)
 #         head, tail = out.shape[0], out.shape[1:]
 #         if array.size == 0:
@@ -209,14 +209,14 @@ def to_numpy(array, allow_missing=True):
 
 #         return out
 
-#     elif isinstance(array, ak.layout.NumpyArray):
+#     elif isinstance(array, ak._v2.contents.NumpyArray):
 #         out = ak.nplike.of(array).asarray(array)
 #         if type(out).__module__.startswith("cupy."):
 #             return out.get()
 #         else:
 #             return out
 
-#     elif isinstance(array, ak.layout.Content):
+#     elif isinstance(array, ak._v2.contents.Content):
 #         raise AssertionError(
 #             "unrecognized Content type: {0}".format(type(array))
 #             + ak._util.exception_suffix(__file__)

--- a/src/awkward/_v2/operations/convert/to_pandas.py
+++ b/src/awkward/_v2/operations/convert/to_pandas.py
@@ -187,7 +187,7 @@ def to_pandas(
 #                     [],
 #                 )
 
-#         elif isinstance(layout, ak.layout.RecordArray):
+#         elif isinstance(layout, ak._v2.contents.RecordArray):
 #             return sum(
 #                 [
 #                     recurse(layout.field(n), row_arrays, col_names + (n,))
@@ -203,7 +203,7 @@ def to_pandas(
 #     if isinstance(layout, ak.partition.PartitionedArray):
 #         layout = layout.toContent()
 
-#     if isinstance(layout, ak.layout.Record):
+#     if isinstance(layout, ak._v2.record.Record):
 #         layout2 = layout.array[layout.at : layout.at + 1]
 #     else:
 #         layout2 = layout
@@ -211,7 +211,7 @@ def to_pandas(
 #     tables = []
 #     last_row_arrays = None
 #     for column, row_arrays, col_names in recurse(layout2, [], ()):
-#         if isinstance(layout, ak.layout.Record):
+#         if isinstance(layout, ak._v2.record.Record):
 #             row_arrays = row_arrays[1:]  # Record --> one-element RecordArray
 #         if len(col_names) == 0:
 #             columns = [anonymous]

--- a/src/awkward/_v2/operations/convert/to_pandas.py
+++ b/src/awkward/_v2/operations/convert/to_pandas.py
@@ -146,10 +146,10 @@ def to_pandas(
 #         return out
 
 #     def recurse(layout, row_arrays, col_names):
-#         if isinstance(layout, ak._util.virtualtypes):
+#         if isinstance(layout, ak._v2._util.virtualtypes):
 #             return recurse(layout.array, row_arrays, col_names)
 
-#         elif isinstance(layout, ak._util.indexedtypes):
+#         elif isinstance(layout, ak._v2._util.indexedtypes):
 #             return recurse(layout.project(), row_arrays, col_names)
 
 #         elif layout.parameter("__array__") in ("string", "bytestring"):
@@ -160,7 +160,7 @@ def to_pandas(
 #             offsets = numpy.asarray(offsets)
 #             starts, stops = offsets[:-1], offsets[1:]
 #             counts = stops - starts
-#             if ak._util.win or ak._util.bits32:
+#             if ak._v2._util.win or ak._v2._util.bits32:
 #                 counts = counts.astype(np.int32)
 #             if len(row_arrays) == 0:
 #                 newrows = [
@@ -174,9 +174,9 @@ def to_pandas(
 #             )
 #             return recurse(flattened, newrows, col_names)
 
-#         elif isinstance(layout, ak._util.uniontypes):
-#             layout = ak._util.union_to_record(layout, anonymous)
-#             if isinstance(layout, ak._util.uniontypes):
+#         elif isinstance(layout, ak._v2._util.uniontypes):
+#             layout = ak._v2._util.union_to_record(layout, anonymous)
+#             if isinstance(layout, ak._v2._util.uniontypes):
 #                 return [(to_numpy(layout), row_arrays, col_names)]
 #             else:
 #                 return sum(

--- a/src/awkward/_v2/operations/convert/to_pandas.py
+++ b/src/awkward/_v2/operations/convert/to_pandas.py
@@ -200,7 +200,7 @@ def to_pandas(
 #             return [(to_numpy(layout), row_arrays, col_names)]
 
 #     layout = to_layout(array, allow_record=True, allow_other=False)
-#     if isinstance(layout, ak.partition.PartitionedArray):
+#     if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         layout = layout.toContent()
 
 #     if isinstance(layout, ak._v2.record.Record):

--- a/src/awkward/_v2/operations/describe/fields.py
+++ b/src/awkward/_v2/operations/describe/fields.py
@@ -23,7 +23,7 @@ def fields(array):
 #     If the array contains neither tuples nor records, this returns an empty
 #     list.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=True, allow_other=False
 #     )
 #     return layout.keys()

--- a/src/awkward/_v2/operations/describe/library.py
+++ b/src/awkward/_v2/operations/describe/library.py
@@ -48,7 +48,7 @@ def library(*arrays):  # note: convert.py's 'kernels'
 #         )
 
 #         if isinstance(
-#             layout, (ak._v2.contents.Content, ak._v2.record.Record, ak.partition.PartitionedArray)
+#             layout, (ak._v2.contents.Content, ak._v2.record.Record, ak.partition.PartitionedArray)   # NO PARTITIONED ARRAY
 #         ):
 #             libs.add(layout.kernels)
 

--- a/src/awkward/_v2/operations/describe/library.py
+++ b/src/awkward/_v2/operations/describe/library.py
@@ -48,7 +48,7 @@ def library(*arrays):  # note: convert.py's 'kernels'
 #         )
 
 #         if isinstance(
-#             layout, (ak.layout.Content, ak.layout.Record, ak.partition.PartitionedArray)
+#             layout, (ak._v2.contents.Content, ak._v2.record.Record, ak.partition.PartitionedArray)
 #         ):
 #             libs.add(layout.kernels)
 

--- a/src/awkward/_v2/operations/describe/library.py
+++ b/src/awkward/_v2/operations/describe/library.py
@@ -41,7 +41,7 @@ def library(*arrays):  # note: convert.py's 'kernels'
 #     """
 #     libs = set()
 #     for array in arrays:
-#         layout = ak.operations.convert.to_layout(
+#         layout = ak._v2.operations.convert.to_layout(
 #             array,
 #             allow_record=True,
 #             allow_other=True,

--- a/src/awkward/_v2/operations/describe/parameters.py
+++ b/src/awkward/_v2/operations/describe/parameters.py
@@ -31,7 +31,7 @@ def parameters(array):
 #         (
 #             ak._v2.contents.Content,
 #             ak._v2.record.Record,
-#             ak.partition.PartitionedArray,
+#             ak.partition.PartitionedArray,   # NO PARTITIONED ARRAY
 #         ),
 #     ):
 #         return array.parameters

--- a/src/awkward/_v2/operations/describe/parameters.py
+++ b/src/awkward/_v2/operations/describe/parameters.py
@@ -23,7 +23,7 @@ def parameters(array):
 #     See #ak.Array and #ak.behavior for a more complete description of
 #     behaviors.
 #     """
-#     if isinstance(array, (ak.highlevel.Array, ak.highlevel.Record)):
+#     if isinstance(array, (ak._v2.highlevel.Array, ak._v2.highlevel.Record)):
 #         return array.layout.parameters
 
 #     elif isinstance(
@@ -36,7 +36,7 @@ def parameters(array):
 #     ):
 #         return array.parameters
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         return array.snapshot().layout.parameters
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):

--- a/src/awkward/_v2/operations/describe/parameters.py
+++ b/src/awkward/_v2/operations/describe/parameters.py
@@ -29,8 +29,8 @@ def parameters(array):
 #     elif isinstance(
 #         array,
 #         (
-#             ak.layout.Content,
-#             ak.layout.Record,
+#             ak._v2.contents.Content,
+#             ak._v2.record.Record,
 #             ak.partition.PartitionedArray,
 #         ),
 #     ):

--- a/src/awkward/_v2/operations/describe/to_library.py
+++ b/src/awkward/_v2/operations/describe/to_library.py
@@ -56,4 +56,4 @@ def to_library(
 #     arr = ak.to_layout(array)
 #     out = arr.copy_to(kernels)
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/describe/type.py
+++ b/src/awkward/_v2/operations/describe/type.py
@@ -57,16 +57,16 @@ def type(array):
 #     to the language.)
 #     """
 #     if array is None:
-#         return ak.types.UnknownType()
+#         return ak._v2.types.UnknownType()
 
 #     elif isinstance(array, (bool, np.bool_)):
-#         return ak.types.PrimitiveType("bool")
+#         return ak._v2.types.PrimitiveType("bool")
 
 #     elif isinstance(array, numbers.Integral):
-#         return ak.types.PrimitiveType("int64")
+#         return ak._v2.types.PrimitiveType("int64")
 
 #     elif isinstance(array, numbers.Real):
-#         return ak.types.PrimitiveType("float64")
+#         return ak._v2.types.PrimitiveType("float64")
 
 #     elif isinstance(
 #         array,
@@ -87,7 +87,7 @@ def type(array):
 #             np.timedelta64,
 #         ),
 #     ):
-#         return ak.types.PrimitiveType(type.dtype2primitive[array.dtype.type])
+#         return ak._v2.types.PrimitiveType(type.dtype2primitive[array.dtype.type])
 
 #     elif isinstance(array, ak._v2.highlevel.Array):
 #         return ak._v2._util.highlevel_type(array.layout, array.behavior, True)
@@ -111,10 +111,10 @@ def type(array):
 #                 raise TypeError(
 #                     "numpy array type is unrecognized by awkward: %r" % array.dtype.type
 #                 )
-#             out = ak.types.PrimitiveType(out)
+#             out = ak._v2.types.PrimitiveType(out)
 #             for x in array.shape[-1:0:-1]:
-#                 out = ak.types.RegularType(out, x)
-#             return ak.types.ArrayType(out, array.shape[0])
+#                 out = ak._v2.types.RegularType(out, x)
+#             return ak._v2.types.ArrayType(out, array.shape[0])
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         return array.type(ak._v2._util.typestrs(None))

--- a/src/awkward/_v2/operations/describe/type.py
+++ b/src/awkward/_v2/operations/describe/type.py
@@ -89,13 +89,13 @@ def type(array):
 #     ):
 #         return ak.types.PrimitiveType(type.dtype2primitive[array.dtype.type])
 
-#     elif isinstance(array, ak.highlevel.Array):
+#     elif isinstance(array, ak._v2.highlevel.Array):
 #         return ak._v2._util.highlevel_type(array.layout, array.behavior, True)
 
-#     elif isinstance(array, ak.highlevel.Record):
+#     elif isinstance(array, ak._v2.highlevel.Record):
 #         return ak._v2._util.highlevel_type(array.layout, array.behavior, False)
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         return ak._v2._util.highlevel_type(array.snapshot().layout, array.behavior, True)
 
 #     elif isinstance(array, ak._v2.record.Record):

--- a/src/awkward/_v2/operations/describe/type.py
+++ b/src/awkward/_v2/operations/describe/type.py
@@ -98,7 +98,7 @@ def type(array):
 #     elif isinstance(array, ak.highlevel.ArrayBuilder):
 #         return ak._util.highlevel_type(array.snapshot().layout, array.behavior, True)
 
-#     elif isinstance(array, ak.layout.Record):
+#     elif isinstance(array, ak._v2.record.Record):
 #         return array.type(ak._util.typestrs(None))
 
 #     elif isinstance(array, np.ndarray):
@@ -119,7 +119,7 @@ def type(array):
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         return array.type(ak._util.typestrs(None))
 
-#     elif isinstance(array, (ak.layout.Content, ak.partition.PartitionedArray)):
+#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
 #         return array.type(ak._util.typestrs(None))
 
 #     else:

--- a/src/awkward/_v2/operations/describe/type.py
+++ b/src/awkward/_v2/operations/describe/type.py
@@ -90,16 +90,16 @@ def type(array):
 #         return ak.types.PrimitiveType(type.dtype2primitive[array.dtype.type])
 
 #     elif isinstance(array, ak.highlevel.Array):
-#         return ak._util.highlevel_type(array.layout, array.behavior, True)
+#         return ak._v2._util.highlevel_type(array.layout, array.behavior, True)
 
 #     elif isinstance(array, ak.highlevel.Record):
-#         return ak._util.highlevel_type(array.layout, array.behavior, False)
+#         return ak._v2._util.highlevel_type(array.layout, array.behavior, False)
 
 #     elif isinstance(array, ak.highlevel.ArrayBuilder):
-#         return ak._util.highlevel_type(array.snapshot().layout, array.behavior, True)
+#         return ak._v2._util.highlevel_type(array.snapshot().layout, array.behavior, True)
 
 #     elif isinstance(array, ak._v2.record.Record):
-#         return array.type(ak._util.typestrs(None))
+#         return array.type(ak._v2._util.typestrs(None))
 
 #     elif isinstance(array, np.ndarray):
 #         if len(array.shape) == 0:
@@ -117,15 +117,15 @@ def type(array):
 #             return ak.types.ArrayType(out, array.shape[0])
 
 #     elif isinstance(array, ak.layout.ArrayBuilder):
-#         return array.type(ak._util.typestrs(None))
+#         return array.type(ak._v2._util.typestrs(None))
 
 #     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
-#         return array.type(ak._util.typestrs(None))
+#         return array.type(ak._v2._util.typestrs(None))
 
 #     else:
 #         raise TypeError(
 #             "unrecognized array type: {0}".format(repr(array))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 

--- a/src/awkward/_v2/operations/describe/type.py
+++ b/src/awkward/_v2/operations/describe/type.py
@@ -119,7 +119,7 @@ def type(array):
 #     elif isinstance(array, ak.layout.ArrayBuilder):
 #         return array.type(ak._v2._util.typestrs(None))
 
-#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):
+#     elif isinstance(array, (ak._v2.contents.Content, ak.partition.PartitionedArray)):   # NO PARTITIONED ARRAY
 #         return array.type(ak._v2._util.typestrs(None))
 
 #     else:

--- a/src/awkward/_v2/operations/describe/type.py
+++ b/src/awkward/_v2/operations/describe/type.py
@@ -125,7 +125,7 @@ def type(array):
 #     else:
 #         raise TypeError(
 #             "unrecognized array type: {0}".format(repr(array))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 

--- a/src/awkward/_v2/operations/describe/validity_error.py
+++ b/src/awkward/_v2/operations/describe/validity_error.py
@@ -26,10 +26,10 @@ def validity_error(array, exception=False):
 
 #     See also #ak.is_valid.
 #     """
-#     if isinstance(array, (ak.highlevel.Array, ak.highlevel.Record)):
+#     if isinstance(array, (ak._v2.highlevel.Array, ak._v2.highlevel.Record)):
 #         return validity_error(array.layout, exception=exception)
 
-#     elif isinstance(array, ak.highlevel.ArrayBuilder):
+#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
 #         return validity_error(array.snapshot().layout, exception=exception)
 
 #     elif isinstance(

--- a/src/awkward/_v2/operations/describe/validity_error.py
+++ b/src/awkward/_v2/operations/describe/validity_error.py
@@ -37,7 +37,7 @@ def validity_error(array, exception=False):
 #         (
 #             ak._v2.contents.Content,
 #             ak._v2.record.Record,
-#             ak.partition.PartitionedArray,
+#             ak.partition.PartitionedArray,   # NO PARTITIONED ARRAY
 #         ),
 #     ):
 #         out = array.validityerror()

--- a/src/awkward/_v2/operations/describe/validity_error.py
+++ b/src/awkward/_v2/operations/describe/validity_error.py
@@ -52,5 +52,5 @@ def validity_error(array, exception=False):
 #     else:
 #         raise TypeError(
 #             "not an awkward array: {0}".format(repr(array))
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )

--- a/src/awkward/_v2/operations/describe/validity_error.py
+++ b/src/awkward/_v2/operations/describe/validity_error.py
@@ -35,8 +35,8 @@ def validity_error(array, exception=False):
 #     elif isinstance(
 #         array,
 #         (
-#             ak.layout.Content,
-#             ak.layout.Record,
+#             ak._v2.contents.Content,
+#             ak._v2.record.Record,
 #             ak.partition.PartitionedArray,
 #         ),
 #     ):

--- a/src/awkward/_v2/operations/describe/validity_error.py
+++ b/src/awkward/_v2/operations/describe/validity_error.py
@@ -52,5 +52,5 @@ def validity_error(array, exception=False):
 #     else:
 #         raise TypeError(
 #             "not an awkward array: {0}".format(repr(array))
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )

--- a/src/awkward/_v2/operations/reducers/all.py
+++ b/src/awkward/_v2/operations/reducers/all.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("all")
+# @ak._v2._connect.numpy.implements("all")
 def all(array, axis=None, keepdims=False, mask_identity=False):
     pass
 

--- a/src/awkward/_v2/operations/reducers/all.py
+++ b/src/awkward/_v2/operations/reducers/all.py
@@ -52,10 +52,10 @@ def all(array, axis=None, keepdims=False, mask_identity=False):
 #                 return xs[0] and reduce(xs[1:])
 
 #         return reduce(
-#             [ak.nplike.of(x).all(x) for x in ak._util.completely_flatten(layout)]
+#             [ak.nplike.of(x).all(x) for x in ak._v2._util.completely_flatten(layout)]
 #         )
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.all(axis=axis, mask=mask_identity, keepdims=keepdims), behavior
 #         )

--- a/src/awkward/_v2/operations/reducers/all.py
+++ b/src/awkward/_v2/operations/reducers/all.py
@@ -40,7 +40,7 @@ def all(array, axis=None, keepdims=False, mask_identity=False):
 #     See #ak.sum for a more complete description of nested list and missing
 #     value (None) handling in reducers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if axis is None:

--- a/src/awkward/_v2/operations/reducers/any.py
+++ b/src/awkward/_v2/operations/reducers/any.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("any")
+# @ak._v2._connect.numpy.implements("any")
 def any(array, axis=None, keepdims=False, mask_identity=False):
     pass
 

--- a/src/awkward/_v2/operations/reducers/any.py
+++ b/src/awkward/_v2/operations/reducers/any.py
@@ -52,10 +52,10 @@ def any(array, axis=None, keepdims=False, mask_identity=False):
 #                 return xs[0] or reduce(xs[1:])
 
 #         return reduce(
-#             [ak.nplike.of(x).any(x) for x in ak._util.completely_flatten(layout)]
+#             [ak.nplike.of(x).any(x) for x in ak._v2._util.completely_flatten(layout)]
 #         )
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.any(axis=axis, mask=mask_identity, keepdims=keepdims), behavior
 #         )

--- a/src/awkward/_v2/operations/reducers/any.py
+++ b/src/awkward/_v2/operations/reducers/any.py
@@ -40,7 +40,7 @@ def any(array, axis=None, keepdims=False, mask_identity=False):
 #     See #ak.sum for a more complete description of nested list and missing
 #     value (None) handling in reducers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if axis is None:

--- a/src/awkward/_v2/operations/reducers/argmax.py
+++ b/src/awkward/_v2/operations/reducers/argmax.py
@@ -50,7 +50,7 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True):
 #     )
 
 #     if axis is None:
-#         if isinstance(layout, ak.partition.PartitionedArray):
+#         if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             start = 0
 #             best_index = None
 #             best_value = None

--- a/src/awkward/_v2/operations/reducers/argmax.py
+++ b/src/awkward/_v2/operations/reducers/argmax.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("argmax")
+# @ak._v2._connect.numpy.implements("argmax")
 def argmax(array, axis=None, keepdims=False, mask_identity=True):
     pass
 

--- a/src/awkward/_v2/operations/reducers/argmax.py
+++ b/src/awkward/_v2/operations/reducers/argmax.py
@@ -55,7 +55,7 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True):
 #             best_index = None
 #             best_value = None
 #             for partition in layout.partitions:
-#                 for tmp in ak._util.completely_flatten(partition):
+#                 for tmp in ak._v2._util.completely_flatten(partition):
 #                     out = ak.nplike.of(tmp).argmax(tmp, axis=None)
 #                     if best_index is None or tmp[out] > best_value:
 #                         best_index = start + out
@@ -66,7 +66,7 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True):
 #         else:
 #             best_index = None
 #             best_value = None
-#             for tmp in ak._util.completely_flatten(layout):
+#             for tmp in ak._v2._util.completely_flatten(layout):
 #                 out = ak.nplike.of(tmp).argmax(tmp, axis=None)
 #                 if best_index is None or tmp[out] > best_value:
 #                     best_index = out
@@ -74,7 +74,7 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True):
 #             return best_index
 
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.argmax(axis=axis, mask=mask_identity, keepdims=keepdims), behavior
 #         )

--- a/src/awkward/_v2/operations/reducers/argmax.py
+++ b/src/awkward/_v2/operations/reducers/argmax.py
@@ -45,7 +45,7 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True):
 #     See #ak.sum for a more complete description of nested list and missing
 #     value (None) handling in reducers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 

--- a/src/awkward/_v2/operations/reducers/argmin.py
+++ b/src/awkward/_v2/operations/reducers/argmin.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("argmin")
+# @ak._v2._connect.numpy.implements("argmin")
 def argmin(array, axis=None, keepdims=False, mask_identity=True):
     pass
 

--- a/src/awkward/_v2/operations/reducers/argmin.py
+++ b/src/awkward/_v2/operations/reducers/argmin.py
@@ -50,7 +50,7 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True):
 #     )
 
 #     if axis is None:
-#         if isinstance(layout, ak.partition.PartitionedArray):
+#         if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             start = 0
 #             best_index = None
 #             best_value = None

--- a/src/awkward/_v2/operations/reducers/argmin.py
+++ b/src/awkward/_v2/operations/reducers/argmin.py
@@ -55,7 +55,7 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True):
 #             best_index = None
 #             best_value = None
 #             for partition in layout.partitions:
-#                 for tmp in ak._util.completely_flatten(partition):
+#                 for tmp in ak._v2._util.completely_flatten(partition):
 #                     out = ak.nplike.of(tmp).argmin(tmp, axis=None)
 #                     if best_index is None or tmp[out] < best_value:
 #                         best_index = start + out
@@ -66,7 +66,7 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True):
 #         else:
 #             best_index = None
 #             best_value = None
-#             for tmp in ak._util.completely_flatten(layout):
+#             for tmp in ak._v2._util.completely_flatten(layout):
 #                 out = ak.nplike.of(tmp).argmin(tmp, axis=None)
 #                 if best_index is None or tmp[out] < best_value:
 #                     best_index = out
@@ -74,7 +74,7 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True):
 #             return best_index
 
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.argmin(axis=axis, mask=mask_identity, keepdims=keepdims), behavior
 #         )

--- a/src/awkward/_v2/operations/reducers/argmin.py
+++ b/src/awkward/_v2/operations/reducers/argmin.py
@@ -45,7 +45,7 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True):
 #     See #ak.sum for a more complete description of nested list and missing
 #     value (None) handling in reducers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 

--- a/src/awkward/_v2/operations/reducers/count.py
+++ b/src/awkward/_v2/operations/reducers/count.py
@@ -91,10 +91,10 @@ def count(array, axis=None, keepdims=False, mask_identity=False):
 #                 return xs[0] + reduce(xs[1:])
 
 #         return reduce(
-#             [ak.nplike.of(x).size(x) for x in ak._util.completely_flatten(layout)]
+#             [ak.nplike.of(x).size(x) for x in ak._v2._util.completely_flatten(layout)]
 #         )
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.count(axis=axis, mask=mask_identity, keepdims=keepdims), behavior
 #         )

--- a/src/awkward/_v2/operations/reducers/count.py
+++ b/src/awkward/_v2/operations/reducers/count.py
@@ -79,7 +79,7 @@ def count(array, axis=None, keepdims=False, mask_identity=False):
 #     If it is desirable to include None values in #ak.count, use #ak.fill_none
 #     to turn the None values into something that would be counted.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if axis is None:

--- a/src/awkward/_v2/operations/reducers/count_nonzero.py
+++ b/src/awkward/_v2/operations/reducers/count_nonzero.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("count_nonzero")
+# @ak._v2._connect.numpy.implements("count_nonzero")
 def count_nonzero(array, axis=None, keepdims=False, mask_identity=False):
     pass
 

--- a/src/awkward/_v2/operations/reducers/count_nonzero.py
+++ b/src/awkward/_v2/operations/reducers/count_nonzero.py
@@ -56,12 +56,12 @@ def count_nonzero(array, axis=None, keepdims=False, mask_identity=False):
 #         return reduce(
 #             [
 #                 ak.nplike.of(x).count_nonzero(x)
-#                 for x in ak._util.completely_flatten(layout)
+#                 for x in ak._v2._util.completely_flatten(layout)
 #             ]
 #         )
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.count_nonzero(axis=axis, mask=mask_identity, keepdims=keepdims),
 #             behavior,
 #         )

--- a/src/awkward/_v2/operations/reducers/count_nonzero.py
+++ b/src/awkward/_v2/operations/reducers/count_nonzero.py
@@ -42,7 +42,7 @@ def count_nonzero(array, axis=None, keepdims=False, mask_identity=False):
 #     count None values. If it is desirable to count them, use #ak.fill_none
 #     to turn them into something that would be counted.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if axis is None:

--- a/src/awkward/_v2/operations/reducers/linear_fit.py
+++ b/src/awkward/_v2/operations/reducers/linear_fit.py
@@ -125,7 +125,7 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #             (
 #                 ak._v2.contents.Content,
 #                 ak._v2.record.Record,
-#                 ak.partition.PartitionedArray,
+#                 ak.partition.PartitionedArray,   # NO PARTITIONED ARRAY
 #             ),
 #         ):
 #             intercept = ak._v2.contents.NumpyArray(nplike.array([intercept]))
@@ -135,7 +135,7 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #             (
 #                 ak._v2.contents.Content,
 #                 ak._v2.record.Record,
-#                 ak.partition.PartitionedArray,
+#                 ak.partition.PartitionedArray,   # NO PARTITIONED ARRAY
 #             ),
 #         ):
 #             slope = ak._v2.contents.NumpyArray(nplike.array([slope]))
@@ -145,7 +145,7 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #             (
 #                 ak._v2.contents.Content,
 #                 ak._v2.record.Record,
-#                 ak.partition.PartitionedArray,
+#                 ak.partition.PartitionedArray,   # NO PARTITIONED ARRAY
 #             ),
 #         ):
 #             intercept_error = ak._v2.contents.NumpyArray(nplike.array([intercept_error]))
@@ -155,20 +155,20 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #             (
 #                 ak._v2.contents.Content,
 #                 ak._v2.record.Record,
-#                 ak.partition.PartitionedArray,
+#                 ak.partition.PartitionedArray,   # NO PARTITIONED ARRAY
 #             ),
 #         ):
 #             slope_error = ak._v2.contents.NumpyArray(nplike.array([slope_error]))
 #             scalar = True
 
 #         sample = None
-#         if isinstance(intercept, ak.partition.PartitionedArray):
+#         if isinstance(intercept, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             sample = intercept
-#         elif isinstance(slope, ak.partition.PartitionedArray):
+#         elif isinstance(slope, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             sample = slope
-#         elif isinstance(intercept_error, ak.partition.PartitionedArray):
+#         elif isinstance(intercept_error, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             sample = intercept_error
-#         elif isinstance(slope_error, ak.partition.PartitionedArray):
+#         elif isinstance(slope_error, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             sample = slope_error
 
 #         if sample is not None:
@@ -191,7 +191,7 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #                         parameters={"__record__": "LinearFit"},
 #                     )
 #                 )
-#             out = ak.partition.IrregularlyPartitionedArray(output)
+#             out = ak.partition.IrregularlyPartitionedArray(output)   # NO PARTITIONED ARRAY
 
 #         else:
 #             out = ak._v2.contents.RecordArray(

--- a/src/awkward/_v2/operations/reducers/linear_fit.py
+++ b/src/awkward/_v2/operations/reducers/linear_fit.py
@@ -106,16 +106,16 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #         intercept_error = nplike.sqrt(nplike.true_divide(sumwxx, delta))
 #         slope_error = nplike.sqrt(nplike.true_divide(sumw, delta))
 
-#         intercept = ak.operations.convert.to_layout(
+#         intercept = ak._v2.operations.convert.to_layout(
 #             intercept, allow_record=True, allow_other=True
 #         )
-#         slope = ak.operations.convert.to_layout(
+#         slope = ak._v2.operations.convert.to_layout(
 #             slope, allow_record=True, allow_other=True
 #         )
-#         intercept_error = ak.operations.convert.to_layout(
+#         intercept_error = ak._v2.operations.convert.to_layout(
 #             intercept_error, allow_record=True, allow_other=True
 #         )
-#         slope_error = ak.operations.convert.to_layout(
+#         slope_error = ak._v2.operations.convert.to_layout(
 #             slope_error, allow_record=True, allow_other=True
 #         )
 

--- a/src/awkward/_v2/operations/reducers/linear_fit.py
+++ b/src/awkward/_v2/operations/reducers/linear_fit.py
@@ -202,4 +202,4 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #             if scalar:
 #                 out = out[0]
 
-#         return ak._util.wrap(out, ak._util.behaviorof(x, y))
+#         return ak._v2._util.wrap(out, ak._v2._util.behaviorof(x, y))

--- a/src/awkward/_v2/operations/reducers/linear_fit.py
+++ b/src/awkward/_v2/operations/reducers/linear_fit.py
@@ -123,42 +123,42 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #         if not isinstance(
 #             intercept,
 #             (
-#                 ak.layout.Content,
-#                 ak.layout.Record,
+#                 ak._v2.contents.Content,
+#                 ak._v2.record.Record,
 #                 ak.partition.PartitionedArray,
 #             ),
 #         ):
-#             intercept = ak.layout.NumpyArray(nplike.array([intercept]))
+#             intercept = ak._v2.contents.NumpyArray(nplike.array([intercept]))
 #             scalar = True
 #         if not isinstance(
 #             slope,
 #             (
-#                 ak.layout.Content,
-#                 ak.layout.Record,
+#                 ak._v2.contents.Content,
+#                 ak._v2.record.Record,
 #                 ak.partition.PartitionedArray,
 #             ),
 #         ):
-#             slope = ak.layout.NumpyArray(nplike.array([slope]))
+#             slope = ak._v2.contents.NumpyArray(nplike.array([slope]))
 #             scalar = True
 #         if not isinstance(
 #             intercept_error,
 #             (
-#                 ak.layout.Content,
-#                 ak.layout.Record,
+#                 ak._v2.contents.Content,
+#                 ak._v2.record.Record,
 #                 ak.partition.PartitionedArray,
 #             ),
 #         ):
-#             intercept_error = ak.layout.NumpyArray(nplike.array([intercept_error]))
+#             intercept_error = ak._v2.contents.NumpyArray(nplike.array([intercept_error]))
 #             scalar = True
 #         if not isinstance(
 #             slope_error,
 #             (
-#                 ak.layout.Content,
-#                 ak.layout.Record,
+#                 ak._v2.contents.Content,
+#                 ak._v2.record.Record,
 #                 ak.partition.PartitionedArray,
 #             ),
 #         ):
-#             slope_error = ak.layout.NumpyArray(nplike.array([slope_error]))
+#             slope_error = ak._v2.contents.NumpyArray(nplike.array([slope_error]))
 #             scalar = True
 
 #         sample = None
@@ -185,7 +185,7 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #                 sample.numpartitions, (intercept, slope, intercept_error, slope_error)
 #             ):
 #                 output.append(
-#                     ak.layout.RecordArray(
+#                     ak._v2.contents.RecordArray(
 #                         [a, b, c, d],
 #                         ["intercept", "slope", "intercept_error", "slope_error"],
 #                         parameters={"__record__": "LinearFit"},
@@ -194,7 +194,7 @@ def linear_fit(x, y, weight=None, axis=None, keepdims=False, mask_identity=True)
 #             out = ak.partition.IrregularlyPartitionedArray(output)
 
 #         else:
-#             out = ak.layout.RecordArray(
+#             out = ak._v2.contents.RecordArray(
 #                 [intercept, slope, intercept_error, slope_error],
 #                 ["intercept", "slope", "intercept_error", "slope_error"],
 #                 parameters={"__record__": "LinearFit"},

--- a/src/awkward/_v2/operations/reducers/max.py
+++ b/src/awkward/_v2/operations/reducers/max.py
@@ -45,7 +45,7 @@ def max(array, axis=None, keepdims=False, initial=None, mask_identity=True):
 #     See #ak.sum for a more complete description of nested list and missing
 #     value (None) handling in reducers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if axis is None:

--- a/src/awkward/_v2/operations/reducers/max.py
+++ b/src/awkward/_v2/operations/reducers/max.py
@@ -59,11 +59,11 @@ def max(array, axis=None, keepdims=False, initial=None, mask_identity=True):
 #                 x, y = xs[0], reduce(xs[1:])
 #                 return x if x > y else y
 
-#         tmp = ak._util.completely_flatten(layout)
+#         tmp = ak._v2._util.completely_flatten(layout)
 #         return reduce([ak.nplike.of(x).max(x) for x in tmp if len(x) > 0])
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.max(
 #                 axis=axis, mask=mask_identity, keepdims=keepdims, initial=initial
 #             ),

--- a/src/awkward/_v2/operations/reducers/max.py
+++ b/src/awkward/_v2/operations/reducers/max.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("max")
+# @ak._v2._connect.numpy.implements("max")
 def max(array, axis=None, keepdims=False, initial=None, mask_identity=True):
     pass
 

--- a/src/awkward/_v2/operations/reducers/mean.py
+++ b/src/awkward/_v2/operations/reducers/mean.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("mean")
+# @ak._v2._connect.numpy.implements("mean")
 def mean(x, weight=None, axis=None, keepdims=False, mask_identity=True):
     pass
 

--- a/src/awkward/_v2/operations/reducers/min.py
+++ b/src/awkward/_v2/operations/reducers/min.py
@@ -59,11 +59,11 @@ def min(array, axis=None, keepdims=False, initial=None, mask_identity=True):
 #                 x, y = xs[0], reduce(xs[1:])
 #                 return x if x < y else y
 
-#         tmp = ak._util.completely_flatten(layout)
+#         tmp = ak._v2._util.completely_flatten(layout)
 #         return reduce([ak.nplike.of(x).min(x) for x in tmp if len(x) > 0])
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.min(
 #                 axis=axis, mask=mask_identity, keepdims=keepdims, initial=initial
 #             ),

--- a/src/awkward/_v2/operations/reducers/min.py
+++ b/src/awkward/_v2/operations/reducers/min.py
@@ -45,7 +45,7 @@ def min(array, axis=None, keepdims=False, initial=None, mask_identity=True):
 #     See #ak.sum for a more complete description of nested list and missing
 #     value (None) handling in reducers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if axis is None:

--- a/src/awkward/_v2/operations/reducers/min.py
+++ b/src/awkward/_v2/operations/reducers/min.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("min")
+# @ak._v2._connect.numpy.implements("min")
 def min(array, axis=None, keepdims=False, initial=None, mask_identity=True):
     pass
 

--- a/src/awkward/_v2/operations/reducers/prod.py
+++ b/src/awkward/_v2/operations/reducers/prod.py
@@ -38,7 +38,7 @@ def prod(array, axis=None, keepdims=False, mask_identity=False):
 #     See #ak.sum for a more complete description of nested list and missing
 #     value (None) handling in reducers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if axis is None:

--- a/src/awkward/_v2/operations/reducers/prod.py
+++ b/src/awkward/_v2/operations/reducers/prod.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("prod")
+# @ak._v2._connect.numpy.implements("prod")
 def prod(array, axis=None, keepdims=False, mask_identity=False):
     pass
 

--- a/src/awkward/_v2/operations/reducers/prod.py
+++ b/src/awkward/_v2/operations/reducers/prod.py
@@ -50,10 +50,10 @@ def prod(array, axis=None, keepdims=False, mask_identity=False):
 #                 return xs[0] * reduce(xs[1:])
 
 #         return reduce(
-#             [ak.nplike.of(x).prod(x) for x in ak._util.completely_flatten(layout)]
+#             [ak.nplike.of(x).prod(x) for x in ak._v2._util.completely_flatten(layout)]
 #         )
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.prod(axis=axis, mask=mask_identity, keepdims=keepdims), behavior
 #         )

--- a/src/awkward/_v2/operations/reducers/ptp.py
+++ b/src/awkward/_v2/operations/reducers/ptp.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("ptp")
+# @ak._v2._connect.numpy.implements("ptp")
 def ptp(arr, axis=None, keepdims=False, mask_identity=True):
     pass
 

--- a/src/awkward/_v2/operations/reducers/std.py
+++ b/src/awkward/_v2/operations/reducers/std.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("std")
+# @ak._v2._connect.numpy.implements("std")
 def std(x, weight=None, ddof=0, axis=None, keepdims=False, mask_identity=True):
     pass
 

--- a/src/awkward/_v2/operations/reducers/sum.py
+++ b/src/awkward/_v2/operations/reducers/sum.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("sum")
+# @ak._v2._connect.numpy.implements("sum")
 def sum(array, axis=None, keepdims=False, mask_identity=False):
     pass
 

--- a/src/awkward/_v2/operations/reducers/sum.py
+++ b/src/awkward/_v2/operations/reducers/sum.py
@@ -182,7 +182,7 @@ def sum(array, axis=None, keepdims=False, mask_identity=False):
 #     the identity of addition, but it is reduced to None if
 #     `mask_identity=True`.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if axis is None:

--- a/src/awkward/_v2/operations/reducers/sum.py
+++ b/src/awkward/_v2/operations/reducers/sum.py
@@ -194,10 +194,10 @@ def sum(array, axis=None, keepdims=False, mask_identity=False):
 #                 return xs[0] + reduce(xs[1:])
 
 #         return reduce(
-#             [ak.nplike.of(x).sum(x) for x in ak._util.completely_flatten(layout)]
+#             [ak.nplike.of(x).sum(x) for x in ak._v2._util.completely_flatten(layout)]
 #         )
 #     else:
-#         behavior = ak._util.behaviorof(array)
-#         return ak._util.wrap(
+#         behavior = ak._v2._util.behaviorof(array)
+#         return ak._v2._util.wrap(
 #             layout.sum(axis=axis, mask=mask_identity, keepdims=keepdims), behavior
 #         )

--- a/src/awkward/_v2/operations/reducers/var.py
+++ b/src/awkward/_v2/operations/reducers/var.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("var")
+# @ak._v2._connect.numpy.implements("var")
 def var(x, weight=None, ddof=0, axis=None, keepdims=False, mask_identity=True):
     pass
 

--- a/src/awkward/_v2/operations/structure/argcartesian.py
+++ b/src/awkward/_v2/operations/structure/argcartesian.py
@@ -78,7 +78,7 @@ def argcartesian(
 #     if axis < 0:
 #         raise ValueError(
 #             "the 'axis' of argcartesian must be non-negative"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     else:

--- a/src/awkward/_v2/operations/structure/argcartesian.py
+++ b/src/awkward/_v2/operations/structure/argcartesian.py
@@ -78,12 +78,12 @@ def argcartesian(
 #     if axis < 0:
 #         raise ValueError(
 #             "the 'axis' of argcartesian must be non-negative"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     else:
 #         if isinstance(arrays, dict):
-#             behavior = ak._util.behaviorof(*arrays.values(), behavior=behavior)
+#             behavior = ak._v2._util.behaviorof(*arrays.values(), behavior=behavior)
 #             layouts = dict(
 #                 (
 #                     n,
@@ -94,7 +94,7 @@ def argcartesian(
 #                 for n, x in arrays.items()
 #             )
 #         else:
-#             behavior = ak._util.behaviorof(*arrays, behavior=behavior)
+#             behavior = ak._v2._util.behaviorof(*arrays, behavior=behavior)
 #             layouts = [
 #                 ak.operations.convert.to_layout(
 #                     x, allow_record=False, allow_other=False
@@ -113,4 +113,4 @@ def argcartesian(
 #             layouts, axis=axis, nested=nested, parameters=parameters, highlevel=False
 #         )
 
-#         return ak._util.maybe_wrap(result, behavior, highlevel)
+#         return ak._v2._util.maybe_wrap(result, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/argcartesian.py
+++ b/src/awkward/_v2/operations/structure/argcartesian.py
@@ -87,7 +87,7 @@ def argcartesian(
 #             layouts = dict(
 #                 (
 #                     n,
-#                     ak.operations.convert.to_layout(
+#                     ak._v2.operations.convert.to_layout(
 #                         x, allow_record=False, allow_other=False
 #                     ).localindex(axis),
 #                 )
@@ -96,7 +96,7 @@ def argcartesian(
 #         else:
 #             behavior = ak._v2._util.behaviorof(*arrays, behavior=behavior)
 #             layouts = [
-#                 ak.operations.convert.to_layout(
+#                 ak._v2.operations.convert.to_layout(
 #                     x, allow_record=False, allow_other=False
 #                 ).localindex(axis)
 #                 for x in arrays

--- a/src/awkward/_v2/operations/structure/argcombinations.py
+++ b/src/awkward/_v2/operations/structure/argcombinations.py
@@ -63,7 +63,7 @@ def argcombinations(
 #     if axis < 0:
 #         raise ValueError(
 #             "the 'axis' for argcombinations must be non-negative"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 #     else:
 #         layout = ak.operations.convert.to_layout(

--- a/src/awkward/_v2/operations/structure/argcombinations.py
+++ b/src/awkward/_v2/operations/structure/argcombinations.py
@@ -66,7 +66,7 @@ def argcombinations(
 #
 #         )
 #     else:
-#         layout = ak.operations.convert.to_layout(
+#         layout = ak._v2.operations.convert.to_layout(
 #             array, allow_record=False, allow_other=False
 #         ).localindex(axis)
 #         out = layout.combinations(

--- a/src/awkward/_v2/operations/structure/argcombinations.py
+++ b/src/awkward/_v2/operations/structure/argcombinations.py
@@ -63,7 +63,7 @@ def argcombinations(
 #     if axis < 0:
 #         raise ValueError(
 #             "the 'axis' for argcombinations must be non-negative"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 #     else:
 #         layout = ak.operations.convert.to_layout(
@@ -72,4 +72,4 @@ def argcombinations(
 #         out = layout.combinations(
 #             n, replacement=replacement, keys=fields, parameters=parameters, axis=axis
 #         )
-#         return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#         return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/argsort.py
+++ b/src/awkward/_v2/operations/structure/argsort.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("argsort")
+# @ak._v2._connect.numpy.implements("argsort")
 def argsort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=None):
     pass
 

--- a/src/awkward/_v2/operations/structure/argsort.py
+++ b/src/awkward/_v2/operations/structure/argsort.py
@@ -51,4 +51,4 @@ def argsort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavio
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = layout.argsort(axis, ascending, stable)
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/argsort.py
+++ b/src/awkward/_v2/operations/structure/argsort.py
@@ -47,7 +47,7 @@ def argsort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavio
 #         >>> data[index]
 #         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = layout.argsort(axis, ascending, stable)

--- a/src/awkward/_v2/operations/structure/broadcast_arrays.py
+++ b/src/awkward/_v2/operations/structure/broadcast_arrays.py
@@ -114,7 +114,7 @@ def broadcast_arrays(*arrays, **kwargs):
 #     #ak.Array.type, but it is lost when converting an array into JSON or
 #     Python objects.
 #     """
-#     (highlevel, left_broadcast, right_broadcast) = ak._util.extra(
+#     (highlevel, left_broadcast, right_broadcast) = ak._v2._util.extra(
 #         (),
 #         kwargs,
 #         [("highlevel", True), ("left_broadcast", True), ("right_broadcast", True)],
@@ -135,8 +135,8 @@ def broadcast_arrays(*arrays, **kwargs):
 #         else:
 #             return None
 
-#     behavior = ak._util.behaviorof(*arrays)
-#     out = ak._util.broadcast_and_apply(
+#     behavior = ak._v2._util.behaviorof(*arrays)
+#     out = ak._v2._util.broadcast_and_apply(
 #         inputs,
 #         getfunction,
 #         behavior,
@@ -147,6 +147,6 @@ def broadcast_arrays(*arrays, **kwargs):
 #     )
 #     assert isinstance(out, tuple)
 #     if highlevel:
-#         return [ak._util.wrap(x, behavior) for x in out]
+#         return [ak._v2._util.wrap(x, behavior) for x in out]
 #     else:
 #         return list(out)

--- a/src/awkward/_v2/operations/structure/broadcast_arrays.py
+++ b/src/awkward/_v2/operations/structure/broadcast_arrays.py
@@ -122,7 +122,7 @@ def broadcast_arrays(*arrays, **kwargs):
 
 #     inputs = []
 #     for x in arrays:
-#         y = ak.operations.convert.to_layout(x, allow_record=True, allow_other=True)
+#         y = ak._v2.operations.convert.to_layout(x, allow_record=True, allow_other=True)
 #         if isinstance(y, ak.partition.PartitionedArray):
 #             y = y.toContent()
 #         if not isinstance(y, (ak._v2.contents.Content, ak._v2.contents.Record)):

--- a/src/awkward/_v2/operations/structure/broadcast_arrays.py
+++ b/src/awkward/_v2/operations/structure/broadcast_arrays.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("broadcast_arrays")
+# @ak._v2._connect.numpy.implements("broadcast_arrays")
 def broadcast_arrays(*arrays, **kwargs):
     pass
 

--- a/src/awkward/_v2/operations/structure/broadcast_arrays.py
+++ b/src/awkward/_v2/operations/structure/broadcast_arrays.py
@@ -123,7 +123,7 @@ def broadcast_arrays(*arrays, **kwargs):
 #     inputs = []
 #     for x in arrays:
 #         y = ak._v2.operations.convert.to_layout(x, allow_record=True, allow_other=True)
-#         if isinstance(y, ak.partition.PartitionedArray):
+#         if isinstance(y, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             y = y.toContent()
 #         if not isinstance(y, (ak._v2.contents.Content, ak._v2.contents.Record)):
 #             y = ak._v2.contents.NumpyArray(ak.nplike.of(*arrays).array([y]))

--- a/src/awkward/_v2/operations/structure/broadcast_arrays.py
+++ b/src/awkward/_v2/operations/structure/broadcast_arrays.py
@@ -125,12 +125,12 @@ def broadcast_arrays(*arrays, **kwargs):
 #         y = ak.operations.convert.to_layout(x, allow_record=True, allow_other=True)
 #         if isinstance(y, ak.partition.PartitionedArray):
 #             y = y.toContent()
-#         if not isinstance(y, (ak.layout.Content, ak.layout.Record)):
-#             y = ak.layout.NumpyArray(ak.nplike.of(*arrays).array([y]))
+#         if not isinstance(y, (ak._v2.contents.Content, ak._v2.contents.Record)):
+#             y = ak._v2.contents.NumpyArray(ak.nplike.of(*arrays).array([y]))
 #         inputs.append(y)
 
 #     def getfunction(inputs):
-#         if all(isinstance(x, ak.layout.NumpyArray) for x in inputs):
+#         if all(isinstance(x, ak._v2.contents.NumpyArray) for x in inputs):
 #             return lambda: tuple(inputs)
 #         else:
 #             return None

--- a/src/awkward/_v2/operations/structure/cartesian.py
+++ b/src/awkward/_v2/operations/structure/cartesian.py
@@ -221,7 +221,7 @@ def cartesian(
 #     """
 #     is_partitioned = False
 #     if isinstance(arrays, dict):
-#         behavior = ak._util.behaviorof(*arrays.values(), behavior=behavior)
+#         behavior = ak._v2._util.behaviorof(*arrays.values(), behavior=behavior)
 #         nplike = ak.nplike.of(*arrays.values())
 #         new_arrays = {}
 #         for n, x in arrays.items():
@@ -231,7 +231,7 @@ def cartesian(
 #             if isinstance(new_arrays[n], ak.partition.PartitionedArray):
 #                 is_partitioned = True
 #     else:
-#         behavior = ak._util.behaviorof(*arrays, behavior=behavior)
+#         behavior = ak._v2._util.behaviorof(*arrays, behavior=behavior)
 #         nplike = ak.nplike.of(*arrays)
 #         new_arrays = []
 #         for x in arrays:
@@ -258,13 +258,13 @@ def cartesian(
 #     posaxis = new_arrays_values[0].axis_wrap_if_negative(axis)
 #     if posaxis < 0:
 #         raise ValueError(
-#             "negative axis depth is ambiguous" + ak._util.exception_suffix(__file__)
+#             "negative axis depth is ambiguous" + ak._v2._util.exception_suffix(__file__)
 #         )
 #     for x in new_arrays_values[1:]:
 #         if x.axis_wrap_if_negative(axis) != posaxis:
 #             raise ValueError(
 #                 "arrays to cartesian-product do not have the same depth for "
-#                 "negative axis" + ak._util.exception_suffix(__file__)
+#                 "negative axis" + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     if posaxis == 0:
@@ -277,7 +277,7 @@ def cartesian(
 #             if any(not (isinstance(n, str) and n in new_arrays) for x in nested):
 #                 raise ValueError(
 #                     "the 'nested' parameter of cartesian must be dict keys "
-#                     "for a dict of arrays" + ak._util.exception_suffix(__file__)
+#                     "for a dict of arrays" + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             recordlookup = []
 #             layouts = []
@@ -299,7 +299,7 @@ def cartesian(
 #                 raise ValueError(
 #                     "the 'nested' prarmeter of cartesian must be integers in "
 #                     "[0, len(arrays) - 1) for an iterable of arrays"
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             recordlookup = None
 #             layouts = []
@@ -386,9 +386,9 @@ def cartesian(
 #                         raise ValueError(
 #                             "ak.cartesian does not compute combinations of the "
 #                             "characters of a string; please split it into lists"
-#                             + ak._util.exception_suffix(__file__)
+#                             + ak._v2._util.exception_suffix(__file__)
 #                         )
-#                     nextlayout = ak._util.recursively_apply(
+#                     nextlayout = ak._v2._util.recursively_apply(
 #                         layout, getgetfunction1(inside), pass_depth=True
 #                     )
 #                     return lambda: newaxis(nextlayout, outside)
@@ -401,7 +401,7 @@ def cartesian(
 #             layout = ak.operations.convert.to_layout(
 #                 x, allow_record=False, allow_other=False
 #             )
-#             return ak._util.recursively_apply(
+#             return ak._v2._util.recursively_apply(
 #                 layout, getgetfunction2(i), pass_depth=True
 #             )
 
@@ -415,7 +415,7 @@ def cartesian(
 #             if any(not (isinstance(n, str) and n in new_arrays) for x in nested):
 #                 raise ValueError(
 #                     "the 'nested' parameter of cartesian must be dict keys "
-#                     "for a dict of arrays" + ak._util.exception_suffix(__file__)
+#                     "for a dict of arrays" + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             recordlookup = []
 #             layouts = []
@@ -435,7 +435,7 @@ def cartesian(
 #                 raise ValueError(
 #                     "the 'nested' parameter of cartesian must be integers in "
 #                     "[0, len(arrays) - 1) for an iterable of arrays"
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             recordlookup = None
 #             layouts = []
@@ -459,7 +459,7 @@ def cartesian(
 #             else:
 #                 return None
 
-#         out = ak._util.broadcast_and_apply(
+#         out = ak._v2._util.broadcast_and_apply(
 #             layouts, getfunction3, behavior, right_broadcast=False, pass_depth=True
 #         )
 #         assert isinstance(out, tuple) and len(out) == 1
@@ -469,4 +469,4 @@ def cartesian(
 #             flatten_axis = toflatten.pop()
 #             result = flatten(result, axis=flatten_axis, highlevel=False)
 
-#     return ak._util.maybe_wrap(result, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(result, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/cartesian.py
+++ b/src/awkward/_v2/operations/structure/cartesian.py
@@ -258,13 +258,13 @@ def cartesian(
 #     posaxis = new_arrays_values[0].axis_wrap_if_negative(axis)
 #     if posaxis < 0:
 #         raise ValueError(
-#             "negative axis depth is ambiguous" + ak._v2._util.exception_suffix(__file__)
+#             "negative axis depth is ambiguous"
 #         )
 #     for x in new_arrays_values[1:]:
 #         if x.axis_wrap_if_negative(axis) != posaxis:
 #             raise ValueError(
 #                 "arrays to cartesian-product do not have the same depth for "
-#                 "negative axis" + ak._v2._util.exception_suffix(__file__)
+#                 "negative axis"
 #             )
 
 #     if posaxis == 0:
@@ -277,7 +277,7 @@ def cartesian(
 #             if any(not (isinstance(n, str) and n in new_arrays) for x in nested):
 #                 raise ValueError(
 #                     "the 'nested' parameter of cartesian must be dict keys "
-#                     "for a dict of arrays" + ak._v2._util.exception_suffix(__file__)
+#                     "for a dict of arrays"
 #                 )
 #             recordlookup = []
 #             layouts = []
@@ -299,7 +299,7 @@ def cartesian(
 #                 raise ValueError(
 #                     "the 'nested' prarmeter of cartesian must be integers in "
 #                     "[0, len(arrays) - 1) for an iterable of arrays"
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #             recordlookup = None
 #             layouts = []
@@ -386,7 +386,7 @@ def cartesian(
 #                         raise ValueError(
 #                             "ak.cartesian does not compute combinations of the "
 #                             "characters of a string; please split it into lists"
-#                             + ak._v2._util.exception_suffix(__file__)
+#
 #                         )
 #                     nextlayout = ak._v2._util.recursively_apply(
 #                         layout, getgetfunction1(inside), pass_depth=True
@@ -415,7 +415,7 @@ def cartesian(
 #             if any(not (isinstance(n, str) and n in new_arrays) for x in nested):
 #                 raise ValueError(
 #                     "the 'nested' parameter of cartesian must be dict keys "
-#                     "for a dict of arrays" + ak._v2._util.exception_suffix(__file__)
+#                     "for a dict of arrays"
 #                 )
 #             recordlookup = []
 #             layouts = []
@@ -435,7 +435,7 @@ def cartesian(
 #                 raise ValueError(
 #                     "the 'nested' parameter of cartesian must be integers in "
 #                     "[0, len(arrays) - 1) for an iterable of arrays"
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #             recordlookup = None
 #             layouts = []

--- a/src/awkward/_v2/operations/structure/cartesian.py
+++ b/src/awkward/_v2/operations/structure/cartesian.py
@@ -312,20 +312,20 @@ def cartesian(
 #         ]
 
 #         indexes = [
-#             ak.layout.Index64(x.reshape(-1))
+#             ak._v2.index.Index64(x.reshape(-1))
 #             for x in nplike.meshgrid(
 #                 *[nplike.arange(len(x), dtype=np.int64) for x in layouts], indexing="ij"
 #             )
 #         ]
 #         outs = [
-#             ak.layout.IndexedArray64(x, y)
+#             ak._v2.contents.IndexedArray64(x, y)
 #             for x, y in __builtins__["zip"](indexes, layouts)
 #         ]
 
-#         result = ak.layout.RecordArray(outs, recordlookup, parameters=parameters)
+#         result = ak._v2.contents.RecordArray(outs, recordlookup, parameters=parameters)
 #         for i in range(len(new_arrays) - 1, -1, -1):
 #             if i in nested:
-#                 result = ak.layout.RegularArray(result, len(layouts[i + 1]), 0)
+#                 result = ak._v2.contents.RegularArray(result, len(layouts[i + 1]), 0)
 
 #     elif is_partitioned:
 #         sample = None
@@ -363,7 +363,7 @@ def cartesian(
 #             if i == 0:
 #                 return layout
 #             else:
-#                 return ak.layout.RegularArray(newaxis(layout, i - 1), 1, 0)
+#                 return ak._v2.contents.RegularArray(newaxis(layout, i - 1), 1, 0)
 
 #         def getgetfunction1(i):
 #             def getfunction1(layout, depth):
@@ -449,12 +449,12 @@ def cartesian(
 #                 if all(len(x) == 0 for x in inputs):
 #                     inputs = [
 #                         x.content
-#                         if isinstance(x, ak.layout.RegularArray) and x.size == 1
+#                         if isinstance(x, ak._v2.contents.RegularArray) and x.size == 1
 #                         else x
 #                         for x in inputs
 #                     ]
 #                 return lambda: (
-#                     ak.layout.RecordArray(inputs, recordlookup, parameters=parameters),
+#                     ak._v2.contents.RecordArray(inputs, recordlookup, parameters=parameters),
 #                 )
 #             else:
 #                 return None

--- a/src/awkward/_v2/operations/structure/cartesian.py
+++ b/src/awkward/_v2/operations/structure/cartesian.py
@@ -225,7 +225,7 @@ def cartesian(
 #         nplike = ak.nplike.of(*arrays.values())
 #         new_arrays = {}
 #         for n, x in arrays.items():
-#             new_arrays[n] = ak.operations.convert.to_layout(
+#             new_arrays[n] = ak._v2.operations.convert.to_layout(
 #                 x, allow_record=False, allow_other=False
 #             )
 #             if isinstance(new_arrays[n], ak.partition.PartitionedArray):
@@ -236,7 +236,7 @@ def cartesian(
 #         new_arrays = []
 #         for x in arrays:
 #             new_arrays.append(
-#                 ak.operations.convert.to_layout(
+#                 ak._v2.operations.convert.to_layout(
 #                     x, allow_record=False, allow_other=False
 #                 )
 #             )
@@ -398,7 +398,7 @@ def cartesian(
 #             return getfunction2
 
 #         def apply(x, i):
-#             layout = ak.operations.convert.to_layout(
+#             layout = ak._v2.operations.convert.to_layout(
 #                 x, allow_record=False, allow_other=False
 #             )
 #             return ak._v2._util.recursively_apply(

--- a/src/awkward/_v2/operations/structure/cartesian.py
+++ b/src/awkward/_v2/operations/structure/cartesian.py
@@ -228,7 +228,7 @@ def cartesian(
 #             new_arrays[n] = ak._v2.operations.convert.to_layout(
 #                 x, allow_record=False, allow_other=False
 #             )
-#             if isinstance(new_arrays[n], ak.partition.PartitionedArray):
+#             if isinstance(new_arrays[n], ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                 is_partitioned = True
 #     else:
 #         behavior = ak._v2._util.behaviorof(*arrays, behavior=behavior)
@@ -240,7 +240,7 @@ def cartesian(
 #                     x, allow_record=False, allow_other=False
 #                 )
 #             )
-#             if isinstance(new_arrays[-1], ak.partition.PartitionedArray):
+#             if isinstance(new_arrays[-1], ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                 is_partitioned = True
 
 #     if with_name is not None:
@@ -307,7 +307,7 @@ def cartesian(
 #                 layouts.append(x)
 
 #         layouts = [
-#             x.toContent() if isinstance(x, ak.partition.PartitionedArray) else x
+#             x.toContent() if isinstance(x, ak.partition.PartitionedArray) else x   # NO PARTITIONED ARRAY
 #             for x in layouts
 #         ]
 
@@ -331,12 +331,12 @@ def cartesian(
 #         sample = None
 #         if isinstance(new_arrays, dict):
 #             for x in new_arrays.values():
-#                 if isinstance(x, ak.partition.PartitionedArray):
+#                 if isinstance(x, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                     sample = x
 #                     break
 #         else:
 #             for x in new_arrays:
-#                 if isinstance(x, ak.partition.PartitionedArray):
+#                 if isinstance(x, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                     sample = x
 #                     break
 
@@ -355,7 +355,7 @@ def cartesian(
 #                 )
 #             )
 
-#         result = ak.partition.IrregularlyPartitionedArray(output)
+#         result = ak.partition.IrregularlyPartitionedArray(output)   # NO PARTITIONED ARRAY
 
 #     else:
 

--- a/src/awkward/_v2/operations/structure/combinations.py
+++ b/src/awkward/_v2/operations/structure/combinations.py
@@ -166,7 +166,7 @@ def combinations(
 #     if with_name is not None:
 #         parameters["__record__"] = with_name
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = layout.combinations(

--- a/src/awkward/_v2/operations/structure/combinations.py
+++ b/src/awkward/_v2/operations/structure/combinations.py
@@ -172,4 +172,4 @@ def combinations(
 #     out = layout.combinations(
 #         n, replacement=replacement, keys=fields, parameters=parameters, axis=axis
 #     )
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/concatenate.py
+++ b/src/awkward/_v2/operations/structure/concatenate.py
@@ -53,7 +53,7 @@ def concatenate(
 #     ):
 #         raise ValueError(
 #             "need at least one array to concatenate"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     first_content = [
@@ -82,14 +82,14 @@ def concatenate(
 #     if not 0 <= posaxis < maxdepth:
 #         raise ValueError(
 #             "axis={0} is beyond the depth of this array or the depth of this array "
-#             "is ambiguous".format(axis) + ak._util.exception_suffix(__file__)
+#             "is ambiguous".format(axis) + ak._v2._util.exception_suffix(__file__)
 #         )
 #     for x in contents:
 #         if isinstance(x, ak._v2.contents.Content):
 #             if x.axis_wrap_if_negative(axis) != posaxis:
 #                 raise ValueError(
 #                     "arrays to concatenate do not have the same depth for negative "
-#                     "axis={0}".format(axis) + ak._util.exception_suffix(__file__)
+#                     "axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #     if any(isinstance(x, ak.partition.PartitionedArray) for x in contents):
@@ -169,19 +169,19 @@ def concatenate(
 #                 batch = [collapsed.merge_as_union(x)]
 
 #         out = batch[0].mergemany(batch[1:])
-#         if isinstance(out, ak._util.uniontypes):
+#         if isinstance(out, ak._v2._util.uniontypes):
 #             out = out.simplify(merge=merge, mergebool=mergebool)
 
 #     else:
 
 #         def getfunction(inputs, depth):
 #             if depth == posaxis and any(
-#                 isinstance(x, ak._util.optiontypes) for x in inputs
+#                 isinstance(x, ak._v2._util.optiontypes) for x in inputs
 #             ):
 #                 nextinputs = []
 #                 for x in inputs:
-#                     if isinstance(x, ak._util.optiontypes) and isinstance(
-#                         x.content, ak._util.listtypes
+#                     if isinstance(x, ak._v2._util.optiontypes) and isinstance(
+#                         x.content, ak._v2._util.listtypes
 #                     ):
 #                         nextinputs.append(fill_none(x, [], axis=0, highlevel=False))
 #                     else:
@@ -189,7 +189,7 @@ def concatenate(
 #                 inputs = nextinputs
 
 #             if depth == posaxis and all(
-#                 isinstance(x, ak._util.listtypes)
+#                 isinstance(x, ak._v2._util.listtypes)
 #                 or (isinstance(x, ak._v2.contents.NumpyArray) and x.ndim > 1)
 #                 or not isinstance(x, ak._v2.contents.Content)
 #                 for x in inputs
@@ -249,23 +249,23 @@ def concatenate(
 #             ):
 #                 raise ValueError(
 #                     "at least one array is not deep enough to concatenate at "
-#                     "axis={0}".format(axis) + ak._util.exception_suffix(__file__)
+#                     "axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #             else:
 #                 return None
 
-#         out = ak._util.broadcast_and_apply(
+#         out = ak._v2._util.broadcast_and_apply(
 #             contents,
 #             getfunction,
-#             behavior=ak._util.behaviorof(*arrays, behavior=behavior),
+#             behavior=ak._v2._util.behaviorof(*arrays, behavior=behavior),
 #             allow_records=True,
 #             right_broadcast=False,
 #             pass_depth=True,
 #         )[0]
 
-#     return ak._util.maybe_wrap(
-#         out, ak._util.behaviorof(*arrays, behavior=behavior), highlevel
+#     return ak._v2._util.maybe_wrap(
+#         out, ak._v2._util.behaviorof(*arrays, behavior=behavior), highlevel
 #     )
 # @ak._connect._numpy.implements("concatenate")
 # def concatenate(
@@ -310,7 +310,7 @@ def concatenate(
 #     ):
 #         raise ValueError(
 #             "need at least one array to concatenate"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     first_content = [
@@ -339,14 +339,14 @@ def concatenate(
 #     if not 0 <= posaxis < maxdepth:
 #         raise ValueError(
 #             "axis={0} is beyond the depth of this array or the depth of this array "
-#             "is ambiguous".format(axis) + ak._util.exception_suffix(__file__)
+#             "is ambiguous".format(axis) + ak._v2._util.exception_suffix(__file__)
 #         )
 #     for x in contents:
 #         if isinstance(x, ak._v2.contents.Content):
 #             if x.axis_wrap_if_negative(axis) != posaxis:
 #                 raise ValueError(
 #                     "arrays to concatenate do not have the same depth for negative "
-#                     "axis={0}".format(axis) + ak._util.exception_suffix(__file__)
+#                     "axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #     if any(isinstance(x, ak.partition.PartitionedArray) for x in contents):
@@ -426,19 +426,19 @@ def concatenate(
 #                 batch = [collapsed.merge_as_union(x)]
 
 #         out = batch[0].mergemany(batch[1:])
-#         if isinstance(out, ak._util.uniontypes):
+#         if isinstance(out, ak._v2._util.uniontypes):
 #             out = out.simplify(merge=merge, mergebool=mergebool)
 
 #     else:
 
 #         def getfunction(inputs, depth):
 #             if depth == posaxis and any(
-#                 isinstance(x, ak._util.optiontypes) for x in inputs
+#                 isinstance(x, ak._v2._util.optiontypes) for x in inputs
 #             ):
 #                 nextinputs = []
 #                 for x in inputs:
-#                     if isinstance(x, ak._util.optiontypes) and isinstance(
-#                         x.content, ak._util.listtypes
+#                     if isinstance(x, ak._v2._util.optiontypes) and isinstance(
+#                         x.content, ak._v2._util.listtypes
 #                     ):
 #                         nextinputs.append(fill_none(x, [], axis=0, highlevel=False))
 #                     else:
@@ -446,7 +446,7 @@ def concatenate(
 #                 inputs = nextinputs
 
 #             if depth == posaxis and all(
-#                 isinstance(x, ak._util.listtypes)
+#                 isinstance(x, ak._v2._util.listtypes)
 #                 or (isinstance(x, ak._v2.contents.NumpyArray) and x.ndim > 1)
 #                 or not isinstance(x, ak._v2.contents.Content)
 #                 for x in inputs
@@ -506,21 +506,21 @@ def concatenate(
 #             ):
 #                 raise ValueError(
 #                     "at least one array is not deep enough to concatenate at "
-#                     "axis={0}".format(axis) + ak._util.exception_suffix(__file__)
+#                     "axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #             else:
 #                 return None
 
-#         out = ak._util.broadcast_and_apply(
+#         out = ak._v2._util.broadcast_and_apply(
 #             contents,
 #             getfunction,
-#             behavior=ak._util.behaviorof(*arrays, behavior=behavior),
+#             behavior=ak._v2._util.behaviorof(*arrays, behavior=behavior),
 #             allow_records=True,
 #             right_broadcast=False,
 #             pass_depth=True,
 #         )[0]
 
-#     return ak._util.maybe_wrap(
-#         out, ak._util.behaviorof(*arrays, behavior=behavior), highlevel
+#     return ak._v2._util.maybe_wrap(
+#         out, ak._v2._util.behaviorof(*arrays, behavior=behavior), highlevel
 #     )

--- a/src/awkward/_v2/operations/structure/concatenate.py
+++ b/src/awkward/_v2/operations/structure/concatenate.py
@@ -39,7 +39,7 @@ def concatenate(
 #     element for element, and similarly for deeper levels.
 #     """
 #     contents = [
-#         ak.operations.convert.to_layout(
+#         ak._v2.operations.convert.to_layout(
 #             x, allow_record=False if axis == 0 else True, allow_other=True
 #         )
 #         for x in arrays
@@ -111,7 +111,7 @@ def concatenate(
 #                     offsets.append(offsets[-1] + len(content))
 #                 else:
 #                     partitions.append(
-#                         ak.operations.convert.from_iter([content], highlevel=False)
+#                         ak._v2.operations.convert.from_iter([content], highlevel=False)
 #                     )
 #                     offsets.append(offsets[-1] + 1)
 
@@ -157,7 +157,7 @@ def concatenate(
 #         contents = [
 #             x
 #             if isinstance(x, ak._v2.contents.Content)
-#             else ak.operations.convert.to_layout([x])
+#             else ak._v2.operations.convert.to_layout([x])
 #             for x in contents
 #         ]
 #         batch = [contents[0]]
@@ -297,7 +297,7 @@ def concatenate(
 #     element for element, and similarly for deeper levels.
 #     """
 #     contents = [
-#         ak.operations.convert.to_layout(
+#         ak._v2.operations.convert.to_layout(
 #             x, allow_record=False if axis == 0 else True, allow_other=True
 #         )
 #         for x in arrays
@@ -369,7 +369,7 @@ def concatenate(
 #                     offsets.append(offsets[-1] + len(content))
 #                 else:
 #                     partitions.append(
-#                         ak.operations.convert.from_iter([content], highlevel=False)
+#                         ak._v2.operations.convert.from_iter([content], highlevel=False)
 #                     )
 #                     offsets.append(offsets[-1] + 1)
 
@@ -415,7 +415,7 @@ def concatenate(
 #         contents = [
 #             x
 #             if isinstance(x, ak._v2.contents.Content)
-#             else ak.operations.convert.to_layout([x])
+#             else ak._v2.operations.convert.to_layout([x])
 #             for x in contents
 #         ]
 #         batch = [contents[0]]

--- a/src/awkward/_v2/operations/structure/concatenate.py
+++ b/src/awkward/_v2/operations/structure/concatenate.py
@@ -47,7 +47,7 @@ def concatenate(
 #     if not any(
 #         isinstance(
 #             x,
-#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
+#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),   # NO PARTITIONED ARRAY
 #         )
 #         for x in contents
 #     ):
@@ -61,7 +61,7 @@ def concatenate(
 #         for x in contents
 #         if isinstance(
 #             x,
-#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
+#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),   # NO PARTITIONED ARRAY
 #         )
 #     ][0]
 #     posaxis = first_content.axis_wrap_if_negative(axis)
@@ -73,7 +73,7 @@ def concatenate(
 #                 x,
 #                 (
 #                     ak._v2.contents.Content,
-#                     ak.partition.PartitionedArray,
+#                     ak.partition.PartitionedArray,   # NO PARTITIONED ARRAY
 #                     ak._v2.contents.Content,
 #                 ),
 #             )
@@ -92,12 +92,12 @@ def concatenate(
 #                     "axis={0}".format(axis)
 #                 )
 
-#     if any(isinstance(x, ak.partition.PartitionedArray) for x in contents):
+#     if any(isinstance(x, ak.partition.PartitionedArray) for x in contents):   # NO PARTITIONED ARRAY
 #         if posaxis == 0:
 #             partitions = []
 #             offsets = [0]
 #             for content in contents:
-#                 if isinstance(content, ak.partition.PartitionedArray):
+#                 if isinstance(content, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                     start = 0
 #                     for stop, part in __builtins__["zip"](
 #                         content.stops, content.partitions
@@ -115,11 +115,11 @@ def concatenate(
 #                     )
 #                     offsets.append(offsets[-1] + 1)
 
-#             out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])
+#             out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])   # NO PARTITIONED ARRAY
 
 #         else:
 #             for content in contents:
-#                 if isinstance(content, ak.partition.PartitionedArray):
+#                 if isinstance(content, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                     stops = content.stops
 #                     slices = []
 #                     start = 0
@@ -133,7 +133,7 @@ def concatenate(
 #             for slc in slices:
 #                 newcontents = []
 #                 for content in contents:
-#                     if isinstance(content, ak.partition.PartitionedArray):
+#                     if isinstance(content, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                         newcontents.append(content[slc].toContent())
 #                     elif isinstance(content, ak._v2.contents.Content):
 #                         newcontents.append(content[slc])
@@ -151,7 +151,7 @@ def concatenate(
 #                 )
 #                 offsets.append(offsets[-1] + len(partitions[-1]))
 
-#             out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])
+#             out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])   # NO PARTITIONED ARRAY
 
 #     elif posaxis == 0:
 #         contents = [
@@ -305,7 +305,7 @@ def concatenate(
 #     if not any(
 #         isinstance(
 #             x,
-#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
+#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),   # NO PARTITIONED ARRAY
 #         )
 #         for x in contents
 #     ):
@@ -319,7 +319,7 @@ def concatenate(
 #         for x in contents
 #         if isinstance(
 #             x,
-#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
+#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),   # NO PARTITIONED ARRAY
 #         )
 #     ][0]
 #     posaxis = first_content.axis_wrap_if_negative(axis)
@@ -331,7 +331,7 @@ def concatenate(
 #                 x,
 #                 (
 #                     ak._v2.contents.Content,
-#                     ak.partition.PartitionedArray,
+#                     ak.partition.PartitionedArray,   # NO PARTITIONED ARRAY
 #                     ak._v2.contents.Content,
 #                 ),
 #             )
@@ -350,12 +350,12 @@ def concatenate(
 #                     "axis={0}".format(axis)
 #                 )
 
-#     if any(isinstance(x, ak.partition.PartitionedArray) for x in contents):
+#     if any(isinstance(x, ak.partition.PartitionedArray) for x in contents):   # NO PARTITIONED ARRAY
 #         if posaxis == 0:
 #             partitions = []
 #             offsets = [0]
 #             for content in contents:
-#                 if isinstance(content, ak.partition.PartitionedArray):
+#                 if isinstance(content, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                     start = 0
 #                     for stop, part in __builtins__["zip"](
 #                         content.stops, content.partitions
@@ -373,11 +373,11 @@ def concatenate(
 #                     )
 #                     offsets.append(offsets[-1] + 1)
 
-#             out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])
+#             out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])   # NO PARTITIONED ARRAY
 
 #         else:
 #             for content in contents:
-#                 if isinstance(content, ak.partition.PartitionedArray):
+#                 if isinstance(content, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                     stops = content.stops
 #                     slices = []
 #                     start = 0
@@ -391,7 +391,7 @@ def concatenate(
 #             for slc in slices:
 #                 newcontents = []
 #                 for content in contents:
-#                     if isinstance(content, ak.partition.PartitionedArray):
+#                     if isinstance(content, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #                         newcontents.append(content[slc].toContent())
 #                     elif isinstance(content, ak._v2.contents.Content):
 #                         newcontents.append(content[slc])
@@ -409,7 +409,7 @@ def concatenate(
 #                 )
 #                 offsets.append(offsets[-1] + len(partitions[-1]))
 
-#             out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])
+#             out = ak.partition.IrregularlyPartitionedArray(partitions, offsets[1:])   # NO PARTITIONED ARRAY
 
 #     elif posaxis == 0:
 #         contents = [

--- a/src/awkward/_v2/operations/structure/concatenate.py
+++ b/src/awkward/_v2/operations/structure/concatenate.py
@@ -53,7 +53,7 @@ def concatenate(
 #     ):
 #         raise ValueError(
 #             "need at least one array to concatenate"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     first_content = [
@@ -82,14 +82,14 @@ def concatenate(
 #     if not 0 <= posaxis < maxdepth:
 #         raise ValueError(
 #             "axis={0} is beyond the depth of this array or the depth of this array "
-#             "is ambiguous".format(axis) + ak._v2._util.exception_suffix(__file__)
+#             "is ambiguous".format(axis)
 #         )
 #     for x in contents:
 #         if isinstance(x, ak._v2.contents.Content):
 #             if x.axis_wrap_if_negative(axis) != posaxis:
 #                 raise ValueError(
 #                     "arrays to concatenate do not have the same depth for negative "
-#                     "axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
+#                     "axis={0}".format(axis)
 #                 )
 
 #     if any(isinstance(x, ak.partition.PartitionedArray) for x in contents):
@@ -249,7 +249,7 @@ def concatenate(
 #             ):
 #                 raise ValueError(
 #                     "at least one array is not deep enough to concatenate at "
-#                     "axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
+#                     "axis={0}".format(axis)
 #                 )
 
 #             else:
@@ -310,7 +310,7 @@ def concatenate(
 #     ):
 #         raise ValueError(
 #             "need at least one array to concatenate"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     first_content = [
@@ -339,14 +339,14 @@ def concatenate(
 #     if not 0 <= posaxis < maxdepth:
 #         raise ValueError(
 #             "axis={0} is beyond the depth of this array or the depth of this array "
-#             "is ambiguous".format(axis) + ak._v2._util.exception_suffix(__file__)
+#             "is ambiguous".format(axis)
 #         )
 #     for x in contents:
 #         if isinstance(x, ak._v2.contents.Content):
 #             if x.axis_wrap_if_negative(axis) != posaxis:
 #                 raise ValueError(
 #                     "arrays to concatenate do not have the same depth for negative "
-#                     "axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
+#                     "axis={0}".format(axis)
 #                 )
 
 #     if any(isinstance(x, ak.partition.PartitionedArray) for x in contents):
@@ -506,7 +506,7 @@ def concatenate(
 #             ):
 #                 raise ValueError(
 #                     "at least one array is not deep enough to concatenate at "
-#                     "axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
+#                     "axis={0}".format(axis)
 #                 )
 
 #             else:

--- a/src/awkward/_v2/operations/structure/concatenate.py
+++ b/src/awkward/_v2/operations/structure/concatenate.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("concatenate")
+# @ak._v2._connect.numpy.implements("concatenate")
 def concatenate(
     arrays, axis=0, merge=True, mergebool=True, highlevel=True, behavior=None
 ):
@@ -267,7 +267,8 @@ def concatenate(
 #     return ak._v2._util.maybe_wrap(
 #         out, ak._v2._util.behaviorof(*arrays, behavior=behavior), highlevel
 #     )
-# @ak._connect._numpy.implements("concatenate")
+
+# @ak._v2._connect.numpy.implements("concatenate")
 # def concatenate(
 #     arrays, axis=0, merge=True, mergebool=True, highlevel=True, behavior=None
 # ):

--- a/src/awkward/_v2/operations/structure/concatenate.py
+++ b/src/awkward/_v2/operations/structure/concatenate.py
@@ -47,7 +47,7 @@ def concatenate(
 #     if not any(
 #         isinstance(
 #             x,
-#             (ak.layout.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
+#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
 #         )
 #         for x in contents
 #     ):
@@ -61,7 +61,7 @@ def concatenate(
 #         for x in contents
 #         if isinstance(
 #             x,
-#             (ak.layout.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
+#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
 #         )
 #     ][0]
 #     posaxis = first_content.axis_wrap_if_negative(axis)
@@ -72,7 +72,7 @@ def concatenate(
 #             if isinstance(
 #                 x,
 #                 (
-#                     ak.layout.Content,
+#                     ak._v2.contents.Content,
 #                     ak.partition.PartitionedArray,
 #                     ak._v2.contents.Content,
 #                 ),
@@ -85,7 +85,7 @@ def concatenate(
 #             "is ambiguous".format(axis) + ak._util.exception_suffix(__file__)
 #         )
 #     for x in contents:
-#         if isinstance(x, ak.layout.Content):
+#         if isinstance(x, ak._v2.contents.Content):
 #             if x.axis_wrap_if_negative(axis) != posaxis:
 #                 raise ValueError(
 #                     "arrays to concatenate do not have the same depth for negative "
@@ -106,7 +106,7 @@ def concatenate(
 #                         start = stop
 #                         partitions.append(part)
 #                         offsets.append(offsets[-1] + count)
-#                 elif isinstance(content, ak.layout.Content):
+#                 elif isinstance(content, ak._v2.contents.Content):
 #                     partitions.append(content)
 #                     offsets.append(offsets[-1] + len(content))
 #                 else:
@@ -135,7 +135,7 @@ def concatenate(
 #                 for content in contents:
 #                     if isinstance(content, ak.partition.PartitionedArray):
 #                         newcontents.append(content[slc].toContent())
-#                     elif isinstance(content, ak.layout.Content):
+#                     elif isinstance(content, ak._v2.contents.Content):
 #                         newcontents.append(content[slc])
 #                     else:
 #                         newcontents.append(content)
@@ -156,7 +156,7 @@ def concatenate(
 #     elif posaxis == 0:
 #         contents = [
 #             x
-#             if isinstance(x, ak.layout.Content)
+#             if isinstance(x, ak._v2.contents.Content)
 #             else ak.operations.convert.to_layout([x])
 #             for x in contents
 #         ]
@@ -190,26 +190,26 @@ def concatenate(
 
 #             if depth == posaxis and all(
 #                 isinstance(x, ak._util.listtypes)
-#                 or (isinstance(x, ak.layout.NumpyArray) and x.ndim > 1)
-#                 or not isinstance(x, ak.layout.Content)
+#                 or (isinstance(x, ak._v2.contents.NumpyArray) and x.ndim > 1)
+#                 or not isinstance(x, ak._v2.contents.Content)
 #                 for x in inputs
 #             ):
 #                 nplike = ak.nplike.of(*inputs)
 
 #                 length = max(
-#                     [len(x) for x in inputs if isinstance(x, ak.layout.Content)]
+#                     [len(x) for x in inputs if isinstance(x, ak._v2.contents.Content)]
 #                 )
 #                 nextinputs = []
 #                 for x in inputs:
-#                     if isinstance(x, ak.layout.Content):
+#                     if isinstance(x, ak._v2.contents.Content):
 #                         nextinputs.append(x)
 #                     else:
 #                         nextinputs.append(
-#                             ak.layout.ListOffsetArray64(
-#                                 ak.layout.Index64(
+#                             ak._v2.contents.ListOffsetArray64(
+#                                 ak._v2.index.Index64(
 #                                     nplike.arange(length + 1, dtype=np.int64)
 #                                 ),
-#                                 ak.layout.NumpyArray(
+#                                 ak._v2.contents.NumpyArray(
 #                                     nplike.broadcast_to(nplike.array([x]), (length,))
 #                                 ),
 #                             )
@@ -230,14 +230,14 @@ def concatenate(
 #                 offsets[0] = 0
 #                 nplike.cumsum(counts, out=offsets[1:])
 
-#                 offsets = ak.layout.Index64(offsets)
-#                 tags, index = ak.layout.UnionArray8_64.nested_tags_index(
+#                 offsets = ak._v2.index.Index64(offsets)
+#                 tags, index = ak._v2.contents.UnionArray8_64.nested_tags_index(
 #                     offsets,
-#                     [ak.layout.Index64(x) for x in all_counts],
+#                     [ak._v2.index.Index64(x) for x in all_counts],
 #                 )
-#                 inner = ak.layout.UnionArray8_64(tags, index, all_flatten)
+#                 inner = ak._v2.contents.UnionArray8_64(tags, index, all_flatten)
 
-#                 out = ak.layout.ListOffsetArray64(
+#                 out = ak._v2.contents.ListOffsetArray64(
 #                     offsets, inner.simplify(merge=merge, mergebool=mergebool)
 #                 )
 #                 return lambda: (out,)
@@ -245,7 +245,7 @@ def concatenate(
 #             elif any(
 #                 x.minmax_depth == (1, 1)
 #                 for x in inputs
-#                 if isinstance(x, ak.layout.Content)
+#                 if isinstance(x, ak._v2.contents.Content)
 #             ):
 #                 raise ValueError(
 #                     "at least one array is not deep enough to concatenate at "
@@ -304,7 +304,7 @@ def concatenate(
 #     if not any(
 #         isinstance(
 #             x,
-#             (ak.layout.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
+#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
 #         )
 #         for x in contents
 #     ):
@@ -318,7 +318,7 @@ def concatenate(
 #         for x in contents
 #         if isinstance(
 #             x,
-#             (ak.layout.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
+#             (ak._v2.contents.Content, ak.partition.PartitionedArray, ak._v2.contents.Content),
 #         )
 #     ][0]
 #     posaxis = first_content.axis_wrap_if_negative(axis)
@@ -329,7 +329,7 @@ def concatenate(
 #             if isinstance(
 #                 x,
 #                 (
-#                     ak.layout.Content,
+#                     ak._v2.contents.Content,
 #                     ak.partition.PartitionedArray,
 #                     ak._v2.contents.Content,
 #                 ),
@@ -342,7 +342,7 @@ def concatenate(
 #             "is ambiguous".format(axis) + ak._util.exception_suffix(__file__)
 #         )
 #     for x in contents:
-#         if isinstance(x, ak.layout.Content):
+#         if isinstance(x, ak._v2.contents.Content):
 #             if x.axis_wrap_if_negative(axis) != posaxis:
 #                 raise ValueError(
 #                     "arrays to concatenate do not have the same depth for negative "
@@ -363,7 +363,7 @@ def concatenate(
 #                         start = stop
 #                         partitions.append(part)
 #                         offsets.append(offsets[-1] + count)
-#                 elif isinstance(content, ak.layout.Content):
+#                 elif isinstance(content, ak._v2.contents.Content):
 #                     partitions.append(content)
 #                     offsets.append(offsets[-1] + len(content))
 #                 else:
@@ -392,7 +392,7 @@ def concatenate(
 #                 for content in contents:
 #                     if isinstance(content, ak.partition.PartitionedArray):
 #                         newcontents.append(content[slc].toContent())
-#                     elif isinstance(content, ak.layout.Content):
+#                     elif isinstance(content, ak._v2.contents.Content):
 #                         newcontents.append(content[slc])
 #                     else:
 #                         newcontents.append(content)
@@ -413,7 +413,7 @@ def concatenate(
 #     elif posaxis == 0:
 #         contents = [
 #             x
-#             if isinstance(x, ak.layout.Content)
+#             if isinstance(x, ak._v2.contents.Content)
 #             else ak.operations.convert.to_layout([x])
 #             for x in contents
 #         ]
@@ -447,26 +447,26 @@ def concatenate(
 
 #             if depth == posaxis and all(
 #                 isinstance(x, ak._util.listtypes)
-#                 or (isinstance(x, ak.layout.NumpyArray) and x.ndim > 1)
-#                 or not isinstance(x, ak.layout.Content)
+#                 or (isinstance(x, ak._v2.contents.NumpyArray) and x.ndim > 1)
+#                 or not isinstance(x, ak._v2.contents.Content)
 #                 for x in inputs
 #             ):
 #                 nplike = ak.nplike.of(*inputs)
 
 #                 length = max(
-#                     [len(x) for x in inputs if isinstance(x, ak.layout.Content)]
+#                     [len(x) for x in inputs if isinstance(x, ak._v2.contents.Content)]
 #                 )
 #                 nextinputs = []
 #                 for x in inputs:
-#                     if isinstance(x, ak.layout.Content):
+#                     if isinstance(x, ak._v2.contents.Content):
 #                         nextinputs.append(x)
 #                     else:
 #                         nextinputs.append(
-#                             ak.layout.ListOffsetArray64(
-#                                 ak.layout.Index64(
+#                             ak._v2.contents.ListOffsetArray64(
+#                                 ak._v2.index.Index64(
 #                                     nplike.arange(length + 1, dtype=np.int64)
 #                                 ),
-#                                 ak.layout.NumpyArray(
+#                                 ak._v2.contents.NumpyArray(
 #                                     nplike.broadcast_to(nplike.array([x]), (length,))
 #                                 ),
 #                             )
@@ -487,14 +487,14 @@ def concatenate(
 #                 offsets[0] = 0
 #                 nplike.cumsum(counts, out=offsets[1:])
 
-#                 offsets = ak.layout.Index64(offsets)
-#                 tags, index = ak.layout.UnionArray8_64.nested_tags_index(
+#                 offsets = ak._v2.index.Index64(offsets)
+#                 tags, index = ak._v2.contents.UnionArray8_64.nested_tags_index(
 #                     offsets,
-#                     [ak.layout.Index64(x) for x in all_counts],
+#                     [ak._v2.index.Index64(x) for x in all_counts],
 #                 )
-#                 inner = ak.layout.UnionArray8_64(tags, index, all_flatten)
+#                 inner = ak._v2.contents.UnionArray8_64(tags, index, all_flatten)
 
-#                 out = ak.layout.ListOffsetArray64(
+#                 out = ak._v2.contents.ListOffsetArray64(
 #                     offsets, inner.simplify(merge=merge, mergebool=mergebool)
 #                 )
 #                 return lambda: (out,)
@@ -502,7 +502,7 @@ def concatenate(
 #             elif any(
 #                 x.minmax_depth == (1, 1)
 #                 for x in inputs
-#                 if isinstance(x, ak.layout.Content)
+#                 if isinstance(x, ak._v2.contents.Content)
 #             ):
 #                 raise ValueError(
 #                     "at least one array is not deep enough to concatenate at "

--- a/src/awkward/_v2/operations/structure/copy.py
+++ b/src/awkward/_v2/operations/structure/copy.py
@@ -55,7 +55,7 @@ def copy(array):
 #     changes, so we don't support it. However, an #ak.Array's data might come from
 #     a mutable third-party library, so this function allows you to make a true copy.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array,
 #         allow_record=True,
 #         allow_other=False,

--- a/src/awkward/_v2/operations/structure/copy.py
+++ b/src/awkward/_v2/operations/structure/copy.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("copy")
+# @ak._v2._connect.numpy.implements("copy")
 def copy(array):
     pass
 

--- a/src/awkward/_v2/operations/structure/copy.py
+++ b/src/awkward/_v2/operations/structure/copy.py
@@ -60,4 +60,4 @@ def copy(array):
 #         allow_record=True,
 #         allow_other=False,
 #     )
-#     return ak._util.wrap(layout.deep_copy(), ak._util.behaviorof(array))
+#     return ak._v2._util.wrap(layout.deep_copy(), ak._v2._util.behaviorof(array))

--- a/src/awkward/_v2/operations/structure/fill_none.py
+++ b/src/awkward/_v2/operations/structure/fill_none.py
@@ -79,7 +79,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #             isinstance(value, (str, bytes))
 #             or (ak._v2._util.py27 and isinstance(value, ak._v2._util.unicode))
 #         )
-#         or isinstance(value, (ak.highlevel.Record, ak._v2.record.Record))
+#         or isinstance(value, (ak._v2.highlevel.Record, ak._v2.record.Record))
 #     ):
 #         valuelayout = ak._v2.operations.convert.to_layout(
 #             value, allow_record=True, allow_other=False

--- a/src/awkward/_v2/operations/structure/fill_none.py
+++ b/src/awkward/_v2/operations/structure/fill_none.py
@@ -79,18 +79,18 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #             isinstance(value, (str, bytes))
 #             or (ak._util.py27 and isinstance(value, ak._util.unicode))
 #         )
-#         or isinstance(value, (ak.highlevel.Record, ak.layout.Record))
+#         or isinstance(value, (ak.highlevel.Record, ak._v2.record.Record))
 #     ):
 #         valuelayout = ak.operations.convert.to_layout(
 #             value, allow_record=True, allow_other=False
 #         )
-#         if isinstance(valuelayout, ak.layout.Record):
+#         if isinstance(valuelayout, ak._v2.record.Record):
 #             valuelayout = valuelayout.array[valuelayout.at : valuelayout.at + 1]
 #         elif len(valuelayout) == 0:
-#             offsets = ak.layout.Index64(nplike.array([0, 0], dtype=np.int64))
-#             valuelayout = ak.layout.ListOffsetArray64(offsets, valuelayout)
+#             offsets = ak._v2.index.Index64(nplike.array([0, 0], dtype=np.int64))
+#             valuelayout = ak._v2.contents.ListOffsetArray64(offsets, valuelayout)
 #         else:
-#             valuelayout = ak.layout.RegularArray(valuelayout, len(valuelayout), 1)
+#             valuelayout = ak._v2.contents.RegularArray(valuelayout, len(valuelayout), 1)
 #     else:
 #         valuelayout = ak.operations.convert.to_layout(
 #             [value], allow_record=False, allow_other=False

--- a/src/awkward/_v2/operations/structure/fill_none.py
+++ b/src/awkward/_v2/operations/structure/fill_none.py
@@ -52,7 +52,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #     The values could be floating-point numbers or strings.
 #     """
 
-#     arraylayout = ak.operations.convert.to_layout(
+#     arraylayout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=True, allow_other=False
 #     )
 #     nplike = ak.nplike.of(arraylayout)
@@ -63,14 +63,14 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #         and issubclass(value.dtype.type, (np.bool_, np.number))
 #         and len(value.shape) != 0
 #     ):
-#         valuelayout = ak.operations.convert.to_layout(
+#         valuelayout = ak._v2.operations.convert.to_layout(
 #             nplike.asarray(value)[np.newaxis], allow_record=False, allow_other=False
 #         )
 #     elif isinstance(value, (bool, numbers.Number, np.bool_, np.number)) or (
 #         isinstance(value, np.ndarray)
 #         and issubclass(value.dtype.type, (np.bool_, np.number))
 #     ):
-#         valuelayout = ak.operations.convert.to_layout(
+#         valuelayout = ak._v2.operations.convert.to_layout(
 #             nplike.asarray(value), allow_record=False, allow_other=False
 #         )
 #     elif (
@@ -81,7 +81,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #         )
 #         or isinstance(value, (ak.highlevel.Record, ak._v2.record.Record))
 #     ):
-#         valuelayout = ak.operations.convert.to_layout(
+#         valuelayout = ak._v2.operations.convert.to_layout(
 #             value, allow_record=True, allow_other=False
 #         )
 #         if isinstance(valuelayout, ak._v2.record.Record):
@@ -92,7 +92,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #         else:
 #             valuelayout = ak._v2.contents.RegularArray(valuelayout, len(valuelayout), 1)
 #     else:
-#         valuelayout = ak.operations.convert.to_layout(
+#         valuelayout = ak._v2.operations.convert.to_layout(
 #             [value], allow_record=False, allow_other=False
 #         )
 

--- a/src/awkward/_v2/operations/structure/fill_none.py
+++ b/src/awkward/_v2/operations/structure/fill_none.py
@@ -77,7 +77,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #         isinstance(value, Iterable)
 #         and not (
 #             isinstance(value, (str, bytes))
-#             or (ak._util.py27 and isinstance(value, ak._util.unicode))
+#             or (ak._v2._util.py27 and isinstance(value, ak._v2._util.unicode))
 #         )
 #         or isinstance(value, (ak.highlevel.Record, ak._v2.record.Record))
 #     ):
@@ -97,7 +97,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #         )
 
 #     def maybe_fillna(layout):
-#         if isinstance(layout, ak._util.optiontypes):
+#         if isinstance(layout, ak._v2._util.optiontypes):
 #             return layout.fillna(valuelayout)
 #         else:
 #             return layout
@@ -105,7 +105,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #     if axis is None:
 
 #         def transform(layout, depth, posaxis):
-#             return ak._util.transform_child_layouts(
+#             return ak._v2._util.transform_child_layouts(
 #                 transform, maybe_fillna(layout), depth, posaxis
 #             )
 
@@ -119,8 +119,8 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 #             if posaxis + 1 == depth:
 #                 layout = maybe_fillna(layout)
 
-#             return ak._util.transform_child_layouts(transform, layout, depth, posaxis)
+#             return ak._v2._util.transform_child_layouts(transform, layout, depth, posaxis)
 
 #     out = transform(arraylayout, 1, axis)
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/firsts.py
+++ b/src/awkward/_v2/operations/structure/firsts.py
@@ -37,7 +37,7 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
 #     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
-#     if isinstance(layout, ak.partition.PartitionedArray):
+#     if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         posaxis = None
 #         for x in layout.partitions:
 #             if posaxis is None:

--- a/src/awkward/_v2/operations/structure/firsts.py
+++ b/src/awkward/_v2/operations/structure/firsts.py
@@ -45,7 +45,7 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
 #             elif posaxis != x.axis_wrap_if_negative(axis):
 #                 raise ValueError(
 #                     "ak.firsts for partitions with different axis depths"
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #     else:
 #         posaxis = layout.axis_wrap_if_negative(axis)
@@ -59,7 +59,7 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
 #         if posaxis < 0:
 #             raise NotImplementedError(
 #                 "ak.firsts with ambiguous negative axis"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         toslice = (slice(None, None, None),) * posaxis + (0,)
 #         out = ak.mask(layout, ak.num(layout, axis=posaxis) > 0, highlevel=False)[

--- a/src/awkward/_v2/operations/structure/firsts.py
+++ b/src/awkward/_v2/operations/structure/firsts.py
@@ -34,7 +34,7 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
 
 #     See #ak.singletons to invert this function.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if isinstance(layout, ak.partition.PartitionedArray):

--- a/src/awkward/_v2/operations/structure/firsts.py
+++ b/src/awkward/_v2/operations/structure/firsts.py
@@ -45,7 +45,7 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
 #             elif posaxis != x.axis_wrap_if_negative(axis):
 #                 raise ValueError(
 #                     "ak.firsts for partitions with different axis depths"
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #     else:
 #         posaxis = layout.axis_wrap_if_negative(axis)
@@ -59,11 +59,11 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
 #         if posaxis < 0:
 #             raise NotImplementedError(
 #                 "ak.firsts with ambiguous negative axis"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         toslice = (slice(None, None, None),) * posaxis + (0,)
 #         out = ak.mask(layout, ak.num(layout, axis=posaxis) > 0, highlevel=False)[
 #             toslice
 #         ]
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/flatten.py
+++ b/src/awkward/_v2/operations/structure/flatten.py
@@ -95,7 +95,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #     However, it is important to keep in mind that this is a special case:
 #     #ak.flatten and `content` are not interchangeable!
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     nplike = ak.nplike.of(layout)

--- a/src/awkward/_v2/operations/structure/flatten.py
+++ b/src/awkward/_v2/operations/structure/flatten.py
@@ -101,7 +101,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #     nplike = ak.nplike.of(layout)
 
 #     if axis is None:
-#         out = ak._util.completely_flatten(layout)
+#         out = ak._v2._util.completely_flatten(layout)
 #         assert isinstance(out, tuple) and all(isinstance(x, np.ndarray) for x in out)
 
 #         if any(isinstance(x, nplike.ma.MaskedArray) for x in out):
@@ -112,18 +112,18 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #     elif axis == 0 or layout.axis_wrap_if_negative(axis) == 0:
 
 #         def apply(layout):
-#             if isinstance(layout, ak._util.virtualtypes):
+#             if isinstance(layout, ak._v2._util.virtualtypes):
 #                 return apply(layout.array)
 
-#             elif isinstance(layout, ak._util.unknowntypes):
+#             elif isinstance(layout, ak._v2._util.unknowntypes):
 #                 return apply(ak._v2.contents.NumpyArray(nplike.array([])))
 
-#             elif isinstance(layout, ak._util.indexedtypes):
+#             elif isinstance(layout, ak._v2._util.indexedtypes):
 #                 return apply(layout.project())
 
-#             elif isinstance(layout, ak._util.uniontypes):
+#             elif isinstance(layout, ak._v2._util.uniontypes):
 #                 if not any(
-#                     isinstance(x, ak._util.optiontypes)
+#                     isinstance(x, ak._v2._util.optiontypes)
 #                     and not isinstance(x, ak._v2.contents.UnmaskedArray)
 #                     for x in layout.contents
 #                 ):
@@ -133,7 +133,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #                 index = nplike.array(nplike.asarray(layout.index), copy=True)
 #                 bigmask = nplike.empty(len(index), dtype=np.bool_)
 #                 for tag, content in enumerate(layout.contents):
-#                     if isinstance(content, ak._util.optiontypes) and not isinstance(
+#                     if isinstance(content, ak._v2._util.optiontypes) and not isinstance(
 #                         content, ak._v2.contents.UnmaskedArray
 #                     ):
 #                         bigmask[:] = False
@@ -149,7 +149,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #                     layout.contents,
 #                 )
 
-#             elif isinstance(layout, ak._util.optiontypes):
+#             elif isinstance(layout, ak._v2._util.optiontypes):
 #                 return layout.project()
 
 #             else:
@@ -162,9 +162,9 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #         else:
 #             out = apply(layout)
 
-#         return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#         return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 #     else:
 #         out = layout.flatten(axis)
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/flatten.py
+++ b/src/awkward/_v2/operations/structure/flatten.py
@@ -105,9 +105,9 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #         assert isinstance(out, tuple) and all(isinstance(x, np.ndarray) for x in out)
 
 #         if any(isinstance(x, nplike.ma.MaskedArray) for x in out):
-#             out = ak.layout.NumpyArray(nplike.ma.concatenate(out))
+#             out = ak._v2.contents.NumpyArray(nplike.ma.concatenate(out))
 #         else:
-#             out = ak.layout.NumpyArray(nplike.concatenate(out))
+#             out = ak._v2.contents.NumpyArray(nplike.concatenate(out))
 
 #     elif axis == 0 or layout.axis_wrap_if_negative(axis) == 0:
 
@@ -116,7 +116,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #                 return apply(layout.array)
 
 #             elif isinstance(layout, ak._util.unknowntypes):
-#                 return apply(ak.layout.NumpyArray(nplike.array([])))
+#                 return apply(ak._v2.contents.NumpyArray(nplike.array([])))
 
 #             elif isinstance(layout, ak._util.indexedtypes):
 #                 return apply(layout.project())
@@ -124,7 +124,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #             elif isinstance(layout, ak._util.uniontypes):
 #                 if not any(
 #                     isinstance(x, ak._util.optiontypes)
-#                     and not isinstance(x, ak.layout.UnmaskedArray)
+#                     and not isinstance(x, ak._v2.contents.UnmaskedArray)
 #                     for x in layout.contents
 #                 ):
 #                     return layout
@@ -134,7 +134,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #                 bigmask = nplike.empty(len(index), dtype=np.bool_)
 #                 for tag, content in enumerate(layout.contents):
 #                     if isinstance(content, ak._util.optiontypes) and not isinstance(
-#                         content, ak.layout.UnmaskedArray
+#                         content, ak._v2.contents.UnmaskedArray
 #                     ):
 #                         bigmask[:] = False
 #                         bigmask[tags == tag] = nplike.asarray(content.bytemask()).view(
@@ -143,9 +143,9 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #                         index[bigmask] = -1
 
 #                 good = index >= 0
-#                 return ak.layout.UnionArray8_64(
-#                     ak.layout.Index8(tags[good]),
-#                     ak.layout.Index64(index[good]),
+#                 return ak._v2.contents.UnionArray8_64(
+#                     ak._v2.index.Index8(tags[good]),
+#                     ak._v2.index.Index64(index[good]),
 #                     layout.contents,
 #                 )
 

--- a/src/awkward/_v2/operations/structure/flatten.py
+++ b/src/awkward/_v2/operations/structure/flatten.py
@@ -155,8 +155,8 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 #             else:
 #                 return layout
 
-#         if isinstance(layout, ak.partition.PartitionedArray):
-#             out = ak.partition.IrregularlyPartitionedArray(
+#         if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
+#             out = ak.partition.IrregularlyPartitionedArray(   # NO PARTITIONED ARRAY
 #                 [apply(x) for x in layout.partitions]
 #             )
 #         else:

--- a/src/awkward/_v2/operations/structure/from_regular.py
+++ b/src/awkward/_v2/operations/structure/from_regular.py
@@ -52,7 +52,7 @@ def from_regular(array, axis=1, highlevel=True, behavior=None):
 #         else:
 #             return posaxis
 
-#     out = ak.operations.convert.to_layout(array)
+#     out = ak._v2.operations.convert.to_layout(array)
 #     if axis != 0:
 #         out = ak._v2._util.recursively_apply(
 #             out,

--- a/src/awkward/_v2/operations/structure/from_regular.py
+++ b/src/awkward/_v2/operations/structure/from_regular.py
@@ -40,7 +40,7 @@ def from_regular(array, axis=1, highlevel=True, behavior=None):
 
 #     def getfunction(layout, depth, posaxis):
 #         posaxis = layout.axis_wrap_if_negative(posaxis)
-#         if posaxis == depth and isinstance(layout, ak.layout.RegularArray):
+#         if posaxis == depth and isinstance(layout, ak._v2.contents.RegularArray):
 #             return lambda: layout.toListOffsetArray64(False)
 #         elif posaxis == depth and isinstance(layout, ak._util.listtypes):
 #             return lambda: layout

--- a/src/awkward/_v2/operations/structure/from_regular.py
+++ b/src/awkward/_v2/operations/structure/from_regular.py
@@ -42,19 +42,19 @@ def from_regular(array, axis=1, highlevel=True, behavior=None):
 #         posaxis = layout.axis_wrap_if_negative(posaxis)
 #         if posaxis == depth and isinstance(layout, ak._v2.contents.RegularArray):
 #             return lambda: layout.toListOffsetArray64(False)
-#         elif posaxis == depth and isinstance(layout, ak._util.listtypes):
+#         elif posaxis == depth and isinstance(layout, ak._v2._util.listtypes):
 #             return lambda: layout
 #         elif posaxis == 0:
 #             raise ValueError(
 #                 "array has no axis {0}".format(axis)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         else:
 #             return posaxis
 
 #     out = ak.operations.convert.to_layout(array)
 #     if axis != 0:
-#         out = ak._util.recursively_apply(
+#         out = ak._v2._util.recursively_apply(
 #             out,
 #             getfunction,
 #             pass_depth=True,
@@ -63,4 +63,4 @@ def from_regular(array, axis=1, highlevel=True, behavior=None):
 #             numpy_to_regular=True,
 #         )
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/from_regular.py
+++ b/src/awkward/_v2/operations/structure/from_regular.py
@@ -47,7 +47,7 @@ def from_regular(array, axis=1, highlevel=True, behavior=None):
 #         elif posaxis == 0:
 #             raise ValueError(
 #                 "array has no axis {0}".format(axis)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         else:
 #             return posaxis

--- a/src/awkward/_v2/operations/structure/full_like.py
+++ b/src/awkward/_v2/operations/structure/full_like.py
@@ -104,7 +104,7 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
 #             if isinstance(fill_value, bytes):
 #                 asbytes = fill_value
 #             elif isinstance(fill_value, str) or (
-#                 ak._util.py27 and isinstance(fill_value, ak._util.unicode)
+#                 ak._v2._util.py27 and isinstance(fill_value, ak._v2._util.unicode)
 #             ):
 #                 asbytes = fill_value.encode("utf-8", "surrogateescape")
 #             else:
@@ -167,8 +167,8 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
 #         else:
 #             return None
 
-#     out = ak._util.recursively_apply(layout, getfunction, pass_depth=False)
+#     out = ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
 #     if dtype is not None:
 #         out = strings_astype(out, dtype)
 #         out = values_astype(out, dtype)
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/full_like.py
+++ b/src/awkward/_v2/operations/structure/full_like.py
@@ -84,7 +84,7 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
 #             # then for bools, only 0 and 1 give correct string behavior
 #             fill_value = int(fill_value)
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=True, allow_other=False
 #     )
 

--- a/src/awkward/_v2/operations/structure/full_like.py
+++ b/src/awkward/_v2/operations/structure/full_like.py
@@ -92,10 +92,10 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
 #         if layout.parameter("__array__") == "bytestring" and fill_value is _ZEROS:
 #             nplike = ak.nplike.of(layout)
 #             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
-#             return lambda: ak.layout.ListArray64(
-#                 ak.layout.Index64(nplike.zeros(len(layout), dtype=np.int64)),
-#                 ak.layout.Index64(nplike.zeros(len(layout), dtype=np.int64)),
-#                 ak.layout.NumpyArray(asbytes, parameters={"__array__": "byte"}),
+#             return lambda: ak._v2.contents.ListArray64(
+#                 ak._v2.index.Index64(nplike.zeros(len(layout), dtype=np.int64)),
+#                 ak._v2.index.Index64(nplike.zeros(len(layout), dtype=np.int64)),
+#                 ak._v2.contents.NumpyArray(asbytes, parameters={"__array__": "byte"}),
 #                 parameters={"__array__": "bytestring"},
 #             )
 
@@ -111,22 +111,22 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
 #                 asbytes = str(fill_value).encode("utf-8", "surrogateescape")
 #             asbytes = nplike.frombuffer(asbytes, dtype=np.uint8)
 
-#             return lambda: ak.layout.ListArray64(
-#                 ak.layout.Index64(nplike.zeros(len(layout), dtype=np.int64)),
-#                 ak.layout.Index64(
+#             return lambda: ak._v2.contents.ListArray64(
+#                 ak._v2.index.Index64(nplike.zeros(len(layout), dtype=np.int64)),
+#                 ak._v2.index.Index64(
 #                     nplike.full(len(layout), len(asbytes), dtype=np.int64)
 #                 ),
-#                 ak.layout.NumpyArray(asbytes, parameters={"__array__": "byte"}),
+#                 ak._v2.contents.NumpyArray(asbytes, parameters={"__array__": "byte"}),
 #                 parameters={"__array__": "bytestring"},
 #             )
 
 #         elif layout.parameter("__array__") == "string" and fill_value is _ZEROS:
 #             nplike = ak.nplike.of(layout)
 #             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
-#             return lambda: ak.layout.ListArray64(
-#                 ak.layout.Index64(nplike.zeros(len(layout), dtype=np.int64)),
-#                 ak.layout.Index64(nplike.zeros(len(layout), dtype=np.int64)),
-#                 ak.layout.NumpyArray(asbytes, parameters={"__array__": "char"}),
+#             return lambda: ak._v2.contents.ListArray64(
+#                 ak._v2.index.Index64(nplike.zeros(len(layout), dtype=np.int64)),
+#                 ak._v2.index.Index64(nplike.zeros(len(layout), dtype=np.int64)),
+#                 ak._v2.contents.NumpyArray(asbytes, parameters={"__array__": "char"}),
 #                 parameters={"__array__": "string"},
 #             )
 
@@ -134,32 +134,32 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
 #             nplike = ak.nplike.of(layout)
 #             asstr = str(fill_value).encode("utf-8", "surrogateescape")
 #             asbytes = nplike.frombuffer(asstr, dtype=np.uint8)
-#             return lambda: ak.layout.ListArray64(
-#                 ak.layout.Index64(nplike.zeros(len(layout), dtype=np.int64)),
-#                 ak.layout.Index64(
+#             return lambda: ak._v2.contents.ListArray64(
+#                 ak._v2.index.Index64(nplike.zeros(len(layout), dtype=np.int64)),
+#                 ak._v2.index.Index64(
 #                     nplike.full(len(layout), len(asbytes), dtype=np.int64)
 #                 ),
-#                 ak.layout.NumpyArray(asbytes, parameters={"__array__": "char"}),
+#                 ak._v2.contents.NumpyArray(asbytes, parameters={"__array__": "char"}),
 #                 parameters={"__array__": "string"},
 #             )
 
-#         elif isinstance(layout, ak.layout.NumpyArray):
+#         elif isinstance(layout, ak._v2.contents.NumpyArray):
 #             nplike = ak.nplike.of(layout)
 #             original = nplike.asarray(layout)
 #             if fill_value == 0 or fill_value is _ZEROS:
-#                 return lambda: ak.layout.NumpyArray(
+#                 return lambda: ak._v2.contents.NumpyArray(
 #                     nplike.zeros_like(original),
 #                     layout.identities,
 #                     layout.parameters,
 #                 )
 #             elif fill_value == 1:
-#                 return lambda: ak.layout.NumpyArray(
+#                 return lambda: ak._v2.contents.NumpyArray(
 #                     nplike.ones_like(original),
 #                     layout.identities,
 #                     layout.parameters,
 #                 )
 #             else:
-#                 return lambda: ak.layout.NumpyArray(
+#                 return lambda: ak._v2.contents.NumpyArray(
 #                     nplike.full_like(original, fill_value),
 #                     layout.identities,
 #                     layout.parameters,

--- a/src/awkward/_v2/operations/structure/full_like.py
+++ b/src/awkward/_v2/operations/structure/full_like.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("full_like")
+# @ak._v2._connect.numpy.implements("full_like")
 def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
     pass
 

--- a/src/awkward/_v2/operations/structure/is_none.py
+++ b/src/awkward/_v2/operations/structure/is_none.py
@@ -32,7 +32,7 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
 #         if posaxis == depth - 1:
 #             nplike = ak.nplike.of(layout)
 #             if isinstance(layout, ak._util.optiontypes):
-#                 return lambda: ak.layout.NumpyArray(
+#                 return lambda: ak._v2.contents.NumpyArray(
 #                     nplike.asarray(layout.bytemask()).view(np.bool_)
 #                 )
 #             elif isinstance(
@@ -41,10 +41,10 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
 #                     ak._util.unknowntypes,
 #                     ak._util.listtypes,
 #                     ak._util.recordtypes,
-#                     ak.layout.NumpyArray,
+#                     ak._v2.contents.NumpyArray,
 #                 ),
 #             ):
-#                 return lambda: ak.layout.NumpyArray(
+#                 return lambda: ak._v2.contents.NumpyArray(
 #                     nplike.zeros(len(layout), dtype=np.bool_)
 #                 )
 #             else:

--- a/src/awkward/_v2/operations/structure/is_none.py
+++ b/src/awkward/_v2/operations/structure/is_none.py
@@ -52,7 +52,7 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
 #         else:
 #             return posaxis
 
-#     layout = ak.operations.convert.to_layout(array)
+#     layout = ak._v2.operations.convert.to_layout(array)
 
 #     out = ak._v2._util.recursively_apply(
 #         layout, getfunction, pass_depth=True, pass_user=True, user=axis

--- a/src/awkward/_v2/operations/structure/is_none.py
+++ b/src/awkward/_v2/operations/structure/is_none.py
@@ -31,16 +31,16 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
 #         posaxis = layout.axis_wrap_if_negative(posaxis)
 #         if posaxis == depth - 1:
 #             nplike = ak.nplike.of(layout)
-#             if isinstance(layout, ak._util.optiontypes):
+#             if isinstance(layout, ak._v2._util.optiontypes):
 #                 return lambda: ak._v2.contents.NumpyArray(
 #                     nplike.asarray(layout.bytemask()).view(np.bool_)
 #                 )
 #             elif isinstance(
 #                 layout,
 #                 (
-#                     ak._util.unknowntypes,
-#                     ak._util.listtypes,
-#                     ak._util.recordtypes,
+#                     ak._v2._util.unknowntypes,
+#                     ak._v2._util.listtypes,
+#                     ak._v2._util.recordtypes,
 #                     ak._v2.contents.NumpyArray,
 #                 ),
 #             ):
@@ -54,8 +54,8 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
 
 #     layout = ak.operations.convert.to_layout(array)
 
-#     out = ak._util.recursively_apply(
+#     out = ak._v2._util.recursively_apply(
 #         layout, getfunction, pass_depth=True, pass_user=True, user=axis
 #     )
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/isclose.py
+++ b/src/awkward/_v2/operations/structure/isclose.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("isclose")
+# @ak._v2._connect.numpy.implements("isclose")
 def isclose(
     a, b, rtol=1e-05, atol=1e-08, equal_nan=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/_v2/operations/structure/isclose.py
+++ b/src/awkward/_v2/operations/structure/isclose.py
@@ -35,11 +35,11 @@ def isclose(
 #     nplike = ak.nplike.of(one, two)
 
 #     def getfunction(inputs):
-#         if isinstance(inputs[0], ak.layout.NumpyArray) and isinstance(
-#             inputs[1], ak.layout.NumpyArray
+#         if isinstance(inputs[0], ak._v2.contents.NumpyArray) and isinstance(
+#             inputs[1], ak._v2.contents.NumpyArray
 #         ):
 #             return lambda: (
-#                 ak.layout.NumpyArray(
+#                 ak._v2.contents.NumpyArray(
 #                     nplike.isclose(
 #                         nplike.asarray(inputs[0]),
 #                         nplike.asarray(inputs[1]),

--- a/src/awkward/_v2/operations/structure/isclose.py
+++ b/src/awkward/_v2/operations/structure/isclose.py
@@ -30,8 +30,8 @@ def isclose(
 #     Implements [np.isclose](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html)
 #     for Awkward Arrays.
 #     """
-#     one = ak.operations.convert.to_layout(a)
-#     two = ak.operations.convert.to_layout(b)
+#     one = ak._v2.operations.convert.to_layout(a)
+#     two = ak._v2.operations.convert.to_layout(b)
 #     nplike = ak.nplike.of(one, two)
 
 #     def getfunction(inputs):

--- a/src/awkward/_v2/operations/structure/isclose.py
+++ b/src/awkward/_v2/operations/structure/isclose.py
@@ -52,11 +52,11 @@ def isclose(
 #         else:
 #             return None
 
-#     behavior = ak._util.behaviorof(one, two, behavior=behavior)
-#     out = ak._util.broadcast_and_apply(
+#     behavior = ak._v2._util.behaviorof(one, two, behavior=behavior)
+#     out = ak._v2._util.broadcast_and_apply(
 #         [one, two], getfunction, behavior, pass_depth=False
 #     )
 #     assert isinstance(out, tuple) and len(out) == 1
 #     result = out[0]
 
-#     return ak._util.maybe_wrap(result, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(result, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/local_index.py
+++ b/src/awkward/_v2/operations/structure/local_index.py
@@ -76,7 +76,7 @@ def local_index(array, axis=-1, highlevel=True, behavior=None):
 #                        2               8.8
 #                        3               9.9
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=True, allow_other=False
 #     )
 #     out = layout.localindex(axis)

--- a/src/awkward/_v2/operations/structure/local_index.py
+++ b/src/awkward/_v2/operations/structure/local_index.py
@@ -80,4 +80,4 @@ def local_index(array, axis=-1, highlevel=True, behavior=None):
 #         array, allow_record=True, allow_other=False
 #     )
 #     out = layout.localindex(axis)
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/mask.py
+++ b/src/awkward/_v2/operations/structure/mask.py
@@ -93,16 +93,16 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
 
 #     def getfunction(inputs):
 #         layoutarray, layoutmask = inputs
-#         if isinstance(layoutmask, ak.layout.NumpyArray):
+#         if isinstance(layoutmask, ak._v2.contents.NumpyArray):
 #             m = ak.nplike.of(layoutmask).asarray(layoutmask)
 #             if not issubclass(m.dtype.type, (bool, np.bool_)):
 #                 raise ValueError(
 #                     "mask must have boolean type, not "
 #                     "{0}".format(repr(m.dtype)) + ak._util.exception_suffix(__file__)
 #                 )
-#             bytemask = ak.layout.Index8(m.view(np.int8))
+#             bytemask = ak._v2.index.Index8(m.view(np.int8))
 #             return lambda: (
-#                 ak.layout.ByteMaskedArray(
+#                 ak._v2.contents.ByteMaskedArray(
 #                     bytemask, layoutarray, valid_when=valid_when
 #                 ).simplify(),
 #             )

--- a/src/awkward/_v2/operations/structure/mask.py
+++ b/src/awkward/_v2/operations/structure/mask.py
@@ -98,7 +98,7 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
 #             if not issubclass(m.dtype.type, (bool, np.bool_)):
 #                 raise ValueError(
 #                     "mask must have boolean type, not "
-#                     "{0}".format(repr(m.dtype)) + ak._util.exception_suffix(__file__)
+#                     "{0}".format(repr(m.dtype)) + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             bytemask = ak._v2.index.Index8(m.view(np.int8))
 #             return lambda: (
@@ -116,8 +116,8 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
 #         mask, allow_record=True, allow_other=False
 #     )
 
-#     behavior = ak._util.behaviorof(array, mask, behavior=behavior)
-#     out = ak._util.broadcast_and_apply(
+#     behavior = ak._v2._util.behaviorof(array, mask, behavior=behavior)
+#     out = ak._v2._util.broadcast_and_apply(
 #         [layoutarray, layoutmask],
 #         getfunction,
 #         behavior,
@@ -126,4 +126,4 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
 #         pass_depth=False,
 #     )
 #     assert isinstance(out, tuple) and len(out) == 1
-#     return ak._util.maybe_wrap(out[0], behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(out[0], behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/mask.py
+++ b/src/awkward/_v2/operations/structure/mask.py
@@ -109,10 +109,10 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
 #         else:
 #             return None
 
-#     layoutarray = ak.operations.convert.to_layout(
+#     layoutarray = ak._v2.operations.convert.to_layout(
 #         array, allow_record=True, allow_other=False
 #     )
-#     layoutmask = ak.operations.convert.to_layout(
+#     layoutmask = ak._v2.operations.convert.to_layout(
 #         mask, allow_record=True, allow_other=False
 #     )
 

--- a/src/awkward/_v2/operations/structure/mask.py
+++ b/src/awkward/_v2/operations/structure/mask.py
@@ -98,7 +98,7 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
 #             if not issubclass(m.dtype.type, (bool, np.bool_)):
 #                 raise ValueError(
 #                     "mask must have boolean type, not "
-#                     "{0}".format(repr(m.dtype)) + ak._v2._util.exception_suffix(__file__)
+#                     "{0}".format(repr(m.dtype))
 #                 )
 #             bytemask = ak._v2.index.Index8(m.view(np.int8))
 #             return lambda: (

--- a/src/awkward/_v2/operations/structure/nan_to_num.py
+++ b/src/awkward/_v2/operations/structure/nan_to_num.py
@@ -47,7 +47,7 @@ def nan_to_num(
 #         else:
 #             return None
 
-#     out = ak._util.recursively_apply(
+#     out = ak._v2._util.recursively_apply(
 #         layout, getfunction, pass_depth=False, pass_user=False
 #     )
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/nan_to_num.py
+++ b/src/awkward/_v2/operations/structure/nan_to_num.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("nan_to_num")
+# @ak._v2._connect.numpy.implements("nan_to_num")
 def nan_to_num(
     array, copy=True, nan=0.0, posinf=None, neginf=None, highlevel=True, behavior=None
 ):

--- a/src/awkward/_v2/operations/structure/nan_to_num.py
+++ b/src/awkward/_v2/operations/structure/nan_to_num.py
@@ -35,8 +35,8 @@ def nan_to_num(
 #     nplike = ak.nplike.of(layout)
 
 #     def getfunction(layout):
-#         if isinstance(layout, ak.layout.NumpyArray):
-#             return lambda: ak.layout.NumpyArray(
+#         if isinstance(layout, ak._v2.contents.NumpyArray):
+#             return lambda: ak._v2.contents.NumpyArray(
 #                 nplike.nan_to_num(
 #                     nplike.asarray(layout),
 #                     nan=nan,

--- a/src/awkward/_v2/operations/structure/nan_to_num.py
+++ b/src/awkward/_v2/operations/structure/nan_to_num.py
@@ -31,7 +31,7 @@ def nan_to_num(
 #     Implements [np.nan_to_num](https://numpy.org/doc/stable/reference/generated/numpy.nan_to_num.html)
 #     for Awkward Arrays.
 #     """
-#     layout = ak.operations.convert.to_layout(array)
+#     layout = ak._v2.operations.convert.to_layout(array)
 #     nplike = ak.nplike.of(layout)
 
 #     def getfunction(layout):

--- a/src/awkward/_v2/operations/structure/num.py
+++ b/src/awkward/_v2/operations/structure/num.py
@@ -75,4 +75,4 @@ def num(array, axis=1, highlevel=True, behavior=None):
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = layout.num(axis=axis)
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/num.py
+++ b/src/awkward/_v2/operations/structure/num.py
@@ -71,7 +71,7 @@ def num(array, axis=1, highlevel=True, behavior=None):
 #         >>> ak.mask(array, ak.num(array) > 0)[:, 0]
 #         <Array [[1.1, 2.2, 3.3], None, [7.7]] type='3 * option[var * float64]'>
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = layout.num(axis=axis)

--- a/src/awkward/_v2/operations/structure/ones_like.py
+++ b/src/awkward/_v2/operations/structure/ones_like.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("ones_like")
+# @ak._v2._connect.numpy.implements("ones_like")
 def ones_like(array, highlevel=True, behavior=None, dtype=None):
     pass
 

--- a/src/awkward/_v2/operations/structure/packed.py
+++ b/src/awkward/_v2/operations/structure/packed.py
@@ -61,7 +61,7 @@ def packed(array, highlevel=True, behavior=None):
 
 #     See also #ak.to_buffers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=True, allow_other=False
 #     )
 

--- a/src/awkward/_v2/operations/structure/packed.py
+++ b/src/awkward/_v2/operations/structure/packed.py
@@ -210,7 +210,7 @@ def packed(array, highlevel=True, behavior=None):
 #     elif isinstance(layout, ak._v2.contents.BitMaskedArray):
 #         layout = layout.simplify()
 
-#         if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
+#         if not isinstance(ak.type(layout.content), ak._v2.types.PrimitiveType):
 #             return layout.toIndexedOptionArray64()
 
 #         return ak._v2.contents.BitMaskedArray(
@@ -227,7 +227,7 @@ def packed(array, highlevel=True, behavior=None):
 #     elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
 #         layout = layout.simplify()
 
-#         if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
+#         if not isinstance(ak.type(layout.content), ak._v2.types.PrimitiveType):
 #             return layout.toIndexedOptionArray64()
 
 #         return ak._v2.contents.ByteMaskedArray(

--- a/src/awkward/_v2/operations/structure/packed.py
+++ b/src/awkward/_v2/operations/structure/packed.py
@@ -78,11 +78,11 @@ def packed(array, highlevel=True, behavior=None):
 # def _pack_layout(layout):
 #     nplike = ak.nplike.of(layout)
 
-#     if isinstance(layout, ak.layout.NumpyArray):
+#     if isinstance(layout, ak._v2.contents.NumpyArray):
 #         return layout.contiguous()
 
 #     # EmptyArray is a no-op
-#     elif isinstance(layout, ak.layout.EmptyArray):
+#     elif isinstance(layout, ak._v2.contents.EmptyArray):
 #         return layout
 
 #     # Project indexed arrays
@@ -97,8 +97,8 @@ def packed(array, highlevel=True, behavior=None):
 #         new_index[is_none] = -1
 #         new_index[~is_none] = nplike.arange(len(new_index) - nplike.sum(is_none))
 
-#         return ak.layout.IndexedOptionArray64(
-#             ak.layout.Index64(new_index),
+#         return ak._v2.contents.IndexedOptionArray64(
+#             ak._v2.index.Index64(new_index),
 #             layout.project(),
 #             layout.identities,
 #             layout.parameters,
@@ -112,9 +112,9 @@ def packed(array, highlevel=True, behavior=None):
 #     elif isinstance(
 #         layout,
 #         (
-#             ak.layout.ListArray32,
-#             ak.layout.ListArrayU32,
-#             ak.layout.ListArray64,
+#             ak._v2.contents.ListArray32,
+#             ak._v2.contents.ListArrayU32,
+#             ak._v2.contents.ListArray64,
 #         ),
 #     ):
 #         return layout.toListOffsetArray64(True)
@@ -123,14 +123,14 @@ def packed(array, highlevel=True, behavior=None):
 #     elif isinstance(
 #         layout,
 #         (
-#             ak.layout.ListOffsetArray32,
-#             ak.layout.ListOffsetArray64,
-#             ak.layout.ListOffsetArrayU32,
+#             ak._v2.contents.ListOffsetArray32,
+#             ak._v2.contents.ListOffsetArray64,
+#             ak._v2.contents.ListOffsetArrayU32,
 #         ),
 #     ):
 #         new_layout = layout.toListOffsetArray64(True)
 #         new_length = new_layout.offsets[-1]
-#         return ak.layout.ListOffsetArray64(
+#         return ak._v2.contents.ListOffsetArray64(
 #             new_layout.offsets,
 #             new_layout.content[:new_length],
 #             new_layout.identities,
@@ -138,8 +138,8 @@ def packed(array, highlevel=True, behavior=None):
 #         )
 
 #     # UnmaskedArray just wraps another array
-#     elif isinstance(layout, ak.layout.UnmaskedArray):
-#         return ak.layout.UnmaskedArray(
+#     elif isinstance(layout, ak._v2.contents.UnmaskedArray):
+#         return ak._v2.contents.UnmaskedArray(
 #             layout.content, layout.identities, layout.parameters
 #         )
 
@@ -166,17 +166,17 @@ def packed(array, highlevel=True, behavior=None):
 #             new_contents[i] = layout.project(i)
 #             new_index[is_i] = nplike.arange(nplike.sum(is_i))
 
-#         return ak.layout.UnionArray8_64(
-#             ak.layout.Index8(tags),
-#             ak.layout.Index64(new_index),
+#         return ak._v2.contents.UnionArray8_64(
+#             ak._v2.index.Index8(tags),
+#             ak._v2.index.Index64(new_index),
 #             new_contents,
 #             layout.identities,
 #             layout.parameters,
 #         )
 
 #     # RecordArray contents can be truncated
-#     elif isinstance(layout, ak.layout.RecordArray):
-#         return ak.layout.RecordArray(
+#     elif isinstance(layout, ak._v2.contents.RecordArray):
+#         return ak._v2.contents.RecordArray(
 #             [c[: len(layout)] for c in layout.contents],
 #             layout.recordlookup,
 #             len(layout),
@@ -185,7 +185,7 @@ def packed(array, highlevel=True, behavior=None):
 #         )
 
 #     # RegularArrays can change length
-#     elif isinstance(layout, ak.layout.RegularArray):
+#     elif isinstance(layout, ak._v2.contents.RegularArray):
 #         if not len(layout):
 #             return layout
 
@@ -198,7 +198,7 @@ def packed(array, highlevel=True, behavior=None):
 #         else:
 #             content = content[:0]
 
-#         return ak.layout.RegularArray(
+#         return ak._v2.contents.RegularArray(
 #             content,
 #             layout.size,
 #             len(layout),
@@ -207,13 +207,13 @@ def packed(array, highlevel=True, behavior=None):
 #         )
 
 #     # BitMaskedArrays can change length
-#     elif isinstance(layout, ak.layout.BitMaskedArray):
+#     elif isinstance(layout, ak._v2.contents.BitMaskedArray):
 #         layout = layout.simplify()
 
 #         if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
 #             return layout.toIndexedOptionArray64()
 
-#         return ak.layout.BitMaskedArray(
+#         return ak._v2.contents.BitMaskedArray(
 #             layout.mask,
 #             layout.content[: len(layout)],
 #             layout.valid_when,
@@ -224,13 +224,13 @@ def packed(array, highlevel=True, behavior=None):
 #         )
 
 #     # ByteMaskedArrays can change length
-#     elif isinstance(layout, ak.layout.ByteMaskedArray):
+#     elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
 #         layout = layout.simplify()
 
 #         if not isinstance(ak.type(layout.content), ak.types.PrimitiveType):
 #             return layout.toIndexedOptionArray64()
 
-#         return ak.layout.ByteMaskedArray(
+#         return ak._v2.contents.ByteMaskedArray(
 #             layout.mask,
 #             layout.content[: len(layout)],
 #             layout.valid_when,
@@ -238,14 +238,14 @@ def packed(array, highlevel=True, behavior=None):
 #             layout.parameters,
 #         )
 
-#     elif isinstance(layout, ak.layout.VirtualArray):
+#     elif isinstance(layout, ak._v2.contents.VirtualArray):
 #         return layout.array
 
 #     elif isinstance(layout, ak.partition.PartitionedArray):
 #         return layout
 
-#     elif isinstance(layout, ak.layout.Record):
-#         return ak.layout.Record(layout.array[layout.at : layout.at + 1], 0)
+#     elif isinstance(layout, ak._v2.record.Record):
+#         return ak._v2.record.Record(layout.array[layout.at : layout.at + 1], 0)
 
 #     # Finally, fall through to failure
 #     else:

--- a/src/awkward/_v2/operations/structure/packed.py
+++ b/src/awkward/_v2/operations/structure/packed.py
@@ -250,5 +250,5 @@ def packed(array, highlevel=True, behavior=None):
 #     # Finally, fall through to failure
 #     else:
 #         raise AssertionError(
-#             "unrecognized layout: " + repr(layout) + ak._v2._util.exception_suffix(__file__)
+#             "unrecognized layout: " + repr(layout)
 #         )

--- a/src/awkward/_v2/operations/structure/packed.py
+++ b/src/awkward/_v2/operations/structure/packed.py
@@ -241,7 +241,7 @@ def packed(array, highlevel=True, behavior=None):
 #     elif isinstance(layout, ak._v2.contents.VirtualArray):
 #         return layout.array
 
-#     elif isinstance(layout, ak.partition.PartitionedArray):
+#     elif isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         return layout
 
 #     elif isinstance(layout, ak._v2.record.Record):

--- a/src/awkward/_v2/operations/structure/packed.py
+++ b/src/awkward/_v2/operations/structure/packed.py
@@ -66,13 +66,13 @@ def packed(array, highlevel=True, behavior=None):
 #     )
 
 #     def transform(layout, depth=1, user=None):
-#         return ak._util.transform_child_layouts(
+#         return ak._v2._util.transform_child_layouts(
 #             transform, _pack_layout(layout), depth, user
 #         )
 
 #     out = transform(layout)
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 # def _pack_layout(layout):
@@ -86,8 +86,8 @@ def packed(array, highlevel=True, behavior=None):
 #         return layout
 
 #     # Project indexed arrays
-#     elif isinstance(layout, ak._util.indexedoptiontypes):
-#         if isinstance(layout.content, ak._util.optiontypes):
+#     elif isinstance(layout, ak._v2._util.indexedoptiontypes):
+#         if isinstance(layout.content, ak._v2._util.optiontypes):
 #             return layout.simplify()
 
 #         index = nplike.asarray(layout.index)
@@ -105,7 +105,7 @@ def packed(array, highlevel=True, behavior=None):
 #         )
 
 #     # Project indexed arrays
-#     elif isinstance(layout, ak._util.indexedtypes):
+#     elif isinstance(layout, ak._v2._util.indexedtypes):
 #         return layout.project()
 
 #     # ListArray performs both ordering and resizing
@@ -145,11 +145,11 @@ def packed(array, highlevel=True, behavior=None):
 
 #     # UnionArrays can be simplified
 #     # and their contents too
-#     elif isinstance(layout, ak._util.uniontypes):
+#     elif isinstance(layout, ak._v2._util.uniontypes):
 #         layout = layout.simplify()
 
 #         # If we managed to lose the drop type entirely
-#         if not isinstance(layout, ak._util.uniontypes):
+#         if not isinstance(layout, ak._v2._util.uniontypes):
 #             return layout
 
 #         # Pack simplified layout
@@ -250,5 +250,5 @@ def packed(array, highlevel=True, behavior=None):
 #     # Finally, fall through to failure
 #     else:
 #         raise AssertionError(
-#             "unrecognized layout: " + repr(layout) + ak._util.exception_suffix(__file__)
+#             "unrecognized layout: " + repr(layout) + ak._v2._util.exception_suffix(__file__)
 #         )

--- a/src/awkward/_v2/operations/structure/pad_none.py
+++ b/src/awkward/_v2/operations/structure/pad_none.py
@@ -133,4 +133,4 @@ def pad_none(array, target, axis=1, clip=False, highlevel=True, behavior=None):
 #         out = layout.rpad_and_clip(target, axis)
 #     else:
 #         out = layout.rpad(target, axis)
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/pad_none.py
+++ b/src/awkward/_v2/operations/structure/pad_none.py
@@ -126,7 +126,7 @@ def pad_none(array, target, axis=1, clip=False, highlevel=True, behavior=None):
 #         >>> ak.type(ak.pad_none(array, 2, axis=2, clip=True))
 #         3 * var *   2 * ?float64
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     if clip:

--- a/src/awkward/_v2/operations/structure/ravel.py
+++ b/src/awkward/_v2/operations/structure/ravel.py
@@ -51,7 +51,7 @@ def ravel(array, highlevel=True, behavior=None):
 #     )
 #     nplike = ak.nplike.of(layout)
 
-#     out = ak._util.completely_flatten(layout)
+#     out = ak._v2._util.completely_flatten(layout)
 #     assert isinstance(out, tuple) and all(isinstance(x, np.ndarray) for x in out)
 
 #     if any(isinstance(x, nplike.ma.MaskedArray) for x in out):
@@ -59,4 +59,4 @@ def ravel(array, highlevel=True, behavior=None):
 #     else:
 #         out = ak._v2.contents.NumpyArray(nplike.concatenate(out))
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/ravel.py
+++ b/src/awkward/_v2/operations/structure/ravel.py
@@ -46,7 +46,7 @@ def ravel(array, highlevel=True, behavior=None):
 #     Missing values are eliminated by flattening: there is no distinction
 #     between an empty list and a value of None at the level of flattening.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     nplike = ak.nplike.of(layout)

--- a/src/awkward/_v2/operations/structure/ravel.py
+++ b/src/awkward/_v2/operations/structure/ravel.py
@@ -55,8 +55,8 @@ def ravel(array, highlevel=True, behavior=None):
 #     assert isinstance(out, tuple) and all(isinstance(x, np.ndarray) for x in out)
 
 #     if any(isinstance(x, nplike.ma.MaskedArray) for x in out):
-#         out = ak.layout.NumpyArray(nplike.ma.concatenate(out))
+#         out = ak._v2.contents.NumpyArray(nplike.ma.concatenate(out))
 #     else:
-#         out = ak.layout.NumpyArray(nplike.concatenate(out))
+#         out = ak._v2.contents.NumpyArray(nplike.concatenate(out))
 
 #     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/ravel.py
+++ b/src/awkward/_v2/operations/structure/ravel.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("ravel")
+# @ak._v2._connect.numpy.implements("ravel")
 def ravel(array, highlevel=True, behavior=None):
     pass
 

--- a/src/awkward/_v2/operations/structure/run_lengths.py
+++ b/src/awkward/_v2/operations/structure/run_lengths.py
@@ -112,7 +112,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 
 #     def getfunction(layout):
 #         if layout.branch_depth == (False, 1):
-#             if isinstance(layout, ak._util.indexedtypes):
+#             if isinstance(layout, ak._v2._util.indexedtypes):
 #                 layout = layout.project()
 
 #             if (
@@ -126,21 +126,21 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 raise NotImplementedError(
 #                     "run_lengths on "
 #                     + type(layout).__name__
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #             nextcontent, _ = lengths_of(nplike.asarray(layout), None)
 #             return lambda: ak._v2.contents.NumpyArray(nextcontent)
 
 #         elif layout.branch_depth == (False, 2):
-#             if isinstance(layout, ak._util.indexedtypes):
+#             if isinstance(layout, ak._v2._util.indexedtypes):
 #                 layout = layout.project()
 
-#             if not isinstance(layout, ak._util.listtypes):
+#             if not isinstance(layout, ak._v2._util.listtypes):
 #                 raise NotImplementedError(
 #                     "run_lengths on "
 #                     + type(layout).__name__
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #             if (
@@ -151,7 +151,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 offsets = nplike.asarray(listoffsetarray.offsets)
 #                 content = listoffsetarray.content[offsets[0] : offsets[-1]]
 
-#                 if isinstance(content, ak._util.indexedtypes):
+#                 if isinstance(content, ak._v2._util.indexedtypes):
 #                     content = content.project()
 
 #                 nextcontent, nextoffsets = lengths_of(
@@ -165,7 +165,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #             offsets = nplike.asarray(listoffsetarray.offsets)
 #             content = listoffsetarray.content[offsets[0] : offsets[-1]]
 
-#             if isinstance(content, ak._util.indexedtypes):
+#             if isinstance(content, ak._v2._util.indexedtypes):
 #                 content = content.project()
 
 #             if not isinstance(content, (ak._v2.contents.NumpyArray, ak._v2.contents.EmptyArray)):
@@ -174,7 +174,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                     + type(layout).__name__
 #                     + " with content "
 #                     + type(content).__name__
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #             nextcontent, nextoffsets = lengths_of(
@@ -196,7 +196,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #             False,
 #             1,
 #         ):
-#             out = ak._util.recursively_apply(
+#             out = ak._v2._util.recursively_apply(
 #                 layout.toContent(),
 #                 getfunction,
 #                 pass_depth=False,
@@ -206,7 +206,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #             outparts = []
 #             for part in layout.partitions:
 #                 outparts.append(
-#                     ak._util.recursively_apply(
+#                     ak._v2._util.recursively_apply(
 #                         part,
 #                         getfunction,
 #                         pass_depth=False,
@@ -215,11 +215,11 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 )
 #             out = ak.partition.IrregularlyPartitionedArray(outparts)
 #     else:
-#         out = ak._util.recursively_apply(
+#         out = ak._v2._util.recursively_apply(
 #             layout,
 #             getfunction,
 #             pass_depth=False,
 #             pass_user=False,
 #         )
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/run_lengths.py
+++ b/src/awkward/_v2/operations/structure/run_lengths.py
@@ -120,9 +120,9 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 or layout.parameter("__array__") == "bytestring"
 #             ):
 #                 nextcontent, _ = lengths_of(ak.highlevel.Array(layout), None)
-#                 return lambda: ak.layout.NumpyArray(nextcontent)
+#                 return lambda: ak._v2.contents.NumpyArray(nextcontent)
 
-#             if not isinstance(layout, (ak.layout.NumpyArray, ak.layout.EmptyArray)):
+#             if not isinstance(layout, (ak._v2.contents.NumpyArray, ak._v2.contents.EmptyArray)):
 #                 raise NotImplementedError(
 #                     "run_lengths on "
 #                     + type(layout).__name__
@@ -130,7 +130,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 )
 
 #             nextcontent, _ = lengths_of(nplike.asarray(layout), None)
-#             return lambda: ak.layout.NumpyArray(nextcontent)
+#             return lambda: ak._v2.contents.NumpyArray(nextcontent)
 
 #         elif layout.branch_depth == (False, 2):
 #             if isinstance(layout, ak._util.indexedtypes):
@@ -157,8 +157,8 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 nextcontent, nextoffsets = lengths_of(
 #                     ak.highlevel.Array(content), offsets - offsets[0]
 #                 )
-#                 return lambda: ak.layout.ListOffsetArray64(
-#                     ak.layout.Index64(nextoffsets), ak.layout.NumpyArray(nextcontent)
+#                 return lambda: ak._v2.contents.ListOffsetArray64(
+#                     ak._v2.index.Index64(nextoffsets), ak._v2.contents.NumpyArray(nextcontent)
 #                 )
 
 #             listoffsetarray = layout.toListOffsetArray64(False)
@@ -168,7 +168,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #             if isinstance(content, ak._util.indexedtypes):
 #                 content = content.project()
 
-#             if not isinstance(content, (ak.layout.NumpyArray, ak.layout.EmptyArray)):
+#             if not isinstance(content, (ak._v2.contents.NumpyArray, ak._v2.contents.EmptyArray)):
 #                 raise NotImplementedError(
 #                     "run_lengths on "
 #                     + type(layout).__name__
@@ -180,8 +180,8 @@ def run_lengths(array, highlevel=True, behavior=None):
 #             nextcontent, nextoffsets = lengths_of(
 #                 nplike.asarray(content), offsets - offsets[0]
 #             )
-#             return lambda: ak.layout.ListOffsetArray64(
-#                 ak.layout.Index64(nextoffsets), ak.layout.NumpyArray(nextcontent)
+#             return lambda: ak._v2.contents.ListOffsetArray64(
+#                 ak._v2.index.Index64(nextoffsets), ak._v2.contents.NumpyArray(nextcontent)
 #             )
 
 #         else:

--- a/src/awkward/_v2/operations/structure/run_lengths.py
+++ b/src/awkward/_v2/operations/structure/run_lengths.py
@@ -191,7 +191,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #         array, allow_record=False, allow_other=False
 #     )
 
-#     if isinstance(layout, ak.partition.PartitionedArray):
+#     if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         if len(layout.partitions) != 0 and layout.partitions[0].branch_depth == (
 #             False,
 #             1,
@@ -213,7 +213,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                         pass_user=False,
 #                     )
 #                 )
-#             out = ak.partition.IrregularlyPartitionedArray(outparts)
+#             out = ak.partition.IrregularlyPartitionedArray(outparts)   # NO PARTITIONED ARRAY
 #     else:
 #         out = ak._v2._util.recursively_apply(
 #             layout,

--- a/src/awkward/_v2/operations/structure/run_lengths.py
+++ b/src/awkward/_v2/operations/structure/run_lengths.py
@@ -94,7 +94,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #             return nplike.empty(0, np.int64), offsets
 #         else:
 #             diffs = data[1:] != data[:-1]
-#             if isinstance(diffs, ak.highlevel.Array):
+#             if isinstance(diffs, ak._v2.highlevel.Array):
 #                 diffs = nplike.asarray(diffs)
 #             if offsets is not None:
 #                 diffs[offsets[1:-1] - 1] = True
@@ -119,7 +119,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 layout.parameter("__array__") == "string"
 #                 or layout.parameter("__array__") == "bytestring"
 #             ):
-#                 nextcontent, _ = lengths_of(ak.highlevel.Array(layout), None)
+#                 nextcontent, _ = lengths_of(ak._v2.highlevel.Array(layout), None)
 #                 return lambda: ak._v2.contents.NumpyArray(nextcontent)
 
 #             if not isinstance(layout, (ak._v2.contents.NumpyArray, ak._v2.contents.EmptyArray)):
@@ -155,7 +155,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                     content = content.project()
 
 #                 nextcontent, nextoffsets = lengths_of(
-#                     ak.highlevel.Array(content), offsets - offsets[0]
+#                     ak._v2.highlevel.Array(content), offsets - offsets[0]
 #                 )
 #                 return lambda: ak._v2.contents.ListOffsetArray64(
 #                     ak._v2.index.Index64(nextoffsets), ak._v2.contents.NumpyArray(nextcontent)

--- a/src/awkward/_v2/operations/structure/run_lengths.py
+++ b/src/awkward/_v2/operations/structure/run_lengths.py
@@ -126,7 +126,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 raise NotImplementedError(
 #                     "run_lengths on "
 #                     + type(layout).__name__
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #             nextcontent, _ = lengths_of(nplike.asarray(layout), None)
@@ -140,7 +140,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                 raise NotImplementedError(
 #                     "run_lengths on "
 #                     + type(layout).__name__
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #             if (
@@ -174,7 +174,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #                     + type(layout).__name__
 #                     + " with content "
 #                     + type(content).__name__
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 
 #             nextcontent, nextoffsets = lengths_of(

--- a/src/awkward/_v2/operations/structure/run_lengths.py
+++ b/src/awkward/_v2/operations/structure/run_lengths.py
@@ -187,7 +187,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 #         else:
 #             return None
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 

--- a/src/awkward/_v2/operations/structure/singletons.py
+++ b/src/awkward/_v2/operations/structure/singletons.py
@@ -35,7 +35,7 @@ def singletons(array, highlevel=True, behavior=None):
 #     def getfunction(layout):
 #         nplike = ak.nplike.of(layout)
 
-#         if isinstance(layout, ak._util.optiontypes):
+#         if isinstance(layout, ak._v2._util.optiontypes):
 #             nulls = nplike.asarray(layout.bytemask()).view(np.bool_)
 #             offsets = nplike.ones(len(layout) + 1, dtype=np.int64)
 #             offsets[0] = 0
@@ -48,6 +48,6 @@ def singletons(array, highlevel=True, behavior=None):
 #             return None
 
 #     layout = ak.operations.convert.to_layout(array)
-#     out = ak._util.recursively_apply(layout, getfunction, pass_depth=False)
+#     out = ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/singletons.py
+++ b/src/awkward/_v2/operations/structure/singletons.py
@@ -41,8 +41,8 @@ def singletons(array, highlevel=True, behavior=None):
 #             offsets[0] = 0
 #             offsets[1:][nulls] = 0
 #             nplike.cumsum(offsets, out=offsets)
-#             return lambda: ak.layout.ListOffsetArray64(
-#                 ak.layout.Index64(offsets), layout.project()
+#             return lambda: ak._v2.contents.ListOffsetArray64(
+#                 ak._v2.index.Index64(offsets), layout.project()
 #             )
 #         else:
 #             return None

--- a/src/awkward/_v2/operations/structure/singletons.py
+++ b/src/awkward/_v2/operations/structure/singletons.py
@@ -47,7 +47,7 @@ def singletons(array, highlevel=True, behavior=None):
 #         else:
 #             return None
 
-#     layout = ak.operations.convert.to_layout(array)
+#     layout = ak._v2.operations.convert.to_layout(array)
 #     out = ak._v2._util.recursively_apply(layout, getfunction, pass_depth=False)
 
 #     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/sort.py
+++ b/src/awkward/_v2/operations/structure/sort.py
@@ -36,7 +36,7 @@ def sort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=N
 #         >>> ak.sort(ak.Array([[7, 5, 7], [], [2], [8, 2]]))
 #         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = layout.sort(axis, ascending, stable)

--- a/src/awkward/_v2/operations/structure/sort.py
+++ b/src/awkward/_v2/operations/structure/sort.py
@@ -40,4 +40,4 @@ def sort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=N
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = layout.sort(axis, ascending, stable)
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/sort.py
+++ b/src/awkward/_v2/operations/structure/sort.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("sort")
+# @ak._v2._connect.numpy.implements("sort")
 def sort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=None):
     pass
 

--- a/src/awkward/_v2/operations/structure/strings_astype.py
+++ b/src/awkward/_v2/operations/structure/strings_astype.py
@@ -53,7 +53,7 @@ def strings_astype(array, to, highlevel=True, behavior=None):
 #             layout = without_parameters(layout, highlevel=False)
 #             max_length = ak.max(num(layout))
 #             regulararray = layout.rpad_and_clip(max_length, 1)
-#             maskedarray = ak.operations.convert.to_numpy(
+#             maskedarray = ak._v2.operations.convert.to_numpy(
 #                 regulararray, allow_missing=True
 #             )
 #             npstrings = maskedarray.data
@@ -66,7 +66,7 @@ def strings_astype(array, to, highlevel=True, behavior=None):
 #         else:
 #             return None
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = ak._v2._util.recursively_apply(

--- a/src/awkward/_v2/operations/structure/strings_astype.py
+++ b/src/awkward/_v2/operations/structure/strings_astype.py
@@ -62,7 +62,7 @@ def strings_astype(array, to, highlevel=True, behavior=None):
 #             npnumbers = (
 #                 npstrings.reshape(-1).view("<S" + str(max_length)).astype(to_dtype)
 #             )
-#             return lambda: ak.layout.NumpyArray(npnumbers)
+#             return lambda: ak._v2.contents.NumpyArray(npnumbers)
 #         else:
 #             return None
 

--- a/src/awkward/_v2/operations/structure/strings_astype.py
+++ b/src/awkward/_v2/operations/structure/strings_astype.py
@@ -46,7 +46,7 @@ def strings_astype(array, to, highlevel=True, behavior=None):
 #     to_dtype = np.dtype(to)
 
 #     def getfunction(layout):
-#         if isinstance(layout, ak._util.listtypes) and (
+#         if isinstance(layout, ak._v2._util.listtypes) and (
 #             layout.parameter("__array__") == "string"
 #             or layout.parameter("__array__") == "bytestring"
 #         ):
@@ -69,10 +69,10 @@ def strings_astype(array, to, highlevel=True, behavior=None):
 #     layout = ak.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
-#     out = ak._util.recursively_apply(
+#     out = ak._v2._util.recursively_apply(
 #         layout,
 #         getfunction,
 #         pass_depth=False,
 #         pass_user=False,
 #     )
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/to_regular.py
+++ b/src/awkward/_v2/operations/structure/to_regular.py
@@ -53,7 +53,7 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 #         elif posaxis == 0:
 #             raise ValueError(
 #                 "array has no axis {0}".format(axis)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 #         else:
 #             return posaxis

--- a/src/awkward/_v2/operations/structure/to_regular.py
+++ b/src/awkward/_v2/operations/structure/to_regular.py
@@ -58,7 +58,7 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 #         else:
 #             return posaxis
 
-#     out = ak.operations.convert.to_layout(array)
+#     out = ak._v2.operations.convert.to_layout(array)
 #     if axis != 0:
 #         out = ak._v2._util.recursively_apply(
 #             out,

--- a/src/awkward/_v2/operations/structure/to_regular.py
+++ b/src/awkward/_v2/operations/structure/to_regular.py
@@ -46,7 +46,7 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 
 #     def getfunction(layout, depth, posaxis):
 #         posaxis = layout.axis_wrap_if_negative(posaxis)
-#         if posaxis == depth and isinstance(layout, ak.layout.RegularArray):
+#         if posaxis == depth and isinstance(layout, ak._v2.contents.RegularArray):
 #             return lambda: layout
 #         elif posaxis == depth and isinstance(layout, ak._util.listtypes):
 #             return lambda: layout.toRegularArray()

--- a/src/awkward/_v2/operations/structure/to_regular.py
+++ b/src/awkward/_v2/operations/structure/to_regular.py
@@ -48,19 +48,19 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 #         posaxis = layout.axis_wrap_if_negative(posaxis)
 #         if posaxis == depth and isinstance(layout, ak._v2.contents.RegularArray):
 #             return lambda: layout
-#         elif posaxis == depth and isinstance(layout, ak._util.listtypes):
+#         elif posaxis == depth and isinstance(layout, ak._v2._util.listtypes):
 #             return lambda: layout.toRegularArray()
 #         elif posaxis == 0:
 #             raise ValueError(
 #                 "array has no axis {0}".format(axis)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 #         else:
 #             return posaxis
 
 #     out = ak.operations.convert.to_layout(array)
 #     if axis != 0:
-#         out = ak._util.recursively_apply(
+#         out = ak._v2._util.recursively_apply(
 #             out,
 #             getfunction,
 #             pass_depth=True,
@@ -69,4 +69,4 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 #             numpy_to_regular=True,
 #         )
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/unflatten.py
+++ b/src/awkward/_v2/operations/structure/unflatten.py
@@ -108,7 +108,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #                     "too large counts for array or negative counts"
 #                     + ak._util.exception_suffix(__file__)
 #                 )
-#             out = ak.layout.RegularArray(layout, counts)
+#             out = ak._v2.contents.RegularArray(layout, counts)
 
 #         else:
 #             position = (
@@ -128,10 +128,10 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #             offsets = current_offsets[0][: position + 1]
 #             current_offsets[0] = current_offsets[0][position:] - len(layout)
 
-#             out = ak.layout.ListOffsetArray64(ak.layout.Index64(offsets), layout)
+#             out = ak._v2.contents.ListOffsetArray64(ak._v2.contents.Index64(offsets), layout)
 #             if not isinstance(mask, (bool, np.bool_)):
-#                 index = ak.layout.Index8(nplike.asarray(mask).astype(np.int8))
-#                 out = ak.layout.ByteMaskedArray(index, out, valid_when=False)
+#                 index = ak._v2.index.Index8(nplike.asarray(mask).astype(np.int8))
+#                 out = ak._v2.contents.ByteMaskedArray(index, out, valid_when=False)
 
 #         return out
 
@@ -159,9 +159,9 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #                 outeroffsets = nplike.asarray(listoffsetarray.offsets)
 
 #                 content = doit(listoffsetarray.content[: outeroffsets[-1]])
-#                 if isinstance(content, ak.layout.ByteMaskedArray):
+#                 if isinstance(content, ak._v2.contents.ByteMaskedArray):
 #                     inneroffsets = nplike.asarray(content.content.offsets)
-#                 elif isinstance(content, ak.layout.RegularArray):
+#                 elif isinstance(content, ak._v2.contents.RegularArray):
 #                     inneroffsets = nplike.asarray(
 #                         content.toListOffsetArray64(True).offsets
 #                     )
@@ -177,8 +177,8 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #                         "at axis={0}".format(axis) + ak._util.exception_suffix(__file__)
 #                     )
 
-#                 return ak.layout.ListOffsetArray64(
-#                     ak.layout.Index64(positions), content
+#                 return ak._v2.contents.ListOffsetArray64(
+#                     ak._v2.index.Index64(positions), content
 #                 )
 
 #             else:

--- a/src/awkward/_v2/operations/structure/unflatten.py
+++ b/src/awkward/_v2/operations/structure/unflatten.py
@@ -136,11 +136,11 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #         return out
 
 #     if axis == 0 or layout.axis_wrap_if_negative(axis) == 0:
-#         if isinstance(layout, ak.partition.PartitionedArray):
+#         if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             outparts = []
 #             for part in layout.partitions:
 #                 outparts.append(doit(part))
-#             out = ak.partition.IrregularlyPartitionedArray(outparts)
+#             out = ak.partition.IrregularlyPartitionedArray(outparts)   # NO PARTITIONED ARRAY
 #         else:
 #             out = doit(layout)
 
@@ -186,11 +186,11 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #                     transform, layout, depth, posaxis
 #                 )
 
-#         if isinstance(layout, ak.partition.PartitionedArray):
+#         if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             outparts = []
 #             for part in layout.partitions:
 #                 outparts.append(transform(part, depth=1, posaxis=axis))
-#             out = ak.partition.IrregularlyPartitionedArray(outparts)
+#             out = ak.partition.IrregularlyPartitionedArray(outparts)   # NO PARTITIONED ARRAY
 #         else:
 #             out = transform(layout, depth=1, posaxis=axis)
 

--- a/src/awkward/_v2/operations/structure/unflatten.py
+++ b/src/awkward/_v2/operations/structure/unflatten.py
@@ -87,15 +87,15 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #             mask = False
 #         else:
 #             raise AssertionError(
-#                 "unrecognized kernels lib" + ak._util.exception_suffix(__file__)
+#                 "unrecognized kernels lib" + ak._v2._util.exception_suffix(__file__)
 #             )
 #         if counts.ndim != 1:
 #             raise ValueError(
-#                 "counts must be one-dimensional" + ak._util.exception_suffix(__file__)
+#                 "counts must be one-dimensional" + ak._v2._util.exception_suffix(__file__)
 #             )
 #         if not issubclass(counts.dtype.type, np.integer):
 #             raise ValueError(
-#                 "counts must be integers" + ak._util.exception_suffix(__file__)
+#                 "counts must be integers" + ak._v2._util.exception_suffix(__file__)
 #             )
 #         current_offsets = [nplike.empty(len(counts) + 1, np.int64)]
 #         current_offsets[0][0] = 0
@@ -106,7 +106,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #             if counts < 0 or counts > len(layout):
 #                 raise ValueError(
 #                     "too large counts for array or negative counts"
-#                     + ak._util.exception_suffix(__file__)
+#                     + ak._v2._util.exception_suffix(__file__)
 #                 )
 #             out = ak._v2.contents.RegularArray(layout, counts)
 
@@ -122,7 +122,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #             ] != len(layout):
 #                 raise ValueError(
 #                     "structure imposed by 'counts' does not fit in the array or partition "
-#                     "at axis={0}".format(axis) + ak._util.exception_suffix(__file__)
+#                     "at axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
 #                 )
 
 #             offsets = current_offsets[0][: position + 1]
@@ -153,7 +153,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #             layout = _pack_layout(layout)
 
 #             posaxis = layout.axis_wrap_if_negative(posaxis)
-#             if posaxis == depth and isinstance(layout, ak._util.listtypes):
+#             if posaxis == depth and isinstance(layout, ak._v2._util.listtypes):
 #                 # We are one *above* the level where we want to apply this.
 #                 listoffsetarray = layout.toListOffsetArray64(True)
 #                 outeroffsets = nplike.asarray(listoffsetarray.offsets)
@@ -174,7 +174,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #                 if not nplike.array_equal(inneroffsets[positions], outeroffsets):
 #                     raise ValueError(
 #                         "structure imposed by 'counts' does not fit in the array or partition "
-#                         "at axis={0}".format(axis) + ak._util.exception_suffix(__file__)
+#                         "at axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
 #                     )
 
 #                 return ak._v2.contents.ListOffsetArray64(
@@ -182,7 +182,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #                 )
 
 #             else:
-#                 return ak._util.transform_child_layouts(
+#                 return ak._v2._util.transform_child_layouts(
 #                     transform, layout, depth, posaxis
 #                 )
 
@@ -199,7 +199,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #     ):
 #         raise ValueError(
 #             "structure imposed by 'counts' does not fit in the array or partition "
-#             "at axis={0}".format(axis) + ak._util.exception_suffix(__file__)
+#             "at axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
 #         )
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/unflatten.py
+++ b/src/awkward/_v2/operations/structure/unflatten.py
@@ -66,24 +66,24 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #     """
 #     nplike = ak.nplike.of(array)
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 
 #     if isinstance(counts, (numbers.Integral, np.integer)):
 #         current_offsets = None
 #     else:
-#         counts = ak.operations.convert.to_layout(
+#         counts = ak._v2.operations.convert.to_layout(
 #             counts, allow_record=False, allow_other=False
 #         )
-#         ptr_lib = ak.operations.convert.kernels(array)
-#         counts = ak.operations.convert.to_kernels(counts, ptr_lib, highlevel=False)
+#         ptr_lib = ak._v2.operations.convert.kernels(array)
+#         counts = ak._v2.operations.convert.to_kernels(counts, ptr_lib, highlevel=False)
 #         if ptr_lib == "cpu":
-#             counts = ak.operations.convert.to_numpy(counts, allow_missing=True)
+#             counts = ak._v2.operations.convert.to_numpy(counts, allow_missing=True)
 #             mask = ak.nplike.numpy.ma.getmask(counts)
 #             counts = ak.nplike.numpy.ma.filled(counts, 0)
 #         elif ptr_lib == "cuda":
-#             counts = ak.operations.convert.to_cupy(counts)
+#             counts = ak._v2.operations.convert.to_cupy(counts)
 #             mask = False
 #         else:
 #             raise AssertionError(

--- a/src/awkward/_v2/operations/structure/unflatten.py
+++ b/src/awkward/_v2/operations/structure/unflatten.py
@@ -87,15 +87,15 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #             mask = False
 #         else:
 #             raise AssertionError(
-#                 "unrecognized kernels lib" + ak._v2._util.exception_suffix(__file__)
+#                 "unrecognized kernels lib"
 #             )
 #         if counts.ndim != 1:
 #             raise ValueError(
-#                 "counts must be one-dimensional" + ak._v2._util.exception_suffix(__file__)
+#                 "counts must be one-dimensional"
 #             )
 #         if not issubclass(counts.dtype.type, np.integer):
 #             raise ValueError(
-#                 "counts must be integers" + ak._v2._util.exception_suffix(__file__)
+#                 "counts must be integers"
 #             )
 #         current_offsets = [nplike.empty(len(counts) + 1, np.int64)]
 #         current_offsets[0][0] = 0
@@ -106,7 +106,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #             if counts < 0 or counts > len(layout):
 #                 raise ValueError(
 #                     "too large counts for array or negative counts"
-#                     + ak._v2._util.exception_suffix(__file__)
+#
 #                 )
 #             out = ak._v2.contents.RegularArray(layout, counts)
 
@@ -122,7 +122,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #             ] != len(layout):
 #                 raise ValueError(
 #                     "structure imposed by 'counts' does not fit in the array or partition "
-#                     "at axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
+#                     "at axis={0}".format(axis)
 #                 )
 
 #             offsets = current_offsets[0][: position + 1]
@@ -174,7 +174,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #                 if not nplike.array_equal(inneroffsets[positions], outeroffsets):
 #                     raise ValueError(
 #                         "structure imposed by 'counts' does not fit in the array or partition "
-#                         "at axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
+#                         "at axis={0}".format(axis)
 #                     )
 
 #                 return ak._v2.contents.ListOffsetArray64(
@@ -199,7 +199,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 #     ):
 #         raise ValueError(
 #             "structure imposed by 'counts' does not fit in the array or partition "
-#             "at axis={0}".format(axis) + ak._v2._util.exception_suffix(__file__)
+#             "at axis={0}".format(axis)
 #         )
 
 #     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/unzip.py
+++ b/src/awkward/_v2/operations/structure/unzip.py
@@ -29,7 +29,7 @@ def unzip(array):
 #         >>> y
 #         <Array [[1], [2, 2], [3, 3, 3]] type='3 * var * int64'>
 #     """
-#     fields = ak.operations.describe.fields(array)
+#     fields = ak._v2.operations.describe.fields(array)
 #     if len(fields) == 0:
 #         return (array,)
 #     else:

--- a/src/awkward/_v2/operations/structure/values_astype.py
+++ b/src/awkward/_v2/operations/structure/values_astype.py
@@ -60,7 +60,7 @@ def values_astype(array, to, highlevel=True, behavior=None):
 #         else:
 #             raise ValueError(
 #                 "cannot use {0} to cast the numeric type of an array".format(to_dtype)
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #     layout = ak.operations.convert.to_layout(
@@ -68,7 +68,7 @@ def values_astype(array, to, highlevel=True, behavior=None):
 #     )
 #     out = layout.numbers_to_type(to_str)
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)
 
 
 # _dtype_to_string = {

--- a/src/awkward/_v2/operations/structure/values_astype.py
+++ b/src/awkward/_v2/operations/structure/values_astype.py
@@ -60,7 +60,7 @@ def values_astype(array, to, highlevel=True, behavior=None):
 #         else:
 #             raise ValueError(
 #                 "cannot use {0} to cast the numeric type of an array".format(to_dtype)
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #     layout = ak.operations.convert.to_layout(

--- a/src/awkward/_v2/operations/structure/values_astype.py
+++ b/src/awkward/_v2/operations/structure/values_astype.py
@@ -63,7 +63,7 @@ def values_astype(array, to, highlevel=True, behavior=None):
 #
 #             )
 
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=False, allow_other=False
 #     )
 #     out = layout.numbers_to_type(to_str)

--- a/src/awkward/_v2/operations/structure/where.py
+++ b/src/awkward/_v2/operations/structure/where.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("where")
+# @ak._v2._connect.numpy.implements("where")
 def where(condition, *args, **kwargs):
     pass
 

--- a/src/awkward/_v2/operations/structure/where.py
+++ b/src/awkward/_v2/operations/structure/where.py
@@ -45,7 +45,7 @@ def where(condition, *args, **kwargs):
 #         (), kwargs, [("mergebool", True), ("highlevel", True)]
 #     )
 
-#     akcondition = ak.operations.convert.to_layout(
+#     akcondition = ak._v2.operations.convert.to_layout(
 #         condition, allow_record=False, allow_other=False
 #     )
 
@@ -54,15 +54,15 @@ def where(condition, *args, **kwargs):
 #         if isinstance(akcondition, ak.partition.PartitionedArray):
 #             akcondition = akcondition.replace_partitions(
 #                 [
-#                     ak._v2.contents.NumpyArray(ak.operations.convert.to_numpy(x))
+#                     ak._v2.contents.NumpyArray(ak._v2.operations.convert.to_numpy(x))
 #                     for x in akcondition.partitions
 #                 ]
 #             )
 #         else:
 #             akcondition = ak._v2.contents.NumpyArray(
-#                 ak.operations.convert.to_numpy(akcondition)
+#                 ak._v2.operations.convert.to_numpy(akcondition)
 #             )
-#         out = nplike.nonzero(ak.operations.convert.to_numpy(akcondition))
+#         out = nplike.nonzero(ak._v2.operations.convert.to_numpy(akcondition))
 #         if highlevel:
 #             return tuple(
 #                 ak._v2._util.wrap(ak._v2.contents.NumpyArray(x), ak._v2._util.behaviorof(condition))
@@ -79,7 +79,7 @@ def where(condition, *args, **kwargs):
 
 #     elif len(args) == 2:
 #         left, right = [
-#             ak.operations.convert.to_layout(x, allow_record=False, allow_other=True)
+#             ak._v2.operations.convert.to_layout(x, allow_record=False, allow_other=True)
 #             for x in args
 #         ]
 #         good_arrays = [akcondition]

--- a/src/awkward/_v2/operations/structure/where.py
+++ b/src/awkward/_v2/operations/structure/where.py
@@ -41,7 +41,7 @@ def where(condition, *args, **kwargs):
 #     for all `i`. The structure of `x` and `y` do not need to be the same; if
 #     they are incompatible types, the output will have #ak.type.UnionType.
 #     """
-#     mergebool, highlevel = ak._util.extra(
+#     mergebool, highlevel = ak._v2._util.extra(
 #         (), kwargs, [("mergebool", True), ("highlevel", True)]
 #     )
 
@@ -65,7 +65,7 @@ def where(condition, *args, **kwargs):
 #         out = nplike.nonzero(ak.operations.convert.to_numpy(akcondition))
 #         if highlevel:
 #             return tuple(
-#                 ak._util.wrap(ak._v2.contents.NumpyArray(x), ak._util.behaviorof(condition))
+#                 ak._v2._util.wrap(ak._v2.contents.NumpyArray(x), ak._v2._util.behaviorof(condition))
 #                 for x in out
 #             )
 #         else:
@@ -74,7 +74,7 @@ def where(condition, *args, **kwargs):
 #     elif len(args) == 1:
 #         raise ValueError(
 #             "either both or neither of x and y should be given"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     elif len(args) == 2:
@@ -104,8 +104,8 @@ def where(condition, *args, **kwargs):
 #             else:
 #                 return None
 
-#         behavior = ak._util.behaviorof(akcondition, left, right)
-#         out = ak._util.broadcast_and_apply(
+#         behavior = ak._v2._util.behaviorof(akcondition, left, right)
+#         out = ak._v2._util.broadcast_and_apply(
 #             [akcondition, left, right],
 #             getfunction,
 #             behavior,
@@ -113,10 +113,10 @@ def where(condition, *args, **kwargs):
 #             numpy_to_regular=True,
 #         )
 
-#         return ak._util.maybe_wrap(out[0], behavior, highlevel)
+#         return ak._v2._util.maybe_wrap(out[0], behavior, highlevel)
 
 #     else:
 #         raise TypeError(
 #             "where() takes from 1 to 3 positional arguments but {0} were "
-#             "given".format(len(args) + 1) + ak._util.exception_suffix(__file__)
+#             "given".format(len(args) + 1) + ak._v2._util.exception_suffix(__file__)
 #         )

--- a/src/awkward/_v2/operations/structure/where.py
+++ b/src/awkward/_v2/operations/structure/where.py
@@ -51,7 +51,7 @@ def where(condition, *args, **kwargs):
 
 #     if len(args) == 0:
 #         nplike = ak.nplike.of(akcondition)
-#         if isinstance(akcondition, ak.partition.PartitionedArray):
+#         if isinstance(akcondition, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #             akcondition = akcondition.replace_partitions(
 #                 [
 #                     ak._v2.contents.NumpyArray(ak._v2.operations.convert.to_numpy(x))

--- a/src/awkward/_v2/operations/structure/where.py
+++ b/src/awkward/_v2/operations/structure/where.py
@@ -74,7 +74,7 @@ def where(condition, *args, **kwargs):
 #     elif len(args) == 1:
 #         raise ValueError(
 #             "either both or neither of x and y should be given"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     elif len(args) == 2:
@@ -118,5 +118,5 @@ def where(condition, *args, **kwargs):
 #     else:
 #         raise TypeError(
 #             "where() takes from 1 to 3 positional arguments but {0} were "
-#             "given".format(len(args) + 1) + ak._v2._util.exception_suffix(__file__)
+#             "given".format(len(args) + 1)
 #         )

--- a/src/awkward/_v2/operations/structure/where.py
+++ b/src/awkward/_v2/operations/structure/where.py
@@ -54,22 +54,22 @@ def where(condition, *args, **kwargs):
 #         if isinstance(akcondition, ak.partition.PartitionedArray):
 #             akcondition = akcondition.replace_partitions(
 #                 [
-#                     ak.layout.NumpyArray(ak.operations.convert.to_numpy(x))
+#                     ak._v2.contents.NumpyArray(ak.operations.convert.to_numpy(x))
 #                     for x in akcondition.partitions
 #                 ]
 #             )
 #         else:
-#             akcondition = ak.layout.NumpyArray(
+#             akcondition = ak._v2.contents.NumpyArray(
 #                 ak.operations.convert.to_numpy(akcondition)
 #             )
 #         out = nplike.nonzero(ak.operations.convert.to_numpy(akcondition))
 #         if highlevel:
 #             return tuple(
-#                 ak._util.wrap(ak.layout.NumpyArray(x), ak._util.behaviorof(condition))
+#                 ak._util.wrap(ak._v2.contents.NumpyArray(x), ak._util.behaviorof(condition))
 #                 for x in out
 #             )
 #         else:
-#             return tuple(ak.layout.NumpyArray(x) for x in out)
+#             return tuple(ak._v2.contents.NumpyArray(x) for x in out)
 
 #     elif len(args) == 1:
 #         raise ValueError(
@@ -83,23 +83,23 @@ def where(condition, *args, **kwargs):
 #             for x in args
 #         ]
 #         good_arrays = [akcondition]
-#         if isinstance(left, ak.layout.Content):
+#         if isinstance(left, ak._v2.contents.Content):
 #             good_arrays.append(left)
-#         if isinstance(right, ak.layout.Content):
+#         if isinstance(right, ak._v2.contents.Content):
 #             good_arrays.append(right)
 #         nplike = ak.nplike.of(*good_arrays)
 
 #         def getfunction(inputs):
 #             akcondition, left, right = inputs
-#             if isinstance(akcondition, ak.layout.NumpyArray):
+#             if isinstance(akcondition, ak._v2.contents.NumpyArray):
 #                 npcondition = nplike.asarray(akcondition)
-#                 tags = ak.layout.Index8((npcondition == 0).view(np.int8))
-#                 index = ak.layout.Index64(nplike.arange(len(tags), dtype=np.int64))
-#                 if not isinstance(left, ak.layout.Content):
-#                     left = ak.layout.NumpyArray(nplike.repeat(left, len(tags)))
-#                 if not isinstance(right, ak.layout.Content):
-#                     right = ak.layout.NumpyArray(nplike.repeat(right, len(tags)))
-#                 tmp = ak.layout.UnionArray8_64(tags, index, [left, right])
+#                 tags = ak._v2.index.Index8((npcondition == 0).view(np.int8))
+#                 index = ak._v2.index.Index64(nplike.arange(len(tags), dtype=np.int64))
+#                 if not isinstance(left, ak._v2.contents.Content):
+#                     left = ak._v2.contents.NumpyArray(nplike.repeat(left, len(tags)))
+#                 if not isinstance(right, ak._v2.contents.Content):
+#                     right = ak._v2.contents.NumpyArray(nplike.repeat(right, len(tags)))
+#                 tmp = ak._v2.contents.UnionArray8_64(tags, index, [left, right])
 #                 return lambda: (tmp.simplify(mergebool=mergebool),)
 #             else:
 #                 return None

--- a/src/awkward/_v2/operations/structure/with_field.py
+++ b/src/awkward/_v2/operations/structure/with_field.py
@@ -45,7 +45,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #         raise TypeError(
 #             "New fields may only be assigned by field name(s) "
 #             "or as a new integer slot by passing None for 'where'"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 #     if (
 #         not isinstance(where, str)
@@ -77,7 +77,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #         if base.numfields < 0:
 #             raise ValueError(
 #                 "no tuples or records in array; cannot add a new field"
-#                 + ak._v2._util.exception_suffix(__file__)
+#
 #             )
 
 #         what = ak.operations.convert.to_layout(

--- a/src/awkward/_v2/operations/structure/with_field.py
+++ b/src/awkward/_v2/operations/structure/with_field.py
@@ -71,7 +71,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #             where = where[0]
 
 #         behavior = ak._v2._util.behaviorof(base, what, behavior=behavior)
-#         base = ak.operations.convert.to_layout(
+#         base = ak._v2.operations.convert.to_layout(
 #             base, allow_record=True, allow_other=False
 #         )
 #         if base.numfields < 0:
@@ -80,7 +80,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #
 #             )
 
-#         what = ak.operations.convert.to_layout(
+#         what = ak._v2.operations.convert.to_layout(
 #             what, allow_record=True, allow_other=True
 #         )
 

--- a/src/awkward/_v2/operations/structure/with_field.py
+++ b/src/awkward/_v2/operations/structure/with_field.py
@@ -45,7 +45,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #         raise TypeError(
 #             "New fields may only be assigned by field name(s) "
 #             "or as a new integer slot by passing None for 'where'"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 #     if (
 #         not isinstance(where, str)
@@ -70,14 +70,14 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #         if not (isinstance(where, str) or where is None):
 #             where = where[0]
 
-#         behavior = ak._util.behaviorof(base, what, behavior=behavior)
+#         behavior = ak._v2._util.behaviorof(base, what, behavior=behavior)
 #         base = ak.operations.convert.to_layout(
 #             base, allow_record=True, allow_other=False
 #         )
 #         if base.numfields < 0:
 #             raise ValueError(
 #                 "no tuples or records in array; cannot add a new field"
-#                 + ak._util.exception_suffix(__file__)
+#                 + ak._v2._util.exception_suffix(__file__)
 #             )
 
 #         what = ak.operations.convert.to_layout(
@@ -122,7 +122,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #                 else:
 #                     return None
 
-#             out = ak._util.broadcast_and_apply(
+#             out = ak._v2._util.broadcast_and_apply(
 #                 [base, what],
 #                 getfunction,
 #                 behavior,
@@ -132,4 +132,4 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 
 #         assert isinstance(out, tuple) and len(out) == 1
 
-#         return ak._util.maybe_wrap(out[0], behavior, highlevel)
+#         return ak._v2._util.maybe_wrap(out[0], behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/with_field.py
+++ b/src/awkward/_v2/operations/structure/with_field.py
@@ -90,21 +90,21 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 
 #         if len(keys) == 0:
 #             # the only key was removed, so just create new Record
-#             out = (ak.layout.RecordArray([what], [where], parameters=base.parameters),)
+#             out = (ak._v2.contents.RecordArray([what], [where], parameters=base.parameters),)
 
 #         else:
 
 #             def getfunction(inputs):
 #                 nplike = ak.nplike.of(*inputs)
 #                 base, what = inputs
-#                 if isinstance(base, ak.layout.RecordArray):
+#                 if isinstance(base, ak._v2.contents.RecordArray):
 #                     if what is None:
-#                         what = ak.layout.IndexedOptionArray64(
-#                             ak.layout.Index64(nplike.full(len(base), -1, np.int64)),
-#                             ak.layout.EmptyArray(),
+#                         what = ak._v2.contents.IndexedOptionArray64(
+#                             ak._v2.index.Index64(nplike.full(len(base), -1, np.int64)),
+#                             ak._v2.contents.EmptyArray(),
 #                         )
-#                     elif not isinstance(what, ak.layout.Content):
-#                         what = ak.layout.NumpyArray(nplike.repeat(what, len(base)))
+#                     elif not isinstance(what, ak._v2.contents.Content):
+#                         what = ak._v2.contents.NumpyArray(nplike.repeat(what, len(base)))
 #                     if base.istuple and where is None:
 #                         recordlookup = None
 #                     elif base.istuple:
@@ -113,7 +113,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #                         recordlookup = keys + [str(len(keys))]
 #                     else:
 #                         recordlookup = keys + [where]
-#                     out = ak.layout.RecordArray(
+#                     out = ak._v2.contents.RecordArray(
 #                         [base[k] for k in keys] + [what],
 #                         recordlookup,
 #                         parameters=base.parameters,

--- a/src/awkward/_v2/operations/structure/with_field.py
+++ b/src/awkward/_v2/operations/structure/with_field.py
@@ -34,7 +34,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 #     other.)
 #     """
 
-#     if isinstance(what, (ak.highlevel.Array, ak.highlevel.Record)):
+#     if isinstance(what, (ak._v2.highlevel.Array, ak._v2.highlevel.Record)):
 #         what_caches = what.caches  # noqa: F841
 
 #     if not (

--- a/src/awkward/_v2/operations/structure/with_name.py
+++ b/src/awkward/_v2/operations/structure/with_name.py
@@ -47,16 +47,16 @@ def with_name(array, name, highlevel=True, behavior=None):
 #         else:
 #             return None
 
-#     out = ak._util.recursively_apply(
+#     out = ak._v2._util.recursively_apply(
 #         ak.operations.convert.to_layout(array), getfunction, pass_depth=False
 #     )
 
 #     def getfunction2(layout):
-#         if isinstance(layout, ak._util.uniontypes):
+#         if isinstance(layout, ak._v2._util.uniontypes):
 #             return lambda: layout.simplify(merge=True, mergebool=False)
 #         else:
 #             return None
 
-#     out2 = ak._util.recursively_apply(out, getfunction2, pass_depth=False)
+#     out2 = ak._v2._util.recursively_apply(out, getfunction2, pass_depth=False)
 
-#     return ak._util.maybe_wrap_like(out2, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out2, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/with_name.py
+++ b/src/awkward/_v2/operations/structure/with_name.py
@@ -34,10 +34,10 @@ def with_name(array, name, highlevel=True, behavior=None):
 #     """
 
 #     def getfunction(layout):
-#         if isinstance(layout, ak.layout.RecordArray):
+#         if isinstance(layout, ak._v2.contents.RecordArray):
 #             parameters = dict(layout.parameters)
 #             parameters["__record__"] = name
-#             return lambda: ak.layout.RecordArray(
+#             return lambda: ak._v2.contents.RecordArray(
 #                 layout.contents,
 #                 layout.recordlookup,
 #                 len(layout),

--- a/src/awkward/_v2/operations/structure/with_name.py
+++ b/src/awkward/_v2/operations/structure/with_name.py
@@ -48,7 +48,7 @@ def with_name(array, name, highlevel=True, behavior=None):
 #             return None
 
 #     out = ak._v2._util.recursively_apply(
-#         ak.operations.convert.to_layout(array), getfunction, pass_depth=False
+#         ak._v2.operations.convert.to_layout(array), getfunction, pass_depth=False
 #     )
 
 #     def getfunction2(layout):

--- a/src/awkward/_v2/operations/structure/with_parameter.py
+++ b/src/awkward/_v2/operations/structure/with_parameter.py
@@ -41,4 +41,4 @@ def with_parameter(array, parameter, value, highlevel=True, behavior=None):
 #     else:
 #         out = layout.withparameter(parameter, value)
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/with_parameter.py
+++ b/src/awkward/_v2/operations/structure/with_parameter.py
@@ -30,7 +30,7 @@ def with_parameter(array, parameter, value, highlevel=True, behavior=None):
 #     You can also remove a single parameter with this function, since setting
 #     a parameter to None is equivalent to removing it.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=True, allow_other=False
 #     )
 

--- a/src/awkward/_v2/operations/structure/with_parameter.py
+++ b/src/awkward/_v2/operations/structure/with_parameter.py
@@ -34,7 +34,7 @@ def with_parameter(array, parameter, value, highlevel=True, behavior=None):
 #         array, allow_record=True, allow_other=False
 #     )
 
-#     if isinstance(layout, ak.partition.PartitionedArray):
+#     if isinstance(layout, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
 #         out = layout.replace_partitions(
 #             x.withparameter(parameter, value) for x in layout.partitions
 #         )

--- a/src/awkward/_v2/operations/structure/without_parameters.py
+++ b/src/awkward/_v2/operations/structure/without_parameters.py
@@ -25,7 +25,7 @@ def without_parameters(array, highlevel=True, behavior=None):
 #     Note that a "new array" is a lightweight shallow copy, not a duplication
 #     of large data buffers.
 #     """
-#     layout = ak.operations.convert.to_layout(
+#     layout = ak._v2.operations.convert.to_layout(
 #         array, allow_record=True, allow_other=False
 #     )
 

--- a/src/awkward/_v2/operations/structure/without_parameters.py
+++ b/src/awkward/_v2/operations/structure/without_parameters.py
@@ -29,8 +29,8 @@ def without_parameters(array, highlevel=True, behavior=None):
 #         array, allow_record=True, allow_other=False
 #     )
 
-#     out = ak._util.recursively_apply(
+#     out = ak._v2._util.recursively_apply(
 #         layout, lambda layout: None, pass_depth=False, keep_parameters=False
 #     )
 
-#     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/zeros_like.py
+++ b/src/awkward/_v2/operations/structure/zeros_like.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplike.NumpyMetadata.instance()
 
 
-# @ak._connect._numpy.implements("zeros_like")
+# @ak._v2._connect.numpy.implements("zeros_like")
 def zeros_like(array, highlevel=True, behavior=None, dtype=None):
     pass
 

--- a/src/awkward/_v2/operations/structure/zip.py
+++ b/src/awkward/_v2/operations/structure/zip.py
@@ -112,11 +112,11 @@ def zip(
 #     if depth_limit is not None and depth_limit <= 0:
 #         raise ValueError(
 #             "depth_limit must be None or at least 1"
-#             + ak._util.exception_suffix(__file__)
+#             + ak._v2._util.exception_suffix(__file__)
 #         )
 
 #     if isinstance(arrays, dict):
-#         behavior = ak._util.behaviorof(*arrays.values(), behavior=behavior)
+#         behavior = ak._v2._util.behaviorof(*arrays.values(), behavior=behavior)
 #         recordlookup = []
 #         layouts = []
 #         num_scalars = 0
@@ -134,7 +134,7 @@ def zip(
 #             layouts.append(layout)
 
 #     else:
-#         behavior = ak._util.behaviorof(*arrays, behavior=behavior)
+#         behavior = ak._v2._util.behaviorof(*arrays, behavior=behavior)
 #         recordlookup = None
 #         layouts = []
 #         num_scalars = 0
@@ -178,7 +178,7 @@ def zip(
 #         else:
 #             return None
 
-#     out = ak._util.broadcast_and_apply(
+#     out = ak._v2._util.broadcast_and_apply(
 #         layouts,
 #         getfunction,
 #         behavior,
@@ -192,4 +192,4 @@ def zip(
 #         out = out[0]
 #         assert isinstance(out, ak.layout.Record)
 
-#     return ak._util.maybe_wrap(out, behavior, highlevel)
+#     return ak._v2._util.maybe_wrap(out, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/zip.py
+++ b/src/awkward/_v2/operations/structure/zip.py
@@ -112,7 +112,7 @@ def zip(
 #     if depth_limit is not None and depth_limit <= 0:
 #         raise ValueError(
 #             "depth_limit must be None or at least 1"
-#             + ak._v2._util.exception_suffix(__file__)
+#
 #         )
 
 #     if isinstance(arrays, dict):

--- a/src/awkward/_v2/operations/structure/zip.py
+++ b/src/awkward/_v2/operations/structure/zip.py
@@ -123,12 +123,12 @@ def zip(
 #         for n, x in arrays.items():
 #             recordlookup.append(n)
 #             try:
-#                 layout = ak.operations.convert.to_layout(
+#                 layout = ak._v2.operations.convert.to_layout(
 #                     x, allow_record=False, allow_other=False
 #                 )
 #             except TypeError:
 #                 num_scalars += 1
-#                 layout = ak.operations.convert.to_layout(
+#                 layout = ak._v2.operations.convert.to_layout(
 #                     [x], allow_record=False, allow_other=False
 #                 )
 #             layouts.append(layout)
@@ -140,12 +140,12 @@ def zip(
 #         num_scalars = 0
 #         for x in arrays:
 #             try:
-#                 layout = ak.operations.convert.to_layout(
+#                 layout = ak._v2.operations.convert.to_layout(
 #                     x, allow_record=False, allow_other=False
 #                 )
 #             except TypeError:
 #                 num_scalars += 1
-#                 layout = ak.operations.convert.to_layout(
+#                 layout = ak._v2.operations.convert.to_layout(
 #                     [x], allow_record=False, allow_other=False
 #                 )
 #             layouts.append(layout)


### PR DESCRIPTION
By replacing a lot of v1 idioms with v2 idioms in the commented-out code, a v1 idiom is less likely to be copy-pasted into the new high-level v2 code. (The commented-out blocks are intended as a guide.)

There's still work to do, like removing references to VirtualArray and PartitionedArray, replacing if-elif-else chains with Content methods where possible (where single-dispatch allows it—functions of only one array argument), some function and method name changes, etc. But with this PR, that future work should proceed more quickly.