### PR TITLE
chore: add dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "actions/*"


### PR DESCRIPTION
I noticed that our cibuildwheel action was really old in #1262, which made me
realise nothing was keeping these up to date. Here's a dependabot that will do
that.
