### PR TITLE
Build wheels for ppc64le

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,6 +73,12 @@ jobs:
       matrix:
         python: [36, 37, 38, 39, 310]
         arch: [aarch64, ppc64le]
+        exclude:
+          - arch: ppc64le
+            python: 36
+          - arch: ppc64le
+            python: 37
+
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         python: [36, 37, 38, 39, 310]
-        arch: [aarch64]
+        arch: [aarch64, ppc64le]
     steps:
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
I've found myself having a need for POWER wheels for awkward array. What do you think about including them in the PyPI releases? I'm excluding Python 3.6 and 3.7 to shrink the build matrix but it's up to you if you want to keep that part.