### PR TITLE
C++ refactoring: handle datetime and timedelta

### DIFF
--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1147,6 +1147,9 @@ at inner {2} of length {3}, using sub-slice {4}.{5}""".format(
             },
         )
 
+    def to_numpy(self, allow_missing):
+        return self._to_numpy(allow_missing)
+
     def completely_flatten(
         self, nplike=None, flatten_records=False, function_name=None
     ):

--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -1071,6 +1071,13 @@ class NumpyArray(Content):
             ),
         )
 
+    def _to_numpy(self, allow_missing):
+        out = ak.nplike.of(self).asarray(self)
+        if type(out).__module__.startswith("cupy."):
+            return out.get()
+        else:
+            return out
+
     def _completely_flatten(self, nplike, options):
         return [self.to(nplike).reshape(-1)]
 

--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -448,14 +448,14 @@ class NumpyArray(Content):
 
         is_equal = ak._v2.index.Index64.zeros(1, nplike)
 
-        tmp = ak._v2.contents.NumpyArray(nplike.empty(length, self.dtype))
+        tmp = nplike.empty(length, self.dtype)
         self._handle_error(
-            nplike[
+            nplike[  # noqa: E231
                 "awkward_NumpyArray_fill",
-                tmp._data.dtype.type,
+                self.dtype.type,
                 self._data.dtype.type,
             ](
-                tmp._data,
+                tmp,
                 0,
                 self._data,
                 length,
@@ -469,13 +469,13 @@ class NumpyArray(Content):
             self._handle_error(
                 nplike[
                     "awkward_quick_sort",
-                    tmp._data.dtype.type,
+                    self.dtype.type,
                     tmp_beg_ptr.dtype.type,
                     tmp_end_ptr.dtype.type,
                     starts.dtype.type,
                     stops.dtype.type,
                 ](
-                    tmp._data,
+                    tmp,
                     tmp_beg_ptr.to(nplike),
                     tmp_end_ptr.to(nplike),
                     starts.to(nplike),
@@ -488,12 +488,12 @@ class NumpyArray(Content):
         self._handle_error(
             nplike[
                 "awkward_NumpyArray_subrange_equal",
-                tmp._data.dtype.type,
+                self.dtype.type,
                 starts.dtype.type,
                 stops.dtype.type,
                 np.bool_,
             ](
-                tmp._data,
+                tmp,
                 starts.to(nplike),
                 stops.to(nplike),
                 len(starts),
@@ -507,17 +507,17 @@ class NumpyArray(Content):
         nplike = self.nplike
 
         outoffsets = ak._v2.index.Index64.empty(len(offsets), nplike)
-        out = ak._v2.contents.NumpyArray(nplike.empty(self.shape[0], self.dtype))
+        out = nplike.empty(self.shape[0], self.dtype)
 
         self._handle_error(
             nplike[
                 "awkward_NumpyArray_sort_asstrings_uint8",
-                out._data.dtype.type,
+                self.dtype.type,
                 self._data.dtype.type,
                 offsets._data.dtype.type,
                 outoffsets.dtype.type,
             ](
-                out._data,
+                out,
                 self._data,
                 offsets.to(nplike),
                 len(offsets),
@@ -532,12 +532,12 @@ class NumpyArray(Content):
         self._handle_error(
             nplike[
                 "awkward_NumpyArray_unique_strings",
-                out._data.dtype.type,
+                self.dtype.type,
                 outoffsets.dtype.type,
                 nextoffsets.dtype.type,
                 outlength.dtype.type,
             ](
-                out._data,
+                out,
                 outoffsets.to(nplike),
                 len(offsets),
                 nextoffsets.to(nplike),
@@ -784,12 +784,17 @@ class NumpyArray(Content):
                 )
             )
 
+            dtype = (
+                np.dtype(np.int64)
+                if self._data.dtype.kind.upper() == "M"
+                else self._data.dtype
+            )
             nextcarry = ak._v2.index.Index64.empty(self.__len__(), nplike)
             self._handle_error(
                 nplike[
                     "awkward_argsort",
                     nextcarry.dtype.type,
-                    self._data.dtype.type,
+                    dtype.type,
                     offsets.dtype.type,
                 ](
                     nextcarry.to(nplike),
@@ -879,15 +884,20 @@ class NumpyArray(Content):
                 )
             )
 
-            out = ak._v2.contents.NumpyArray(nplike.empty(len(self._data), self.dtype))
+            dtype = (
+                np.dtype(np.int64)
+                if self._data.dtype.kind.upper() == "M"
+                else self._data.dtype
+            )
+            out = nplike.empty(len(self._data), dtype)
             self._handle_error(
-                nplike[
+                nplike[  # noqa: E231
                     "awkward_sort",
-                    out._data.dtype.type,
-                    self._data.dtype.type,
+                    dtype.type,
+                    dtype.type,
                     offsets.dtype.type,
                 ](
-                    out._data,
+                    out,
                     self._data,
                     self.shape[0],
                     offsets.to(nplike),
@@ -897,7 +907,7 @@ class NumpyArray(Content):
                     stable,
                 )
             )
-            return out
+            return ak._v2.contents.NumpyArray(nplike.asarray(out, self.dtype))
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -921,7 +921,7 @@ class UnionArray(Content):
     def _completely_flatten(self, nplike, options):
         out = []
         for content in self._contents:
-            out.extend(content[: len(self)]._completely_flatten(nplike, options))
+            out.extend(content[: len(self._tags)]._completely_flatten(nplike, options))
         return out
 
     def _recursively_apply(

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -921,7 +921,7 @@ class UnionArray(Content):
     def _completely_flatten(self, nplike, options):
         out = []
         for content in self._contents:
-            out.extend(content[: self._length]._completely_flatten(nplike, options))
+            out.extend(content[: len(self)]._completely_flatten(nplike, options))
         return out
 
     def _recursively_apply(

--- a/src/awkward/_v2/operations/convert/ak_to_numpy.py
+++ b/src/awkward/_v2/operations/convert/ak_to_numpy.py
@@ -8,225 +8,227 @@ np = ak.nplike.NumpyMetadata.instance()
 
 
 def to_numpy(array, allow_missing=True):
-    raise NotImplementedError
+    """
+    Converts `array` (many types supported, including all Awkward Arrays and
+    Records) into a NumPy array, if possible.
 
