### PR TITLE
'behaviorof' should take Array, not layouts, and setting 'behavior' should set the '__class__'.

### DIFF
--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -365,8 +365,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, Mapping):
-            if self.__class__ is Array:
-                self.__class__ = ak._v2._util.arrayclass(self._layout, behavior)
+            self.__class__ = ak._v2._util.arrayclass(self._layout, behavior)
             self._behavior = behavior
         else:
             raise TypeError("behavior must be None or a dict")
@@ -1627,9 +1626,8 @@ class Record(NDArrayOperatorsMixin):
 
     @behavior.setter
     def behavior(self, behavior):
-        if behavior is None or isinstance(behavior, dict):
-            if self.__class__ is Record:
-                self.__class__ = ak._v2._util.recordclass(self._layout, behavior)
+        if behavior is None or isinstance(behavior, Mapping):
+            self.__class__ = ak._v2._util.recordclass(self._layout, behavior)
             self._behavior = behavior
         else:
             raise TypeError("behavior must be None or a dict")

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -275,8 +275,6 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             layout = ak._v2.operations.structure.with_name(
                 layout, with_name, highlevel=False
             )
-        if self.__class__ is Array:
-            self.__class__ = ak._v2._util.arrayclass(layout, behavior)
 
         if library is not None and library != ak._v2.operations.convert.library(layout):
             layout = ak._v2.operations.convert.to_library(
@@ -367,6 +365,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, Mapping):
+            if self.__class__ is Array:
+                self.__class__ = ak._v2._util.arrayclass(self._layout, behavior)
             self._behavior = behavior
         else:
             raise TypeError("behavior must be None or a dict")
@@ -1447,8 +1447,6 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 layout = ak._v2.operations.structure.concatenate(
                     layouts, highlevel=False
                 )
-        if self.__class__ is Array:
-            self.__class__ = ak._v2._util.arrayclass(layout, behavior)
         self.layout = layout
         self.behavior = behavior
 
@@ -1544,8 +1542,6 @@ class Record(NDArrayOperatorsMixin):
             layout = ak._v2.operations.structure.with_name(
                 layout, with_name, highlevel=False
             )
-        if self.__class__ is Record:
-            self.__class__ = ak._v2._util.recordclass(layout, behavior)
 
         if library is not None and library != ak._v2.operations.convert.library(layout):
             layout = ak._v2.operations.convert.to_library(
@@ -1632,6 +1628,8 @@ class Record(NDArrayOperatorsMixin):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, dict):
+            if self.__class__ is Record:
+                self.__class__ = ak._v2._util.recordclass(self._layout, behavior)
             self._behavior = behavior
         else:
             raise TypeError("behavior must be None or a dict")
@@ -2048,8 +2046,6 @@ class Record(NDArrayOperatorsMixin):
                     layouts, highlevel=False
                 )
         layout = ak._v2.record.Record(layout, at)
-        if self.__class__ is Record:
-            self.__class__ = ak._v2._util.recordclass(layout, behavior)
         self.layout = layout
         self.behavior = behavior
 

--- a/src/awkward/_v2/operations/structure/ak_isclose.py
+++ b/src/awkward/_v2/operations/structure/ak_isclose.py
@@ -46,7 +46,7 @@ def isclose(
                 ),
             )
 
-    behavior = ak._v2._util.behavior_of(one, two, behavior=behavior)
+    behavior = ak._v2._util.behavior_of(a, b, behavior=behavior)
     out = ak._v2._broadcasting.broadcast_and_apply([one, two], action, behavior)
     assert isinstance(out, tuple) and len(out) == 1
 

--- a/src/awkward/_v2/operations/structure/ak_where.py
+++ b/src/awkward/_v2/operations/structure/ak_where.py
@@ -104,7 +104,7 @@ def where(condition, *args, **kwargs):
 #             else:
 #                 return None
 
-#         behavior = ak._v2._util.behaviorof(akcondition, left, right)
+#         behavior = ak._v2._util.behaviorof(condition, *args)
 #         out = ak._v2._util.broadcast_and_apply(
 #             [akcondition, left, right],
 #             getfunction,

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -267,8 +267,6 @@ class Array(
             layout = ak.operations.structure.with_name(
                 layout, with_name, highlevel=False
             )
-        if self.__class__ is Array:
-            self.__class__ = ak._util.arrayclass(layout, behavior)
 
         if kernels is not None and kernels != ak.operations.convert.kernels(layout):
             layout = ak.operations.convert.to_kernels(layout, kernels, highlevel=False)
@@ -360,6 +358,8 @@ class Array(
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, dict):
+            if self.__class__ is Array:
+                self.__class__ = ak._util.arrayclass(self._layout, behavior)
             self._behavior = behavior
         else:
             raise TypeError(
@@ -1480,8 +1480,6 @@ class Array(
             layout = ak.operations.convert.from_buffers(
                 form, length, container, highlevel=False, behavior=behavior
             )
-        if self.__class__ is Array:
-            self.__class__ = ak._util.arrayclass(layout, behavior)
         self.layout = layout
         self.behavior = behavior
         self._caches = ak._util.find_caches(self.layout)
@@ -1585,8 +1583,6 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
             layout = ak.operations.structure.with_name(
                 layout, with_name, highlevel=False
             )
-        if self.__class__ is Record:
-            self.__class__ = ak._util.recordclass(layout, behavior)
 
         if kernels is not None and kernels != ak.operations.convert.kernels(layout):
             layout = ak.operations.convert.to_kernels(layout, kernels, highlevel=False)
@@ -1674,6 +1670,8 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, dict):
+            if self.__class__ is Record:
+                self.__class__ = ak._util.recordclass(self._layout, behavior)
             self._behavior = behavior
         else:
             raise TypeError(
@@ -2082,8 +2080,6 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
                 form, length, container, highlevel=False, behavior=behavior
             )
         layout = ak.layout.Record(layout, at)
-        if self.__class__ is Record:
-            self.__class__ = ak._util.recordclass(layout, behavior)
         self.layout = layout
         self.behavior = behavior
         self._caches = ak._util.find_caches(self.layout)

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -358,8 +358,7 @@ class Array(
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, dict):
-            if self.__class__ is Array:
-                self.__class__ = ak._util.arrayclass(self._layout, behavior)
+            self.__class__ = ak._util.arrayclass(self._layout, behavior)
             self._behavior = behavior
         else:
             raise TypeError(
@@ -1670,8 +1669,7 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, dict):
-            if self.__class__ is Record:
-                self.__class__ = ak._util.recordclass(self._layout, behavior)
+            self.__class__ = ak._util.recordclass(self._layout, behavior)
             self._behavior = behavior
         else:
             raise TypeError(

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -4417,7 +4417,7 @@ def isclose(
         else:
             return None
 
-    behavior = ak._util.behaviorof(one, two, behavior=behavior)
+    behavior = ak._util.behaviorof(a, b, behavior=behavior)
     out = ak._util.broadcast_and_apply(
         [one, two], getfunction, behavior, pass_depth=False
     )

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -1744,7 +1744,7 @@ def where(condition, *args, **kwargs):
             else:
                 return None
 
-        behavior = ak._util.behaviorof(akcondition, left, right)
+        behavior = ak._util.behaviorof(condition, *args)
         out = ak._util.broadcast_and_apply(
             [akcondition, left, right],
             getfunction,


### PR DESCRIPTION
  - [ ] Also, all of the other uses of `ak._util.behaviorof` that are being passed layouts, rather than `ak.Array` wrappers (which is the level that could possibly have behaviors).