### PR TITLE
C++ refactoring: Fixed handling of list-nested boolean slices.

### DIFF
--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -315,6 +315,14 @@ class TypeTracerArray(object):
             assert len(self._shape) != 0
             return TypeTracerArray(self._dtype, where.shape + self._shape[1:])
 
+        elif (
+            hasattr(where, "dtype")
+            and hasattr(where, "shape")
+            and issubclass(where.dtype.type, (np.bool_, bool))
+        ):
+            assert len(self._shape) != 0
+            return TypeTracerArray(self._dtype, (UnknownLength,) + self._shape[1:])
+
         elif isinstance(where, tuple) and any(
             hasattr(x, "dtype") and hasattr(x, "shape") for x in where
         ):

--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -33,12 +33,15 @@ class RegularArray(Content):
                     type(self).__name__, repr(content)
                 )
             )
-        if not (ak._util.isint(size) and size >= 0):
-            raise TypeError(
-                "{0} 'size' must be a non-negative integer, not {1}".format(
-                    type(self).__name__, size
+        if not isinstance(size, ak._v2._typetracer.UnknownLengthType):
+            if not (ak._util.isint(size) and size >= 0):
+                raise TypeError(
+                    "{0} 'size' must be a non-negative integer, not {1}".format(
+                        type(self).__name__, size
+                    )
                 )
-            )
+            else:
+                size = int(size)
         if not isinstance(zeros_length, ak._v2._typetracer.UnknownLengthType):
             if not (ak._util.isint(zeros_length) and zeros_length >= 0):
                 raise TypeError(
@@ -50,7 +53,7 @@ class RegularArray(Content):
             nplike = content.nplike
 
         self._content = content
-        self._size = int(size)
+        self._size = size
         if size != 0:
             self._length = content.length // size  # floor division
         else:


### PR DESCRIPTION
@douglasdavis This fixes the NotImplementedError you mentioned in Slack and also an error with greater-than-depth-1 nested booleans:

```python
>>> a = ak._v2.highlevel.Array([[[0, 1, 2]], [[], [3, 4]], [], [[5], [6, 7, 8, 9]]])
>>> a[a % 2 == 0].show()
```

should not be

```python
[[[1, 0, 1]],
 [[], [3, 4]],
 [],
 [[5], [7, 6, 7, 6]]]
```

but should be

```python
[[[0, 2]],
 [[], [4]],
 [],
 [[], [6, 8]]]
```

(The booleans were being interpreted as integer positions, `0` and `1`, for lists of lists of numbers and deeper. A recursion wasn't getting passed on as it should be.)