### PR TITLE
style: add shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,8 @@ repos:
     language: pygrep
     entry: PyBind|Cmake|CCache|Github|PyTest
     exclude: .pre-commit-config.yaml
+
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: "v0.8.0.3"
+  hooks:
+  - id: shellcheck

--- a/cuda-build.sh
+++ b/cuda-build.sh
@@ -6,41 +6,35 @@ set -e
 PLATFORM="manylinux2014_x86_64"
 CUDA_VERSION=9.0
 
-AWKWARD_VERSION=`cat VERSION_INFO | tr -d '[:space:]'`
+AWKWARD_VERSION=$(tr -d '[:space:]' < VERSION_INFO)
 
-if [[ "$CUDA_VERSION" == "11.0" ]]; then
-    export DOCKER_IMAGE_TAG="11.0-devel-ubuntu18.04"
-elif [[ "$CUDA_VERSION" == "10.2" ]]; then
-    export DOCKER_IMAGE_TAG="10.2-devel-ubuntu18.04"
-elif [[ "$CUDA_VERSION" == "10.1" ]]; then
-    export DOCKER_IMAGE_TAG="10.1-devel-ubuntu18.04"
-elif [[ "$CUDA_VERSION" == "10.0" ]]; then
-    export DOCKER_IMAGE_TAG="10.0-devel-ubuntu18.04"
-elif [[ "$CUDA_VERSION" == "9.2" ]]; then
-    export DOCKER_IMAGE_TAG="9.2-devel-ubuntu18.04"
-elif [[ "$CUDA_VERSION" == "9.1" ]]; then
-    export DOCKER_IMAGE_TAG="9.1-devel-ubuntu16.04"
-elif [[ "$CUDA_VERSION" == "9.0" ]]; then
-    export DOCKER_IMAGE_TAG="9.0-devel-ubuntu16.04"
-elif [[ "$CUDA_VERSION" == "8.0" ]]; then
-    export DOCKER_IMAGE_TAG="8.0-devel-ubuntu16.04"
-else
-    echo "Docker image for CUDA version" $CUDA_VERSION "is not known"
+case $CUDA_VERSION in
+  "11.0" | "10.2" | "10.1" | "10.0" | "9.2")
+    export DOCKER_IMAGE_TAG="$CUDA_VERSION-devel-ubuntu18.04"
+    ;;
+  "9.1" | "9.0" | "8.0" )
+    export DOCKER_IMAGE_TAG="$CUDA_VERSION-devel-ubuntu16.04"
+    ;;
+  *)
+    echo "Docker image for CUDA version $CUDA_VERSION is not known"
     exit 1
-fi
+    ;;
+esac
 
 rm -rf build dist
 mkdir build
 cp -r src/awkward_cuda_kernels build
 
-echo "__version__ ='"$AWKWARD_VERSION"'" >> build/awkward_cuda_kernels/__init__.py
-echo "cuda_version ='"$CUDA_VERSION"'" >> build/awkward_cuda_kernels/__init__.py
-echo "docker_image ='docker.io/nvidia/cuda:"$DOCKER_IMAGE_TAG"'" >> build/awkward_cuda_kernels/__init__.py
+{
+  echo "__version__ = \"$AWKWARD_VERSION\""
+  echo "cuda_version = \"$CUDA_VERSION\""
+  echo "docker_image = \"docker.io/nvidia/cuda:$DOCKER_IMAGE_TAG\""
+} >> build/awkward_cuda_kernels/__init__.py
 