+    If the data are numerical and regular (nested lists have equal lengths
+    in each dimension, as described by the #type), they can be losslessly
+    converted to a NumPy array and this function returns without an error.
 
-#     """
-#     Converts `array` (many types supported, including all Awkward Arrays and
-#     Records) into a NumPy array, if possible.
+    Otherwise, the function raises an error. It does not create a NumPy
+    array with dtype `"O"` for `np.object_` (see the
+    [note on object_ type](https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html#arrays-scalars-built-in))
+    since silent conversions to dtype `"O"` arrays would not only be a
+    significant performance hit, but would also break functionality, since
+    nested lists in a NumPy `"O"` array are severed from the array and
+    cannot be sliced as dimensions.
 
-#     If the data are numerical and regular (nested lists have equal lengths
-#     in each dimension, as described by the #type), they can be losslessly
-#     converted to a NumPy array and this function returns without an error.
+    If `array` is a scalar, it is converted into a NumPy scalar.
 
-#     Otherwise, the function raises an error. It does not create a NumPy
-#     array with dtype `"O"` for `np.object_` (see the
-#     [note on object_ type](https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html#arrays-scalars-built-in))
-#     since silent conversions to dtype `"O"` arrays would not only be a
-#     significant performance hit, but would also break functionality, since
-#     nested lists in a NumPy `"O"` array are severed from the array and
-#     cannot be sliced as dimensions.
+    If `allow_missing` is True; NumPy
+    [masked arrays](https://docs.scipy.org/doc/numpy/reference/maskedarray.html)
+    are a possible result; otherwise, missing values (None) cause this
+    function to raise an error.
 
-#     If `array` is a scalar, it is converted into a NumPy scalar.
-
-#     If `allow_missing` is True; NumPy
-#     [masked arrays](https://docs.scipy.org/doc/numpy/reference/maskedarray.html)
-#     are a possible result; otherwise, missing values (None) cause this
-#     function to raise an error.
-
-#     See also #ak.from_numpy and #ak.to_cupy.
-#     """
-#     if isinstance(array, (bool, str, bytes, numbers.Number)):
-#         return numpy.array([array])[0]
-
-#     elif ak._v2._util.py27 and isinstance(array, ak._v2._util.unicode):
-#         return numpy.array([array])[0]
-
-#     elif isinstance(array, np.ndarray):
-#         return array
-
-#     elif isinstance(array, ak._v2.highlevel.Array):
-#         return to_numpy(array.layout, allow_missing=allow_missing)
-
-#     elif isinstance(array, ak._v2.highlevel.Record):
-#         out = array.layout
-#         return to_numpy(out.array[out.at : out.at + 1], allow_missing=allow_missing)[0]
-
-#     elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
-#         return to_numpy(array.snapshot().layout, allow_missing=allow_missing)
-
-#     elif isinstance(array, ak.layout.ArrayBuilder):
-#         return to_numpy(array.snapshot(), allow_missing=allow_missing)
-
-#     elif ak._v2.operations.describe.parameters(array).get("__array__") == "bytestring":
-#         return numpy.array(
-#             [
-#                 ak._v2.behaviors.string.ByteBehavior(array[i]).__bytes__()
-#                 for i in range(len(array))
-#             ]
-#         )
-
-#     elif ak._v2.operations.describe.parameters(array).get("__array__") == "string":
-#         return numpy.array(
-#             [
-#                 ak._v2.behaviors.string.CharBehavior(array[i]).__str__()
-#                 for i in range(len(array))
-#             ]
-#         )
-
-#     elif (
-#         str(ak._v2.operations.describe.type(array)) == "datetime64"
-#         or str(ak._v2.operations.describe.type(array)) == "timedelta64"
-#     ):
-#         return array
-
-#     elif isinstance(array, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
-#         tocat = [to_numpy(x, allow_missing=allow_missing) for x in array.partitions]
-#         if any(isinstance(x, numpy.ma.MaskedArray) for x in tocat):
-#             return numpy.ma.concatenate(tocat)
-#         else:
-#             return numpy.concatenate(tocat)
-
-#     elif isinstance(array, ak._v2._util.virtualtypes):
-#         return to_numpy(array.array, allow_missing=True)
-
-#     elif isinstance(array, ak._v2._util.unknowntypes):
-#         return numpy.array([])
-
-#     elif isinstance(array, ak._v2._util.indexedtypes):
-#         return to_numpy(array.project(), allow_missing=allow_missing)
-
-#     elif isinstance(array, ak._v2._util.uniontypes):
-#         contents = [
-#             to_numpy(array.project(i), allow_missing=allow_missing)
-#             for i in range(array.numcontents)
-#         ]
-
-#         if any(isinstance(x, numpy.ma.MaskedArray) for x in contents):
-#             try:
-#                 out = numpy.ma.concatenate(contents)
-#             except Exception:
-#                 raise ValueError(
-#                     "cannot convert {0} into numpy.ma.MaskedArray".format(array)
-#
-#                 )
-#         else:
-#             try:
-#                 out = numpy.concatenate(contents)
-#             except Exception:
-#                 raise ValueError(
-#                     "cannot convert {0} into np.ndarray".format(array)
-#
-#                 )
-
-#         tags = numpy.asarray(array.tags)
-#         for tag, content in enumerate(contents):
-#             mask = tags == tag
-#             out[mask] = content
-#         return out
-
-#     elif isinstance(array, ak._v2.contents.UnmaskedArray):
-#         content = to_numpy(array.content, allow_missing=allow_missing)
-#         if allow_missing:
-#             return numpy.ma.MaskedArray(content)
-#         else:
-#             return content
-
-#     elif isinstance(array, ak._v2._util.optiontypes):
-#         content = to_numpy(array.project(), allow_missing=allow_missing)
-
-#         shape = list(content.shape)
-#         shape[0] = len(array)
-#         data = numpy.empty(shape, dtype=content.dtype)
-#         mask0 = numpy.asarray(array.bytemask()).view(np.bool_)
-#         if mask0.any():
-#             if allow_missing:
-#                 mask = numpy.broadcast_to(
-#                     mask0.reshape((shape[0],) + (1,) * (len(shape) - 1)), shape
-#                 )
-#                 if isinstance(content, numpy.ma.MaskedArray):
-#                     mask1 = numpy.ma.getmaskarray(content)
-#                     mask = mask.copy()
-#                     mask[~mask0] |= mask1
-
-#                 data[~mask0] = content
-#                 return numpy.ma.MaskedArray(data, mask)
-#             else:
-#                 raise ValueError(
-#                     "ak.to_numpy cannot convert 'None' values to "
-#                     "np.ma.MaskedArray unless the "
-#                     "'allow_missing' parameter is set to True"
-#
-#                 )
-#         else:
-#             if allow_missing:
-#                 return numpy.ma.MaskedArray(content)
-#             else:
-#                 return content
-
-#     elif isinstance(array, ak._v2.contents.RegularArray):
-#         out = to_numpy(array.content, allow_missing=allow_missing)
-#         head, tail = out.shape[0], out.shape[1:]
-#         if array.size == 0:
-#             shape = (0, 0) + tail
-#         else:
-#             shape = (head // array.size, array.size) + tail
-#         return out[: shape[0] * array.size].reshape(shape)
-
-#     elif isinstance(array, ak._v2._util.listtypes):
-#         return to_numpy(array.toRegularArray(), allow_missing=allow_missing)
-
-#     elif isinstance(array, ak._v2._util.recordtypes):
-#         if array.numfields == 0:
-#             return numpy.empty(len(array), dtype=[])
-#         contents = [
-#             to_numpy(array.field(i), allow_missing=allow_missing)
-#             for i in range(array.numfields)
-#         ]
-#         if any(len(x.shape) != 1 for x in contents):
-#             raise ValueError(
-#                 "cannot convert {0} into np.ndarray".format(array)
-#
-#             )
-#         out = numpy.empty(
-#             len(contents[0]),
-#             dtype=[(str(n), x.dtype) for n, x in zip(array.keys(), contents)],
-#         )
-
-#         mask = None
-#         for n, x in zip(array.keys(), contents):
-#             if isinstance(x, numpy.ma.MaskedArray):
-#                 if mask is None:
-#                     mask = numpy.ma.zeros(
-#                         len(array), [(n, np.bool_) for n in array.keys()]
-#                     )
-#                 if x.mask is not None:
-#                     mask[n] |= x.mask
-#             out[n] = x
-
-#         if mask is not None:
-#             out = numpy.ma.MaskedArray(out, mask)
-
-#         return out
-
-#     elif isinstance(array, ak._v2.contents.NumpyArray):
-#         out = ak.nplike.of(array).asarray(array)
-#         if type(out).__module__.startswith("cupy."):
-#             return out.get()
-#         else:
-#             return out
-
-#     elif isinstance(array, ak._v2.contents.Content):
-#         raise AssertionError(
-#             "unrecognized Content type: {0}".format(type(array))
-#
-#         )
-
-#     elif isinstance(array, Iterable):
-#         return numpy.asarray(array)
-
-#     else:
-#         raise ValueError(
-#             "cannot convert {0} into np.ndarray".format(array)
-#
-#         )
+    See also #ak.from_numpy and #ak.to_cupy.
+    """
+    layout = ak._v2.operations.convert.to_layout(
+        array, allow_record=False, allow_other=False
+    )
+    return layout.to_numpy(allow_missing=allow_missing)
+    #
+    # if isinstance(array, (bool, str, bytes, numbers.Number)):
+    #     return numpy.array([array])[0]
+    #
+    # elif ak._v2._util.py27 and isinstance(array, ak._v2._util.unicode):
+    #     return numpy.array([array])[0]
+    #
+    # elif isinstance(array, np.ndarray):
+    #     return array
+    #
+    # elif isinstance(array, ak._v2.highlevel.Array):
+    #     return to_numpy(array.layout, allow_missing=allow_missing)
+    #
+    # elif isinstance(array, ak._v2.highlevel.Record):
+    #     out = array.layout
+    #     return to_numpy(out.array[out.at : out.at + 1], allow_missing=allow_missing)[0]
+    #
+    # elif isinstance(array, ak._v2.highlevel.ArrayBuilder):
+    #     return to_numpy(array.snapshot().layout, allow_missing=allow_missing)
+    #
+    # elif isinstance(array, ak.layout.ArrayBuilder):
+    #     return to_numpy(array.snapshot(), allow_missing=allow_missing)
+    #
+    # elif ak._v2.operations.describe.parameters(array).get("__array__") == "bytestring":
+    #     return numpy.array(
+    #         [
+    #             ak._v2.behaviors.string.ByteBehavior(array[i]).__bytes__()
+    #             for i in range(len(array))
+    #         ]
+    #     )
+    #
+    # elif ak._v2.operations.describe.parameters(array).get("__array__") == "string":
+    #     return numpy.array(
+    #         [
+    #             ak._v2.behaviors.string.CharBehavior(array[i]).__str__()
+    #             for i in range(len(array))
+    #         ]
+    #     )
+    #
+    # elif (
+    #     str(ak._v2.operations.describe.type(array)) == "datetime64"
+    #     or str(ak._v2.operations.describe.type(array)) == "timedelta64"
+    # ):
+    #     return array
+    #
+    # elif isinstance(array, ak.partition.PartitionedArray):   # NO PARTITIONED ARRAY
+    #     tocat = [to_numpy(x, allow_missing=allow_missing) for x in array.partitions]
+    #     if any(isinstance(x, numpy.ma.MaskedArray) for x in tocat):
+    #         return numpy.ma.concatenate(tocat)
+    #     else:
+    #         return numpy.concatenate(tocat)
+    #
+    # elif isinstance(array, ak._v2._util.virtualtypes):
+    #     return to_numpy(array.array, allow_missing=True)
+    #
+    # elif isinstance(array, ak._v2._util.unknowntypes):
+    #     return numpy.array([])
+    #
+    # elif isinstance(array, ak._v2._util.indexedtypes):
+    #     return to_numpy(array.project(), allow_missing=allow_missing)
+    #
+    # elif isinstance(array, ak._v2._util.uniontypes):
+    #     contents = [
+    #         to_numpy(array.project(i), allow_missing=allow_missing)
+    #         for i in range(array.numcontents)
+    #     ]
+    #
+    #     if any(isinstance(x, numpy.ma.MaskedArray) for x in contents):
+    #         try:
+    #             out = numpy.ma.concatenate(contents)
+    #         except Exception:
+    #             raise ValueError(
+    #                 "cannot convert {0} into numpy.ma.MaskedArray".format(array)
+    #
+    #             )
+    #     else:
+    #         try:
+    #             out = numpy.concatenate(contents)
+    #         except Exception:
+    #             raise ValueError(
+    #                 "cannot convert {0} into np.ndarray".format(array)
+    #
+    #             )
+    #
+    #     tags = numpy.asarray(array.tags)
+    #     for tag, content in enumerate(contents):
+    #         mask = tags == tag
+    #         out[mask] = content
+    #     return out
+    #
+    # elif isinstance(array, ak._v2.contents.UnmaskedArray):
+    #     content = to_numpy(array.content, allow_missing=allow_missing)
+    #     if allow_missing:
+    #         return numpy.ma.MaskedArray(content)
+    #     else:
+    #         return content
+    #
+    # elif isinstance(array, ak._v2._util.optiontypes):
+    #     content = to_numpy(array.project(), allow_missing=allow_missing)
+    #
+    #     shape = list(content.shape)
+    #     shape[0] = len(array)
+    #     data = numpy.empty(shape, dtype=content.dtype)
+    #     mask0 = numpy.asarray(array.bytemask()).view(np.bool_)
+    #     if mask0.any():
+    #         if allow_missing:
+    #             mask = numpy.broadcast_to(
+    #                 mask0.reshape((shape[0],) + (1,) * (len(shape) - 1)), shape
+    #             )
+    #             if isinstance(content, numpy.ma.MaskedArray):
+    #                 mask1 = numpy.ma.getmaskarray(content)
+    #                 mask = mask.copy()
+    #                 mask[~mask0] |= mask1
+    #
+    #             data[~mask0] = content
+    #             return numpy.ma.MaskedArray(data, mask)
+    #         else:
+    #             raise ValueError(
+    #                 "ak.to_numpy cannot convert 'None' values to "
+    #                 "np.ma.MaskedArray unless the "
+    #                 "'allow_missing' parameter is set to True"
+    #
+    #             )
+    #     else:
+    #         if allow_missing:
+    #             return numpy.ma.MaskedArray(content)
+    #         else:
+    #             return content
+    #
+    # elif isinstance(array, ak._v2.contents.RegularArray):
+    #     out = to_numpy(array.content, allow_missing=allow_missing)
+    #     head, tail = out.shape[0], out.shape[1:]
+    #     if array.size == 0:
+    #         shape = (0, 0) + tail
+    #     else:
+    #         shape = (head // array.size, array.size) + tail
+    #     return out[: shape[0] * array.size].reshape(shape)
+    #
+    # elif isinstance(array, ak._v2._util.listtypes):
+    #     return to_numpy(array.toRegularArray(), allow_missing=allow_missing)
+    #
+    # elif isinstance(array, ak._v2._util.recordtypes):
+    #     if array.numfields == 0:
+    #         return numpy.empty(len(array), dtype=[])
+    #     contents = [
+    #         to_numpy(array.field(i), allow_missing=allow_missing)
+    #         for i in range(array.numfields)
+    #     ]
+    #     if any(len(x.shape) != 1 for x in contents):
+    #         raise ValueError(
+    #             "cannot convert {0} into np.ndarray".format(array)
+    #
+    #         )
+    #     out = numpy.empty(
+    #         len(contents[0]),
+    #         dtype=[(str(n), x.dtype) for n, x in zip(array.keys(), contents)],
+    #     )
+    #
+    #     mask = None
+    #     for n, x in zip(array.keys(), contents):
+    #         if isinstance(x, numpy.ma.MaskedArray):
+    #             if mask is None:
+    #                 mask = numpy.ma.zeros(
+    #                     len(array), [(n, np.bool_) for n in array.keys()]
+    #                 )
+    #             if x.mask is not None:
+    #                 mask[n] |= x.mask
+    #         out[n] = x
+    #
+    #     if mask is not None:
+    #         out = numpy.ma.MaskedArray(out, mask)
+    #
+    #     return out
+    #
+    # elif isinstance(array, ak._v2.contents.NumpyArray):
+    #     out = ak.nplike.of(array).asarray(array)
+    #     if type(out).__module__.startswith("cupy."):
+    #         return out.get()
+    #     else:
+    #         return out
+    #
+    # elif isinstance(array, ak._v2.contents.Content):
+    #     raise AssertionError(
+    #         "unrecognized Content type: {0}".format(type(array))
+    #
+    #     )
+    #
+    # elif isinstance(array, Iterable):
+    #     return numpy.asarray(array)
+    #
+    # else:
+    #     raise ValueError(
+    #         "cannot convert {0} into np.ndarray".format(array)
+    #
+    #     )

--- a/tests/v2/test_0264-reduce-last-empty.py
+++ b/tests/v2/test_0264-reduce-last-empty.py
@@ -1,0 +1,33 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+pytestmark = pytest.mark.skipif(
+    ak._util.py27, reason="No Python 2.7 support in Awkward 2.x"
+)
+
+
+def test():
+    assert ak.to_list(
+        ak._v2.operations.reducers.prod(
+            ak._v2.highlevel.Array([[[2, 3, 5]], [[7], [11]], [[]]]), axis=-1
+        )
+    ) == [
+        [30],
+        [7, 11],
+        [1],
+    ]
+
+    assert ak.to_list(
+        ak._v2.operations.reducers.prod(
+            ak._v2.highlevel.Array([[[2, 3, 5]], [[7], [11]], []]), axis=-1
+        )
+    ) == [
+        [30],
+        [7, 11],
+        [],
+    ]

--- a/tests/v2/test_0835-datetime-type.py
+++ b/tests/v2/test_0835-datetime-type.py
@@ -168,9 +168,6 @@ def test_highlevel_timedelta64_ArrayBuilder():
     ]
 
 
-@pytest.mark.skip(
-    reason="AttributeError: module 'awkward._v2._util' has no attribute 'completely_flatten'"
-)
 def test_count_axis_None():
     array = ak.Array(
         [
@@ -238,9 +235,6 @@ def test_count():
     ]
 
 
-@pytest.mark.skip(
-    reason="AttributeError: module 'awkward._v2._util' has no attribute 'completely_flatten'"
-)
 def test_count_nonzeroaxis_None():
     array = ak.Array(
         [
@@ -311,9 +305,6 @@ def test_all_nonzero():
     ]
 
 
-@pytest.mark.skip(
-    reason="AttributeError: module 'awkward._v2._util' has no attribute 'completely_flatten'"
-)
 def test_argmin_argmax_axis_None():
     array = ak.Array(
         [
@@ -495,7 +486,7 @@ def test_min_max():
 
 
 @pytest.mark.skip(
-    reason="AttributeError: module 'awkward._v2._util' has no attribute 'completely_flatten'"
+    reason="AttributeError: 'UnionArray' object has no attribute '_length'"
 )
 def test_highlevel_min_max_axis_None():
     array = ak.Array(

--- a/tests/v2/test_0835-datetime-type.py
+++ b/tests/v2/test_0835-datetime-type.py
@@ -528,7 +528,7 @@ def test_highlevel_min_max_axis_None():
 
 
 def test_highlevel_min_max():
-    array = ak.Array(
+    array = ak._v2.highlevel.Array(
         [
             [
                 np.datetime64("2020-03-27T10:41:11"),
@@ -596,9 +596,6 @@ def test_highlevel_min_max():
     ]
 
 
-@pytest.mark.skip(
-    reason="awkward/_v2/operations/convert/ak_to_numpy.py:11: NotImplementedError"
-)
 def test_date_time_units():
     array1 = np.array(
         ["2020-07-27T10:41:11", "2019-01-01", "2020-01-01"], "datetime64[s]"

--- a/tests/v2/test_0835-datetime-type.py
+++ b/tests/v2/test_0835-datetime-type.py
@@ -56,8 +56,7 @@ def test_time_delta():
 
     array = ak.Array(numpy_array)
     array = v1_to_v2(array.layout)
-    # FIXME:
-    # assert str(array.type) == "3 * timedelta64"
+    assert str(array.form.type) == "timedelta64[D]"
     assert ak.to_list(array) == [
         np.timedelta64("41", "D"),
         np.timedelta64("1", "D"),
@@ -474,15 +473,11 @@ def test_min_max():
         np.datetime64("2020-01-27T10:41:11"),
         np.datetime64("2020-01-27T10:41:11"),
     ]
-    # FIXME: default axis is -1
-    # np.datetime64("2020-01-27T10:41:11")
     assert ak.to_list(array.max()) == [
         datetime.datetime(2020, 5, 1, 0, 0),
         datetime.datetime(2020, 6, 27, 10, 41, 11),
         datetime.datetime(2020, 3, 27, 10, 41, 11),
     ]
-    # FIXME: default axis is -1
-    # np.datetime64("2020-06-27T10:41:11")
 
 
 @pytest.mark.skip(

--- a/tests/v2/test_0835-datetime-type.py
+++ b/tests/v2/test_0835-datetime-type.py
@@ -692,12 +692,7 @@ def test_ufunc_mul():
     assert ak._v2.highlevel.Array([np.timedelta64(3, "D")])[0] == np.timedelta64(3, "D")
 
 
-def test_NumpyArray_layout_FIXME():
-    # FIXME: are strings as follows supported?
-    # "2019-09-02T09:30:00",
-    # "2019-09-13T09:30:00",
-    # "2019-09-21T20:00:00",
-
+def test_NumpyArray_layout_as_objects():
     array = ak.layout.NumpyArray(
         ["2019-09-02T09:30:00", "2019-09-13T09:30:00", "2019-09-21T20:00:00"]
     )

--- a/tests/v2/test_0835-datetime-type.py
+++ b/tests/v2/test_0835-datetime-type.py
@@ -480,11 +480,8 @@ def test_min_max():
     ]
 
 
-@pytest.mark.skip(
-    reason="AttributeError: 'UnionArray' object has no attribute '_length'"
-)
 def test_highlevel_min_max_axis_None():
-    array = ak.Array(
+    array = ak._v2.highlevel.Array(
         [
             [
                 np.datetime64("2020-03-27T10:41:11"),
@@ -698,16 +695,29 @@ def test_ufunc_mul():
     assert ak._v2.highlevel.Array([np.timedelta64(3, "D")])[0] == np.timedelta64(3, "D")
 
 
-@pytest.mark.skip(reason="awkward/_v2/contents/numpyarray.py:26: TypeError")
 def test_NumpyArray_layout_FIXME():
-    array0 = ak._v2.contents.NumpyArray(
+    # FIXME: are strings as follows supported?
+    # "2019-09-02T09:30:00",
+    # "2019-09-13T09:30:00",
+    # "2019-09-21T20:00:00",
+
+    array = ak.layout.NumpyArray(
         ["2019-09-02T09:30:00", "2019-09-13T09:30:00", "2019-09-21T20:00:00"]
+    )
+    with pytest.raises(TypeError):
+        v1_to_v2(array)
+
+    array0 = ak._v2.contents.NumpyArray(
+        np.array(
+            ["2019-09-02T09:30:00", "2019-09-13T09:30:00", "2019-09-21T20:00:00"],
+            dtype=np.datetime64,
+        )
     )
 
     assert ak.to_list(array0) == [
-        "2019-09-02T09:30:00",
-        "2019-09-13T09:30:00",
-        "2019-09-21T20:00:00",
+        datetime.datetime(2019, 9, 2, 9, 30),
+        datetime.datetime(2019, 9, 13, 9, 30),
+        datetime.datetime(2019, 9, 21, 20, 0),
     ]
 
 

--- a/tests/v2/test_1149-datetime-sort.py
+++ b/tests/v2/test_1149-datetime-sort.py
@@ -1,0 +1,86 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+import datetime
+
+from awkward._v2.tmp_for_testing import v1_to_v2
+
+pytestmark = pytest.mark.skipif(
+    ak._util.py27, reason="No Python 2.7 support in Awkward 2.x"
+)
+
+
+def test_date_time():
+    numpy_array = np.array(
+        ["2020-07-27T10:41:11", "2019-01-01", "2020-01-01"], "datetime64[s]"
+    )
+
+    array = ak._v2.contents.NumpyArray(numpy_array)
+    assert str(array.form.type) == "datetime64[s]"
+    assert ak.to_list(array) == [
+        np.datetime64("2020-07-27T10:41:11"),
+        np.datetime64("2019-01-01T00:00:00"),
+        np.datetime64("2020-01-01T00:00:00"),
+    ]
+    for i in range(len(array)):
+        assert array[i] == numpy_array[i]
+
+    date_time = np.datetime64("2020-07-27T10:41:11.200000011", "us")
+    array1 = ak._v2.contents.NumpyArray(
+        np.array(["2020-07-27T10:41:11.200000011"], "datetime64[us]")
+    )
+    assert np.datetime64(array1[0], "us") == date_time
+
+    assert ak.to_list(ak.from_iter(array1)) == [
+        np.datetime64("2020-07-27T10:41:11.200000")
+    ]
+
+
+def test_date_time_sort_argsort_unique():
+    numpy_array = np.array(
+        ["2020-07-27T10:41:11", "2019-01-01", "2020-01-01"], "datetime64[s]"
+    )
+    array = ak._v2.contents.NumpyArray(numpy_array)
+    assert ak.to_list(array.sort()) == [
+        datetime.datetime(2019, 1, 1, 0, 0),
+        datetime.datetime(2020, 1, 1, 0, 0),
+        datetime.datetime(2020, 7, 27, 10, 41, 11),
+    ]
+    assert ak.to_list(array.argsort()) == [1, 2, 0]
+    assert array.is_unique() is True
+    assert ak.to_list(array.unique()) == [
+        datetime.datetime(2019, 1, 1, 0, 0),
+        datetime.datetime(2020, 1, 1, 0, 0),
+        datetime.datetime(2020, 7, 27, 10, 41, 11),
+    ]
+
+
+def test_time_delta_sort_argsort_unique():
+
+    numpy_array = np.array(["41", "1", "20"], "timedelta64[D]")
+
+    array = ak.Array(numpy_array)
+    array = v1_to_v2(array.layout)
+    assert str(array.form.type) == "timedelta64[D]"
+    assert ak.to_list(array) == [
+        np.timedelta64("41", "D"),
+        np.timedelta64("1", "D"),
+        np.timedelta64("20", "D"),
+    ]
+    assert ak.to_list(array.sort()) == [
+        datetime.timedelta(days=1),
+        datetime.timedelta(days=20),
+        datetime.timedelta(days=41),
+    ]
+    assert ak.to_list(array.argsort()) == [1, 2, 0]
+    assert array.is_unique() is True
+    assert ak.to_list(array.unique()) == [
+        datetime.timedelta(days=1),
+        datetime.timedelta(days=20),
+        datetime.timedelta(days=41),
+    ]


### PR DESCRIPTION
- [x] test reducers on `datetime` and `timedelta` at axis `None`

- [x] `sort` and `argsort` `datetime` and `timedelta` types

- [x] `unique` and `is_unique` for `datetime` and `timedelta` types
