### PR TITLE
Fix: support mixed array types in `NumpyLike.to_rectilinear`

### DIFF
--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -403,6 +403,7 @@ class Numpy(NumpyLike):
         if isinstance(
             array,
             (
+                numpy.ndarray,
                 ak.Array,
                 ak.Record,
                 ak.ArrayBuilder,

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -400,10 +400,12 @@ class NumpyKernel:
 
 class Numpy(NumpyLike):
     def to_rectilinear(self, array, *args, **kwargs):
-        if isinstance(
+        if isinstance(array, numpy.ndarray):
+            return array
+
+        elif isinstance(
             array,
             (
-                numpy.ndarray,
                 ak.Array,
                 ak.Record,
                 ak.ArrayBuilder,

--- a/tests/test_1247-numpy-to_rectilinear-ndarray.py
+++ b/tests/test_1247-numpy-to_rectilinear-ndarray.py
@@ -6,6 +6,8 @@ import awkward as ak  # noqa: F401
 
 
 def test():
-    reference = np.r_[1, 2, 3, 4]
-    test = ak.Array([1, 2, 9, 0])
-    assert ak.to_list(np.isin(test, reference)) == [True, True, False, False]
+    array = np.array([1, 2, 9, 0])
+    nplike = ak.nplike.of(array)
+
+    ak_array = ak.from_numpy(array)
+    assert ak.to_list(nplike.to_rectilinear(array)) == ak.to_list(ak_array)

--- a/tests/test_1247-numpy-to_rectilinear-ndarray.py
+++ b/tests/test_1247-numpy-to_rectilinear-ndarray.py
@@ -1,0 +1,11 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    reference = np.r_[1, 2, 3, 4]
+    test = ak.Array([1, 2, 9, 0])
+    assert ak.to_list(np.isin(test, reference)) == [True, True, False, False]

--- a/tests/v2/test_1247-numpy-to_rectilinear-ndarray.py
+++ b/tests/v2/test_1247-numpy-to_rectilinear-ndarray.py
@@ -1,0 +1,12 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = np.array([1, 2, 9, 0])
+    nplike = ak.nplike.of(array)
+    ak_array = ak._v2.operations.convert.from_numpy(array)
+    assert nplike.to_rectilinear(array).tolist() == ak_array.tolist()


### PR DESCRIPTION
Fixes #1247