### PR TITLE
chore: initial nox and pylint support

### DIFF
--- a/.github/matchers/pylint.json
+++ b/.github/matchers/pylint.json
@@ -1,0 +1,32 @@
+{
+  "problemMatcher": [
+    {
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):(\\d+):(\\d+): ([A-DF-Z]\\d+): \\033\\[[\\d;]+m([^\\033]+).*$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "code": 4,
+          "message": 5
+        }
+      ],
+      "owner": "pylint-warning"
+    },
+    {
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):(\\d+):(\\d+): (E\\d+): \\033\\[[\\d;]+m([^\\033]+).*$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "code": 4,
+          "message": 5
+        }
+      ],
+      "owner": "pylint-error"
+    }
+  ]
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,19 +2,30 @@ name: Tests
 
 on:
   pull_request:
+  workflow_dispatch:
 
-env:
-  CIBW_TEST_EXTRAS: test
-  CIBW_TEST_COMMAND: pytest {project}/tests
-  CIBW_BUILD_VERBOSITY: 1
-  CIBW_TEST_SKIP: "*universal2:arm64 pp*"
-  CIBW_ENVIRONMENT: PIP_ONLY_BINARY=cmake,numpy
-  CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-  CIBW_ARCHS_MACOS: universal2
-  CIBW_BUILD: cp39-win_amd64 cp36-manylinux_x86_64 cp38-macosx_universal2
+
+concurrency:
+  group: wheels-${{ github.head_ref }}
+  cancel-in-progress: true
 
 
 jobs:
+  pylint:
+    name: "PyLint"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Run PyLint
+      run: |
+        echo "::add-matcher::$GITHUB_WORKSPACE/.github/matchers/pylint.json"
+        pipx run nox -s pylint
+
+
   make_sdist:
     name: "Make SDist"
     runs-on: ubuntu-latest
@@ -48,6 +59,10 @@ jobs:
         submodules: true
 
     - uses: pypa/cibuildwheel@v2.3.1
+      env:
+        CIBW_ARCHS_MACOS: universal2
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+        CIBW_BUILD: cp39-win_amd64 cp36-manylinux_x86_64 cp38-macosx_universal2
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,63 @@
+import nox
+
+ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
+nox.options.sessions = ["lint", "tests"]
+
+
+@nox.session(python=ALL_PYTHONS)
+def tests(session):
+    """
+    Run the unit and regular tests.
+    """
+    session.install(".[test]", "numba")
+    session.run("pytest", *session.posargs if session.posargs else ["tests"])
+
+
+@nox.session
+def lint(session):
+    """
+    Run the linter.
+    """
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files", *session.posargs)
+
+
+@nox.session
+def pylint(session):
+    """
+    Run the pylint process.
+    """
+
+    session.install(".")
+    session.install("pylint==2.12.2")
+    session.run("pylint", "src", *session.posargs)
+
+
+@nox.session(python=ALL_PYTHONS)
+def coverage(session):
+    """
+    Run the unit and regular tests.
+    """
+    session.install(".[test]", "pytest-cov")
+    session.run(
+        "pytest", "tests", "--cov=awkward", "--cov-report=xml", *session.posargs
+    )
+
+
+@nox.session
+def docs(session):
+    """
+    Build the docs. Pass "serve" to serve.
+    """
+
+    session.chdir("docs")
+    session.install("-r", "requirements.txt")
+    session.run("sphinx-build", "-M", "html", ".", "_build")
+
+    if session.posargs:
+        if "serve" in session.posargs:
+            session.log("Launching docs at http://localhost:8000/ - use Ctrl-C to quit")
+            session.run("python", "-m", "http.server", "8000", "-d", "_build/html")
+        else:
+            session.error("Unsupported argument to docs")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,88 @@ filterwarnings = [
   "ignore:The NumPy module was reloaded:UserWarning",
 ]
 log_cli_level = "info"
