### PR TITLE
primitive_to_dtype and dtype_to_primitive as functions.

### DIFF
--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -19,19 +19,7 @@ class NumpyArray(Content):
         self._nplike = ak.nplike.of(data) if nplike is None else nplike
         self._data = self._nplike.asarray(data)
 
-        if (
-            self._data.dtype not in ak._v2.types.numpytype._dtype_to_primitive
-            and not issubclass(self._data.dtype.type, (np.datetime64, np.timedelta64))
-        ):
-            raise TypeError(
-                "{0} 'data' dtype {1} is not supported; must be one of {2}".format(
-                    type(self).__name__,
-                    repr(self._data.dtype),
-                    ", ".join(
-                        repr(x) for x in ak._v2.types.numpytype._dtype_to_primitive
-                    ),
-                )
-            )
+        ak._v2.types.numpytype.dtype_to_primitive(self._data.dtype)
         if len(self._data.shape) == 0:
             raise TypeError(
                 "{0} 'data' must be an array, not {1}".format(
@@ -73,7 +61,7 @@ class NumpyArray(Content):
 
     def _form_with_key(self, getkey):
         return self.Form(
-            ak._v2.types.numpytype._dtype_to_primitive[self._data.dtype],
+            ak._v2.types.numpytype.dtype_to_primitive(self._data.dtype),
             self._data.shape[1:],
             has_identifier=self._identifier is not None,
             parameters=self._parameters,

--- a/src/awkward/_v2/forms/numpyform.py
+++ b/src/awkward/_v2/forms/numpyform.py
@@ -33,17 +33,8 @@ def from_dtype(dtype, parameters=None):
             parameters["__unit__"] = unitstr
             dtype = np.dtype(dtype.type)
 
-    primitive = ak._v2.types.numpytype._dtype_to_primitive.get(dtype)
-    if primitive is None:
-        raise TypeError(
-            "dtype {0} is not supported; must be one of {1}".format(
-                repr(dtype),
-                ", ".join(repr(x) for x in ak._v2.types.numpytype._dtype_to_primitive),
-            )
-        )
-
     return NumpyForm(
-        primitive=primitive,
+        primitive=ak._v2.types.numpytype.dtype_to_primitive(dtype),
         parameters=parameters,
         inner_shape=inner_shape,
     )
@@ -58,16 +49,9 @@ class NumpyForm(Form):
         parameters=None,
         form_key=None,
     ):
-        if primitive not in ak._v2.types.numpytype._primitive_to_dtype:
-            raise TypeError(
-                "{0} 'primitive' must be one of {1}, not {2}".format(
-                    type(self).__name__,
-                    ", ".join(
-                        repr(x) for x in ak._v2.types.numpytype._primitive_to_dtype
-                    ),
-                    repr(primitive),
-                )
-            )
+        primitive = ak._v2.types.numpytype.dtype_to_primitive(
+            ak._v2.types.numpytype.primitive_to_dtype(primitive)
+        )
         if not isinstance(inner_shape, Iterable):
             raise TypeError(
                 "{0} 'inner_shape' must be iterable, not {1}".format(
@@ -89,7 +73,7 @@ class NumpyForm(Form):
 
     @property
     def itemsize(self):
-        return ak._v2.types.numpytype._primitive_to_dtype[self._primitive].itemsize
+        return ak._v2.types.numpytype.primitive_to_dtype(self._primitive).itemsize
 
     def __repr__(self):
         args = [repr(self._primitive)]
@@ -147,8 +131,8 @@ class NumpyForm(Form):
 
         elif isinstance(other, NumpyForm):
             return (
-                ak._v2.types.numpytype._primitive_to_dtype[self._primitive]
-                == ak._v2.types.numpytype._primitive_to_dtype[other._primitive]
+                ak._v2.types.numpytype.primitive_to_dtype(self._primitive)
+                == ak._v2.types.numpytype.primitive_to_dtype(other._primitive)
                 and self._inner_shape == other._inner_shape
                 and _parameters_equal(self._parameters, other._parameters)
             )

--- a/src/awkward/_v2/operations/convert/ak_from_buffers.py
+++ b/src/awkward/_v2/operations/convert/ak_from_buffers.py
@@ -61,7 +61,7 @@ def from_buffers(
     See #ak.to_buffers for examples.
     """
     if ak._v2._util.isstr(form):
-        if form in ak._v2.types.numpytype._primitive_to_dtype:
+        if ak._v2.types.numpytype.is_primitive(form):
             form = ak._v2.forms.NumpyForm(form)
         else:
             form = ak._v2.forms.from_json(form)
@@ -120,7 +120,7 @@ def reconstitute(form, length, container, getkey, nplike):
         return ak._v2.contents.EmptyArray(identifier, form.parameters)
 
     elif isinstance(form, ak._v2.forms.NumpyForm):
-        dtype = ak._v2.types.numpytype._primitive_to_dtype[form.primitive]
+        dtype = ak._v2.types.numpytype.primitive_to_dtype(form.primitive)
         raw_array = container[getkey(form, "data")]
         real_length = length
         for x in form.inner_shape:


### PR DESCRIPTION
Rather than as dicts. This allows for datetime64 and timedelta64 to have arbitrary units.