### PR TITLE
Fix: support nested option types in `ak.is_none`

### DIFF
--- a/src/awkward/_v2/operations/structure/ak_is_none.py
+++ b/src/awkward/_v2/operations/structure/ak_is_none.py
@@ -38,9 +38,7 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
                     ak._v2.index.Index8(tag),
                     ak._v2.index.Index64(index),
                     [
-                        layout.content.recursively_apply(
-                            getfunction_inner
-                        ),
+                        layout.content.recursively_apply(getfunction_inner),
                         ak._v2.contents.NumpyArray(
                             nplike.array([True], dtype=np.bool_)
                         ),
@@ -66,7 +64,7 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
         if posaxis != depth - 1:
             return
 
-        return getfunction_inner(layout, depth)
+        return layout.recursively_apply(getfunction_inner)
 
     layout = ak._v2.operations.convert.to_layout(array)
     behavior = ak._v2._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/_v2/operations/structure/ak_is_none.py
+++ b/src/awkward/_v2/operations/structure/ak_is_none.py
@@ -23,8 +23,6 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
     False otherwise (at a given `axis` depth).
     """
 
-    layout = ak._v2.operations.convert.to_layout(array)
-
     # Determine the (potentially nested) bytemask
     def getfunction_inner(layout, depth, **kwargs):
         if not isinstance(layout, ak._v2.contents.Content):
@@ -65,6 +63,7 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
         if depth_context["posaxis"] == depth - 1:
             return layout.recursively_apply(getfunction_inner)
 
+    layout = ak._v2.operations.convert.to_layout(array)
     behavior = ak._v2._util.behavior_of(array, behavior=behavior)
     depth_context = {"posaxis": axis}
     out = layout.recursively_apply(getfunction_outer, depth_context=depth_context)

--- a/src/awkward/_v2/operations/structure/ak_is_none.py
+++ b/src/awkward/_v2/operations/structure/ak_is_none.py
@@ -7,54 +7,70 @@ np = ak.nplike.NumpyMetadata.instance()
 
 
 def is_none(array, axis=0, highlevel=True, behavior=None):
-    raise NotImplementedError
+    """
+    Args:
+        array: Data to check for missing values (None).
+        axis (int): The dimension at which this operation is applied. The
+            outermost dimension is `0`, followed by `1`, etc., and negative
+            values count backward from the innermost: `-1` is the innermost
+            dimension, `-2` is the next level up, etc.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.layout.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
 
+    Returns an array whose value is True where an element of `array` is None;
+    False otherwise (at a given `axis` depth).
+    """
 
-#     """
-#     Args:
-#         array: Data to check for missing values (None).
-#         axis (int): The dimension at which this operation is applied. The
-#             outermost dimension is `0`, followed by `1`, etc., and negative
-#             values count backward from the innermost: `-1` is the innermost
-#             dimension, `-2` is the next level up, etc.
-#         highlevel (bool): If True, return an #ak.Array; otherwise, return
-#             a low-level #ak.layout.Content subclass.
-#         behavior (None or dict): Custom #ak.behavior for the output array, if
-#             high-level.
+    def getfunction_inner(layout, depth, **kwargs):
+        nplike = ak.nplike.of(layout)
+        if isinstance(layout, ak._v2.contents.Content):
+            if layout.is_OptionType:
+                layout = layout.toIndexedOptionArray64()
 
-#     Returns an array whose value is True where an element of `array` is None;
-#     False otherwise (at a given `axis` depth).
-#     """
+                # Convert the option type into a union, using the mask
+                # as a tag.
+                tag = nplike.asarray(layout.bytemask())
+                index = nplike.where(tag, 0, nplike.asarray(layout.index))
 
-#     def getfunction(layout, depth, posaxis):
-#         posaxis = layout.axis_wrap_if_negative(posaxis)
-#         if posaxis == depth - 1:
-#             nplike = ak.nplike.of(layout)
-#             if isinstance(layout, ak._v2._util.optiontypes):
-#                 return lambda: ak._v2.contents.NumpyArray(
-#                     nplike.asarray(layout.bytemask()).view(np.bool_)
-#                 )
-#             elif isinstance(
-#                 layout,
-#                 (
-#                     ak._v2._util.unknowntypes,
-#                     ak._v2._util.listtypes,
-#                     ak._v2._util.recordtypes,
-#                     ak._v2.contents.NumpyArray,
-#                 ),
-#             ):
-#                 return lambda: ak._v2.contents.NumpyArray(
-#                     nplike.zeros(len(layout), dtype=np.bool_)
-#                 )
-#             else:
-#                 return posaxis
-#         else:
-#             return posaxis
+                return ak._v2.contents.UnionArray(
+                    ak._v2.index.Index8(tag),
+                    ak._v2.index.Index64(index),
+                    [
+                        layout.content.recursively_apply(
+                            getfunction_inner
+                        ),
+                        ak._v2.contents.NumpyArray(
+                            nplike.array([True], dtype=np.bool_)
+                        ),
+                    ],
+                ).simplify_uniontype()
 
-#     layout = ak._v2.operations.convert.to_layout(array)
+            elif (
+                layout.is_UnknownType
+                or layout.is_ListType
+                or layout.is_RecordType
+                or layout.is_NumpyType
+            ):
+                return ak._v2.contents.NumpyArray(
+                    nplike.zeros(len(layout), dtype=np.bool_)
+                )
+            else:
+                return
+        else:
+            return
 
-#     out = ak._v2._util.recursively_apply(
-#         layout, getfunction, pass_depth=True, pass_user=True, user=axis
-#     )
+    def getfunction_outer(layout, depth, depth_context, **kwargs):
+        posaxis = layout.axis_wrap_if_negative(depth_context["posaxis"])
+        if posaxis != depth - 1:
+            return
 
-#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)
+        return getfunction_inner(layout, depth)
+
+    layout = ak._v2.operations.convert.to_layout(array)
+    behavior = ak._v2._util.behavior_of(array, behavior=behavior)
+
+    depth_context = {"posaxis": axis}
+    out = layout.recursively_apply(getfunction_outer, depth_context=depth_context)
+    return ak._v2._util.wrap(out, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/ak_is_none.py
+++ b/src/awkward/_v2/operations/structure/ak_is_none.py
@@ -60,8 +60,10 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
             return
 
     def getfunction_outer(layout, depth, depth_context, **kwargs):
-        posaxis = layout.axis_wrap_if_negative(depth_context["posaxis"])
-        if posaxis != depth - 1:
+        depth_context["posaxis"] = layout.axis_wrap_if_negative(
+            depth_context["posaxis"]
+        )
+        if depth_context["posaxis"] != depth - 1:
             return
 
         return layout.recursively_apply(getfunction_inner)

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2851,7 +2851,7 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
     False otherwise (at a given `axis` depth).
     """
 
-    def transform_inner(layout, depth):
+    def transform_inner(layout, depth, user=None):
         nplike = ak.nplike.of(layout)
         if isinstance(layout, ak._util.optiontypes):
             if not isinstance(layout, ak.layout.IndexedOptionArray64):

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -2851,36 +2851,50 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
     False otherwise (at a given `axis` depth).
     """
 
-    def getfunction(layout, depth, posaxis):
-        posaxis = layout.axis_wrap_if_negative(posaxis)
-        if posaxis == depth - 1:
-            nplike = ak.nplike.of(layout)
-            if isinstance(layout, ak._util.optiontypes):
-                return lambda: ak.layout.NumpyArray(
-                    nplike.asarray(layout.bytemask()).view(np.bool_)
-                )
-            elif isinstance(
-                layout,
-                (
-                    ak._util.unknowntypes,
-                    ak._util.listtypes,
-                    ak._util.recordtypes,
-                    ak.layout.NumpyArray,
-                ),
-            ):
-                return lambda: ak.layout.NumpyArray(
-                    nplike.zeros(len(layout), dtype=np.bool_)
-                )
-            else:
-                return posaxis
+    def transform_inner(layout, depth):
+        nplike = ak.nplike.of(layout)
+        if isinstance(layout, ak._util.optiontypes):
+            if not isinstance(layout, ak.layout.IndexedOptionArray64):
+                layout = layout.toIndexedOptionArray64()
+
+            # Convert the option type into a union, using the mask
+            # as a tag.
+            tag = nplike.asarray(layout.bytemask())
+            index = nplike.where(tag, 0, nplike.asarray(layout.index))
+
+            return ak.layout.UnionArray8_64(
+                ak.layout.Index8(tag),
+                ak.layout.Index64(index),
+                [
+                    transform_inner(layout.content, depth),
+                    ak.layout.NumpyArray(nplike.array([True], dtype=np.bool_)),
+                ],
+            ).simplify()
+        elif isinstance(
+            layout,
+            (
+                ak._util.unknowntypes,
+                ak._util.listtypes,
+                ak._util.recordtypes,
+                ak.layout.NumpyArray,
+            ),
+        ):
+            return ak.layout.NumpyArray(nplike.zeros(len(layout), dtype=np.bool_))
         else:
-            return posaxis
+            return ak._util.transform_child_layouts(transform_inner, layout, depth)
+
+    def transform_outer(layout, depth, posaxis):
+        posaxis = layout.axis_wrap_if_negative(posaxis)
+        if posaxis != depth - 1:
+            return ak._util.transform_child_layouts(
+                transform_outer, layout, depth, posaxis
+            )
+        else:
+            return transform_inner(layout, depth)
 
     layout = ak.operations.convert.to_layout(array)
 
-    out = ak._util.recursively_apply(
-        layout, getfunction, pass_depth=True, pass_user=True, user=axis
-    )
+    out = transform_outer(layout, 1, axis)
 
     return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
 

--- a/tests/test_1193-is-none-nested-option.py
+++ b/tests/test_1193-is-none-nested-option.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    index_of_index = ak.Array(
+        ak.layout.IndexedOptionArray64(
+            ak.layout.Index64(np.r_[0, 1, 2, -1]),
+            ak.layout.IndexedOptionArray64(
+                ak.layout.Index64(np.r_[0, -1, 2, 3]),
+                ak.layout.NumpyArray(np.r_[1, 2, 3, 4]),
+            ),
+        )
+    )
+
+    mask = ak.is_none(index_of_index)
+    assert ak.to_list(mask) == [False, True, False, True]

--- a/tests/v2/test_0713-getitem_field-should-simplify_optiontype.py
+++ b/tests/v2/test_0713-getitem_field-should-simplify_optiontype.py
@@ -8,7 +8,6 @@ import awkward as ak  # noqa: F401
 to_list = ak._v2.operations.convert.to_list
 
 
-@pytest.mark.skip(reason="FIXME: ak._v2.operations.structure.is_none not implemented")
 def test():
     arr1 = ak._v2.highlevel.Array({"a": [1, 2], "b": [1, None]})
     arr2 = ak._v2.operations.structure.mask(arr1, [True, True])

--- a/tests/v2/test_1193-is-none-nested-option.py
+++ b/tests/v2/test_1193-is-none-nested-option.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    index_of_index = ak._v2.highlevel.Array(
+        ak._v2.contents.IndexedOptionArray(
+            ak._v2.index.Index64(np.r_[0, 1, 2, -1]),
+            ak._v2.contents.IndexedOptionArray(
+                ak._v2.index.Index64(np.r_[0, -1, 2, 3]),
+                ak._v2.contents.NumpyArray(np.r_[1, 2, 3, 4]),
+            ),
+        )
+    )
+
+    mask = ak._v2.operations.structure.is_none(index_of_index)
+    assert mask.tolist() == [False, True, False, True]


### PR DESCRIPTION
Fixes #1193
Requires #1279

To implement this feature, I introduce a temporary union. Let me know if there's a more elegant way to do this! Given that, unlike most other layout transformers, we need to modify several layers, I've split the transformation process into two different transforms - one to locate the first layout, another to actually perform the transformation.

I also wondered whether it would be possible to write the new recursive `getfunction`s with an early-return style instead of explicitly handling each case? In the past, the return value had a lot of interpretation modes, so it was more dangerous. With v2, I wonder if we could re-consider this position?