+
+[tool.pylint]
+master.py-version = "3.6"
+master.jobs = "0"
+master.ignore-paths = [
+  "src/awkward/_typeparser/generated_parser.py"
+]
+reports.output-format = "colorized"
+messages_control.enable = [
+  "useless-suppression",
+]
+messages_control.disable = [
+  "abstract-method",  # TODO: check but might need to keep disabled
+  "arguments-differ",  # TODO: some of these can be cleaned up
+  "attribute-defined-outside-init",  # TODO: These should be avoided!
+  "bad-super-call",  # TODO: investigate!
+  "broad-except", # TODO: investigate
+  "cell-var-from-loop",  # TODO: investigate and locally disable if needed (unlikely)
+  "chained-comparison", # TODO
+  "consider-iterating-dictionary",  # TODO
+  "consider-merging-isinstance",  # TODO
+  "consider-using-enumerate", # TODO
+  "consider-using-f-string",  # TODO
+  "consider-using-in",  # TODO
+  "consider-using-max-builtin",  # TODO
+  "consider-using-min-builtin",  # TODO
+  "duplicate-code",  # Hahahaha
+  "exec-used",  # TODO: locally disable
+  "fixme",
+  "global-statement",  # TODO: locally disable if really required
+  "global-variable-not-assigned",  # TODO: investigate!
+  "import-error",
+  "import-outside-toplevel", # Could be done per-use to discourage
+  "inconsistent-return-statements",  # TODO: probably fix
+  "invalid-class-object",  # TODO: investigate!
+  "invalid-name",
+  "invalid-unary-operand-type",  # TODO: investigate!
+  "keyword-arg-before-vararg",  # TODO: investigate
+  "line-too-long",
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+  "no-else-break",  # TODO perhaps?
+  "no-else-raise",  # TODO perhaps?
+  "no-else-return",  # TODO perhaps?
+  "no-member",
+  "no-name-in-module",
+  "no-self-use",  # TODO: investigate and locally disable
+  "no-value-for-parameter",  # TODO: investigate
+  "property-with-parameters",  # TODO: investigate
+  "protected-access",
+  "raise-missing-from",  # TODO
+  "redefined-builtin",  # TODO: fix or locally disable if in a signature
+  "redefined-outer-name",  # TODO: fix
+  "simplifiable-if-expression",  # TODO
+  "super-init-not-called",  # TODO: probably fix
+  "too-few-public-methods",
+  "too-many-arguments",
+  "too-many-boolean-expressions",
+  "too-many-branches",
+  "too-many-function-args",
+  "too-many-instance-attributes",
+  "too-many-lines",
+  "too-many-locals",
+  "too-many-nested-blocks",
+  "too-many-public-methods",
+  "too-many-return-statements",
+  "too-many-statements",
+  "unbalanced-tuple-unpacking",  # TODO: investigate!
+  "undefined-loop-variable", # TODO: fix if possible
+  "ungrouped-imports",
+  "unidiomatic-typecheck",  # TODO
+  "unnecessary-comprehension", # TODO
+  "unnecessary-lambda",  # TODO
+  "unreachable",  # TODO
+  "unsubscriptable-object",  # TODO: check, but possibly a false positive
+  "unused-argument",  # TODO: investigate and locally disable
+  "unused-import", # TODO: remove
+  "unused-variable",  # TODO
+  "use-a-generator",  # TODO
+  "use-implicit-booleaness-not-len", # TODO perhaps?
+  "useless-else-on-loop",  # TODO
+  "wrong-import-order",  # Could use isort
+  "wrong-import-position",
+]


### PR DESCRIPTION
This adds an initial noxfile. No "fly by" contributor docs for it yet, that
will probably come a bit later, after we get editable installs working.

This adds configuration and a nox job for PyLint. I've avoided touching the
code, and instead added suppression with a "TODO" on anything I think we should
work on fixing. I think we could make PRs once in a while removing some of
these suppressions. (Otherwise this becomes too many changes at once). Some are
minor stylistic improvements, sometimes related to Python 3, some are
simplifications, and some are highly bug-prone that probably should be checked
sooner rather than later (marked with `investigate!`).

The syntax for disabling inline is `# pylint: disable=<name>`, or
`disable-next` to put it on the line before, or it can be at the top of a file.
This serves as nice documentation for a user to explain you know you are doing
something a bit naughty.

PyLint also has a bunch of over-the-top checks like `too-many-*` that I'd
expect we would always leave off. This is intentional - it's easier to see and
turn off a check vs. find it and turn it on. I _think_ many of them are in the
"design" group, but I can't see how to tell what is in a group, I only know how
to list all groups (`pylint --list-groups`).
