### PR TITLE
Remove distutils reference in test (now an error).

### DIFF
--- a/tests/test_0080-flatpandas-multiindex-rows-and-columns.py
+++ b/tests/test_0080-flatpandas-multiindex-rows-and-columns.py
@@ -2,7 +2,7 @@
 
 
 import json
-import distutils.version
+import setuptools
 
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
@@ -12,8 +12,8 @@ pandas = pytest.importorskip("pandas")
 
 
 @pytest.mark.skipif(
-    distutils.version.LooseVersion(pandas.__version__)
-    < distutils.version.LooseVersion("1.0"),
+    setuptools.extern.packaging.version.parse(pandas.__version__)
+    < setuptools.extern.packaging.version.parse("1.0"),
     reason="Test Pandas in 1.0+ because they had to fix their JSON format.",
 )
 def test():


### PR DESCRIPTION
Because pytest treats warnings as errors now: #1255. Also, the fact that this didn't cause failures in #1255 must mean that Pandas is not being installed in any of the tests, so it's skipping the Pandas tests (except when it runs locally). Maybe we want to test that one (and only one) Pandas-related function? Something to think about.