### PR TITLE
C++ refactoring: layout.completely_flatten should not concatenate (performance issue).

### DIFF
--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1263,10 +1263,7 @@ at inner {2} of length {3}, using sub-slice {4}.{5}""".format(
                 "function_name": function_name,
             },
         )
-        if len(arrays) == 0:
-            return nplike.empty(0, dtype=np.float64)
-        else:
-            return nplike.concatenate(arrays)
+        return tuple(arrays)
 
     def recursively_apply(
         self,

--- a/src/awkward/_v2/operations/reducers/ak_all.py
+++ b/src/awkward/_v2/operations/reducers/ak_all.py
@@ -44,10 +44,20 @@ def all(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
     )
 
     if axis is None:
-        return layout.nplike.all(
-            layout.completely_flatten(
-                function_name="ak.all", flatten_records=flatten_records
-            )
+
+        def reduce(xs):
+            if len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.logical_and(xs[0], reduce(xs[1:]))
+
+        return reduce(
+            [
+                layout.nplike.all(x)
+                for x in layout.completely_flatten(
+                    function_name="ak.all", flatten_records=flatten_records
+                )
+            ]
         )
 
     else:

--- a/src/awkward/_v2/operations/reducers/ak_any.py
+++ b/src/awkward/_v2/operations/reducers/ak_any.py
@@ -44,10 +44,20 @@ def any(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
     )
 
     if axis is None:
-        return layout.nplike.any(
-            layout.completely_flatten(
-                function_name="ak.any", flatten_records=flatten_records
-            )
+
+        def reduce(xs):
+            if len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.logical_or(xs[0], reduce(xs[1:]))
+
+        return reduce(
+            [
+                layout.nplike.any(x)
+                for x in layout.completely_flatten(
+                    function_name="ak.any", flatten_records=flatten_records
+                )
+            ]
         )
 
     else:

--- a/src/awkward/_v2/operations/reducers/ak_argmax.py
+++ b/src/awkward/_v2/operations/reducers/ak_argmax.py
@@ -52,13 +52,18 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True, flatten_records
         layout = ak._v2.operations.structure.fill_none(
             layout, -np.inf, axis=-1, highlevel=False
         )
-        flat = layout.completely_flatten(
+
+        best_index = None
+        best_value = None
+        for tmp in layout.completely_flatten(
             function_name="ak.argmax", flatten_records=flatten_records
-        )
-        if len(flat) == 0:
-            return None
-        else:
-            return layout.nplike.argmax(flat)
+        ):
+            # FIXME: this isn't going to survive a type-tracer!
+            out = layout.nplike.argmax(tmp, axis=None)
+            if best_index is None or tmp[out] > best_value:
+                best_index = out
+                best_value = tmp[out]
+        return best_index
 
     else:
         behavior = ak._v2._util.behavior_of(array)

--- a/src/awkward/_v2/operations/reducers/ak_argmin.py
+++ b/src/awkward/_v2/operations/reducers/ak_argmin.py
@@ -52,13 +52,18 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True, flatten_records
         layout = ak._v2.operations.structure.fill_none(
             layout, np.inf, axis=-1, highlevel=False
         )
-        flat = layout.completely_flatten(
+
+        best_index = None
+        best_value = None
+        for tmp in layout.completely_flatten(
             function_name="ak.argmin", flatten_records=flatten_records
-        )
-        if len(flat) == 0:
-            return None
-        else:
-            return layout.nplike.argmin(flat)
+        ):
+            # FIXME: this isn't going to survive a type-tracer!
+            out = layout.nplike.argmin(tmp, axis=None)
+            if best_index is None or tmp[out] < best_value:
+                best_index = out
+                best_value = tmp[out]
+        return best_index
 
     else:
         behavior = ak._v2._util.behavior_of(array)

--- a/src/awkward/_v2/operations/reducers/ak_count.py
+++ b/src/awkward/_v2/operations/reducers/ak_count.py
@@ -83,10 +83,20 @@ def count(array, axis=None, keepdims=False, mask_identity=False, flatten_records
     )
 
     if axis is None:
-        return layout.nplike.size(
-            layout.completely_flatten(
-                function_name="ak.count", flatten_records=flatten_records
-            )
+
+        def reduce(xs):
+            if len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.add(xs[0], reduce(xs[1:]))
+
+        return reduce(
+            [
+                layout.nplike.size(x)
+                for x in layout.completely_flatten(
+                    function_name="ak.count", flatten_records=flatten_records
+                )
+            ]
         )
 
     else:

--- a/src/awkward/_v2/operations/reducers/ak_count_nonzero.py
+++ b/src/awkward/_v2/operations/reducers/ak_count_nonzero.py
@@ -48,10 +48,20 @@ def count_nonzero(
     )
 
     if axis is None:
-        return layout.nplike.count_nonzero(
-            layout.completely_flatten(
-                function_name="ak.count_nonzero", flatten_records=flatten_records
-            )
+
+        def reduce(xs):
+            if len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.add(xs[0], reduce(xs[1:]))
+
+        return reduce(
+            [
+                layout.nplike.count_nonzero(x)
+                for x in layout.completely_flatten(
+                    function_name="ak.count_nonzero", flatten_records=flatten_records
+                )
+            ]
         )
 
     else:

--- a/src/awkward/_v2/operations/reducers/ak_max.py
+++ b/src/awkward/_v2/operations/reducers/ak_max.py
@@ -56,13 +56,19 @@ def max(
     )
 
     if axis is None:
-        flat = layout.completely_flatten(
+
+        def reduce(xs):
+            if len(xs) == 0:
+                return None
+            elif len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.maximum(xs[0], reduce(xs[1:]))
+
+        tmp = layout.completely_flatten(
             function_name="ak.max", flatten_records=flatten_records
         )
-        if len(flat) == 0:
-            return None if mask_identity else np.iinfo(flat.dtype.type).min
-        else:
-            return layout.nplike.max(flat)
+        return reduce([layout.nplike.max(x) for x in tmp if len(x) > 0])
 
     else:
         behavior = ak._v2._util.behavior_of(array)

--- a/src/awkward/_v2/operations/reducers/ak_min.py
+++ b/src/awkward/_v2/operations/reducers/ak_min.py
@@ -56,13 +56,19 @@ def min(
     )
 
     if axis is None:
-        flat = layout.completely_flatten(
+
+        def reduce(xs):
+            if len(xs) == 0:
+                return None
+            elif len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.minimum(xs[0], reduce(xs[1:]))
+
+        tmp = layout.completely_flatten(
             function_name="ak.min", flatten_records=flatten_records
         )
-        if len(flat) == 0:
-            return None if mask_identity else np.iinfo(flat.dtype.type).max
-        else:
-            return layout.nplike.min(flat)
+        return reduce([layout.nplike.min(x) for x in tmp if len(x) > 0])
 
     else:
         behavior = ak._v2._util.behavior_of(array)

--- a/src/awkward/_v2/operations/reducers/ak_prod.py
+++ b/src/awkward/_v2/operations/reducers/ak_prod.py
@@ -42,10 +42,20 @@ def prod(array, axis=None, keepdims=False, mask_identity=False, flatten_records=
     )
 
     if axis is None:
-        return layout.nplike.prod(
-            layout.completely_flatten(
-                function_name="ak.prod", flatten_records=flatten_records
-            )
+
+        def reduce(xs):
+            if len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.multiply(xs[0], reduce(xs[1:]))
+
+        return reduce(
+            [
+                layout.nplike.prod(x)
+                for x in layout.completely_flatten(
+                    function_name="ak.prod", flatten_records=flatten_records
+                )
+            ]
         )
 
     else:

--- a/src/awkward/_v2/operations/reducers/ak_sum.py
+++ b/src/awkward/_v2/operations/reducers/ak_sum.py
@@ -187,10 +187,20 @@ def sum(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
     )
 
     if axis is None:
-        return layout.nplike.sum(
-            layout.completely_flatten(
-                function_name="ak.sum", flatten_records=flatten_records
-            )
+
+        def reduce(xs):
+            if len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.add(xs[0], reduce(xs[1:]))
+
+        return reduce(
+            [
+                layout.nplike.sum(x)
+                for x in layout.completely_flatten(
+                    function_name="ak.sum", flatten_records=flatten_records
+                )
+            ]
         )
 
     else:

--- a/src/awkward/_v2/operations/structure/ak_flatten.py
+++ b/src/awkward/_v2/operations/structure/ak_flatten.py
@@ -99,7 +99,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
     nplike = ak.nplike.of(layout)
 
     if axis is None:
-        out = (layout.completely_flatten(),)
+        out = layout.completely_flatten(function_name="ak.flatten")
         assert isinstance(out, tuple) and all(isinstance(x, np.ndarray) for x in out)
 
         out = ak._v2.contents.NumpyArray(nplike.concatenate(out))

--- a/src/awkward/_v2/operations/structure/ak_ravel.py
+++ b/src/awkward/_v2/operations/structure/ak_ravel.py
@@ -49,7 +49,7 @@ def ravel(array, highlevel=True, behavior=None):
     )
     nplike = ak.nplike.of(layout)
 
-    out = (layout.completely_flatten(),)
+    out = layout.completely_flatten(function_name="ak.ravel")
     assert isinstance(out, tuple) and all(isinstance(x, np.ndarray) for x in out)
 
     if any(isinstance(x, nplike.ma.MaskedArray) for x in out):

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -209,10 +209,6 @@ class NumpyLike(Singleton):
         # array1[, array2[, ...]]
         return self._module.broadcast_arrays(*args, **kwargs)
 
-    def add(self, *args, **kwargs):
-        # array1, array2[, out=]
-        return self._module.add(*args, **kwargs)
-
     def cumsum(self, *args, **kwargs):
         # arrays[, out=]
         return self._module.cumsum(*args, **kwargs)
@@ -272,6 +268,22 @@ class NumpyLike(Singleton):
 
     ############################ ufuncs
 
+    def add(self, *args, **kwargs):
+        # array1, array2
+        return self._module.add(*args, **kwargs)
+
+    def multiply(self, *args, **kwargs):
+        # array1, array2
+        return self._module.multiply(*args, **kwargs)
+
+    def logical_or(self, *args, **kwargs):
+        # array1, array2
+        return self._module.logical_or(*args, **kwargs)
+
+    def logical_and(self, *args, **kwargs):
+        # array1, array2
+        return self._module.logical_and(*args, **kwargs)
+
     def sqrt(self, *args, **kwargs):
         # array
         return self._module.sqrt(*args, **kwargs)
@@ -288,10 +300,6 @@ class NumpyLike(Singleton):
         # array1, array2[, out=output]
         return self._module.bitwise_or(*args, **kwargs)
 
-    def logical_and(self, *args, **kwargs):
-        # array1, array2
-        return self._module.logical_and(*args, **kwargs)
-
     def equal(self, *args, **kwargs):
         # array1, array2
         return self._module.equal(*args, **kwargs)
@@ -299,6 +307,14 @@ class NumpyLike(Singleton):
     def ceil(self, *args, **kwargs):
         # array
         return self._module.ceil(*args, **kwargs)
+
+    def minimum(self, *args, **kwargs):
+        # array1, array2
+        return self._module.minimum(*args, **kwargs)
+
+    def maximum(self, *args, **kwargs):
+        # array1, array2
+        return self._module.maximum(*args, **kwargs)
 
     ############################ almost-ufuncs
 


### PR DESCRIPTION
This was raised on Slack by @martindurant and @douglasdavis.

**Before:**

```python
In [1]: import awkward._v2 as ak, numpy as np

In [2]: x = np.ones((100, 100, 100))

In [3]: arr = ak.Array(x)

In [4]: %timeit ak.sum(arr, axis=None)
813 µs ± 6.08 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [5]: %timeit x.sum()
332 µs ± 5.38 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

**After:**

```python
In [1]: import awkward._v2 as ak, numpy as np

In [2]: x = np.ones((100, 100, 100))

In [3]: arr = ak.Array(x)

In [4]: %timeit ak.sum(arr, axis=None)
317 µs ± 20.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [5]: %timeit x.sum()
295 µs ± 8.65 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

It removes an unnecessary concatenation.