### PR TITLE
C++ refactoring: Redo PR #1227: fixing 'emptyArray' typo.

### DIFF
--- a/src/awkward/_v2/contents/bitmaskedarray.py
+++ b/src/awkward/_v2/contents/bitmaskedarray.py
@@ -354,7 +354,7 @@ class BitMaskedArray(Content):
         if isinstance(
             other,
             (
-                ak._v2.contents.emptyArray.EmptyArray,
+                ak._v2.contents.emptyarray.EmptyArray,
                 ak._v2.contents.unionarray.UnionArray,
             ),
         ):

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -415,7 +415,7 @@ class IndexedArray(Content):
         if isinstance(
             other,
             (
-                ak._v2.contents.emptyArray.EmptyArray,
+                ak._v2.contents.emptyarray.EmptyArray,
                 ak._v2.contents.unionarray.UnionArray,
             ),
         ):


### PR DESCRIPTION
This replaces #1227, @martindurant.