### PR TITLE
style: further cleanup for Python 3.6+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,15 +269,15 @@ Templating is only used for integer specialization.
 
 We target Python 3.6 and above. Import statements can assume Python 3 names, string-checking can assume Python 3 meanings of `str` and `bytes`, Unicode literals don't need to be prefixed by `u`, and dict order can be assumed to be stable. Python's f-strings can now be used, but not with equals signs (e.g. `f"{something = }"` rather than `f"something = {something}"`) because that's a Python 3.8 feature (its main use is in debugging, anyway).
 
-If you see any `if ak._util.py27` or `py35` checks in the code, you can safely remove the old code branch (and that will increase test coverage, since we don't test in old Pythons). You may see old-Python inspired idioms like `"some: {0} thing: {1}".format(some, thing)` (which is position-based to be compatible with Python 2.6!) and can freely update them if it makes the code you're working on easier to read. Updating all anachronisms en mass is not a high priority. (Some strings are not easier to read as f-strings; it should be a case-by-case basis.) Similarly, explicit class inheritance from `object` can be implicit now.
+If you see any outdated (pre-Python 3.6) code, you can safely clean them up. Some strings are not easier to read as f-strings or require some work to make them more readable; it should be a case-by-case basis.
 
-Although newer versions of the Python language have great features, none of them have been "painful" to not have (such as the pain of writing tests around an unstable dict order, or completely different module names and syntax in Python 2). Python 3.6 will be the standard until it becomes "painful" to keep it (like, when CI and build tools no longer support it, or if we adopt type annotations).
+Python 3.6 will be the standard until it becomes "painful" to keep it (like, when CI and build tools no longer support it, or if we adopt type annotations).
 
 ### Third party dependencies
 
 Awkward Array's C++ codebase only depends on pybind11 and rapidjson, which are both header-only and included as git submodules (the reason for the `git clone --recursive`).
 
-The Python codebase only strictly depends on NumPy 1.13.1, the first version with [NEP 13](https://numpy.org/neps/nep-0013-ufunc-overrides.html). This fixes the minimum Python at 2.7.
+The Python codebase only strictly depends on NumPy 1.13.1, the first version with [NEP 13](https://numpy.org/neps/nep-0013-ufunc-overrides.html). This fixes the minimum Python at 2.7 for older versions of awkward.
 
 Other third party libraries are used if they exist (can be imported), and we only accept certain versions of these libraries. Both the test-import and any version-testing must be within runtime code, not startup code, so that they're only invoked when users explicitly call for the feature that requires them.
 

--- a/dev/generate-cuda.py
+++ b/dev/generate-cuda.py
@@ -112,9 +112,7 @@ def traverse(node, args={}, forvars=[], declared=[]):  # noqa: B006
             code += traverse(subnode, args, copy.copy(forvars), declared)
         code += "}\n"
     elif node.__class__.__name__ == "Raise":
-        if sys.version_info[0] == 2:
-            code = f'err->str = "{node.type.args[0].s}";\n'
-        elif sys.version_info[0] == 3 and sys.version_info[1] in [5, 6, 7]:
+        if sys.version_info < (3, 8):
             code = f'err->str = "{node.exc.args[0].s}";\n'
         else:
             code = f'err->str = "{node.exc.args[0].value}";\n'

--- a/dev/kernel-diagnostics.py
+++ b/dev/kernel-diagnostics.py
@@ -4,7 +4,6 @@
 import argparse
 import copy
 import os
-import sys
 from collections import OrderedDict
 
 import yaml
@@ -85,10 +84,6 @@ def check_specorder(kerneldict):
             count = 0
             display = []
             flag = False
-            if sys.version_info.major == 2:
-                for dummy in specializations:
-                    if type(sort_specializations(dummy)) == str:
-                        raise TypeError
             for specialization in sorted(
                 copy.copy(specializations), key=sort_specializations
             ):

--- a/docs-sphinx/index.rst
+++ b/docs-sphinx/index.rst
@@ -20,8 +20,8 @@
    :alt: Conda-Forge
    :target: https://github.com/conda-forge/awkward-feedstock
 
-.. image:: https://img.shields.io/badge/python-2.7%2c3.5%E2%80%923.9-blue
-   :alt: Python 2.7,3.5‒3.9
+.. image:: https://img.shields.io/badge/python-3.6%E2%80%923.10-blue
+   :alt: Python 3.6‒3.10
    :target: https://www.python.org
 
 .. image:: https://img.shields.io/badge/license-BSD%203--Clause-blue.svg

--- a/docs-src/quickstart.md
+++ b/docs-src/quickstart.md
@@ -15,7 +15,7 @@ kernelspec:
 
 [![PyPI version](https://badge.fury.io/py/awkward.svg)](https://pypi.org/project/awkward)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
-[![Python 2.7,3.5‒3.9](https://img.shields.io/badge/python-2.7%2c3.5%E2%80%923.9-blue)](https://www.python.org)
+[![Python 3.6‒3.10](https://img.shields.io/badge/python-3.6%E2%80%923.10-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Continuous integration tests](https://img.shields.io/azure-devops/build/jpivarski/Scikit-HEP/3/main?label=tests)](https://dev.azure.com/jpivarski/Scikit-HEP/_build)
 

--- a/localbuild.py
+++ b/localbuild.py
@@ -25,12 +25,10 @@ args = arguments.parse_args()
 args.buildpython = not args.no_buildpython
 args.dependencies = not args.no_dependencies
 
-
-if sys.version_info[0] >= 3:
-    git_root = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"], stdout=subprocess.PIPE
-    )
-    os.chdir(git_root.stdout.decode().strip())
+git_root = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"], stdout=subprocess.PIPE
+)
+os.chdir(git_root.stdout.decode().strip())
 
 if args.clean:
     for x in ("localbuild", "awkward", ".pytest_cache", "tests/__pycache__"):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ try:
     import cmake
 
     CMAKE = os.path.join(cmake.CMAKE_BIN_DIR, "cmake")
-except ImportError:
+except ModuleNotFoundError:
     CMAKE = "cmake"
 
 PYTHON = sys.executable

--- a/src/awkward/_connect/_jax/__init__.py
+++ b/src/awkward/_connect/_jax/__init__.py
@@ -14,8 +14,8 @@ def register_and_check():
     global checked_version
     try:
         import jax
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'jax' package with:
 
     pip install jax jaxlib --upgrade
@@ -23,7 +23,7 @@ def register_and_check():
 or
 
     conda install jax jaxlib"""
-        )
+        ) from None
     else:
         if not checked_version and ak._v2._util.parse_version(
             jax.__version__

--- a/src/awkward/_connect/_numba/__init__.py
+++ b/src/awkward/_connect/_numba/__init__.py
@@ -14,8 +14,8 @@ def register_and_check():
     global checked_version
     try:
         import numba
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'numba' package with:
 
     pip install numba --upgrade
@@ -23,7 +23,7 @@ def register_and_check():
 or
 
     conda install numba"""
-        )
+        ) from None
     else:
         if not checked_version and ak._v2._util.parse_version(
             numba.__version__

--- a/src/awkward/_connect/_numba/__init__.py
+++ b/src/awkward/_connect/_numba/__init__.py
@@ -96,7 +96,7 @@ def castint(context, builder, fromtype, totype, val):
             fromtype = numba.int64
     if not isinstance(fromtype, numba.types.Integer):
         raise AssertionError(
-            f"unrecognized integer type: {repr(fromtype)}"
+            f"unrecognized integer type: {fromtype!r}"
             + ak._util.exception_suffix(__file__)
         )
 

--- a/src/awkward/_connect/_numba/builder.py
+++ b/src/awkward/_connect/_numba/builder.py
@@ -19,7 +19,7 @@ def globalstring(context, builder, pyvalue):
 
     if pyvalue not in dynamic_addrs:
         buf = dynamic_addrs[pyvalue] = numpy.array(pyvalue.encode("utf-8") + b"\x00")
-        context.add_dynamic_addr(builder, buf.ctypes.data, info=f"str({repr(pyvalue)})")
+        context.add_dynamic_addr(builder, buf.ctypes.data, info=f"str({pyvalue!r})")
     ptr = context.get_constant(numba.types.uintp, dynamic_addrs[pyvalue].ctypes.data)
     return builder.inttoptr(
         ptr, llvmlite.llvmpy.core.Type.pointer(llvmlite.llvmpy.core.Type.int(8))

--- a/src/awkward/_connect/_numba/layout.py
+++ b/src/awkward/_connect/_numba/layout.py
@@ -336,7 +336,7 @@ class ContentType(numba.types.Type):
             )
         else:
             raise TypeError(
-                f"array does not have a field with key {repr(key)}"
+                f"array does not have a field with key {key!r}"
                 + ak._util.exception_suffix(__file__)
             )
 

--- a/src/awkward/_connect/_numexpr.py
+++ b/src/awkward/_connect/_numexpr.py
@@ -16,8 +16,8 @@ def import_numexpr():
     global checked_version
     try:
         import numexpr
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'numexpr' package with:
 
     pip install numexpr --upgrade
@@ -25,7 +25,7 @@ def import_numexpr():
 or
 
     conda install numexpr"""
-        )
+        ) from None
     else:
         if not checked_version and ak._v2._util.parse_version(
             numexpr.__version__

--- a/src/awkward/_connect/_numpy.py
+++ b/src/awkward/_connect/_numpy.py
@@ -3,10 +3,7 @@
 # v2: replace with src/awkward/_v2/_connect/numpy.py
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import numpy
 

--- a/src/awkward/_connect/_numpy.py
+++ b/src/awkward/_connect/_numpy.py
@@ -3,8 +3,6 @@
 # v2: replace with src/awkward/_v2/_connect/numpy.py
 
 
-import sys
-
 try:
     from collections.abc import Iterable
 except ImportError:
@@ -444,8 +442,6 @@ except AttributeError:
         __sub__, __rsub__, __isub__ = _numeric_methods(um.subtract, "sub")
         __mul__, __rmul__, __imul__ = _numeric_methods(um.multiply, "mul")
         __matmul__, __rmatmul__, __imatmul__ = _numeric_methods(um.matmul, "matmul")
-        if sys.version_info.major < 3:
-            __div__, __rdiv__, __idiv__ = _numeric_methods(um.divide, "div")
         __truediv__, __rtruediv__, __itruediv__ = _numeric_methods(
             um.true_divide, "truediv"
         )

--- a/src/awkward/_typeparser/generated_parser.py
+++ b/src/awkward/_typeparser/generated_parser.py
@@ -312,7 +312,7 @@ def smart_decorator(f, create_decorator):
 
 try:
     import regex
-except ImportError:
+except ModuleNotFoundError:
     regex = None
 
 import sre_parse

--- a/src/awkward/_typeparser/generated_parser.py
+++ b/src/awkward/_typeparser/generated_parser.py
@@ -181,11 +181,7 @@ logger = logging.getLogger("lark")
 logger.addHandler(logging.StreamHandler())
 ##
 
-##
-
 logger.setLevel(logging.CRITICAL)
-
-Py36 = (sys.version_info[:2] >= (3, 6))
 
 
 def classify(seq, key=None, value=None):
@@ -967,19 +963,10 @@ class Pattern(Serialize):
     def to_regexp(self):
         raise NotImplementedError()
 
-    if Py36:
-        ##
-
-        def _get_flags(self, value):
-            for f in self.flags:
-                value = ('(?%s:%s)' % (f, value))
-            return value
-
-    else:
-        def _get_flags(self, value):
-            for f in self.flags:
-                value = ('(?%s)' % f) + value
-            return value
+    def _get_flags(self, value):
+        for f in self.flags:
+            value = f'(?{f}:{value})'
+        return value
 
 
 class PatternStr(Pattern):
@@ -2290,9 +2277,6 @@ class Lark(Serialize):
         if self.options.use_bytes:
             if not isascii(grammar):
                 raise ValueError("Grammar must be ascii only, when use_bytes=True")
-            if sys.version_info[0] == 2 and self.options.use_bytes != 'force':
-                raise NotImplementedError("`use_bytes=True` may have issues on python2."
-                                          "Use `use_bytes='force'` to use it at your own risk.")
 
         cache_fn = None
         if self.options.cache:

--- a/src/awkward/_typeparser/parser.py
+++ b/src/awkward/_typeparser/parser.py
@@ -3,8 +3,6 @@
 # v2: keep this file, but change the Type-generation to generate v2 Types.
 
 
-import sys
-
 import awkward as ak
 
 from awkward._typeparser.generated_parser import Lark_StandAlone, Transformer
@@ -13,8 +11,6 @@ from awkward._typeparser.generated_parser import Lark_StandAlone, Transformer
 class TreeToJson(Transformer):
     def string(self, s):
         (s,) = s
-        if sys.version_info[0] == 2:
-            s = s.encode("utf-8")
         return s[1:-1]
 
     def number(self, n):

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -548,7 +548,7 @@ def key2index(keys, key):
 
     if attempt is None:
         raise ValueError(
-            f"key {repr(key)} not found in record" + exception_suffix(__file__)
+            f"key {key!r} not found in record" + exception_suffix(__file__)
         )
     else:
         return attempt

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -29,11 +29,7 @@ py36 = sys.version_info[0] == 3 and sys.version_info[1] <= 6
 win = os.name == "nt"
 bits32 = ak.nplike.numpy.iinfo(np.intp).bits == 32
 
-# to silence flake8 F821 errors
-if py27:
-    unicode = eval("unicode")
-else:
-    unicode = None
+unicode = None
 
 # matches include/awkward/common.h
 kMaxInt8 = 127  # 2**7  - 1

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -22,14 +22,8 @@ import awkward as ak
 
 np = ak.nplike.NumpyMetadata.instance()
 
-py27 = sys.version_info[0] < 3
-py35 = sys.version_info[0] == 3 and sys.version_info[1] <= 5
-py36 = sys.version_info[0] == 3 and sys.version_info[1] <= 6
-
 win = os.name == "nt"
 bits32 = ak.nplike.numpy.iinfo(np.intp).bits == 32
-
-unicode = None
 
 # matches include/awkward/common.h
 kMaxInt8 = 127  # 2**7  - 1
@@ -70,12 +64,10 @@ def isnum(x):
 
 def isstr(x):
     """
-    Returns True if and only if ``x`` is a string (including Python 2 unicode).
+    Returns True if and only if ``x`` is a string. Mostly needed for Python 2
+    compatibility in the past, but still mirrors isnum.
     """
-    if py27:
-        return isinstance(x, (bytes, unicode))
-    else:
-        return isinstance(x, str)
+    return isinstance(x, str)
 
 
 def exception_suffix(filename):
@@ -230,17 +222,17 @@ def arrayclass(layout, behavior):
     layout = ak.partition.first(layout)
     behavior = Behavior(ak.behavior, behavior)
     arr = layout.parameter("__array__")
-    if isinstance(arr, str) or (py27 and isinstance(arr, unicode)):
+    if isinstance(arr, str):
         cls = behavior[arr]
         if isinstance(cls, type) and issubclass(cls, ak.highlevel.Array):
             return cls
     rec = layout.parameter("__record__")
-    if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
+    if isinstance(rec, str):
         cls = behavior[".", rec]
         if isinstance(cls, type) and issubclass(cls, ak.highlevel.Array):
             return cls
     deeprec = layout.purelist_parameter("__record__")
-    if isinstance(deeprec, str) or (py27 and isinstance(deeprec, unicode)):
+    if isinstance(deeprec, str):
         cls = behavior["*", deeprec]
         if isinstance(cls, type) and issubclass(cls, ak.highlevel.Array):
             return cls
@@ -264,11 +256,11 @@ def custom_broadcast(layout, behavior):
     layout = ak.partition.first(layout)
     behavior = Behavior(ak.behavior, behavior)
     custom = layout.parameter("__array__")
-    if not (isinstance(custom, str) or (py27 and isinstance(custom, unicode))):
+    if not isinstance(custom, str):
         custom = layout.parameter("__record__")
-    if not (isinstance(custom, str) or (py27 and isinstance(custom, unicode))):
+    if not isinstance(custom, str):
         custom = layout.purelist_parameter("__record__")
-    if isinstance(custom, str) or (py27 and isinstance(custom, unicode)):
+    if isinstance(custom, str):
         for key, fcn in behavior.items():
             if (
                 isinstance(key, tuple)
@@ -283,17 +275,17 @@ def custom_broadcast(layout, behavior):
 def numba_array_typer(layouttype, behavior):
     behavior = Behavior(ak.behavior, behavior)
     arr = layouttype.parameters.get("__array__")
-    if isinstance(arr, str) or (py27 and isinstance(arr, unicode)):
+    if isinstance(arr, str):
         typer = behavior["__numba_typer__", arr]
         if callable(typer):
             return typer
     rec = layouttype.parameters.get("__record__")
-    if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
+    if isinstance(rec, str):
         typer = behavior["__numba_typer__", ".", rec]
         if callable(typer):
             return typer
     deeprec = layouttype.parameters.get("__record__")
-    if isinstance(deeprec, str) or (py27 and isinstance(deeprec, unicode)):
+    if isinstance(deeprec, str):
         typer = behavior["__numba_typer__", "*", deeprec]
         if callable(typer):
             return typer
@@ -303,17 +295,17 @@ def numba_array_typer(layouttype, behavior):
 def numba_array_lower(layouttype, behavior):
     behavior = Behavior(ak.behavior, behavior)
     arr = layouttype.parameters.get("__array__")
-    if isinstance(arr, str) or (py27 and isinstance(arr, unicode)):
+    if isinstance(arr, str):
         lower = behavior["__numba_lower__", arr]
         if callable(lower):
             return lower
     rec = layouttype.parameters.get("__record__")
-    if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
+    if isinstance(rec, str):
         lower = behavior["__numba_lower__", ".", rec]
         if callable(lower):
             return lower
     deeprec = layouttype.parameters.get("__record__")
-    if isinstance(deeprec, str) or (py27 and isinstance(deeprec, unicode)):
+    if isinstance(deeprec, str):
         lower = behavior["__numba_lower__", "*", deeprec]
         if callable(lower):
             return lower
@@ -324,7 +316,7 @@ def recordclass(layout, behavior):
     layout = ak.partition.first(layout)
     behavior = Behavior(ak.behavior, behavior)
     rec = layout.parameter("__record__")
-    if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
+    if isinstance(rec, str):
         cls = behavior[rec]
         if isinstance(cls, type) and issubclass(cls, ak.highlevel.Record):
             return cls
@@ -339,8 +331,8 @@ def typestrs(behavior):
             isinstance(key, tuple)
             and len(key) == 2
             and key[0] == "__typestr__"
-            and (isinstance(key[1], str) or (py27 and isinstance(key[1], unicode)))
-            and (isinstance(typestr, str) or (py27 and isinstance(typestr, unicode)))
+            and isinstance(key[1], str)
+            and isinstance(typestr, str)
         ):
             out[key[1]] = typestr
     return out
@@ -364,7 +356,7 @@ def gettypestr(parameters, typestrs):
 def numba_record_typer(layouttype, behavior):
     behavior = Behavior(ak.behavior, behavior)
     rec = layouttype.parameters.get("__record__")
-    if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
+    if isinstance(rec, str):
         typer = behavior["__numba_typer__", rec]
         if callable(typer):
             return typer
@@ -374,7 +366,7 @@ def numba_record_typer(layouttype, behavior):
 def numba_record_lower(layouttype, behavior):
     behavior = Behavior(ak.behavior, behavior)
     rec = layouttype.parameters.get("__record__")
-    if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
+    if isinstance(rec, str):
         lower = behavior["__numba_lower__", rec]
         if callable(lower):
             return lower
@@ -403,7 +395,7 @@ def overload(behavior, signature):
 def numba_attrs(layouttype, behavior):
     behavior = Behavior(ak.behavior, behavior)
     rec = layouttype.parameters.get("__record__")
-    if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
+    if isinstance(rec, str):
         for key, typer in behavior.items():
             if (
                 isinstance(key, tuple)
@@ -418,7 +410,7 @@ def numba_attrs(layouttype, behavior):
 def numba_methods(layouttype, behavior):
     behavior = Behavior(ak.behavior, behavior)
     rec = layouttype.parameters.get("__record__")
-    if isinstance(rec, str) or (py27 and isinstance(rec, unicode)):
+    if isinstance(rec, str):
         for key, typer in behavior.items():
             if (
                 isinstance(key, tuple)
@@ -437,7 +429,7 @@ def numba_unaryops(unaryop, left, behavior):
 
     if isinstance(left, ak._connect._numba.layout.ContentType):
         left = left.parameters.get("__record__")
-        if not (isinstance(left, str) or (py27 and isinstance(left, unicode))):
+        if not isinstance(left, str):
             done = True
 
     if not done:
@@ -459,12 +451,12 @@ def numba_binops(binop, left, right, behavior):
 
     if isinstance(left, ak._connect._numba.layout.ContentType):
         left = left.parameters.get("__record__")
-        if not (isinstance(left, str) or (py27 and isinstance(left, unicode))):
+        if not isinstance(left, str):
             done = True
 
     if isinstance(right, ak._connect._numba.layout.ContentType):
         right = right.parameters.get("__record__")
-        if not isinstance(right, str) and not (py27 and isinstance(right, unicode)):
+        if not isinstance(right, str):
             done = True
 
     if not done:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -11,12 +11,8 @@ import warnings
 import itertools
 import numbers
 
-try:
-    from collections.abc import Mapping
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import Mapping
-    from collections import MutableMapping
+from collections.abc import Mapping
+from collections.abc import MutableMapping
 
 import awkward as ak
 

--- a/src/awkward/_v2/_connect/numpy.py
+++ b/src/awkward/_v2/_connect/numpy.py
@@ -1,8 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-import sys
-
 import numpy
 
 import awkward as ak
@@ -466,8 +464,6 @@ except AttributeError:
         __sub__, __rsub__, __isub__ = _numeric_methods(um.subtract, "sub")
         __mul__, __rmul__, __imul__ = _numeric_methods(um.multiply, "mul")
         __matmul__, __rmatmul__, __imatmul__ = _numeric_methods(um.matmul, "matmul")
-        if sys.version_info.major < 3:
-            __div__, __rdiv__, __idiv__ = _numeric_methods(um.divide, "div")
         __truediv__, __rtruediv__, __itruediv__ = _numeric_methods(
             um.true_divide, "truediv"
         )

--- a/src/awkward/_v2/_connect/pyarrow.py
+++ b/src/awkward/_v2/_connect/pyarrow.py
@@ -3,10 +3,7 @@
 
 import json
 
-try:
-    from collections.abc import Iterable, Sized
-except ImportError:
-    from collections import Iterable, Sized
+from collections.abc import Iterable, Sized
 
 import numpy
 
@@ -19,7 +16,7 @@ try:
 
     error_message = None
 
-except ImportError:
+except ModuleNotFoundError:
     pyarrow = None
     error_message = """to use {0}, you must install pyarrow:
 

--- a/src/awkward/_v2/_connect/pyarrow.py
+++ b/src/awkward/_v2/_connect/pyarrow.py
@@ -86,7 +86,7 @@ if pyarrow is not None:
             return "ak:" + str(self.storage_type)
 
         def __repr__(self):
-            return f"awkward<{repr(self.storage_type)}>"
+            return f"awkward<{self.storage_type!r}>"
 
         @property
         def mask_type(self):
@@ -550,7 +550,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers):
         return popbuffers_finalize(out, paarray, validbits, awkwardarrow_type)
 
     else:
-        raise TypeError(f"unrecognized Arrow array type: {repr(storage_type)}")
+        raise TypeError(f"unrecognized Arrow array type: {storage_type!r}")
 
 
 def to_awkwardarrow_type(storage_type, use_extensionarray, mask, node):

--- a/src/awkward/_v2/_reducers.py
+++ b/src/awkward/_v2/_reducers.py
@@ -210,7 +210,7 @@ class Sum(Reducer):
     def apply(cls, array, parents, outlength):
         assert isinstance(array, ak._v2.contents.NumpyArray)
         if array.dtype.kind == "M":
-            raise ValueError(f"cannot compute the sum (ak.sum) of {repr(array.dtype)}")
+            raise ValueError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
         else:
             dtype = cls.maybe_other_type(array.dtype)
         result = array.nplike.empty(
@@ -298,9 +298,7 @@ class Prod(Reducer):
     def apply(cls, array, parents, outlength):
         assert isinstance(array, ak._v2.contents.NumpyArray)
         if array.dtype.kind.upper() == "M":
-            raise ValueError(
-                f"cannot compute the product (ak.prod) of {repr(array.dtype)}"
-            )
+            raise ValueError(f"cannot compute the product (ak.prod) of {array.dtype!r}")
         result = array.nplike.empty(
             cls.maybe_double_length(array.dtype.type, outlength),
             dtype=cls.return_dtype(array.dtype),

--- a/src/awkward/_v2/_slicing.py
+++ b/src/awkward/_v2/_slicing.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 from awkward._v2.tmp_for_testing import v1_to_v2

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -96,7 +96,7 @@ class UnknownScalar:
         return self._dtype
 
     def __repr__(self):
-        return f"UnknownScalar({repr(self._dtype)})"
+        return f"UnknownScalar({self._dtype!r})"
 
     def __str__(self):
         return f"unknown-{str(self._dtype)}"
@@ -159,7 +159,7 @@ class MaybeNone:
             return False
 
     def __repr__(self):
-        return f"MaybeNone({repr(self._content)})"
+        return f"MaybeNone({self._content!r})"
 
 
 class OneOf:
@@ -177,7 +177,7 @@ class OneOf:
             return False
 
     def __repr__(self):
-        return f"OneOf({repr(self._contents)})"
+        return f"OneOf({self._contents!r})"
 
 
 def _length_after_slice(slice, original_length):

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -53,9 +53,6 @@ class UnknownLengthType:
     def __rmul__(self, other):
         return UnknownLength
 
-    def __div__(self, other):
-        return UnknownLength
-
     def __truediv__(self, other):
         return UnknownLength
 
@@ -121,9 +118,6 @@ class UnknownScalar:
 
     def __rmul__(self, other):
         return UnknownScalar((_emptyarray(self) * _emptyarray(other)).dtype)
-
-    def __div__(self, other):
-        return UnknownScalar((_emptyarray(self) / _emptyarray(other)).dtype)
 
     def __truediv__(self, other):
         return UnknownScalar((_emptyarray(self) / _emptyarray(other)).dtype)

--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -11,10 +11,7 @@ import setuptools
 import os
 import numbers
 
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 
 import awkward as ak
 

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 import awkward._v2._reducers

--- a/src/awkward/_v2/contents/recordarray.py
+++ b/src/awkward/_v2/contents/recordarray.py
@@ -4,10 +4,7 @@
 import json
 import copy
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 from awkward._v2.record import Record

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -4,10 +4,7 @@
 import copy
 import ctypes
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 from awkward._v2.index import Index

--- a/src/awkward/_v2/forms/numpyform.py
+++ b/src/awkward/_v2/forms/numpyform.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 from awkward._v2.contents.content import NestedIndexError
 from awkward._v2.forms.form import Form, _parameters_equal

--- a/src/awkward/_v2/forms/recordform.py
+++ b/src/awkward/_v2/forms/recordform.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 from awkward._v2.forms.form import Form, _parameters_equal

--- a/src/awkward/_v2/forms/unionform.py
+++ b/src/awkward/_v2/forms/unionform.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 from awkward._v2.forms.form import Form, _parameters_equal

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -28,14 +28,9 @@ import sys
 import re
 import keyword
 
-try:
-    from collections.abc import Iterable
-    from collections.abc import Sized
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Iterable
-    from collections import Sized
-    from collections import Mapping
+from collections.abc import Iterable
+from collections.abc import Sized
+from collections.abc import Mapping
 
 import awkward as ak
 from awkward._v2._connect.numpy import NDArrayOperatorsMixin

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -1132,7 +1132,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                         "occurred:\n{}: {}".format(repr(where), type(err), str(err))
                     )
             else:
-                raise AttributeError(f"no field named {repr(where)}")
+                raise AttributeError(f"no field named {where!r}")
 
     def __dir__(self):
         """
@@ -1812,7 +1812,7 @@ class Record(NDArrayOperatorsMixin):
                         "occurred:\n{}: {}".format(repr(where), type(err), str(err))
                     )
             else:
-                raise AttributeError(f"no field named {repr(where)}")
+                raise AttributeError(f"no field named {where!r}")
 
     def __dir__(self):
         """

--- a/src/awkward/_v2/index.py
+++ b/src/awkward/_v2/index.py
@@ -128,9 +128,7 @@ class Index:
             if self._metadata is not None:
                 for k, v in self._metadata.items():
                     out.append(
-                        f"<metadata key={repr(k)}>{repr(v)}</metadata>\n"
-                        + indent
-                        + "    "
+                        f"<metadata key={k!r}>{v!r}</metadata>\n" + indent + "    "
                     )
             out.append(("\n" + indent + "    ").join(arraystr_lines))
             out.append("\n" + indent + "</Index>")

--- a/src/awkward/_v2/operations/convert/ak_from_json_schema.py
+++ b/src/awkward/_v2/operations/convert/ak_from_json_schema.py
@@ -68,7 +68,7 @@ def from_json_schema(
         schema = json.loads(schema)
 
     if not isinstance(schema, dict):
-        raise TypeError(f"malformed JSONSchema: expected dict, got {repr(schema)}")
+        raise TypeError(f"malformed JSONSchema: expected dict, got {schema!r}")
 
     container = {}
     instructions = []
@@ -132,10 +132,10 @@ def from_json_schema(
 
 def build_assembly(schema, container, instructions):
     if not isinstance(schema, dict):
-        raise TypeError(f"unrecognized JSONSchema: expected dict, got {repr(schema)}")
+        raise TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
 
     if "type" not in schema is None:
-        raise TypeError(f"unrecognized JSONSchema: no 'type' in {repr(schema)}")
+        raise TypeError(f"unrecognized JSONSchema: no 'type' in {schema!r}")
 
     tpe = schema["type"]
 
@@ -343,4 +343,4 @@ def build_assembly(schema, container, instructions):
         raise NotImplementedError("arbitrary unions of types are not yet supported")
 
     else:
-        raise TypeError(f"unrecognized JSONSchema: {repr(tpe)}")
+        raise TypeError(f"unrecognized JSONSchema: {tpe!r}")

--- a/src/awkward/_v2/operations/convert/ak_to_layout.py
+++ b/src/awkward/_v2/operations/convert/ak_to_layout.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 

--- a/src/awkward/_v2/operations/convert/ak_to_layout.py
+++ b/src/awkward/_v2/operations/convert/ak_to_layout.py
@@ -53,7 +53,7 @@ def to_layout(
 
     elif isinstance(array, (np.ndarray, numpy.ma.MaskedArray)):
         if not issubclass(array.dtype.type, numpytype):
-            raise ValueError(f"dtype {repr(array.dtype)} not allowed")
+            raise ValueError(f"dtype {array.dtype!r} not allowed")
         return to_layout(
             ak._v2.operations.convert.from_numpy(
                 array, regulararray=True, recordarray=True, highlevel=False
@@ -66,7 +66,7 @@ def to_layout(
         type(array).__module__.startswith("cupy.") and type(array).__name__ == "ndarray"
     ):
         if not issubclass(array.dtype.type, numpytype):
-            raise ValueError(f"dtype {repr(array.dtype)} not allowed")
+            raise ValueError(f"dtype {array.dtype!r} not allowed")
         return to_layout(
             ak._v2.operations.convert.from_cupy(
                 array, regulararray=True, highlevel=False

--- a/src/awkward/_v2/operations/convert/ak_to_list.py
+++ b/src/awkward/_v2/operations/convert/ak_to_list.py
@@ -1,12 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Iterable
-    from collections import Mapping
+from collections.abc import Iterable
+from collections.abc import Mapping
 
 import awkward as ak
 

--- a/src/awkward/_v2/operations/describe/ak_type.py
+++ b/src/awkward/_v2/operations/describe/ak_type.py
@@ -119,4 +119,4 @@ def type(array):
         raise TypeError("do not use ak._v2.operations.convert.to_list on v1 arrays")
 
     else:
-        raise TypeError(f"unrecognized array type: {repr(array)}")
+        raise TypeError(f"unrecognized array type: {array!r}")

--- a/src/awkward/_v2/operations/io/ak_from_parquet.py
+++ b/src/awkward/_v2/operations/io/ak_from_parquet.py
@@ -17,7 +17,7 @@ def from_parquet(  # this will be going through Awkward-Dask
     lazy_cache_key=None,
     highlevel=True,
     behavior=None,
-    **options  # NOTE: a comma after **options breaks Python 2
+    **options
 ):
     raise NotImplementedError
 

--- a/src/awkward/_v2/operations/io/ak_to_parquet.py
+++ b/src/awkward/_v2/operations/io/ak_to_parquet.py
@@ -13,7 +13,7 @@ def to_parquet(  # this will be going through Awkward-Dask
     list_to32=False,
     string_to32=True,
     bytestring_to32=True,
-    **options  # NOTE: a comma after **options breaks Python 2
+    **options
 ):
     raise NotImplementedError
 

--- a/src/awkward/_v2/operations/structure/ak_fill_none.py
+++ b/src/awkward/_v2/operations/structure/ak_fill_none.py
@@ -3,10 +3,7 @@
 
 import numbers
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 

--- a/src/awkward/_v2/record.py
+++ b/src/awkward/_v2/record.py
@@ -12,14 +12,12 @@ np = ak.nplike.NumpyMetadata.instance()
 class Record:
     def __init__(self, array, at):
         if not isinstance(array, ak._v2.contents.recordarray.RecordArray):
-            raise TypeError(f"Record 'array' must be a RecordArray, not {repr(array)}")
+            raise TypeError(f"Record 'array' must be a RecordArray, not {array!r}")
         if not ak._util.isint(at):
-            raise TypeError(f"Record 'at' must be an integer, not {repr(array)}")
+            raise TypeError(f"Record 'at' must be an integer, not {array!r}")
         if at < 0 or at >= array.length:
             raise ValueError(
-                "Record 'at' must be >= 0 and < len(array) == {}, not {}".format(
-                    array.length, at
-                )
+                f"Record 'at' must be >= 0 and < len(array) == {array.length}, not {at}"
             )
         else:
             self._array = array

--- a/src/awkward/_v2/record.py
+++ b/src/awkward/_v2/record.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 from awkward._v2.contents.content import Content

--- a/src/awkward/_v2/types/recordtype.py
+++ b/src/awkward/_v2/types/recordtype.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import json
 

--- a/src/awkward/_v2/types/uniontype.py
+++ b/src/awkward/_v2/types/uniontype.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 from awkward._v2.types.type import Type

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -6,12 +6,8 @@
 import re
 import keyword
 
-try:
-    from collections.abc import Iterable
-    from collections.abc import Sized
-except ImportError:
-    from collections import Iterable
-    from collections import Sized
+from collections.abc import Iterable
+from collections.abc import Sized
 
 import awkward as ak
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1000,7 +1000,7 @@ class Array(
         if isinstance(tmp, ak.behaviors.string.ByteBehavior):
             return bytes(tmp)
         elif isinstance(tmp, ak.behaviors.string.CharBehavior):
-            return ak._util.unicode(tmp) if ak._util.py27 else str(tmp)
+            return str(tmp)
         else:
             return tmp
 
@@ -1772,7 +1772,7 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
         if isinstance(tmp, ak.behaviors.string.ByteBehavior):
             return bytes(tmp)
         elif isinstance(tmp, ak.behaviors.string.CharBehavior):
-            return ak._util.unicode(tmp) if ak._util.py27 else str(tmp)
+            return str(tmp)
         else:
             return tmp
 
@@ -2310,7 +2310,7 @@ class ArrayBuilder(Iterable, Sized):
         if isinstance(tmp, ak.behaviors.string.ByteBehavior):
             return bytes(tmp)
         elif isinstance(tmp, ak.behaviors.string.CharBehavior):
-            return ak._util.unicode(tmp) if ak._util.py27 else str(tmp)
+            return str(tmp)
         else:
             return tmp
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1122,8 +1122,7 @@ class Array(
                     )
             else:
                 raise AttributeError(
-                    f"no field named {repr(where)}"
-                    + ak._util.exception_suffix(__file__)
+                    f"no field named {where!r}" + ak._util.exception_suffix(__file__)
                 )
 
     def __dir__(self):
@@ -1845,8 +1844,7 @@ class Record(ak._connect._numpy.NDArrayOperatorsMixin):
                     )
             else:
                 raise AttributeError(
-                    f"no field named {repr(where)}"
-                    + ak._util.exception_suffix(__file__)
+                    f"no field named {where!r}" + ak._util.exception_suffix(__file__)
                 )
 
     def __dir__(self):

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -5,10 +5,7 @@
 
 import ctypes
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import numpy
 
@@ -453,8 +450,8 @@ class Cupy(NumpyLike):
     def __init__(self):
         try:
             import cupy
-        except ImportError:
-            raise ImportError(
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
                 """to use CUDA arrays in Python, install the 'cupy' package with:
 
     pip install cupy --upgrade
@@ -462,7 +459,7 @@ class Cupy(NumpyLike):
 or
 
     conda install cupy"""
-            )
+            ) from None
         self._module = cupy
 
     @property

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -2952,7 +2952,7 @@ def to_parquet(
     list_to32=False,
     string_to32=True,
     bytestring_to32=True,
-    **options,  # NOTE: a comma after **options breaks Python 2
+    **options
 ):
     """
     Args:
@@ -3843,7 +3843,7 @@ def from_parquet(
     lazy_cache_key=None,
     highlevel=True,
     behavior=None,
-    **options,  # NOTE: a comma after **options breaks Python 2
+    **options
 ):
     """
     Args:

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -12,12 +12,8 @@ import threading
 import glob
 import re
 
-try:
-    from collections.abc import Iterable, Sized
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import Iterable, Sized
-    from collections import MutableMapping
+from collections.abc import Iterable, Sized
+from collections.abc import MutableMapping
 
 import awkward as ak
 
@@ -613,13 +609,13 @@ def to_jax(array):
     """
     try:
         import jax
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """to use {0}, you must install jax:
 
                 pip install jax jaxlib
             """
-        )
+        ) from None
 
     if isinstance(array, (bool, numbers.Number)):
         return jax.numpy.array([array])[0]
@@ -1966,19 +1962,17 @@ def regularize_numpyarray(array, allow_empty=True, highlevel=True, behavior=None
 def _import_pyarrow(name):
     try:
         import pyarrow
-    except ImportError:
-        raise ImportError(
-            """to use {}, you must install pyarrow:
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            f"""to use {name}, you must install pyarrow:
 
     pip install pyarrow
 
 or
 
     conda install -c conda-forge pyarrow
-""".format(
-                name
-            )
-        )
+"""
+        ) from None
     else:
         if ak._v2._util.parse_version(pyarrow.__version__) < ak._v2._util.parse_version(
             "2.0.0"
@@ -2952,7 +2946,7 @@ def to_parquet(
     list_to32=False,
     string_to32=True,
     bytestring_to32=True,
-    **options
+    **options,
 ):
     """
     Args:
@@ -3843,7 +3837,7 @@ def from_parquet(
     lazy_cache_key=None,
     highlevel=True,
     behavior=None,
-    **options
+    **options,
 ):
     """
     Args:
@@ -5251,8 +5245,8 @@ def to_pandas(
     """
     try:
         import pandas
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'pandas' package with:
 
     pip install pandas --upgrade
@@ -5260,7 +5254,7 @@ def to_pandas(
 or
 
     conda install pandas"""
-        )
+        ) from None
 
     if how is not None:
         out = None

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -1219,8 +1219,7 @@ def to_json(
 
     else:
         raise TypeError(
-            f"unrecognized array type: {repr(array)}"
-            + ak._util.exception_suffix(__file__)
+            f"unrecognized array type: {array!r}" + ak._util.exception_suffix(__file__)
         )
 
     if complex_record_fields is None:
@@ -1574,7 +1573,7 @@ def from_awkward0(
                 out.setparameter("__array__", "string")
             else:
                 raise ValueError(
-                    f"unsupported encoding: {repr(array.encoding)}"
+                    f"unsupported encoding: {array.encoding!r}"
                     + ak._util.exception_suffix(__file__)
                 )
             return out
@@ -1634,7 +1633,7 @@ def from_awkward0(
 
         else:
             raise TypeError(
-                f"not an awkward0 array: {repr(array)}"
+                f"not an awkward0 array: {array!r}"
                 + ak._util.exception_suffix(__file__)
             )
 
@@ -1898,7 +1897,7 @@ def to_layout(
     elif isinstance(array, (np.ndarray, numpy.ma.MaskedArray)):
         if not issubclass(array.dtype.type, numpytype):
             raise ValueError(
-                f"NumPy {repr(array.dtype)} not allowed"
+                f"NumPy {array.dtype!r} not allowed"
                 + ak._util.exception_suffix(__file__)
             )
         return from_numpy(array, regulararray=True, recordarray=True, highlevel=False)
@@ -2498,7 +2497,7 @@ def to_arrow(
 
         else:
             raise TypeError(
-                f"unrecognized array type: {repr(layout)}"
+                f"unrecognized array type: {layout!r}"
                 + ak._util.exception_suffix(__file__)
             )
 
@@ -2723,7 +2722,7 @@ def _from_arrow(
                 assert tpe.num_buffers == 3
             else:
                 raise TypeError(
-                    f"unrecognized Arrow union array mode: {repr(tpe.mode)}"
+                    f"unrecognized Arrow union array mode: {tpe.mode!r}"
                     + ak._util.exception_suffix(__file__)
                 )
 
@@ -2848,7 +2847,7 @@ def _from_arrow(
 
         else:
             raise TypeError(
-                f"unrecognized Arrow array type: {repr(tpe)}"
+                f"unrecognized Arrow array type: {tpe!r}"
                 + ak._util.exception_suffix(__file__)
             )
 
@@ -3109,7 +3108,7 @@ def _to_parquet_dataset(directory, filenames=None, filename_extension=".parquet"
     directory = _regularize_path(directory)
     if not os.path.isdir(directory):
         raise ValueError(
-            f"{repr(directory)} is not a local filesystem directory"
+            f"{directory!r} is not a local filesystem directory"
             + ak._util.exception_suffix(__file__)
         )
 
@@ -3729,7 +3728,7 @@ def _partial_schema_from_columns(schema, columns):
     for x in columns:
         if x not in schema.names:
             raise ValueError(
-                f"column {repr(x)} not found in schema"
+                f"column {x!r} not found in schema"
                 + ak._util.exception_suffix(__file__)
             )
         pa_fields.append(schema.field(x))

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -194,9 +194,6 @@ def to_numpy(array, allow_missing=True):
     if isinstance(array, (bool, str, bytes, numbers.Number)):
         return numpy.array([array])[0]
 
-    elif ak._util.py27 and isinstance(array, ak._util.unicode):
-        return numpy.array([array])[0]
-
     elif isinstance(array, np.ndarray):
         return array
 
@@ -941,9 +938,6 @@ def to_list(array):
     elif array is None or isinstance(array, (bool, str, bytes, numbers.Number)):
         return array
 
-    elif ak._util.py27 and isinstance(array, ak._util.unicode):
-        return array
-
     elif isinstance(array, np.ndarray):
         return array.tolist()
 
@@ -1112,11 +1106,7 @@ def from_json(
             buffersize=buffersize,
         )
     else:
-        if ak._util.py27:
-            exc = IOError
-        else:
-            exc = FileNotFoundError
-        raise exc(f"file not found or not a regular file: {source}")
+        raise FileNotFoundError(f"file not found or not a regular file: {source}")
 
     def getfunction(recordnode):
         if isinstance(recordnode, ak.layout.RecordArray):
@@ -1206,9 +1196,6 @@ def to_json(
 
     elif isinstance(array, bytes):
         return json.dumps(array.decode("utf-8", "surrogateescape"))
-
-    elif ak._util.py27 and isinstance(array, ak._util.unicode):
-        return json.dumps(array)
 
     elif isinstance(array, np.ndarray):
         out = ak.layout.NumpyArray(array)
@@ -1925,9 +1912,7 @@ def to_layout(
     ):
         return from_cupy(array, regulararray=True, highlevel=False)
 
-    elif isinstance(array, (str, bytes)) or (
-        ak._util.py27 and isinstance(array, ak._util.unicode)
-    ):
+    elif isinstance(array, (str, bytes)):
         return from_iter([array], highlevel=False)
 
     elif isinstance(array, Iterable):
@@ -5059,7 +5044,7 @@ def from_buffers(
 
     See #ak.to_buffers for examples.
     """
-    if isinstance(form, str) or (ak._util.py27 and isinstance(form, ak._util.unicode)):
+    if isinstance(form, str):
         form = ak.forms.Form.fromjson(form)
     elif isinstance(form, dict):
         form = ak.forms.Form.fromjson(json.dumps(form))

--- a/src/awkward/operations/describe.py
+++ b/src/awkward/operations/describe.py
@@ -71,7 +71,7 @@ def validity_error(array, exception=False):
 
     else:
         raise TypeError(
-            f"not an awkward array: {repr(array)}" + ak._util.exception_suffix(__file__)
+            f"not an awkward array: {array!r}" + ak._util.exception_suffix(__file__)
         )
 
 
@@ -189,8 +189,7 @@ def type(array):
 
     else:
         raise TypeError(
-            f"unrecognized array type: {repr(array)}"
-            + ak._util.exception_suffix(__file__)
+            f"unrecognized array type: {array!r}" + ak._util.exception_suffix(__file__)
         )
 
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -6,10 +6,7 @@
 import numbers
 import json
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -1218,9 +1218,7 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
             nplike = ak.nplike.of(layout)
             if isinstance(fill_value, bytes):
                 asbytes = fill_value
-            elif isinstance(fill_value, str) or (
-                ak._util.py27 and isinstance(fill_value, ak._util.unicode)
-            ):
+            elif isinstance(fill_value, str):
                 asbytes = fill_value.encode("utf-8", "surrogateescape")
             else:
                 asbytes = str(fill_value).encode("utf-8", "surrogateescape")
@@ -2791,10 +2789,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
         )
     elif (
         isinstance(value, Iterable)
-        and not (
-            isinstance(value, (str, bytes))
-            or (ak._util.py27 and isinstance(value, ak._util.unicode))
-        )
+        and not isinstance(value, (str, bytes))
         or isinstance(value, (ak.highlevel.Record, ak.layout.Record))
     ):
         valuelayout = ak.operations.convert.to_layout(
@@ -4139,9 +4134,7 @@ def virtual(
     ):
         form = ak.forms.Form.fromjson('"' + form + '"')
 
-    elif isinstance(form, (str, bytes)) or (
-        ak._util.py27 and isinstance(form, ak._util.unicode)
-    ):
+    elif isinstance(form, (str, bytes)):
         form = ak.forms.Form.fromjson(form)
 
     elif form is not None and not isinstance(form, ak.forms.Form):

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -3226,11 +3226,9 @@ def cartesian(
          [(4, 3.3, 'a'), (4, 3.3, 'b')]
         ]
 
-    The order of the output is fixed: it is always lexicographical in the
-    order that the `arrays` are written. (Before Python 3.6, the order of
-    keys in a dict were not guaranteed, so the dict interface is not
-    recommended for these versions of Python.) Thus, it is not possible to
-    group by `three` in the example above.
+    The order of the output is fixed: it is always lexicographical in the order
+    that the `arrays` are written. Thus, it is not possible to group by `three`
+    in the example above.
 
     To emulate an SQL or Pandas "group by" operation, put the keys that you
     wish to group by *first* and use `nested=[0]` or `nested=[n]` to group by

--- a/src/awkward/partition.py
+++ b/src/awkward/partition.py
@@ -236,9 +236,7 @@ class PartitionedArray:
                 self._ext.getitem_range(where.start, where.stop, where.step)
             )
 
-        elif isinstance(where, str) or (
-            ak._util.py27 and isinstance(where, ak._util.unicode)
-        ):
+        elif isinstance(where, str):
             return self.replace_partitions([x[where] for x in self.partitions])
 
         elif isinstance(where, tuple) and len(where) == 0:
@@ -247,13 +245,7 @@ class PartitionedArray:
         elif (
             isinstance(where, Iterable)
             and len(where) > 0
-            and all(
-                (
-                    isinstance(x, str)
-                    or (ak._util.py27 and isinstance(x, ak._util.unicode))
-                )
-                for x in where
-            )
+            and all(isinstance(x, str) for x in where)
         ):
             return self.replace_partitions([x[where] for x in self.partitions])
 
@@ -288,9 +280,7 @@ class PartitionedArray:
                     [x[(head,) + tail] for x in self.partitions]
                 )
 
-            elif isinstance(head, str) or (
-                ak._util.py27 and isinstance(head, ak._util.unicode)
-            ):
+            elif isinstance(head, str):
                 y = IrregularlyPartitionedArray([x[head] for x in self.partitions])
                 if len(tail) == 0:
                     return y
@@ -300,13 +290,7 @@ class PartitionedArray:
             elif (
                 isinstance(head, Iterable)
                 and len(head) > 0
-                and all(
-                    (
-                        isinstance(x, str)
-                        or (ak._util.py27 and isinstance(x, ak._util.unicode))
-                    )
-                    for x in head
-                )
+                and all(isinstance(x, str) for x in head)
             ):
                 y = IrregularlyPartitionedArray(
                     [x[list(head)] for x in self.partitions]

--- a/src/awkward/partition.py
+++ b/src/awkward/partition.py
@@ -5,10 +5,7 @@
 
 import numbers
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import awkward as ak
 

--- a/studies/type-parser/generated_parser.py
+++ b/studies/type-parser/generated_parser.py
@@ -314,7 +314,7 @@ def smart_decorator(f, create_decorator):
 
 try:
     import regex
-except ImportError:
+except ModuleNotFoundError:
     regex = None
 
 import sre_parse
@@ -332,7 +332,7 @@ def get_regexp_width(expr):
         regexp_final = re.sub(categ_pattern, 'A', expr)
     else:
         if re.search(categ_pattern, expr):
-            raise ImportError('`regex` module must be installed in order to use Unicode categories.', expr)
+            raise ModuleNotFoundError('`regex` module must be installed in order to use Unicode categories.', expr)
         regexp_final = expr
     try:
         return [int(x) for x in sre_parse.parse(regexp_final).getwidth()]
@@ -2251,7 +2251,7 @@ class Lark(Serialize):
             if regex:
                 re_module = regex
             else:
-                raise ImportError('`regex` module must be installed if calling `Lark(regex=True)`.')
+                raise ModuleNotFoundError('`regex` module must be installed if calling `Lark(regex=True)`.')
         else:
             re_module = re
 

--- a/studies/type-parser/generated_parser.py
+++ b/studies/type-parser/generated_parser.py
@@ -185,8 +185,6 @@ logger.addHandler(logging.StreamHandler())
 
 logger.setLevel(logging.CRITICAL)
 
-Py36 = (sys.version_info[:2] >= (3, 6))
-
 
 def classify(seq, key=None, value=None):
     d = {}
@@ -967,19 +965,10 @@ class Pattern(Serialize):
     def to_regexp(self):
         raise NotImplementedError()
 
-    if Py36:
-        ##
-
-        def _get_flags(self, value):
-            for f in self.flags:
-                value = ('(?%s:%s)' % (f, value))
-            return value
-
-    else:
-        def _get_flags(self, value):
-            for f in self.flags:
-                value = ('(?%s)' % f) + value
-            return value
+    def _get_flags(self, value):
+        for f in self.flags:
+            value = ('(?%s:%s)' % (f, value))
+        return value
 
 
 class PatternStr(Pattern):
@@ -2290,9 +2279,6 @@ class Lark(Serialize):
         if self.options.use_bytes:
             if not isascii(grammar):
                 raise ValueError("Grammar must be ascii only, when use_bytes=True")
-            if sys.version_info[0] == 2 and self.options.use_bytes != 'force':
-                raise NotImplementedError("`use_bytes=True` may have issues on python2."
-                                          "Use `use_bytes='force'` to use it at your own risk.")
 
         cache_fn = None
         if self.options.cache:

--- a/studies/type-parser/generated_parser.py
+++ b/studies/type-parser/generated_parser.py
@@ -2130,7 +2130,7 @@ class LarkOptions(Serialize):
     lexer_callbacks
             Dictionary of callbacks for the lexer. May alter tokens during lexing. Use with caution.
     use_bytes
-            Accept an input of type ``bytes`` instead of ``str`` (Python 3 only).
+            Accept an input of type ``bytes`` instead of ``str``.
     edit_terminals
             A callback for editing the terminals before parse.
     import_paths

--- a/studies/type-parser/parser.py
+++ b/studies/type-parser/parser.py
@@ -8,8 +8,6 @@ from generated_parser import Lark_StandAlone, Transformer
 class TreeToJson(Transformer):
     def string(self, s):
         (s,) = s
-        if sys.version_info[0] == 2:
-            s = s.encode("utf-8")
         return s[1:-1]
 
     def number(self, n):

--- a/tests/test_0057-virtual-array.py
+++ b/tests/test_0057-virtual-array.py
@@ -3,12 +3,7 @@
 
 import json
 
-try:
-    # pybind11 only supports cPickle protocol 2+ (-1 in pickle.dumps)
-    # (automatically satisfied in Python 3; this is just to keep testing Python 2.7)
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401

--- a/tests/test_0348-form-keys.py
+++ b/tests/test_0348-form-keys.py
@@ -1,12 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    # pybind11 only supports cPickle protocol 2+ (-1 in pickle.dumps)
-    # (automatically satisfied in Python 3; this is just to keep testing Python 2.7)
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401

--- a/tests/test_0479-lazy-arrays-lose-weak-reference.py
+++ b/tests/test_0479-lazy-arrays-lose-weak-reference.py
@@ -1,10 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import MutableMapping
+from collections.abc import MutableMapping
 
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401

--- a/tests/test_1136-regulararray-zeros-in-shape.py
+++ b/tests/test_1136-regulararray-zeros-in-shape.py
@@ -158,5 +158,4 @@ def test_actual():
     x = ak.from_numpy(np.arange(2 * 3 * 4, dtype=np.int64).reshape(2, 3, 4))
     s = x[..., :0]
     result = ak.zip({"q": s, "t": s})
-    if not ak._util.py27 and not ak._util.py35:
-        assert str(ak.type(result)) == '2 * 3 * 0 * {"q": int64, "t": int64}'
+    assert str(ak.type(result)) == '2 * 3 * 0 * {"q": int64, "t": int64}'

--- a/tests/v2/test_0018-fromiter-fillable.py
+++ b/tests/v2/test_0018-fromiter-fillable.py
@@ -1,13 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-import pytest  # noqa: F401
-import numpy as np  # noqa: F401
-import awkward as ak  # noqa: F401
+import pytest
+import awkward as ak
 
-pytestmark = pytest.mark.skipif(
-    ak._util.py27, reason="No Python 2.7 support in Awkward 2.x"
-)
 
 to_list = ak._v2.operations.convert.to_list
 

--- a/tests/v2/test_0057-introducing-forms.py
+++ b/tests/v2/test_0057-introducing-forms.py
@@ -3,12 +3,7 @@
 
 import json
 
-try:
-    # pybind11 only supports cPickle protocol 2+ (-1 in pickle.dumps)
-    # (automatically satisfied in Python 3; this is just to keep testing Python 2.7)
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401

--- a/tests/v2/test_1136-regulararray-zeros-in-shape.py
+++ b/tests/v2/test_1136-regulararray-zeros-in-shape.py
@@ -160,8 +160,7 @@ def test_actual():
     )
     s = x[..., :0]
     result = ak._v2.operations.structure.zip({"q": s, "t": s})
-    if not ak._util.py27 and not ak._util.py35:
-        assert (
-            str(ak._v2.operations.describe.type(result))
-            == "2 * 3 * 0 * {q: int64, t: int64}"
-        )
+    assert (
+        str(ak._v2.operations.describe.type(result))
+        == "2 * 3 * 0 * {q: int64, t: int64}"
+    )


### PR DESCRIPTION
Followup to #1244 with some simi-manual and manual changes.


- chore: drop sys.version_info checks
- chore: drop py27,py35,py36 checks
- chore: clean up things that mention 'ython 2/3'
- chore: clean up ImportErrors
- chore: replace repr with !r
- chore: remove `__div__`

I'd recommend always using the idiom `sys.version_info >= (3, 8)` or similar - never define a `py36` constant, it's less readable and far less automatable / statically typeable. Especially since there was one for >= 3.6 and one for <= 3.6! :)
