### PR TITLE
C++ refactoring: ak._v2 namespace is now filled with the right symbols.

### DIFF
--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -19,12 +19,6 @@ import awkward._cpu_kernels
 import awkward._libawkward
 import awkward._util
 
-# NumPy 1.13.1 introduced NEP13, without which Awkward ufuncs won't work, which
-# would be worse than lacking a feature: it would cause unexpected output.
-# NumPy 1.17.0 introduced NEP18, which is optional (use ak.* instead of np.*).
-if not awkward._v2._util.numpy_at_least("1.13.1"):
-    raise ImportError("NumPy 1.13.1 or later required")
-
 # third-party connectors
 import awkward._connect._numpy
 import awkward._connect._numba

--- a/src/awkward/_v2/__init__.py
+++ b/src/awkward/_v2/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+# layout classes; functionality that used to be in C++ (in Awkward 1.x)
 import awkward._v2.index  # noqa: F401
 import awkward._v2.identifier  # noqa: F401
 import awkward._v2.contents  # noqa: F401
@@ -12,15 +13,28 @@ import awkward._v2._slicing  # noqa: F401
 import awkward._v2._broadcasting  # noqa: F401
 import awkward._v2._typetracer  # noqa: F401
 
+# internal
 import awkward._v2._util  # noqa: F401
-import awkward._v2.operations.io  # noqa: F401
-import awkward._v2.operations.convert  # noqa: F401
-import awkward._v2.operations.describe  # noqa: F401
-import awkward._v2.operations.structure  # noqa: F401
-import awkward._v2.operations.reducers  # noqa: F401
 
+# third-party connectors
+import awkward._v2._connect.numpy
+import awkward._v2._connect.numba
+import awkward._v2._connect.numexpr  # noqa: F401
+
+# high-level interface
+from awkward._v2.highlevel import Array  # noqa: F401
+from awkward._v2.highlevel import Record  # noqa: F401
+from awkward._v2.highlevel import ArrayBuilder  # noqa: F401
+
+# behaviors
 behavior = {}
-import awkward._v2.highlevel  # noqa: F401, E402
-import awkward._v2.behaviors.categorical  # noqa: F401, E402
-import awkward._v2.behaviors.mixins  # noqa: F401, E402
-import awkward._v2.behaviors.string  # noqa: F401, E402
+from awkward._v2.behaviors.categorical import *  # noqa: E402, F401, F403
+from awkward._v2.behaviors.mixins import *  # noqa: E402, F401, F403
+from awkward._v2.behaviors.string import *  # noqa: E402, F401, F403
+
+# operations
+from awkward._v2.operations.io import *  # noqa: E402, F401, F403
+from awkward._v2.operations.convert import *  # noqa: E402, F401, F403
+from awkward._v2.operations.describe import *  # noqa: E402, F401, F403
+from awkward._v2.operations.structure import *  # noqa: E402, F401, F403
+from awkward._v2.operations.reducers import *  # noqa: E402, F401, F403

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -7,7 +7,14 @@ import sys
 import numpy
 
 import awkward as ak
+from awkward._v2._util import numpy_at_least
 from awkward._v2.contents.numpyarray import NumpyArray
+
+# NumPy 1.13.1 introduced NEP13, without which Awkward ufuncs won't work, which
+# would be worse than lacking a feature: it would cause unexpected output.
+# NumPy 1.17.0 introduced NEP18, which is optional (use ak.* instead of np.*).
+if not numpy_at_least("1.13.1"):
+    raise ImportError("NumPy 1.13.1 or later required")
 
 
 # def convert_to_array(layout, args, kwargs):


### PR DESCRIPTION
@douglasdavis and @martindurant, this adds `ak._v2.Array`, `ak._v2.sum`, and all other functions that will be in the `ak` namespace after version 2.0.

```python
import awkward._v2 as ak
```

would be a good stepping stone to minimize changes when the 2.0 version is released.