### PR TITLE
Revert "Build wheels for ppc64le"

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -77,13 +77,7 @@ jobs:
     strategy:
       matrix:
         python: [36, 37, 38, 39, 310]
-        arch: [aarch64, ppc64le]
-        exclude:
-          - arch: ppc64le
-            python: 36
-          - arch: ppc64le
-            python: 37
-
+        arch: [aarch64]
     steps:
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
Reverts scikit-hep/awkward-1.0#1224

@chrisburr I should have done a manual CD test, first. It didn't deploy: https://github.com/scikit-hep/awkward-1.0/actions/runs/1724731128

I'm reverting this to release 1.8.0rc3. We'll revisit it!