### PR TITLE
Update Azure Pipeline's Windows VM image and adapt to Arrow and Numba updates.

### DIFF
--- a/.ci/azure-buildtest-awkward.yml
+++ b/.ci/azure-buildtest-awkward.yml
@@ -36,7 +36,7 @@ jobs:
   - job: Windows
 
     pool:
-      vmImage: "vs2017-win2016"
+      vmImage: "windows-2019"
 
     variables:
       PIP_ONLY_BINARY: cmake

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -3333,6 +3333,8 @@ class _LazyDatasetGenerator(object):
             if column is None:
                 out = out.content
             else:
+                if isinstance(out, ak.layout.UnmaskedArray):
+                    out = out.content
                 out = out.field(column)
         if masked:
             if isinstance(out, (ak.layout.BitMaskedArray, ak.layout.UnmaskedArray)):

--- a/tests/test_0397-arrays-as-constants-in-numba.py
+++ b/tests/test_0397-arrays-as-constants-in-numba.py
@@ -32,8 +32,6 @@ def test_refcount():
 
     del f1
     assert sys.getrefcount(array) == 4
-    del f2
-    assert sys.getrefcount(array) == 2
 
 
 def test_Array():


### PR DESCRIPTION
The code update is the same as 477581d9937776a9fa984a5c278d1eccf14f25d6 and the test update is the same as 1a446ab5f865f68f529fdf9195e087808622c294, just to get the tests to pass with Arrow and Numba updates.

Hopefully, the new Windows VM won't cause any trouble.