### PR TITLE
C++ refactoring: Make highlevel __repr__ safe for typetracers.

### DIFF
--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -1247,14 +1247,20 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         import awkward._v2._prettyprint
 
         pytype = type(self).__name__
-        valuestr = awkward._v2._prettyprint.valuestr(self, 1, 50)
+        if self._layout.nplike.known_shape and self._layout.nplike.known_data:
+            valuestr = " " + awkward._v2._prettyprint.valuestr(self, 1, 50)
+            typestr = repr(str(self.type))[1:-1]
+        else:
+            valuestr = "-typetracer"
+            typestr = repr(
+                "?? * " + str(self._layout.form.type_from_behavior(self._behavior))
+            )[1:-1]
         length = max(10, 80 - len(pytype) - 10 - len(valuestr))
-        typestr = repr(str(self.type))[1:-1]
         if len(typestr) > length:
             typestr = "'" + typestr[: length - 3] + "...'"
         else:
             typestr = "'" + typestr + "'"
-        return "<{0} {1} type={2}>".format(pytype, valuestr, typestr)
+        return "<{0}{1} type={2}>".format(pytype, valuestr, typestr)
 
     def show(self, limit_rows=20, limit_cols=80, type=False, stream=sys.stdout):
         """
@@ -1933,14 +1939,23 @@ class Record(NDArrayOperatorsMixin):
         import awkward._v2._prettyprint
 
         pytype = type(self).__name__
-        valuestr = awkward._v2._prettyprint.valuestr(self, 1, 50)
+        if (
+            self._layout.array.nplike.known_shape
+            and self._layout.array.nplike.known_data
+        ):
+            valuestr = " " + awkward._v2._prettyprint.valuestr(self, 1, 50)
+            typestr = repr(str(self.type))[1:-1]
+        else:
+            valuestr = "-typetracer"
+            typestr = repr(
+                str(self._layout.array.form.type_from_behavior(self._behavior))
+            )[1:-1]
         length = max(10, 80 - len(pytype) - 10 - len(valuestr))
-        typestr = repr(str(self.type))[1:-1]
         if len(typestr) > length:
             typestr = "'" + typestr[: length - 3] + "...'"
         else:
             typestr = "'" + typestr + "'"
-        return "<{0} {1} type={2}>".format(pytype, valuestr, typestr)
+        return "<{0}{1} type={2}>".format(pytype, valuestr, typestr)
 
     def show(self, limit_rows=20, limit_cols=80, type=False, stream=sys.stdout):
         """


### PR DESCRIPTION
@douglasdavis, here's what it looks like with only the type section (no values section).

```python
>>> import awkward._v2 as ak

>>> x = ak.Array([[1, 2, 3], [], [4]])
>>> ak.Array(x.layout.typetracer)
<Array-typetracer type='?? * var * int64'>

>>> x = ak.Record({"x": [1, 2, 3], "y": 1.1})
>>> ak.Record(ak.record.Record(x.layout.array.typetracer, 0))
<Record-typetracer type='{x: var * int64, y: float64}'>
```