### PR TITLE
Allow ak.nan_to_num arguments to be arrays.

### DIFF
--- a/src/awkward/_v2/operations/structure/ak_nan_to_num.py
+++ b/src/awkward/_v2/operations/structure/ak_nan_to_num.py
@@ -17,10 +17,10 @@ def nan_to_num(
 #     Args:
 #         array: Array whose `NaN` values should be converted to a number.
 #         copy (bool): Ignored (Awkward Arrays are immutable).
-#         nan (int or float): Value to be used to fill `NaN` values.
-#         posinf (int, float, or None): Value to be used to fill positive infinity
+#         nan (int, float, broadcastable array): Value to be used to fill `NaN` values.
+#         posinf (None, int, float, broadcastable array): Value to be used to fill positive infinity
 #             values. If None, positive infinities are replaced with a very large number.
-#         neginf (int, float, or None): Value to be used to fill negative infinity
+#         neginf (None, int, float, broadcastable array): Value to be used to fill negative infinity
 #             values. If None, negative infinities are replaced with a very small number.
 #         highlevel (bool): If True, return an #ak.Array; otherwise, return
 #             a low-level #ak.layout.Content subclass.
@@ -30,23 +30,85 @@ def nan_to_num(
 #     Implements [np.nan_to_num](https://numpy.org/doc/stable/reference/generated/numpy.nan_to_num.html)
 #     for Awkward Arrays.
 #     """
-#     layout = ak._v2.operations.convert.to_layout(array)
+#     behavior = ak._util.behaviorof(array, behavior=behavior)
+
+#     broadcasting_ids = {}
+#     broadcasting = []
+
+#     layout = ak.operations.convert.to_layout(array)
+#     broadcasting.append(layout)
+
+#     nan_layout = ak.operations.convert.to_layout(nan, allow_other=True)
+#     if isinstance(nan_layout, ak.layout.Content):
+#         broadcasting_ids[id(nan)] = len(broadcasting)
+#         broadcasting.append(nan_layout)
+
+#     posinf_layout = ak.operations.convert.to_layout(posinf, allow_other=True)
+#     if isinstance(posinf_layout, ak.layout.Content):
+#         broadcasting_ids[id(posinf)] = len(broadcasting)
+#         broadcasting.append(posinf_layout)
+
+#     neginf_layout = ak.operations.convert.to_layout(neginf, allow_other=True)
+#     if isinstance(neginf_layout, ak.layout.Content):
+#         broadcasting_ids[id(neginf)] = len(broadcasting)
+#         broadcasting.append(neginf_layout)
+
 #     nplike = ak.nplike.of(layout)
 
-#     def getfunction(layout):
-#         if isinstance(layout, ak._v2.contents.NumpyArray):
-#             return lambda: ak._v2.contents.NumpyArray(
-#                 nplike.nan_to_num(
-#                     nplike.asarray(layout),
-#                     nan=nan,
-#                     posinf=posinf,
-#                     neginf=neginf,
-#                 )
-#             )
-#         else:
-#             return None
+#     if len(broadcasting) == 1:
 
-#     out = ak._v2._util.recursively_apply(
-#         layout, getfunction, pass_depth=False, pass_user=False
-#     )
-#     return ak._v2._util.maybe_wrap_like(out, array, behavior, highlevel)
+#         def getfunction(layout):
+#             if isinstance(layout, ak.layout.NumpyArray):
+#                 return lambda: ak.layout.NumpyArray(
+#                     nplike.nan_to_num(
+#                         nplike.asarray(layout),
+#                         nan=nan,
+#                         posinf=posinf,
+#                         neginf=neginf,
+#                     )
+#                 )
+#             else:
+#                 return None
+
+#         out = ak._util.recursively_apply(
+#             layout, getfunction, pass_depth=False, pass_user=False
+#         )
+
+#     else:
+
+#         def getfunction(inputs):
+#             if all(isinstance(x, ak.layout.NumpyArray) for x in inputs):
+#                 tmp_layout = nplike.asarray(inputs[0])
+#                 if id(nan) in broadcasting_ids:
+#                     tmp_nan = nplike.asarray(inputs[broadcasting_ids[id(nan)]])
+#                 else:
+#                     tmp_nan = nan
+#                 if id(posinf) in broadcasting_ids:
+#                     tmp_posinf = nplike.asarray(inputs[broadcasting_ids[id(posinf)]])
+#                 else:
+#                     tmp_posinf = posinf
+#                 if id(neginf) in broadcasting_ids:
+#                     tmp_neginf = nplike.asarray(inputs[broadcasting_ids[id(neginf)]])
+#                 else:
+#                     tmp_neginf = neginf
+#                 return lambda: (ak.layout.NumpyArray(
+#                     nplike.nan_to_num(
+#                         tmp_layout,
+#                         nan=tmp_nan,
+#                         posinf=tmp_posinf,
+#                         neginf=tmp_neginf,
+#                     )
+#                 ),)
+#             else:
+#                 return None
+
+#         out = ak._util.broadcast_and_apply(
+#             broadcasting,
+#             getfunction,
+#             behavior,
+#             pass_depth=False,
+#         )
+#         assert isinstance(out, tuple) and len(out) == 1
+#         out = out[0]
+
+#     return ak._util.maybe_wrap(out, behavior, highlevel)

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -4419,10 +4419,10 @@ def nan_to_num(
     Args:
         array: Array whose `NaN` values should be converted to a number.
         copy (bool): Ignored (Awkward Arrays are immutable).
-        nan (int or float): Value to be used to fill `NaN` values.
-        posinf (int, float, or None): Value to be used to fill positive infinity
+        nan (int, float, broadcastable array): Value to be used to fill `NaN` values.
+        posinf (None, int, float, broadcastable array): Value to be used to fill positive infinity
             values. If None, positive infinities are replaced with a very large number.
-        neginf (int, float, or None): Value to be used to fill negative infinity
+        neginf (None, int, float, broadcastable array): Value to be used to fill negative infinity
             values. If None, negative infinities are replaced with a very small number.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.layout.Content subclass.
@@ -4432,26 +4432,90 @@ def nan_to_num(
     Implements [np.nan_to_num](https://numpy.org/doc/stable/reference/generated/numpy.nan_to_num.html)
     for Awkward Arrays.
     """
+    behavior = ak._util.behaviorof(array, behavior=behavior)
+
+    broadcasting_ids = {}
+    broadcasting = []
+
     layout = ak.operations.convert.to_layout(array)
+    broadcasting.append(layout)
+
+    nan_layout = ak.operations.convert.to_layout(nan, allow_other=True)
+    if isinstance(nan_layout, ak.layout.Content):
+        broadcasting_ids[id(nan)] = len(broadcasting)
+        broadcasting.append(nan_layout)
+
+    posinf_layout = ak.operations.convert.to_layout(posinf, allow_other=True)
+    if isinstance(posinf_layout, ak.layout.Content):
+        broadcasting_ids[id(posinf)] = len(broadcasting)
+        broadcasting.append(posinf_layout)
+
+    neginf_layout = ak.operations.convert.to_layout(neginf, allow_other=True)
+    if isinstance(neginf_layout, ak.layout.Content):
+        broadcasting_ids[id(neginf)] = len(broadcasting)
+        broadcasting.append(neginf_layout)
+
     nplike = ak.nplike.of(layout)
 
-    def getfunction(layout):
-        if isinstance(layout, ak.layout.NumpyArray):
-            return lambda: ak.layout.NumpyArray(
-                nplike.nan_to_num(
-                    nplike.asarray(layout),
-                    nan=nan,
-                    posinf=posinf,
-                    neginf=neginf,
-                )
-            )
-        else:
-            return None
+    if len(broadcasting) == 1:
 
-    out = ak._util.recursively_apply(
-        layout, getfunction, pass_depth=False, pass_user=False
-    )
-    return ak._util.maybe_wrap_like(out, array, behavior, highlevel)
+        def getfunction(layout):
+            if isinstance(layout, ak.layout.NumpyArray):
+                return lambda: ak.layout.NumpyArray(
+                    nplike.nan_to_num(
+                        nplike.asarray(layout),
+                        nan=nan,
+                        posinf=posinf,
+                        neginf=neginf,
+                    )
+                )
+            else:
+                return None
+
+        out = ak._util.recursively_apply(
+            layout, getfunction, pass_depth=False, pass_user=False
+        )
+
+    else:
+
+        def getfunction(inputs):
+            if all(isinstance(x, ak.layout.NumpyArray) for x in inputs):
+                tmp_layout = nplike.asarray(inputs[0])
+                if id(nan) in broadcasting_ids:
+                    tmp_nan = nplike.asarray(inputs[broadcasting_ids[id(nan)]])
+                else:
+                    tmp_nan = nan
+                if id(posinf) in broadcasting_ids:
+                    tmp_posinf = nplike.asarray(inputs[broadcasting_ids[id(posinf)]])
+                else:
+                    tmp_posinf = posinf
+                if id(neginf) in broadcasting_ids:
+                    tmp_neginf = nplike.asarray(inputs[broadcasting_ids[id(neginf)]])
+                else:
+                    tmp_neginf = neginf
+                return lambda: (
+                    ak.layout.NumpyArray(
+                        nplike.nan_to_num(
+                            tmp_layout,
+                            nan=tmp_nan,
+                            posinf=tmp_posinf,
+                            neginf=tmp_neginf,
+                        )
+                    ),
+                )
+            else:
+                return None
+
+        out = ak._util.broadcast_and_apply(
+            broadcasting,
+            getfunction,
+            behavior,
+            pass_depth=False,
+        )
+        assert isinstance(out, tuple) and len(out) == 1
+        out = out[0]
+
+    return ak._util.maybe_wrap(out, behavior, highlevel)
 
 
 @ak._connect._numpy.implements("isclose")

--- a/tests/test_1298-allow-nan_to_num-arguments-to-be-arrays.py
+++ b/tests/test_1298-allow-nan_to_num-arguments-to-be-arrays.py
@@ -1,0 +1,60 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array(
+        [[1.1, 2.2], [], [3.3, float("nan")], [float("-inf"), float("inf"), 7.7]]
+    )
+
+    assert ak.to_list(
+        np.nan_to_num(array, nan=999, posinf=float("-inf"), neginf=float("inf"))
+    ) == [[1.1, 2.2], [], [3.3, 999.0], [float("inf"), float("-inf"), 7.7]]
+
+    assert ak.to_list(
+        np.nan_to_num(
+            array,
+            nan=[[-1, -2], [], [-3, -4], [-5, -6, -7]],
+            posinf=float("-inf"),
+            neginf=float("inf"),
+        )
+    ) == [[1.1, 2.2], [], [3.3, -4], [float("inf"), float("-inf"), 7.7]]
+
+    assert ak.to_list(
+        np.nan_to_num(
+            array,
+            nan=[[-1, -2], [], [-3, -4], [-5, -6, -7]],
+            posinf=[[1, 2], [], [3, 4], [5, 6, 7]],
+            neginf=float("inf"),
+        )
+    ) == [[1.1, 2.2], [], [3.3, -4], [float("inf"), 6.0, 7.7]]
+
+    assert ak.to_list(
+        np.nan_to_num(
+            array,
+            nan=[[-1, -2], [], [-3, -4], [-5, -6, -7]],
+            posinf=[[1, 2], [], [3, 4], [5, 6, 7]],
+            neginf=[[10, 20], [], [30, 40], [50, 60, 70]],
+        )
+    ) == [[1.1, 2.2], [], [3.3, -4], [50.0, 6.0, 7.7]]
+
+    assert ak.to_list(
+        np.nan_to_num(
+            array,
+            nan=[[-1, -2], [], [-3, -4], [-5, -6, -7]],
+            posinf=float("-inf"),
+            neginf=[[10, 20], [], [30, 40], [50, 60, 70]],
+        )
+    ) == [[1.1, 2.2], [], [3.3, -4], [50.0, float("-inf"), 7.7]]
+
+    assert ak.to_list(
+        np.nan_to_num(
+            array,
+            nan=999,
+            posinf=float("-inf"),
+            neginf=[[10, 20], [], [30, 40], [50, 60, 70]],
+        )
+    ) == [[1.1, 2.2], [], [3.3, 999.0], [50.0, float("-inf"), 7.7]]


### PR DESCRIPTION
This will unblock https://github.com/scikit-hep/vector/pull/172, as soon is it gets into a release.

Rather than change Vector to get non-release candidate versions, I should try to get a release candidate for Awkward out. It's overdue.