### PR TITLE
Fix a typo

### DIFF
--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -464,7 +464,7 @@ class IndexedArray(Content):
         i = 0
         while i < len(others):
             other = others[i]
-            if isinstance(other, ak._v2.content.unionarray.UnionArray):
+            if isinstance(other, ak._v2.contents.unionarray.UnionArray):
                 break
             else:
                 head.append(other)


### PR DESCRIPTION
Stumbled upon this while working on dask-awkward. It's getting triggered from an upstream concatenate

<details>
<summary>traceback</summary>

```python
In [40]: da[:, :, "x"]
Out[40]: dask.awkward<getitem, npartitions=2>

In [41]: da[:, :, "x"].compute()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [41], in <module>
----> 1 da[:, :, "x"].compute()

File ~/software/repos/dask/dask/base.py:290, in DaskMethodsMixin.compute(self, **kwargs)
    266 def compute(self, **kwargs):
    267     """Compute this dask collection
    268 
    269     This turns a lazy Dask collection into its in-memory equivalent.
   (...)
    288     dask.base.compute
    289     """
--> 290     (result,) = compute(self, traverse=False, **kwargs)
    291     return result

File ~/software/repos/dask/dask/base.py:574, in compute(traverse, optimize_graph, scheduler, get, *args, **kwargs)
    571     postcomputes.append(x.__dask_postcompute__())
    573 results = schedule(dsk, keys, **kwargs)
--> 574 return repack([f(r, *a) for r, (f, a) in zip(results, postcomputes)])

File ~/software/repos/dask/dask/base.py:574, in <listcomp>(.0)
    571     postcomputes.append(x.__dask_postcompute__())
    573 results = schedule(dsk, keys, **kwargs)
--> 574 return repack([f(r, *a) for r, (f, a) in zip(results, postcomputes)])

File ~/software/repos/dask-awkward/src/dask_awkward/core.py:32, in _finalize_array(results)
     30 def _finalize_array(results: Any) -> Any:
     31     if any(isinstance(r, ak.Array) for r in results):
---> 32         return ak.concatenate(results)
     33     elif len(results) == 1 and isinstance(results[0], int):
     34         return results[0]

File ~/.pyenv/versions/3.10.2/envs/dask-awkward/lib/python3.10/site-packages/awkward/_v2/operations/structure/ak_concatenate.py:90, in concatenate(arrays, axis, merge, mergebool, highlevel, behavior)
     87         collapsed = batch[0].mergemany(batch[1:])
     88         batch = [collapsed.merge_as_union(x)]
---> 90 out = batch[0].mergemany(batch[1:])
     91 if isinstance(out, ak._v2.contents.unionarray.UnionArray):
     92     out = out.simplify_uniontype(merge=merge, mergebool=mergebool)

File ~/.pyenv/versions/3.10.2/envs/dask-awkward/lib/python3.10/site-packages/awkward/_v2/contents/listoffsetarray.py:732, in ListOffsetArray.mergemany(self, others)
    728     return self
    729 listarray = ak._v2.contents.listarray.ListArray(
    730     self.starts, self.stops, self._content, None, self._parameters, self._nplike
    731 )
--> 732 return listarray.mergemany(others)

File ~/.pyenv/versions/3.10.2/envs/dask-awkward/lib/python3.10/site-packages/awkward/_v2/contents/listarray.py:941, in ListArray.mergemany(self, others)
    932         raise ValueError(
    933             "cannot merge "
    934             + type(self).__name__
   (...)
    937             + "."
    938         )
    940 tail_contents = contents[1:]
--> 941 nextcontent = contents[0].mergemany(tail_contents)
    943 nextstarts = ak._v2.index.Index64.empty(total_length, self._nplike)
    944 nextstops = ak._v2.index.Index64.empty(total_length, self._nplike)

File ~/.pyenv/versions/3.10.2/envs/dask-awkward/lib/python3.10/site-packages/awkward/_v2/contents/indexedarray.py:541, in IndexedArray.mergemany(self, others)
    538 if len(others) == 0:
    539     return self
--> 541 head, tail = self._merging_strategy(others)
    543 total_length = 0
    544 for array in head:

File ~/.pyenv/versions/3.10.2/envs/dask-awkward/lib/python3.10/site-packages/awkward/_v2/contents/indexedarray.py:467, in IndexedArray._merging_strategy(self, others)
    465 while i < len(others):
    466     other = others[i]
--> 467     if isinstance(other, ak._v2.content.unionarray.UnionArray):
    468         break
    469     else:

AttributeError: module 'awkward._v2' has no attribute 'content'
```
</details