### PR TITLE
Fix: _pack_layout should also pack projected index arrays

### DIFF
--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2244,7 +2244,7 @@ def _pack_layout(layout):
 
     # Project indexed arrays
     elif isinstance(layout, ak._util.indexedtypes):
-        return layout.project()
+        return _pack_layout(layout.project())
 
     # ListArray performs both ordering and resizing
     elif isinstance(


### PR DESCRIPTION
When _pack_layout is passed an indexed array, it returns `layout.project()`. However,  `_pack_layout` is *supposed* to return a layout whereby only its children may need packing. In this case, by returning `layout.project()`, we are not guaranteed to satisfy this expectation.

This PR fix the issue by ensuring that we pack the result of `project`.