-export DOCKER_ARGS="-v`pwd`:/home -w/home docker.io/nvidia/cuda:"$DOCKER_IMAGE_TAG
-export BUILD_SHARED_LIBRARY="nvcc -std=c++11 -Xcompiler -fPIC -Xcompiler -DVERSION_INFO="$AWKWARD_VERSION" -Iinclude src/cuda-kernels/*.cu --shared -o build/awkward_cuda_kernels/libawkward-cuda-kernels.so"
+export DOCKER_ARGS=("-v$PWD:/home" -w/home "docker.io/nvidia/cuda:$DOCKER_IMAGE_TAG")
+export BUILD_SHARED_LIBRARY=(nvcc -std=c++11 -Xcompiler -fPIC -Xcompiler "-DVERSION_INFO=$AWKWARD_VERSION" -Iinclude src/cuda-kernels/*.cu --shared -o build/awkward_cuda_kernels/libawkward-cuda-kernels.so)
 
-docker run $DOCKER_ARGS $BUILD_SHARED_LIBRARY
+docker run "${DOCKER_ARGS[@]}" "${BUILD_SHARED_LIBRARY[@]}"
 
 cat > build/cuda-setup.py << EOF
 
@@ -84,6 +78,8 @@ setup(name = "awkward-cuda-kernels",
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.9",
+          "Programming Language :: Python :: 3.10",
           "Topic :: Scientific/Engineering",
           "Topic :: Scientific/Engineering :: Information Analysis",
           "Topic :: Scientific/Engineering :: Mathematics",
@@ -97,17 +93,17 @@ EOF
 python build/cuda-setup.py bdist_wheel
 
 cd dist
-rm -f awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-$PLATFORM.whl
+rm -f "awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-$PLATFORM.whl"
 
-unzip awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-any.whl
+unzip "awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-any.whl"
 
-cp awkward_cuda_kernels-$AWKWARD_VERSION.dist-info/WHEEL tmp_WHEEL
-cat tmp_WHEEL | sed "s/Root-Is-Purelib: true/Root-Is-Purelib: false/" | sed "s/Tag: py3-none-any/Tag: py3-none-"$PLATFORM"/" > awkward_cuda_kernels-$AWKWARD_VERSION.dist-info/WHEEL
+cp "awkward_cuda_kernels-$AWKWARD_VERSION.dist-info/WHEEL" tmp_WHEEL
+sed "s/Root-Is-Purelib: true/Root-Is-Purelib: false/" < tmp_WHEEL | sed "s/Tag: py3-none-any/Tag: py3-none-$PLATFORM" > "awkward_cuda_kernels-$AWKWARD_VERSION.dist-info/WHEEL"
 
-zip awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-$PLATFORM.whl -r awkward_cuda_kernels awkward_cuda_kernels-$AWKWARD_VERSION.dist-info
+zip "awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-$PLATFORM.whl" -r awkward_cuda_kernels "awkward_cuda_kernels-$AWKWARD_VERSION.dist-info"
 
 cd ..
 
 if [ "$1" == "--install" ]; then
-    pip install dist/awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-$PLATFORM.whl
+    pip install "dist/awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-$PLATFORM.whl"
 fi

--- a/cuda-build.sh
+++ b/cuda-build.sh
@@ -98,7 +98,7 @@ rm -f "awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-$PLATFORM.whl"
 unzip "awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-any.whl"
 
 cp "awkward_cuda_kernels-$AWKWARD_VERSION.dist-info/WHEEL" tmp_WHEEL
-sed "s/Root-Is-Purelib: true/Root-Is-Purelib: false/" < tmp_WHEEL | sed "s/Tag: py3-none-any/Tag: py3-none-$PLATFORM" > "awkward_cuda_kernels-$AWKWARD_VERSION.dist-info/WHEEL"
+sed "s/Root-Is-Purelib: true/Root-Is-Purelib: false/" < tmp_WHEEL | sed "s/Tag: py3-none-any/Tag: py3-none-$PLATFORM/" > "awkward_cuda_kernels-$AWKWARD_VERSION.dist-info/WHEEL"
 
 zip "awkward_cuda_kernels-$AWKWARD_VERSION-py3-none-$PLATFORM.whl" -r awkward_cuda_kernels "awkward_cuda_kernels-$AWKWARD_VERSION.dist-info"
 


### PR DESCRIPTION
This cleans up the recommendations produced for cuda-build.sh. I don't think this is checked in CI, and I haven't run the changes. Not sure the old one wwas working properly either. This really needs to be further redone, it should not be injecting things like the WHEEL file; wheels are hashed and can't be edited like this. And there are ways to indicate they are not pure Python other than hacking it like this. But this is a start. CC @swishdiff 
