### PR TITLE
Fix: fix `ByteMaskedArray.simplify_optiontype()`

### DIFF
--- a/src/awkward/_v2/contents/bitmaskedarray.py
+++ b/src/awkward/_v2/contents/bitmaskedarray.py
@@ -332,11 +332,11 @@ class BitMaskedArray(Content):
                 ak._v2.contents.indexedarray.IndexedArray,
                 ak._v2.contents.indexedoptionarray.IndexedOptionArray,
                 ak._v2.contents.bytemaskedarray.ByteMaskedArray,
-                ak._v2.contents.bitmaskeddarray.BitMaskedArray,
-                ak._v2.contents.unmaskeddarray.UnmaskedArray,
+                ak._v2.contents.bitmaskedarray.BitMaskedArray,
+                ak._v2.contents.unmaskedarray.UnmaskedArray,
             ),
         ):
-            return self.toIndexedOptionArray64.simplify_optiontype
+            return self.toIndexedOptionArray64().simplify_optiontype()
         else:
             return self
 

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -434,7 +434,7 @@ class ByteMaskedArray(Content):
                 ak._v2.contents.unmaskedarray.UnmaskedArray,
             ),
         ):
-            return self.toIndexedOptionArray64.simplify_optiontype
+            return self.toIndexedOptionArray64().simplify_optiontype()
         else:
             return self
 

--- a/tests/v2/test_1259-simplify_optiontype.py
+++ b/tests/v2/test_1259-simplify_optiontype.py
@@ -1,0 +1,23 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    layout = ak._v2.contents.ByteMaskedArray(
+        ak._v2.index.Index8(np.r_[0, 1, 1]),
+        ak._v2.contents.IndexedOptionArray(
+            ak._v2.index.Index64([0, 1, -1]), ak._v2.contents.NumpyArray(np.arange(3))
+        ),
+        valid_when=True,
+    )
+    assert layout.tolist() == [None, 1, None]
+
+    simplified = layout.simplify_optiontype()
+    assert simplified.tolist() == [None, 1, None]
+
+    assert isinstance(simplified, ak._v2.contents.IndexedOptionArray)
+    assert np.asarray(simplified.index).tolist() == [-1, 1, -1]

--- a/tests/v2/test_1259-simplify_optiontype.py
+++ b/tests/v2/test_1259-simplify_optiontype.py
@@ -6,13 +6,32 @@ import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
 
-def test():
+def test_byte_masked_array():
     layout = ak._v2.contents.ByteMaskedArray(
         ak._v2.index.Index8(np.r_[0, 1, 1]),
         ak._v2.contents.IndexedOptionArray(
             ak._v2.index.Index64([0, 1, -1]), ak._v2.contents.NumpyArray(np.arange(3))
         ),
         valid_when=True,
+    )
+    assert layout.tolist() == [None, 1, None]
+
+    simplified = layout.simplify_optiontype()
+    assert simplified.tolist() == [None, 1, None]
+
+    assert isinstance(simplified, ak._v2.contents.IndexedOptionArray)
+    assert np.asarray(simplified.index).tolist() == [-1, 1, -1]
+
+
+def test_bit_masked_array():
+    layout = ak._v2.contents.BitMaskedArray(
+        ak._v2.index.IndexU8(np.array([0 | 1 << 1 | 1 << 2], dtype=np.uint8)),
+        ak._v2.contents.IndexedOptionArray(
+            ak._v2.index.Index64([0, 1, -1]), ak._v2.contents.NumpyArray(np.arange(3))
+        ),
+        valid_when=True,
+        length=3,
+        lsb_order=True,
     )
     assert layout.tolist() == [None, 1, None]
 


### PR DESCRIPTION
Currently `ByteMaskedArray.simplify_optiontype()` has a few typos that mean it raises an `AttributeError` instead of returning a simplified layout.