### PR TITLE
Implement Awkward --> C++ with Cling.

### DIFF
--- a/src/awkward/_v2/__init__.py
+++ b/src/awkward/_v2/__init__.py
@@ -13,6 +13,7 @@ import awkward._v2._typetracer  # noqa: F401
 
 # internal
 import awkward._v2._util  # noqa: F401
+import awkward._v2._lookup  # noqa: F401
 
 # third-party connectors
 import awkward._v2._connect.numpy

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -160,8 +160,8 @@ class Generator:
 """.strip()
 
     def entry(self, length="length", ptrs="ptrs", flatlist_as_rvec=False):
-        # key = (self, flatlist_as_rvec)
-        return f"awkward::{self.class_type()}(0, {length}, 0, {ptrs})"
+        key = (self, flatlist_as_rvec)
+        return f"awkward::{self.class_type(key)}(0, {length}, 0, {ptrs})"
 
 
 class NumpyArrayGenerator(Generator, ak._v2._lookup.NumpyLookup):
@@ -194,10 +194,10 @@ class NumpyArrayGenerator(Generator, ak._v2._lookup.NumpyLookup):
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         return f"NumpyArray_{self.primitive}_{self.class_type_suffix(self)}"
 
-    def value_type(self):
+    def value_type(self, key):
         return {
             "bool": "bool",
             "int8": "int8_t",
@@ -223,17 +223,17 @@ class NumpyArrayGenerator(Generator, ak._v2._lookup.NumpyLookup):
         if not use_cached or key not in cache:
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
     value_type operator[](size_t at) const noexcept {{
-      return reinterpret_cast<{self.value_type()}*>(ptrs_[which_ + {self.ARRAY}])[start_ + at];
+      return reinterpret_cast<{self.value_type(key)}*>(ptrs_[which_ + {self.ARRAY}])[start_ + at];
     }}
   }};
 }}
@@ -287,11 +287,11 @@ class RegularArrayGenerator(Generator, ak._v2._lookup.RegularLookup):
     def is_flatlist(self):
         return isinstance(self.content, NumpyArrayGenerator)
 
-    def class_type(self):
+    def class_type(self, key):
         return f"RegularArray_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return self.content.class_type()
+    def value_type(self, key):
+        return self.content.class_type(key)
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -303,9 +303,9 @@ class RegularArrayGenerator(Generator, ak._v2._lookup.RegularLookup):
             if self.is_string:
                 out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
     typedef std::string value_type;
@@ -323,13 +323,13 @@ namespace awkward {{
 }}
 """.strip()
             elif flatlist_as_rvec and self.is_flatlist:
-                nested_type = self.content.value_type()
+                nested_type = self.content.value_type(key)
                 value_type = f"ROOT::RVec<{nested_type}>"
                 out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
     typedef {value_type} value_type;
@@ -349,12 +349,12 @@ namespace awkward {{
             else:
                 out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
@@ -427,11 +427,11 @@ class ListArrayGenerator(Generator, ak._v2._lookup.ListLookup):
     def is_flatlist(self):
         return isinstance(self.content, NumpyArrayGenerator)
 
-    def class_type(self):
+    def class_type(self, key):
         return f"ListArray_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return self.content.class_type()
+    def value_type(self, key):
+        return self.content.class_type(key)
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -443,9 +443,9 @@ class ListArrayGenerator(Generator, ak._v2._lookup.ListLookup):
             if self.is_string:
                 out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
     typedef std::string value_type;
@@ -463,13 +463,13 @@ namespace awkward {{
 }}
 """.strip()
             elif flatlist_as_rvec and self.is_flatlist:
-                nested_type = self.content.value_type()
+                nested_type = self.content.value_type(key)
                 value_type = f"ROOT::RVec<{nested_type}>"
                 out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
     typedef {value_type} value_type;
@@ -489,12 +489,12 @@ namespace awkward {{
             else:
                 out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
@@ -553,11 +553,11 @@ class IndexedArrayGenerator(Generator, ak._v2._lookup.IndexedLookup):
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         return f"IndexedArray_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return self.content.value_type()
+    def value_type(self, key):
+        return self.content.value_type(key)
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -567,18 +567,18 @@ class IndexedArrayGenerator(Generator, ak._v2._lookup.IndexedLookup):
         if not use_cached or key not in cache:
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
     value_type operator[](size_t at) const noexcept {{
       ssize_t index = reinterpret_cast<{self.index_type}*>(ptrs_[which_ + {self.INDEX}])[start_ + at];
-      return {self.content.class_type()}(index, index + 1, ptrs_[which_ + {self.CONTENT}], ptrs_)[0];
+      return {self.content.class_type(key)}(index, index + 1, ptrs_[which_ + {self.CONTENT}], ptrs_)[0];
     }}
   }};
 }}
@@ -628,11 +628,11 @@ class IndexedOptionArrayGenerator(Generator, ak._v2._lookup.IndexedOptionLookup)
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         return f"IndexedOptionArray_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return f"std::optional<{self.content.value_type()}>"
+    def value_type(self, key):
+        return f"std::optional<{self.content.value_type(key)}>"
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -642,19 +642,19 @@ class IndexedOptionArrayGenerator(Generator, ak._v2._lookup.IndexedOptionLookup)
         if not use_cached or key not in cache:
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
     value_type operator[](size_t at) const noexcept {{
       ssize_t index = reinterpret_cast<{self.index_type}*>(ptrs_[which_ + {self.INDEX}])[start_ + at];
       if (index >= 0) {{
-        return value_type{{ {self.content.class_type()}(index, index + 1, ptrs_[which_ + {self.CONTENT}], ptrs_)[0] }};
+        return value_type{{ {self.content.class_type(key)}(index, index + 1, ptrs_[which_ + {self.CONTENT}], ptrs_)[0] }};
       }}
       else {{
         return std::nullopt;
@@ -703,11 +703,11 @@ class ByteMaskedArrayGenerator(Generator, ak._v2._lookup.ByteMaskedLookup):
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         return f"ByteMaskedArray_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return f"std::optional<{self.content.value_type()}>"
+    def value_type(self, key):
+        return f"std::optional<{self.content.value_type(key)}>"
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -717,19 +717,19 @@ class ByteMaskedArrayGenerator(Generator, ak._v2._lookup.ByteMaskedLookup):
         if not use_cached or key not in cache:
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
     value_type operator[](size_t at) const noexcept {{
       int8_t mask = reinterpret_cast<int8_t*>(ptrs_[which_ + {self.MASK}])[start_ + at];
       if ({"mask != 0" if self.valid_when else "mask == 0"}) {{
-        return value_type{{ {self.content.class_type()}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_)[at] }};
+        return value_type{{ {self.content.class_type(key)}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_)[at] }};
       }}
       else {{
         return std::nullopt;
@@ -781,11 +781,11 @@ class BitMaskedArrayGenerator(Generator, ak._v2._lookup.BitMaskedLookup):
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         return f"BitMaskedArray_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return f"std::optional<{self.content.value_type()}>"
+    def value_type(self, key):
+        return f"std::optional<{self.content.value_type(key)}>"
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -795,12 +795,12 @@ class BitMaskedArrayGenerator(Generator, ak._v2._lookup.BitMaskedLookup):
         if not use_cached or key not in cache:
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
@@ -812,7 +812,7 @@ namespace awkward {{
       uint8_t mask = {"(byte >> shift) & 1" if self.lsb_order else "(byte << shift) & 128"};
 
       if ({"mask != 0" if self.valid_when else "mask == 0"}) {{
-        return value_type{{ {self.content.class_type()}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_)[at] }};
+        return value_type{{ {self.content.class_type(key)}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_)[at] }};
       }}
       else {{
         return std::nullopt;
@@ -850,11 +850,11 @@ class UnmaskedArrayGenerator(Generator, ak._v2._lookup.UnmaskedLookup):
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         return f"UnmaskedArray_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return f"std::optional<{self.content.value_type()}>"
+    def value_type(self, key):
+        return f"std::optional<{self.content.value_type(key)}>"
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -864,17 +864,17 @@ class UnmaskedArrayGenerator(Generator, ak._v2._lookup.UnmaskedLookup):
         if not use_cached or key not in cache:
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
     value_type operator[](size_t at) const noexcept {{
-      return value_type{{ {self.content.class_type()}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_)[at] }};
+      return value_type{{ {self.content.class_type(key)}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_)[at] }};
     }}
   }};
 }}
@@ -907,7 +907,7 @@ class RecordGenerator(Generator, ak._v2._lookup.RecordLookup):
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         if (
             isinstance(self.parameters, dict)
             and self.parameters.get("__record__") is not None
@@ -938,8 +938,8 @@ class RecordGenerator(Generator, ak._v2._lookup.RecordLookup):
                 if re.match("^[A-Za-z_][A-Za-z_0-9]*$", fieldname) is not None:
                     getfields.append(
                         f"""
-    {content.value_type()} {fieldname}() const noexcept {{
-      return {content.class_type()}(at_, at_ + 1, ptrs_[which_ + {self.CONTENTS + i}], ptrs_)[0];
+    {content.value_type(key)} {fieldname}() const noexcept {{
+      return {content.class_type(key)}(at_, at_ + 1, ptrs_[which_ + {self.CONTENTS + i}], ptrs_)[0];
     }}
 """.strip()
                     )
@@ -947,9 +947,9 @@ class RecordGenerator(Generator, ak._v2._lookup.RecordLookup):
             eoln = "\n    "
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public RecordView {{
+  class {self.class_type(key)}: public RecordView {{
   public:
-    {self.class_type()}(ssize_t at, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t at, ssize_t which, ssize_t* ptrs)
       : RecordView(at, which, ptrs) {{ }}
 
     const std::string parameter(const std::string& parameter) const noexcept {{
@@ -1002,7 +1002,7 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         if (
             isinstance(self.parameters, dict)
             and self.parameters.get("__record__") is not None
@@ -1012,8 +1012,8 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
             insert = ""
         return f"RecordArray{insert}_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return self.record.class_type()
+    def value_type(self, key):
+        return self.record.class_type(key)
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -1023,12 +1023,12 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
         if not use_cached or key not in cache:
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
@@ -1085,11 +1085,11 @@ class UnionArrayGenerator(Generator, ak._v2._lookup.UnionLookup):
             and self.parameters == other.parameters
         )
 
-    def class_type(self):
+    def class_type(self, key):
         return f"UnionArray_{self.class_type_suffix(self)}"
 
-    def value_type(self):
-        return f"std::variant<{','.join(x.value_type() for x in self.contents)}>"
+    def value_type(self, key):
+        return f"std::variant<{','.join(x.value_type(key) for x in self.contents)}>"
 
     def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
         generate_ArrayView(compiler, use_cached=use_cached)
@@ -1103,19 +1103,19 @@ class UnionArrayGenerator(Generator, ak._v2._lookup.UnionLookup):
                 cases.append(
                     f"""
         case {i}:
-          return value_type{{ {content.class_type()}(index, index + 1, ptrs_[which_ + {self.CONTENTS + i}], ptrs_)[0] }};
+          return value_type{{ {content.class_type(key)}(index, index + 1, ptrs_[which_ + {self.CONTENTS + i}], ptrs_)[0] }};
 """.strip()
                 )
 
             eoln = "\n        "
             out = f"""
 namespace awkward {{
-  class {self.class_type()}: public ArrayView {{
+  class {self.class_type(key)}: public ArrayView {{
   public:
-    {self.class_type()}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    {self.class_type(key)}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
       : ArrayView(start, stop, which, ptrs) {{ }}
 
-    typedef {self.value_type()} value_type;
+    typedef {self.value_type(key)} value_type;
 
     {self._generate_common()}
 
@@ -1125,7 +1125,7 @@ namespace awkward {{
       switch (tag) {{
         {eoln.join(cases)}
         default:
-          return value_type{{ {self.contents[0].class_type()}(index, index + 1, ptrs_[which_ + {self.CONTENTS + 0}], ptrs_)[0] }};
+          return value_type{{ {self.contents[0].class_type(key)}(index, index + 1, ptrs_[which_ + {self.CONTENTS + 0}], ptrs_)[0] }};
       }}
     }}
   }};

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -1,0 +1,6 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+# import ROOT
+
+# This is where I'll make Awkward Arrays iterable in C++.
+# It will be needed for @ianna's Awkward --> RDataFrame conversions.

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -82,7 +82,7 @@ namespace awkward {
 
 def togenerator(form):
     if isinstance(form, ak._v2.forms.EmptyForm):
-        return togenerator(form.toEmptyForm(np.dtype(np.float64)))
+        return togenerator(form.toNumpyForm(np.dtype(np.float64)))
 
     elif isinstance(form, ak._v2.forms.NumpyForm):
         if len(form.inner_shape) == 0:
@@ -692,10 +692,12 @@ namespace awkward {{
     {self._generate_common()}
 
     value_type operator[](size_t at) const noexcept {{
-      size_t bitat = at / 8;
-      size_t shift = at % 8;
-      uint8_t byte = reinterpret_cast<uint8_t*>(ptrs_[which_ + {self.MASK}])[start_ + bitat];
+      size_t startat = start_ + at;
+      size_t bitat = startat / 8;
+      size_t shift = startat % 8;
+      uint8_t byte = reinterpret_cast<uint8_t*>(ptrs_[which_ + {self.MASK}])[bitat];
       uint8_t mask = {"(byte >> shift) & 1" if self.lsb_order else "(byte << shift) & 128"};
+
       if ({"mask != 0" if self.valid_when else "mask == 0"}) {{
         return value_type{{ {self.content.class_type}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_)[at] }};
       }}

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -1,6 +1,545 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-# import ROOT
+import base64
+import struct
 
-# This is where I'll make Awkward Arrays iterable in C++.
-# It will be needed for @ianna's Awkward --> RDataFrame conversions.
+import awkward as ak
+
+np = ak.nplike.NumpyMetadata.instance()
+
+
+cache = {}
+
+
+def generate_ArrayView(compiler, use_cached=True):
+    key = "ArrayView"
+    if use_cached:
+        out = cache.get(key)
+    else:
+        out = None
+
+    if out is None:
+        cache[
+            key
+        ] = out = """
+namespace awkward {
+  class ArrayView {
+  public:
+    ArrayView(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+      : start_(start), stop_(stop), which_(which), ptrs_(ptrs) { }
+
+  protected:
+    ssize_t start_;
+    ssize_t stop_;
+    ssize_t which_;
+    ssize_t* ptrs_;
+  };
+}
+""".strip()
+        compiler(out)
+
+    return out
+
+
+def generate_RecordView(compiler, use_cached=True):
+    key = "RecordView"
+    if use_cached:
+        out = cache.get(key)
+    else:
+        out = None
+
+    if out is None:
+        cache[
+            key
+        ] = out = """
+namespace awkward {
+  class RecordView {
+  public:
+    ArrayView(ssize_t at, ssize_t which, ssize_t* ptrs)
+      : at_(at), which_(which), ptrs_(ptrs) { }
+
+  protected:
+    ssize_t at_;
+    ssize_t which_;
+    ssize_t* ptrs_;
+  };
+}
+""".strip()
+        compiler(out)
+
+    return out
+
+
+def togenerator(form):
+    if isinstance(form, ak._v2.forms.EmptyForm):
+        return togenerator(form.toEmptyForm(np.dtype(np.float64)))
+
+    elif isinstance(form, ak._v2.forms.NumpyForm):
+        if len(form.inner_shape) == 0:
+            return NumpyGenerator.from_form(form)
+        else:
+            return togenerator(form.toRegularForm())
+
+    elif isinstance(form, ak._v2.forms.RegularForm):
+        return RegularGenerator.from_form(form)
+
+    elif isinstance(form, (ak._v2.forms.ListForm, ak._v2.forms.ListOffsetForm)):
+        return ListGenerator.from_form(form)
+
+    elif isinstance(form, ak._v2.forms.IndexedForm):
+        return IndexedGenerator.from_form(form)
+
+    elif isinstance(form, ak._v2.forms.IndexedOptionForm):
+        return IndexedOptionGenerator.from_form(form)
+
+    elif isinstance(form, ak._v2.forms.ByteMaskedForm):
+        return ByteMaskedGenerator.from_form(form)
+
+    elif isinstance(form, ak._v2.forms.BitMaskedForm):
+        return BitMaskedGenerator.from_form(form)
+
+    elif isinstance(form, ak._v2.forms.UnmaskedForm):
+        return UnmaskedGenerator.from_form(form)
+
+    elif isinstance(form, ak._v2.forms.RecordForm):
+        return RecordGenerator.from_form(form)
+
+    elif isinstance(form, ak._v2.forms.UnionForm):
+        return UnionGenerator.from_form(form)
+
+    else:
+        raise AssertionError(f"unrecognized Form: {type(form)}")
+
+
+class Generator:
+    @classmethod
+    def form_from_identifier(cls, form):
+        if not form.has_identifier:
+            return None
+        else:
+            raise NotImplementedError("TODO: identifiers in C++")
+
+    @property
+    def name_suffix(self):
+        return (
+            base64.encodebytes(struct.pack("q", hash(self)))
+            .rstrip(b"=\n")
+            .replace(b"+", b"")
+            .replace(b"/", b"")
+            .decode("ascii")
+        )
+
+    def generate(self, compiler, use_cached=True, flatlist_as_rvec=False):
+        generate_ArrayView(compiler, use_cached=True)
+
+        optionnames = ("flatlist_as_rvec",)
+        options = (flatlist_as_rvec,)
+
+        key = (self, options)
+        if use_cached:
+            out = cache.get(key)
+        else:
+            out = None
+
+        if out is None:
+            cache[key] = out = self._generate(dict(zip(optionnames, options)))
+            eoln = "\n"
+            compiler(
+                f"""
+namespace awkward {{
+  {out.replace(eoln, eoln + "  ")}
+}}
+""".strip()
+            )
+        return out
+
+    def entry(self, length="length", ptrs="ptrs"):
+        return f"awkward::{self.name}(0, {length}, 0, {ptrs})"
+
+
+class NumpyGenerator(Generator, ak._v2._lookup.NumpyLookup):
+    @classmethod
+    def from_form(cls, form):
+        return NumpyGenerator(
+            form.primitive, cls.form_from_identifier(form), form.parameters
+        )
+
+    def __init__(self, primitive, identifier, parameters):
+        self.primitive = primitive
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.primitive,
+                self.identifier,
+                tuple(self.parameters.items()),
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.primitive == other.primitive
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+    @property
+    def name(self):
+        return f"NumpyArray_{self.primitive}_{self.name_suffix}"
+
+    @property
+    def itemtype(self):
+        return {
+            "bool": "bool",
+            "int8": "int8_t",
+            "uint8": "uint8_t",
+            "int16": "int16_t",
+            "uint16": "uint16_t",
+            "int32": "int32_t",
+            "uint32": "uint32_t",
+            "int64": "int64_t",
+            "uint64": "uint64_t",
+            "float32": "float",
+            "float64": "double",
+            "complex64": "std::complex<float>",
+            "complex128": "std::complex<double>",
+            "datetime64": "std::time_point",
+            "timedelta64": "std::duration",
+        }[self.primitive]
+
+    def _generate(self, options):
+        return f"""
+class {self.name}: public ArrayView {{
+public:
+  {self.name}(ssize_t start, ssize_t stop, ssize_t which, ssize_t* ptrs)
+    : ArrayView(start, stop, which, ptrs) {{ }}
+
+  {self.itemtype} operator[](ssize_t at) {{
+    return 123;
+  }}
+}};
+""".strip()
+
+
+class RegularGenerator(Generator, ak._v2._lookup.RegularLookup):
+    @classmethod
+    def from_form(cls, form):
+        return RegularGenerator(
+            togenerator(form.content),
+            form.size,
+            cls.form_from_identifier(form),
+            form.parameters,
+        )
+
+    def __init__(self, content, size, identifier, parameters):
+        self.content = content
+        self.size = size
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.content,
+                self.size,
+                self.identifier,
+                tuple(self.parameters.items()),
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.content == other.content
+            and self.size == other.size
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+
+class ListGenerator(Generator, ak._v2._lookup.ListLookup):
+    @classmethod
+    def from_form(cls, form):
+        if isinstance(form, ak._v2.forms.ListForm):
+            index_string = form.starts
+        else:
+            index_string = form.offsets
+
+        return ListGenerator(
+            index_string,
+            togenerator(form.content),
+            cls.form_from_identifier(form),
+            form.parameters,
+        )
+
+    def __init__(self, indextype, content, identifier, parameters):
+        self.indextype = indextype
+        self.content = content
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.indextype,
+                self.content,
+                self.identifier,
+                tuple(self.parameters.items()),
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.indextype == other.indextype
+            and self.content == other.content
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+
+class IndexedGenerator(Generator, ak._v2._lookup.IndexedLookup):
+    @classmethod
+    def from_form(cls, form):
+        return IndexedGenerator(
+            form.index,
+            togenerator(form.content),
+            cls.form_from_identifier(form),
+            form.parameters,
+        )
+
+    def __init__(self, indextype, content, identifier, parameters):
+        self.indextype = indextype
+        self.content = content
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.indextype,
+                self.content,
+                self.identifier,
+                tuple(self.parameters.items()),
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.indextype == other.indextype
+            and self.content == other.content
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+
+class IndexedOptionGenerator(Generator, ak._v2._lookup.IndexedOptionLookup):
+    @classmethod
+    def from_form(cls, form):
+        return IndexedOptionGenerator(
+            form.index,
+            togenerator(form.content),
+            cls.form_from_identifier(form),
+            form.parameters,
+        )
+
+    def __init__(self, indextype, content, identifier, parameters):
+        self.indextype = indextype
+        self.content = content
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.indextype,
+                self.content,
+                self.identifier,
+                tuple(self.parameters.items()),
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.indextype == other.indextype
+            and self.content == other.content
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+
+class ByteMaskedGenerator(Generator, ak._v2._lookup.ByteMaskedLookup):
+    @classmethod
+    def from_form(cls, form):
+        return ByteMaskedGenerator(
+            togenerator(form.content),
+            form.valid_when,
+            cls.form_from_identifier(form),
+            form.parameters,
+        )
+
+    def __init__(self, content, valid_when, identifier, parameters):
+        self.content = content
+        self.valid_when = valid_when
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.content,
+                self.valid_when,
+                self.identifier,
+                tuple(self.parameters.items()),
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.content == other.content
+            and self.valid_when == other.valid_when
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+
+class BitMaskedGenerator(Generator, ak._v2._lookup.BitMaskedLookup):
+    @classmethod
+    def from_form(cls, form):
+        return BitMaskedGenerator(
+            togenerator(form.content),
+            form.valid_when,
+            form.lsb_order,
+            cls.form_from_identifier(form),
+            form.parameters,
+        )
+
+    def __init__(self, content, valid_when, lsb_order, identifier, parameters):
+        self.content = content
+        self.valid_when = valid_when
+        self.lsb_order = lsb_order
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                self.content,
+                self.valid_when,
+                self.lsb_order,
+                self.identifier,
+                self.parameters,
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.content == other.content
+            and self.valid_when == other.valid_when
+            and self.lsb_order == other.lsb_order
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+
+class UnmaskedGenerator(Generator, ak._v2._lookup.UnmaskedLookup):
+    @classmethod
+    def from_form(cls, form):
+        return UnmaskedGenerator(
+            togenerator(form.content), cls.form_from_identifier(form), form.parameters
+        )
+
+    def __init__(self, content, identifier, parameters):
+        self.content = content
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (type(self), self.content, self.identifier, tuple(self.parameters.items()))
+        )
+
+    def __eq__(self, other):
+        return (
+            self.content == other.content
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+
+class RecordGenerator(Generator, ak._v2._lookup.RecordLookup):
+    @classmethod
+    def from_form(cls, form):
+        return RecordGenerator(
+            [togenerator(x) for x in form.contents],
+            None if form.is_tuple else form.fields,
+            cls.form_from_identifier(form),
+            form.parameters,
+        )
+
+    def __init__(self, contents, fields, identifier, parameters):
+        self.contents = contents
+        self.fields = fields
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.contents,
+                self.fields,
+                self.identifier,
+                tuple(self.parameters.items()),
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.contents == other.contents
+            and self.fields == other.fields
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )
+
+
+class UnionGenerator(Generator, ak._v2._lookup.UnionLookup):
+    @classmethod
+    def from_form(cls, form):
+        return UnionGenerator(
+            form.index,
+            [togenerator(x) for x in form.contents],
+            cls.form_from_identifier(form),
+            form.parameters,
+        )
+
+    def __init__(self, indextype, contents, identifier, parameters):
+        self.indextype = indextype
+        self.contents = contents
+        self.identifier = identifier
+        self.parameters = parameters
+
+    def __hash__(self):
+        return hash(
+            (
+                type(self),
+                self.indextype,
+                self.contents,
+                self.identifier,
+                tuple(self.parameters.items()),
+            )
+        )
+
+    def __eq__(self, other):
+        return (
+            self.indextype == other.indextype
+            and self.contents == other.contents
+            and self.identifier == other.identifier
+            and self.parameters == other.parameters
+        )

--- a/src/awkward/_v2/_connect/numba/arrayview.py
+++ b/src/awkward/_v2/_connect/numba/arrayview.py
@@ -10,8 +10,6 @@ import awkward as ak
 
 np = ak.nplike.NumpyMetadata.instance()
 
-########## for code that's built up from strings
-
 
 def code_to_function(code, function_name, externals=None, debug=False):
     if debug:
@@ -20,83 +18,6 @@ def code_to_function(code, function_name, externals=None, debug=False):
     namespace = {} if externals is None else dict(externals)
     exec(code, namespace)
     return namespace[function_name]
-
-
-########## Lookup
-
-
-class Lookup:
-    def __init__(self, layout):
-        positions = []
-        tolookup(layout, positions)
-
-        def arrayptr(x):
-            if isinstance(x, int):
-                return x
-            else:
-                return x.ctypes.data
-
-        self.nplike = layout.nplike
-        self.positions = positions
-        self.arrayptrs = self.nplike.array(
-            [arrayptr(x) for x in positions], dtype=np.intp
-        )
-
-
-def tolookup(layout, positions):
-    if isinstance(layout, ak._v2.contents.EmptyArray):
-        return tolookup(layout.toNumpyArray(np.dtype(np.float64)), positions)
-
-    elif isinstance(layout, ak._v2.contents.NumpyArray):
-        if len(layout.shape) == 1:
-            return ak._v2._connect.numba.layout.NumpyArrayType.tolookup(
-                layout, positions
-            )
-        else:
-            return tolookup(layout.toRegularArray(), positions)
-
-    elif isinstance(layout, ak._v2.contents.RegularArray):
-        return ak._v2._connect.numba.layout.RegularArrayType.tolookup(layout, positions)
-
-    elif isinstance(
-        layout, (ak._v2.contents.ListArray, ak._v2.contents.ListOffsetArray)
-    ):
-        return ak._v2._connect.numba.layout.ListArrayType.tolookup(layout, positions)
-
-    elif isinstance(layout, ak._v2.contents.IndexedArray):
-        return ak._v2._connect.numba.layout.IndexedArrayType.tolookup(layout, positions)
-
-    elif isinstance(layout, ak._v2.contents.IndexedOptionArray):
-        return ak._v2._connect.numba.layout.IndexedOptionArrayType.tolookup(
-            layout, positions
-        )
-
-    elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
-        return ak._v2._connect.numba.layout.ByteMaskedArrayType.tolookup(
-            layout, positions
-        )
-
-    elif isinstance(layout, ak._v2.contents.BitMaskedArray):
-        return ak._v2._connect.numba.layout.BitMaskedArrayType.tolookup(
-            layout, positions
-        )
-
-    elif isinstance(layout, ak._v2.contents.UnmaskedArray):
-        return ak._v2._connect.numba.layout.UnmaskedArrayType.tolookup(
-            layout, positions
-        )
-
-    elif isinstance(layout, ak._v2.contents.RecordArray):
-        return ak._v2._connect.numba.layout.RecordArrayType.tolookup(layout, positions)
-
-    elif isinstance(layout, ak._v2.record.Record):
-        return ak._v2._connect.numba.layout.RecordType.tolookup(layout, positions)
-
-    elif isinstance(layout, ak._v2.contents.UnionArray):
-        return ak._v2._connect.numba.layout.UnionArrayType.tolookup(layout, positions)
-
-    else:
-        raise AssertionError(f"unrecognized Content or Record: {type(layout)}")
 
 
 def tonumbatype(form):
@@ -140,7 +61,10 @@ def tonumbatype(form):
         raise AssertionError(f"unrecognized Form: {type(form)}")
 
 
-@numba.extending.typeof_impl.register(Lookup)
+########## Lookup
+
+
+@numba.extending.typeof_impl.register(ak._v2._lookup.Lookup)
 def typeof_Lookup(obj, c):
     return LookupType()
 
@@ -188,7 +112,13 @@ class ArrayView:
             numpytype=(np.number, np.bool_, np.datetime64, np.timedelta64),
         )
         return ArrayView(
-            tonumbatype(layout.form), behavior, Lookup(layout), 0, 0, len(layout), ()
+            tonumbatype(layout.form),
+            behavior,
+            ak._v2._lookup.Lookup(layout),
+            0,
+            0,
+            len(layout),
+            (),
         )
 
     def __init__(self, type, behavior, lookup, pos, start, stop, fields):
@@ -578,7 +508,7 @@ class RecordView:
             ArrayView(
                 tonumbatype(arraylayout.form),
                 behavior,
-                Lookup(arraylayout),
+                ak._v2._lookup.Lookup(arraylayout),
                 0,
                 0,
                 len(arraylayout),

--- a/src/awkward/_v2/_connect/numba/arrayview.py
+++ b/src/awkward/_v2/_connect/numba/arrayview.py
@@ -22,7 +22,7 @@ def code_to_function(code, function_name, externals=None, debug=False):
 
 def tonumbatype(form):
     if isinstance(form, ak._v2.forms.EmptyForm):
-        return tonumbatype(form.toEmptyForm(np.dtype(np.float64)))
+        return tonumbatype(form.toNumpyForm(np.dtype(np.float64)))
 
     elif isinstance(form, ak._v2.forms.NumpyForm):
         if len(form.inner_shape) == 0:

--- a/src/awkward/_v2/_connect/numba/layout.py
+++ b/src/awkward/_v2/_connect/numba/layout.py
@@ -896,18 +896,19 @@ class BitMaskedArrayType(ContentType, ak._v2._lookup.BitMaskedLookup):
         atval = regularize_atval(
             context, builder, viewproxy, attype, atval, wrapneg, checkbounds
         )
-        bitatval = builder.sdiv(atval, context.get_constant(numba.intp, 8))
+        startatval = builder.add(viewproxy.start, atval)
+        bitatval = builder.sdiv(startatval, context.get_constant(numba.intp, 8))
         shiftval = castint(
             context,
             builder,
             numba.intp,
             numba.uint8,
-            builder.srem(atval, context.get_constant(numba.intp, 8)),
+            builder.srem(startatval, context.get_constant(numba.intp, 8)),
         )
 
         maskpos = posat(context, builder, viewproxy.pos, self.MASK)
         maskptr = getat(context, builder, viewproxy.arrayptrs, maskpos)
-        maskarraypos = builder.add(viewproxy.start, bitatval)
+        maskarraypos = bitatval
         byte = getat(
             context, builder, maskptr, maskarraypos, rettype=self.masktype.dtype
         )

--- a/src/awkward/_v2/_connect/numba/layout.py
+++ b/src/awkward/_v2/_connect/numba/layout.py
@@ -45,20 +45,6 @@ class ContentType(numba.types.Type):
         else:
             raise AssertionError(f"unrecognized Form index type: {index_string!r}")
 
-    def IndexOf(self, arraytype):
-        if arraytype.dtype.bitwidth == 8 and arraytype.dtype.signed:
-            return ak._v2.index.Index8
-        elif arraytype.dtype.bitwidth == 8:
-            return ak._v2.index.IndexU8
-        elif arraytype.dtype.bitwidth == 32 and arraytype.dtype.signed:
-            return ak._v2.index.Index32
-        elif arraytype.dtype.bitwidth == 32:
-            return ak._v2.index.IndexU32
-        elif arraytype.dtype.bitwidth == 64:
-            return ak._v2.index.Index64
-        else:
-            raise AssertionError(f"no Index* type for array: {arraytype}")
-
     def getitem_at_check(self, viewtype):
         typer = ak._v2._util.numba_array_typer(viewtype.type, viewtype.behavior)
         if typer is None:

--- a/src/awkward/_v2/_connect/numba/layout.py
+++ b/src/awkward/_v2/_connect/numba/layout.py
@@ -24,13 +24,6 @@ def fake_typeof(obj, c):
 
 class ContentType(numba.types.Type):
     @classmethod
-    def tolookup_identifier(cls, layout, positions):
-        if layout.identifier is None:
-            positions.append(-1)
-        else:
-            positions.append(layout.identifier.data)
-
-    @classmethod
     def from_form_identifier(cls, form):
         if not form.has_identifier:
             return numba.none
@@ -273,17 +266,7 @@ def regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkb
     return castint(context, builder, atval.type, numba.intp, atval)
 
 
-class NumpyArrayType(ContentType):
-    IDENTIFIER = 0
-    ARRAY = 1
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(layout.contiguous().data)
-        return pos
-
+class NumpyArrayType(ContentType, ak._v2._lookup.NumpyLookup):
     @classmethod
     def from_form(cls, form):
         t = numba.from_dtype(ak._v2.types.numpytype.primitive_to_dtype(form.primitive))
@@ -301,13 +284,6 @@ class NumpyArrayType(ContentType):
         self.arraytype = arraytype
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        assert fields == ()
-        return ak._v2.contents.NumpyArray(
-            lookup.positions[pos + self.ARRAY], parameters=self.parameters
-        )
 
     def has_field(self, key):
         return False
@@ -353,22 +329,7 @@ class NumpyArrayType(ContentType):
         return False
 
 
-class RegularArrayType(ContentType):
-    IDENTIFIER = 0
-    ZEROS_LENGTH = 1
-    CONTENT = 2
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(len(layout))
-        positions.append(None)
-        positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
-            layout.content, positions
-        )
-        return pos
-
+class RegularArrayType(ContentType, ak._v2._lookup.RegularLookup):
     @classmethod
     def from_form(cls, form):
         return RegularArrayType(
@@ -388,18 +349,6 @@ class RegularArrayType(ContentType):
         self.size = size
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        content = self.contenttype.tolayout(
-            lookup, lookup.positions[pos + self.CONTENT], fields
-        )
-        return ak._v2.contents.RegularArray(
-            content,
-            self.size,
-            lookup.positions[pos + self.ZEROS_LENGTH],
-            parameters=self.parameters,
-        )
 
     def has_field(self, key):
         return self.contenttype.has_field(key)
@@ -458,24 +407,7 @@ class RegularArrayType(ContentType):
         return False
 
 
-class ListArrayType(ContentType):
-    IDENTIFIER = 0
-    STARTS = 1
-    STOPS = 2
-    CONTENT = 3
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(layout.starts.data)
-        positions.append(layout.stops.data)
-        positions.append(None)
-        positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
-            layout.content, positions
-        )
-        return pos
-
+class ListArrayType(ContentType, ak._v2._lookup.ListLookup):
     @classmethod
     def from_form(cls, form):
         if isinstance(form, ak._v2.forms.ListForm):
@@ -503,17 +435,6 @@ class ListArrayType(ContentType):
         self.contenttype = contenttype
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        starts = self.IndexOf(self.indextype)(lookup.positions[pos + self.STARTS])
-        stops = self.IndexOf(self.indextype)(lookup.positions[pos + self.STOPS])
-        content = self.contenttype.tolayout(
-            lookup, lookup.positions[pos + self.CONTENT], fields
-        )
-        return ak._v2.contents.ListArray(
-            starts, stops, content, parameters=self.parameters
-        )
 
     def has_field(self, key):
         return self.contenttype.has_field(key)
@@ -584,22 +505,7 @@ class ListArrayType(ContentType):
         return False
 
 
-class IndexedArrayType(ContentType):
-    IDENTIFIER = 0
-    INDEX = 1
-    CONTENT = 2
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(layout.index.data)
-        positions.append(None)
-        positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
-            layout.content, positions
-        )
-        return pos
-
+class IndexedArrayType(ContentType, ak._v2._lookup.IndexedLookup):
     @classmethod
     def from_form(cls, form):
         return IndexedArrayType(
@@ -622,14 +528,6 @@ class IndexedArrayType(ContentType):
         self.contenttype = contenttype
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
-        content = self.contenttype.tolayout(
-            lookup, lookup.positions[pos + self.CONTENT], fields
-        )
-        return ak._v2.contents.IndexedArray(index, content, parameters=self.parameters)
 
     def has_field(self, key):
         return self.contenttype.has_field(key)
@@ -710,22 +608,7 @@ class IndexedArrayType(ContentType):
         return self.contenttype.is_recordtype
 
 
-class IndexedOptionArrayType(ContentType):
-    IDENTIFIER = 0
-    INDEX = 1
-    CONTENT = 2
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(layout.index.data)
-        positions.append(None)
-        positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
-            layout.content, positions
-        )
-        return pos
-
+class IndexedOptionArrayType(ContentType, ak._v2._lookup.IndexedOptionLookup):
     @classmethod
     def from_form(cls, form):
         return IndexedOptionArrayType(
@@ -748,16 +631,6 @@ class IndexedOptionArrayType(ContentType):
         self.contenttype = contenttype
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
-        content = self.contenttype.tolayout(
-            lookup, lookup.positions[pos + self.CONTENT], fields
-        )
-        return ak._v2.contents.IndexedOptionArray(
-            index, content, parameters=self.parameters
-        )
 
     def has_field(self, key):
         return self.contenttype.has_field(key)
@@ -855,22 +728,7 @@ class IndexedOptionArrayType(ContentType):
         return self.contenttype.is_recordtype
 
 
-class ByteMaskedArrayType(ContentType):
-    IDENTIFIER = 0
-    MASK = 1
-    CONTENT = 2
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(layout.mask.data)
-        positions.append(None)
-        positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
-            layout.content, positions
-        )
-        return pos
-
+class ByteMaskedArrayType(ContentType, ak._v2._lookup.ByteMaskedLookup):
     @classmethod
     def from_form(cls, form):
         return ByteMaskedArrayType(
@@ -896,16 +754,6 @@ class ByteMaskedArrayType(ContentType):
         self.valid_when = valid_when
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        mask = self.IndexOf(self.masktype)(lookup.positions[pos + self.MASK])
-        content = self.contenttype.tolayout(
-            lookup, lookup.positions[pos + self.CONTENT], fields
-        )
-        return ak._v2.contents.ByteMaskedArray(
-            mask, content, self.valid_when, parameters=self.parameters
-        )
 
     def has_field(self, key):
         return self.contenttype.has_field(key)
@@ -1002,24 +850,7 @@ class ByteMaskedArrayType(ContentType):
         return self.contenttype.is_recordtype
 
 
-class BitMaskedArrayType(ContentType):
-    IDENTIFIER = 0
-    LENGTH = 1
-    MASK = 2
-    CONTENT = 3
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(len(layout))
-        positions.append(layout.mask.data)
-        positions.append(None)
-        positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
-            layout.content, positions
-        )
-        return pos
-
+class BitMaskedArrayType(ContentType, ak._v2._lookup.BitMaskedLookup):
     @classmethod
     def from_form(cls, form):
         return BitMaskedArrayType(
@@ -1050,21 +881,6 @@ class BitMaskedArrayType(ContentType):
         self.lsb_order = lsb_order
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        mask = self.IndexOf(self.masktype)(lookup.positions[pos + self.MASK])
-        content = self.contenttype.tolayout(
-            lookup, lookup.positions[pos + self.CONTENT], fields
-        )
-        return ak._v2.contents.BitMaskedArray(
-            mask,
-            content,
-            self.valid_when,
-            lookup.positions[pos + self.LENGTH],
-            self.lsb_order,
-            parameters=self.parameters,
-        )
 
     def has_field(self, key):
         return self.contenttype.has_field(key)
@@ -1179,20 +995,7 @@ class BitMaskedArrayType(ContentType):
         return self.contenttype.is_recordtype
 
 
-class UnmaskedArrayType(ContentType):
-    IDENTIFIER = 0
-    CONTENT = 1
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(None)
-        positions[pos + cls.CONTENT] = ak._v2._connect.numba.arrayview.tolookup(
-            layout.content, positions
-        )
-        return pos
-
+class UnmaskedArrayType(ContentType, ak._v2._lookup.UnmaskedLookup):
     @classmethod
     def from_form(cls, form):
         return UnmaskedArrayType(
@@ -1210,13 +1013,6 @@ class UnmaskedArrayType(ContentType):
         self.contenttype = contenttype
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        content = self.contenttype.tolayout(
-            lookup, lookup.positions[pos + self.CONTENT], fields
-        )
-        return ak._v2.contents.UnmaskedArray(content, parameters=self.parameters)
 
     def has_field(self, key):
         return self.contenttype.has_field(key)
@@ -1294,23 +1090,7 @@ class UnmaskedArrayType(ContentType):
         return self.contenttype.is_recordtype
 
 
-class RecordArrayType(ContentType):
-    IDENTIFIER = 0
-    LENGTH = 1
-    CONTENTS = 2
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(len(layout))
-        positions.extend([None] * len(layout.contents))
-        for i, content in enumerate(layout.contents):
-            positions[
-                pos + cls.CONTENTS + i
-            ] = ak._v2._connect.numba.arrayview.tolookup(content, positions)
-        return pos
-
+class RecordArrayType(ContentType, ak._v2._lookup.RecordLookup):
     @classmethod
     def from_form(cls, form):
         return RecordArrayType(
@@ -1334,29 +1114,6 @@ class RecordArrayType(ContentType):
         self.fields = fields
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        if len(fields) > 0:
-            index = self.fieldindex(fields[0])
-            assert index is not None
-            return self.contenttypes[index].tolayout(
-                lookup, lookup.positions[pos + self.CONTENTS + index], fields[1:]
-            )
-        else:
-            contents = []
-            for i, contenttype in enumerate(self.contenttypes):
-                layout = contenttype.tolayout(
-                    lookup, lookup.positions[pos + self.CONTENTS + i], fields
-                )
-                contents.append(layout)
-
-            return ak._v2.contents.RecordArray(
-                contents,
-                self.fields,
-                lookup.positions[pos + self.LENGTH],
-                parameters=self.parameters,
-            )
 
     def fieldindex(self, key):
         out = -1
@@ -1627,25 +1384,7 @@ class RecordArrayType(ContentType):
         return True
 
 
-class UnionArrayType(ContentType):
-    IDENTIFIER = 0
-    TAGS = 1
-    INDEX = 2
-    CONTENTS = 3
-
-    @classmethod
-    def tolookup(cls, layout, positions):
-        pos = len(positions)
-        cls.tolookup_identifier(layout, positions)
-        positions.append(layout.tags.data)
-        positions.append(layout.index.data)
-        positions.extend([None] * len(layout.contents))
-        for i, content in enumerate(layout.contents):
-            positions[
-                pos + cls.CONTENTS + i
-            ] = ak._v2._connect.numba.arrayview.tolookup(content, positions)
-        return pos
-
+class UnionArrayType(ContentType, ak._v2._lookup.UnionLookup):
     @classmethod
     def from_form(cls, form):
         return UnionArrayType(
@@ -1672,20 +1411,6 @@ class UnionArrayType(ContentType):
         self.contenttypes = contenttypes
         self.identifiertype = identifiertype
         self.parameters = parameters
-
-    def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos + self.IDENTIFIER] == -1
-        tags = self.IndexOf(self.tagstype)(lookup.positions[pos + self.TAGS])
-        index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
-        contents = []
-        for i, contenttype in enumerate(self.contenttypes):
-            layout = contenttype.tolayout(
-                lookup, lookup.positions[pos + self.CONTENTS + i], fields
-            )
-            contents.append(layout)
-        return ak._v2.contents.UnionArray(
-            tags, index, contents, parameters=self.parameters
-        )
 
     def has_field(self, key):
         return any(x.has_field(key) for x in self.contenttypes)

--- a/src/awkward/_v2/_lookup.py
+++ b/src/awkward/_v2/_lookup.py
@@ -1,0 +1,348 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+np = ak.nplike.NumpyMetadata.instance()
+
+
+class Lookup:
+    def __init__(self, layout):
+        positions = []
+        tolookup(layout, positions)
+
+        def arrayptr(x):
+            if isinstance(x, int):
+                return x
+            else:
+                return x.ctypes.data
+
+        self.nplike = layout.nplike
+        self.positions = positions
+        self.arrayptrs = self.nplike.array(
+            [arrayptr(x) for x in positions], dtype=np.intp
+        )
+
+
+def tolookup(layout, positions):
+    if isinstance(layout, ak._v2.contents.EmptyArray):
+        return tolookup(layout.toNumpyArray(np.dtype(np.float64)), positions)
+
+    elif isinstance(layout, ak._v2.contents.NumpyArray):
+        if len(layout.shape) == 1:
+            return NumpyLookup.tolookup(layout, positions)
+        else:
+            return tolookup(layout.toRegularArray(), positions)
+
+    elif isinstance(layout, ak._v2.contents.RegularArray):
+        return RegularLookup.tolookup(layout, positions)
+
+    elif isinstance(
+        layout, (ak._v2.contents.ListArray, ak._v2.contents.ListOffsetArray)
+    ):
+        return ListLookup.tolookup(layout, positions)
+
+    elif isinstance(layout, ak._v2.contents.IndexedArray):
+        return IndexedLookup.tolookup(layout, positions)
+
+    elif isinstance(layout, ak._v2.contents.IndexedOptionArray):
+        return IndexedOptionLookup.tolookup(layout, positions)
+
+    elif isinstance(layout, ak._v2.contents.ByteMaskedArray):
+        return ByteMaskedLookup.tolookup(layout, positions)
+
+    elif isinstance(layout, ak._v2.contents.BitMaskedArray):
+        return BitMaskedLookup.tolookup(layout, positions)
+
+    elif isinstance(layout, ak._v2.contents.UnmaskedArray):
+        return UnmaskedLookup.tolookup(layout, positions)
+
+    elif isinstance(layout, ak._v2.contents.RecordArray):
+        return RecordLookup.tolookup(layout, positions)
+
+    elif isinstance(layout, ak._v2.record.Record):
+        return RecordLookup.tolookup(layout, positions)
+
+    elif isinstance(layout, ak._v2.contents.UnionArray):
+        return UnionLookup.tolookup(layout, positions)
+
+    else:
+        raise AssertionError(f"unrecognized Content: {type(layout)}")
+
+
+class ContentLookup:
+    @classmethod
+    def tolookup_identifier(cls, layout, positions):
+        if layout.identifier is None:
+            positions.append(-1)
+        else:
+            positions.append(layout.identifier.data)
+
+
+class NumpyLookup(ContentLookup):
+    IDENTIFIER = 0
+    ARRAY = 1
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(layout.contiguous().data)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        assert fields == ()
+        return ak._v2.contents.NumpyArray(
+            lookup.positions[pos + self.ARRAY], parameters=self.parameters
+        )
+
+
+class RegularLookup(ContentLookup):
+    IDENTIFIER = 0
+    ZEROS_LENGTH = 1
+    CONTENT = 2
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(len(layout))
+        positions.append(None)
+        positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields
+        )
+        return ak._v2.contents.RegularArray(
+            content,
+            self.size,
+            lookup.positions[pos + self.ZEROS_LENGTH],
+            parameters=self.parameters,
+        )
+
+
+class ListLookup(ContentLookup):
+    IDENTIFIER = 0
+    STARTS = 1
+    STOPS = 2
+    CONTENT = 3
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(layout.starts.data)
+        positions.append(layout.stops.data)
+        positions.append(None)
+        positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        starts = self.IndexOf(self.indextype)(lookup.positions[pos + self.STARTS])
+        stops = self.IndexOf(self.indextype)(lookup.positions[pos + self.STOPS])
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields
+        )
+        return ak._v2.contents.ListArray(
+            starts, stops, content, parameters=self.parameters
+        )
+
+
+class IndexedLookup(ContentLookup):
+    IDENTIFIER = 0
+    INDEX = 1
+    CONTENT = 2
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(layout.index.data)
+        positions.append(None)
+        positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields
+        )
+        return ak._v2.contents.IndexedArray(index, content, parameters=self.parameters)
+
+
+class IndexedOptionLookup(ContentLookup):
+    IDENTIFIER = 0
+    INDEX = 1
+    CONTENT = 2
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(layout.index.data)
+        positions.append(None)
+        positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields
+        )
+        return ak._v2.contents.IndexedOptionArray(
+            index, content, parameters=self.parameters
+        )
+
+
+class ByteMaskedLookup(ContentLookup):
+    IDENTIFIER = 0
+    MASK = 1
+    CONTENT = 2
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(layout.mask.data)
+        positions.append(None)
+        positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        mask = self.IndexOf(self.masktype)(lookup.positions[pos + self.MASK])
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields
+        )
+        return ak._v2.contents.ByteMaskedArray(
+            mask, content, self.valid_when, parameters=self.parameters
+        )
+
+
+class BitMaskedLookup(ContentLookup):
+    IDENTIFIER = 0
+    LENGTH = 1
+    MASK = 2
+    CONTENT = 3
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(len(layout))
+        positions.append(layout.mask.data)
+        positions.append(None)
+        positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        mask = self.IndexOf(self.masktype)(lookup.positions[pos + self.MASK])
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields
+        )
+        return ak._v2.contents.BitMaskedArray(
+            mask,
+            content,
+            self.valid_when,
+            lookup.positions[pos + self.LENGTH],
+            self.lsb_order,
+            parameters=self.parameters,
+        )
+
+
+class UnmaskedLookup(ContentLookup):
+    IDENTIFIER = 0
+    CONTENT = 1
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(None)
+        positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        content = self.contenttype.tolayout(
+            lookup, lookup.positions[pos + self.CONTENT], fields
+        )
+        return ak._v2.contents.UnmaskedArray(content, parameters=self.parameters)
+
+
+class RecordLookup(ContentLookup):
+    IDENTIFIER = 0
+    LENGTH = 1
+    CONTENTS = 2
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(len(layout))
+        positions.extend([None] * len(layout.contents))
+        for i, content in enumerate(layout.contents):
+            positions[pos + cls.CONTENTS + i] = tolookup(content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        if len(fields) > 0:
+            index = self.fieldindex(fields[0])
+            assert index is not None
+            return self.contenttypes[index].tolayout(
+                lookup, lookup.positions[pos + self.CONTENTS + index], fields[1:]
+            )
+        else:
+            contents = []
+            for i, contenttype in enumerate(self.contenttypes):
+                layout = contenttype.tolayout(
+                    lookup, lookup.positions[pos + self.CONTENTS + i], fields
+                )
+                contents.append(layout)
+
+            return ak._v2.contents.RecordArray(
+                contents,
+                self.fields,
+                lookup.positions[pos + self.LENGTH],
+                parameters=self.parameters,
+            )
+
+
+class UnionLookup(ContentLookup):
+    IDENTIFIER = 0
+    TAGS = 1
+    INDEX = 2
+    CONTENTS = 3
+
+    @classmethod
+    def tolookup(cls, layout, positions):
+        pos = len(positions)
+        cls.tolookup_identifier(layout, positions)
+        positions.append(layout.tags.data)
+        positions.append(layout.index.data)
+        positions.extend([None] * len(layout.contents))
+        for i, content in enumerate(layout.contents):
+            positions[pos + cls.CONTENTS + i] = tolookup(content, positions)
+        return pos
+
+    def tolayout(self, lookup, pos, fields):
+        assert lookup.positions[pos + self.IDENTIFIER] == -1
+        tags = self.IndexOf(self.tagstype)(lookup.positions[pos + self.TAGS])
+        index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
+        contents = []
+        for i, contenttype in enumerate(self.contenttypes):
+            layout = contenttype.tolayout(
+                lookup, lookup.positions[pos + self.CONTENTS + i], fields
+            )
+            contents.append(layout)
+        return ak._v2.contents.UnionArray(
+            tags, index, contents, parameters=self.parameters
+        )

--- a/src/awkward/_v2/_lookup.py
+++ b/src/awkward/_v2/_lookup.py
@@ -77,6 +77,20 @@ class ContentLookup:
         else:
             positions.append(layout.identifier.data)
 
+    def IndexOf(self, arraytype):
+        if arraytype.dtype.bitwidth == 8 and arraytype.dtype.signed:
+            return ak._v2.index.Index8
+        elif arraytype.dtype.bitwidth == 8:
+            return ak._v2.index.IndexU8
+        elif arraytype.dtype.bitwidth == 32 and arraytype.dtype.signed:
+            return ak._v2.index.Index32
+        elif arraytype.dtype.bitwidth == 32:
+            return ak._v2.index.IndexU32
+        elif arraytype.dtype.bitwidth == 64:
+            return ak._v2.index.Index64
+        else:
+            raise AssertionError(f"no Index* type for array: {arraytype}")
+
 
 class NumpyLookup(ContentLookup):
     IDENTIFIER = 0

--- a/tests/v2/test_1240-v2-implementation-of-numba-1.py
+++ b/tests/v2/test_1240-v2-implementation-of-numba-1.py
@@ -18,8 +18,8 @@ ak_numba.register_and_check()
 def roundtrip(layout):
     assert isinstance(layout, ak._v2.contents.Content)
 
-    lookup = ak_numba_arrayview.Lookup(layout)
-    assert isinstance(lookup, ak_numba_arrayview.Lookup)
+    lookup = ak._v2._lookup.Lookup(layout)
+    assert isinstance(lookup, ak._v2._lookup.Lookup)
 
     numbatype = ak_numba_arrayview.tonumbatype(layout.form)
     assert isinstance(numbatype, ak_numba_layout.ContentType)

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -217,30 +217,111 @@ void roottest_ListOffsetArray_NumpyArray(double* out, ssize_t length, ssize_t* p
     assert out.tolist() == [4.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5, 1.0, 7.7]
 
 
-# def test_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.recordarray.RecordArray(
-#         [
-#             ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
-#             ak._v2.contents.numpyarray.NumpyArray(
-#                 np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
-#             ),
-#         ],
-#         ["x", "y"],
-#     )
+def test_RecordArray_NumpyArray():
+    v2a = ak._v2.contents.recordarray.RecordArray(
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ],
+        ["x", "y"],
+        parameters={"__record__": "Something"},
+    )
 
-#     v2b = ak._v2.contents.recordarray.RecordArray(
-#         [
-#             ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
-#             ak._v2.contents.numpyarray.NumpyArray(
-#                 np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
-#             ),
-#         ],
-#         None,
-#     )
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
 
-#     v2c = ak._v2.contents.recordarray.RecordArray([], [], 10)
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_RecordArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  auto rec1 = obj[1];
+  auto rec4 = obj[4];
+  out[1] = rec1.x();
+  out[2] = rec1.y();
+  out[3] = rec4.x();
+  out[4] = rec4.y();
+}}
+"""
+    )
+    out = np.zeros(5, dtype=np.float64)
+    ROOT.roottest_RecordArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [5.0, 1, 1.1, 4, 4.4]
 
-#     v2d = ak._v2.contents.recordarray.RecordArray([], None, 10)
+    v2b = ak._v2.contents.recordarray.RecordArray(
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ],
+        None,
+    )
+
+    layout = v2b
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_RecordArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  auto rec1 = obj[1];
+  auto rec4 = obj[4];
+  out[1] = rec1.slot0();
+  out[2] = rec1.slot1();
+  out[3] = rec4.slot0();
+  out[4] = rec4.slot1();
+}}
+"""
+    )
+    out = np.zeros(5, dtype=np.float64)
+    ROOT.roottest_RecordArray_NumpyArray_v2b(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [5.0, 1, 1.1, 4, 4.4]
+
+    v2c = ak._v2.contents.recordarray.RecordArray([], [], 10)
+
+    layout = v2c
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_RecordArray_NumpyArray_v2c(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+}}
+"""
+    )
+    out = np.zeros(1, dtype=np.float64)
+    ROOT.roottest_RecordArray_NumpyArray_v2c(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [10.0]
+
+    v2d = ak._v2.contents.recordarray.RecordArray([], None, 10)
+
+    layout = v2d
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_RecordArray_NumpyArray_v2d(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+}}
+"""
+    )
+    out = np.zeros(1, dtype=np.float64)
+    ROOT.roottest_RecordArray_NumpyArray_v2d(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [10.0]
 
 
 # def test_IndexedArray_NumpyArray():

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -324,18 +324,66 @@ void roottest_RecordArray_NumpyArray_v2d(double* out, ssize_t length, ssize_t* p
     assert out.tolist() == [10.0]
 
 
-# def test_IndexedArray_NumpyArray():
-#     v2a = ak._v2.contents.indexedarray.IndexedArray(
-#         ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4], np.int64)),
-#         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
-#     )
+def test_IndexedArray_NumpyArray():
+    v2a = ak._v2.contents.indexedarray.IndexedArray(
+        ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_IndexedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0];
+  out[2] = obj[1];
+  out[3] = obj[2];
+  out[4] = obj[3];
+  out[5] = obj[4];
+  out[6] = obj[5];
+  out[7] = obj[6];
+}}
+"""
+    )
+    out = np.zeros(8, dtype=np.float64)
+    ROOT.roottest_IndexedArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [7.0, 2.2, 2.2, 0.0, 1.1, 4.4, 5.5, 4.4]
 
 
-# def test_IndexedOptionArray_NumpyArray():
-#     v2a = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
-#         ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
-#         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
-#     )
+def test_IndexedOptionArray_NumpyArray():
+    v2a = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+        ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_IndexedOptionArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(8, dtype=np.float64)
+    ROOT.roottest_IndexedOptionArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [7.0, 2.2, 2.2, 999.0, 1.1, 999.0, 5.5, 4.4]
 
 
 # def test_ByteMaskedArray_NumpyArray():

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -386,18 +386,62 @@ void roottest_IndexedOptionArray_NumpyArray_v2a(double* out, ssize_t length, ssi
     assert out.tolist() == [7.0, 2.2, 2.2, 999.0, 1.1, 999.0, 5.5, 4.4]
 
 
-# def test_ByteMaskedArray_NumpyArray():
-#     v2a = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
-#         ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
-#         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
-#         valid_when=True,
-#     )
+def test_ByteMaskedArray_NumpyArray():
+    v2a = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=True,
+    )
 
-#     v2b = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
-#         ak._v2.index.Index(np.array([0, 1, 0, 1, 0], np.int8)),
-#         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
-#         valid_when=False,
-#     )
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(debug_compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_ByteMaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(6, dtype=np.float64)
+    ROOT.roottest_ByteMaskedArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
+
+    v2b = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([0, 1, 0, 1, 0], np.int8)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=False,
+    )
+
+    layout = v2b
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(debug_compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_ByteMaskedArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(6, dtype=np.float64)
+    ROOT.roottest_ByteMaskedArray_NumpyArray_v2b(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
 
 
 # def test_BitMaskedArray_NumpyArray():

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -10,20 +10,662 @@ import awkward._v2._lookup  # noqa: E402
 import awkward._v2._connect.cling  # noqa: E402
 
 
-def test():
-    array = ak._v2.Array([5, 4, 3, 2, 1])
-    generator = ak._v2._connect.cling.togenerator(array.layout.form)
-    lookup = ak._v2._lookup.Lookup(array.layout)
+compiler = ROOT.gInterpreter.Declare
 
-    generator.generate(ROOT.gInterpreter.Declare)
+
+def debug_compiler(code):
+    print(code)
+    ROOT.gInterpreter.Declare(code)
+
+
+def test_NumpyArray():
+    v2a = ak._v2.contents.numpyarray.NumpyArray(
+        np.array([0.0, 1.1, 2.2, 3.3]),
+        parameters={"some": "stuff", "other": [1, 2, "three"]},
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
 
     ROOT.gInterpreter.Declare(
         f"""
-void roottest_1(ssize_t length, ssize_t* ptrs) {{
+void roottest_1(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()};
-  std::cout << "HEY " << obj[0] << std::endl;
+  out[0] = obj.size();
+  out[1] = obj[1];
+  out[2] = obj.at(3);
 }}
 """
     )
+    out = np.zeros(3, dtype=np.float64)
+    ROOT.roottest_1(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [4.0, 1.1, 3.3]
 
-    ROOT.roottest_1(len(array), lookup.arrayptrs)
+
+def test_EmptyArray():
+    v2a = ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(np.dtype(np.float64))
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+size_t roottest_2(ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  return obj.size();
+}}
+"""
+    )
+    assert ROOT.roottest_2(len(layout), lookup.arrayptrs) == 0
+
+
+# def test_NumpyArray_shape():
+#     v2a = ak._v2.contents.numpyarray.NumpyArray(
+#         np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
+#     )
+
+
+# def test_RegularArray_NumpyArray():
+#     v2a = ak._v2.contents.regulararray.RegularArray(
+#         ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+#         3,
+#     )
+
+#     v2b = ak._v2.contents.regulararray.RegularArray(
+#         ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(np.dtype(np.float64)),
+#         0,
+#         zeros_length=10,
+#     )
+
+
+# def test_ListArray_NumpyArray():
+#     v2a = ak._v2.contents.listarray.ListArray(
+#         ak._v2.index.Index(np.array([4, 100, 1], np.int64)),
+#         ak._v2.index.Index(np.array([7, 100, 3, 200], np.int64)),
+#         ak._v2.contents.numpyarray.NumpyArray(
+#             np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+#         ),
+#     )
+
+
+# def test_ListOffsetArray_NumpyArray():
+#     v2a = ak._v2.contents.listoffsetarray.ListOffsetArray(
+#         ak._v2.index.Index(np.array([1, 4, 4, 6, 7], np.int64)),
+#         ak._v2.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]),
+#     )
+
+
+# def test_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.recordarray.RecordArray(
+#         [
+#             ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
+#             ak._v2.contents.numpyarray.NumpyArray(
+#                 np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+#             ),
+#         ],
+#         ["x", "y"],
+#     )
+
+#     v2b = ak._v2.contents.recordarray.RecordArray(
+#         [
+#             ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
+#             ak._v2.contents.numpyarray.NumpyArray(
+#                 np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+#             ),
+#         ],
+#         None,
+#     )
+
+#     v2c = ak._v2.contents.recordarray.RecordArray([], [], 10)
+
+#     v2d = ak._v2.contents.recordarray.RecordArray([], None, 10)
+
+
+# def test_IndexedArray_NumpyArray():
+#     v2a = ak._v2.contents.indexedarray.IndexedArray(
+#         ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4], np.int64)),
+#         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+#     )
+
+
+# def test_IndexedOptionArray_NumpyArray():
+#     v2a = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+#         ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
+#         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+#     )
+
+
+# def test_ByteMaskedArray_NumpyArray():
+#     v2a = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+#         ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
+#         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+#         valid_when=True,
+#     )
+
+#     v2b = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+#         ak._v2.index.Index(np.array([0, 1, 0, 1, 0], np.int8)),
+#         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+#         valid_when=False,
+#     )
+
+
+# def test_BitMaskedArray_NumpyArray():
+#     v2a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         1,
+#                         1,
+#                         1,
+#                         1,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                     ],
+#                     np.uint8,
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.numpyarray.NumpyArray(
+#             np.array(
+#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+#             )
+#         ),
+#         valid_when=True,
+#         length=13,
+#         lsb_order=False,
+#     )
+
+#     v2b = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         1,
+#                         1,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                     ],
+#                     np.uint8,
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.numpyarray.NumpyArray(
+#             np.array(
+#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+#             )
+#         ),
+#         valid_when=False,
+#         length=13,
+#         lsb_order=False,
+#     )
+
+#     v2c = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         1,
+#                         1,
+#                         1,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                     ],
+#                     np.uint8,
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.numpyarray.NumpyArray(
+#             np.array(
+#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+#             )
+#         ),
+#         valid_when=True,
+#         length=13,
+#         lsb_order=True,
+#     )
+
+#     v2d = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         1,
+#                         1,
+#                         1,
+#                         1,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                     ],
+#                     np.uint8,
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.numpyarray.NumpyArray(
+#             np.array(
+#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+#             )
+#         ),
+#         valid_when=False,
+#         length=13,
+#         lsb_order=True,
+#     )
+
+
+# def test_UnmaskedArray_NumpyArray():
+#     v2a = ak._v2.contents.unmaskedarray.UnmaskedArray(
+#         ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3]))
+#     )
+
+
+# def test_UnionArray_NumpyArray():
+#     v2a = ak._v2.contents.unionarray.UnionArray(
+#         ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),
+#         ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
+#         [
+#             ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3], np.int64)),
+#             ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
+#         ],
+#     )
+
+
+# def test_RegularArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.regulararray.RegularArray(
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#         3,
+#     )
+
+#     v2b = ak._v2.contents.regulararray.RegularArray(
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(
+#                     np.dtype(np.float64)
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#         0,
+#         zeros_length=10,
+#     )
+
+
+# def test_ListArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.listarray.ListArray(
+#         ak._v2.index.Index(np.array([4, 100, 1], np.int64)),
+#         ak._v2.index.Index(np.array([7, 100, 3, 200], np.int64)),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#     )
+
+
+# def test_ListOffsetArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.listoffsetarray.ListOffsetArray(
+#         ak._v2.index.Index(np.array([1, 4, 4, 6], np.int64)),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     [6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#     )
+
+
+# def test_IndexedArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.indexedarray.IndexedArray(
+#         ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4], np.int64)),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#     )
+
+
+# def test_IndexedOptionArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+#         ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#     )
+
+
+# def test_ByteMaskedArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+#         ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#         valid_when=True,
+#     )
+
+#     v2b = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+#         ak._v2.index.Index(np.array([0, 1, 0, 1, 0], np.int8)),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#         valid_when=False,
+#     )
+
+
+# def test_BitMaskedArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         True,
+#                         True,
+#                         True,
+#                         True,
+#                         False,
+#                         False,
+#                         False,
+#                         False,
+#                         True,
+#                         False,
+#                         True,
+#                         False,
+#                         True,
+#                     ]
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array(
+#                         [
+#                             0.0,
+#                             1.0,
+#                             2.0,
+#                             3.0,
+#                             4.0,
+#                             5.0,
+#                             6.0,
+#                             7.0,
+#                             1.1,
+#                             2.2,
+#                             3.3,
+#                             4.4,
+#                             5.5,
+#                             6.6,
+#                         ]
+#                     )
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#         valid_when=True,
+#         length=13,
+#         lsb_order=False,
+#     )
+
+#     v2b = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         1,
+#                         1,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                     ],
+#                     np.uint8,
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array(
+#                         [
+#                             0.0,
+#                             1.0,
+#                             2.0,
+#                             3.0,
+#                             4.0,
+#                             5.0,
+#                             6.0,
+#                             7.0,
+#                             1.1,
+#                             2.2,
+#                             3.3,
+#                             4.4,
+#                             5.5,
+#                             6.6,
+#                         ]
+#                     )
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#         valid_when=False,
+#         length=13,
+#         lsb_order=False,
+#     )
+
+#     v2c = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         1,
+#                         1,
+#                         1,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                     ],
+#                     np.uint8,
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array(
+#                         [
+#                             0.0,
+#                             1.0,
+#                             2.0,
+#                             3.0,
+#                             4.0,
+#                             5.0,
+#                             6.0,
+#                             7.0,
+#                             1.1,
+#                             2.2,
+#                             3.3,
+#                             4.4,
+#                             5.5,
+#                             6.6,
+#                         ]
+#                     )
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#         valid_when=True,
+#         length=13,
+#         lsb_order=True,
+#     )
+
+#     v2d = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         1,
+#                         1,
+#                         1,
+#                         1,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                     ],
+#                     np.uint8,
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.recordarray.RecordArray(
+#             [
+#                 ak._v2.contents.numpyarray.NumpyArray(
+#                     np.array(
+#                         [
+#                             0.0,
+#                             1.0,
+#                             2.0,
+#                             3.0,
+#                             4.0,
+#                             5.0,
+#                             6.0,
+#                             7.0,
+#                             1.1,
+#                             2.2,
+#                             3.3,
+#                             4.4,
+#                             5.5,
+#                             6.6,
+#                         ]
+#                     )
+#                 )
+#             ],
+#             ["nest"],
+#         ),
+#         valid_when=False,
+#         length=13,
+#         lsb_order=True,
+#     )
+
+
+# def test_UnmaskedArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.unmaskedarray.UnmaskedArray(
+#         ak._v2.contents.recordarray.RecordArray(
+#             [ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3]))],
+#             ["nest"],
+#         )
+#     )
+
+
+# def test_UnionArray_RecordArray_NumpyArray():
+#     v2a = ak._v2.contents.unionarray.UnionArray(
+#         ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),
+#         ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
+#         [
+#             ak._v2.contents.recordarray.RecordArray(
+#                 [ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3], np.int64))],
+#                 ["nest"],
+#             ),
+#             ak._v2.contents.recordarray.RecordArray(
+#                 [
+#                     ak._v2.contents.numpyarray.NumpyArray(
+#                         np.array([1.1, 2.2, 3.3, 4.4, 5.5])
+#                     )
+#                 ],
+#                 ["nest"],
+#             ),
+#         ],
+#     )

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -148,21 +148,73 @@ void roottest_RegularArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* 
     assert out.tolist() == [10.0, 0.0, 0.0]
 
 
-# def test_ListArray_NumpyArray():
-#     v2a = ak._v2.contents.listarray.ListArray(
-#         ak._v2.index.Index(np.array([4, 100, 1], np.int64)),
-#         ak._v2.index.Index(np.array([7, 100, 3, 200], np.int64)),
-#         ak._v2.contents.numpyarray.NumpyArray(
-#             np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
-#         ),
-#     )
+def test_ListArray_NumpyArray():
+    v2a = ak._v2.contents.listarray.ListArray(
+        ak._v2.index.Index(np.array([4, 100, 1], np.int64)),
+        ak._v2.index.Index(np.array([7, 100, 3, 200], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_ListArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].size();
+  out[2] = obj[0][0];
+  out[3] = obj[0][1];
+  out[4] = obj[0][2];
+  out[5] = obj[1].size();
+  out[6] = obj[2].size();
+  out[7] = obj[2][0];
+  out[8] = obj[2][1];
+}}
+"""
+    )
+    out = np.zeros(9, dtype=np.float64)
+    ROOT.roottest_ListArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [3.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5]
 
 
-# def test_ListOffsetArray_NumpyArray():
-#     v2a = ak._v2.contents.listoffsetarray.ListOffsetArray(
-#         ak._v2.index.Index(np.array([1, 4, 4, 6, 7], np.int64)),
-#         ak._v2.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]),
-#     )
+def test_ListOffsetArray_NumpyArray():
+    v2a = ak._v2.contents.listoffsetarray.ListOffsetArray(
+        ak._v2.index.Index(np.array([1, 4, 4, 6, 7], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_ListOffsetArray_NumpyArray(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].size();
+  out[2] = obj[0][0];
+  out[3] = obj[0][1];
+  out[4] = obj[0][2];
+  out[5] = obj[1].size();
+  out[6] = obj[2].size();
+  out[7] = obj[2][0];
+  out[8] = obj[2][1];
+  out[9] = obj[3].size();
+  out[10] = obj[3][0];
+}}
+"""
+    )
+    out = np.zeros(11, dtype=np.float64)
+    ROOT.roottest_ListOffsetArray_NumpyArray(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [4.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5, 1.0, 7.7]
 
 
 # def test_RecordArray_NumpyArray():

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -396,7 +396,7 @@ def test_ByteMaskedArray_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(debug_compiler)
+    generator.generate(compiler)
 
     ROOT.gInterpreter.Declare(
         f"""
@@ -424,7 +424,7 @@ void roottest_ByteMaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_
     layout = v2b
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(debug_compiler)
+    generator.generate(compiler)
 
     ROOT.gInterpreter.Declare(
         f"""
@@ -444,144 +444,324 @@ void roottest_ByteMaskedArray_NumpyArray_v2b(double* out, ssize_t length, ssize_
     assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
 
 
-# def test_BitMaskedArray_NumpyArray():
-#     v2a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
-#         ak._v2.index.Index(
-#             np.packbits(
-#                 np.array(
-#                     [
-#                         1,
-#                         1,
-#                         1,
-#                         1,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                     ],
-#                     np.uint8,
-#                 )
-#             )
-#         ),
-#         ak._v2.contents.numpyarray.NumpyArray(
-#             np.array(
-#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
-#             )
-#         ),
-#         valid_when=True,
-#         length=13,
-#         lsb_order=False,
-#     )
+def test_BitMaskedArray_NumpyArray():
+    v2a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
 
-#     v2b = ak._v2.contents.bitmaskedarray.BitMaskedArray(
-#         ak._v2.index.Index(
-#             np.packbits(
-#                 np.array(
-#                     [
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         1,
-#                         1,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                     ],
-#                     np.uint8,
-#                 )
-#             )
-#         ),
-#         ak._v2.contents.numpyarray.NumpyArray(
-#             np.array(
-#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
-#             )
-#         ),
-#         valid_when=False,
-#         length=13,
-#         lsb_order=False,
-#     )
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
 
-#     v2c = ak._v2.contents.bitmaskedarray.BitMaskedArray(
-#         ak._v2.index.Index(
-#             np.packbits(
-#                 np.array(
-#                     [
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         1,
-#                         1,
-#                         1,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                     ],
-#                     np.uint8,
-#                 )
-#             )
-#         ),
-#         ak._v2.contents.numpyarray.NumpyArray(
-#             np.array(
-#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
-#             )
-#         ),
-#         valid_when=True,
-#         length=13,
-#         lsb_order=True,
-#     )
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_BitMaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+  out[8] = obj[7].has_value() ? obj[7].value() : 999.0;
+  out[9] = obj[8].has_value() ? obj[8].value() : 999.0;
+  out[10] = obj[9].has_value() ? obj[9].value() : 999.0;
+  out[11] = obj[10].has_value() ? obj[10].value() : 999.0;
+  out[12] = obj[11].has_value() ? obj[11].value() : 999.0;
+  out[13] = obj[12].has_value() ? obj[12].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(14, dtype=np.float64)
+    ROOT.roottest_BitMaskedArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
 
-#     v2d = ak._v2.contents.bitmaskedarray.BitMaskedArray(
-#         ak._v2.index.Index(
-#             np.packbits(
-#                 np.array(
-#                     [
-#                         1,
-#                         1,
-#                         1,
-#                         1,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                     ],
-#                     np.uint8,
-#                 )
-#             )
-#         ),
-#         ak._v2.contents.numpyarray.NumpyArray(
-#             np.array(
-#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
-#             )
-#         ),
-#         valid_when=False,
-#         length=13,
-#         lsb_order=True,
-#     )
+    v2b = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=False,
+    )
+
+    layout = v2b
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_BitMaskedArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+  out[8] = obj[7].has_value() ? obj[7].value() : 999.0;
+  out[9] = obj[8].has_value() ? obj[8].value() : 999.0;
+  out[10] = obj[9].has_value() ? obj[9].value() : 999.0;
+  out[11] = obj[10].has_value() ? obj[10].value() : 999.0;
+  out[12] = obj[11].has_value() ? obj[11].value() : 999.0;
+  out[13] = obj[12].has_value() ? obj[12].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(14, dtype=np.float64)
+    ROOT.roottest_BitMaskedArray_NumpyArray_v2b(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2c = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=True,
+    )
+
+    layout = v2c
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_BitMaskedArray_NumpyArray_v2c(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+  out[8] = obj[7].has_value() ? obj[7].value() : 999.0;
+  out[9] = obj[8].has_value() ? obj[8].value() : 999.0;
+  out[10] = obj[9].has_value() ? obj[9].value() : 999.0;
+  out[11] = obj[10].has_value() ? obj[10].value() : 999.0;
+  out[12] = obj[11].has_value() ? obj[11].value() : 999.0;
+  out[13] = obj[12].has_value() ? obj[12].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(14, dtype=np.float64)
+    ROOT.roottest_BitMaskedArray_NumpyArray_v2c(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2d = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=True,
+    )
+
+    layout = v2d
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_BitMaskedArray_NumpyArray_v2d(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+  out[8] = obj[7].has_value() ? obj[7].value() : 999.0;
+  out[9] = obj[8].has_value() ? obj[8].value() : 999.0;
+  out[10] = obj[9].has_value() ? obj[9].value() : 999.0;
+  out[11] = obj[10].has_value() ? obj[10].value() : 999.0;
+  out[12] = obj[11].has_value() ? obj[11].value() : 999.0;
+  out[13] = obj[12].has_value() ? obj[12].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(14, dtype=np.float64)
+    ROOT.roottest_BitMaskedArray_NumpyArray_v2d(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
 
 
 # def test_UnmaskedArray_NumpyArray():

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -764,10 +764,29 @@ void roottest_BitMaskedArray_NumpyArray_v2d(double* out, ssize_t length, ssize_t
     ]
 
 
-# def test_UnmaskedArray_NumpyArray():
-#     v2a = ak._v2.contents.unmaskedarray.UnmaskedArray(
-#         ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3]))
-#     )
+def test_UnmaskedArray_NumpyArray():
+    v2a = ak._v2.contents.unmaskedarray.UnmaskedArray(
+        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3]))
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_UnmaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[2] = obj[3].has_value() ? obj[3].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(3, dtype=np.float64)
+    ROOT.roottest_UnmaskedArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [4.0, 1.1, 3.3]
 
 
 # def test_UnionArray_NumpyArray():
@@ -779,6 +798,25 @@ void roottest_BitMaskedArray_NumpyArray_v2d(double* out, ssize_t length, ssize_t
 #             ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
 #         ],
 #     )
+
+#     layout = v2a
+#     generator = ak._v2._connect.cling.togenerator(layout.form)
+#     lookup = ak._v2._lookup.Lookup(layout)
+#     generator.generate(compiler)
+
+#     ROOT.gInterpreter.Declare(
+#         f"""
+# void roottest_UnmaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+#   auto obj = {generator.entry()};
+#   out[0] = obj.size();
+#   out[1] = obj[1].has_value() ? obj[1].value() : 999.0;
+#   out[2] = obj[3].has_value() ? obj[3].value() : 999.0;
+# }}
+# """
+#     )
+#     out = np.zeros(3, dtype=np.float64)
+#     ROOT.roottest_UnmaskedArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+#     assert out.tolist() == [4.0, 1.1, 3.3]
 
 
 # def test_RegularArray_RecordArray_NumpyArray():

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -1788,3 +1788,61 @@ void roottest_nested_UnionArray_NumpyArray_v2a(double* out, ssize_t length, ssiz
     out = np.zeros(15, dtype=np.float64)
     ROOT.roottest_nested_UnionArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
     assert out.tolist() == [7, 1, 1, 0, 0, 1, 0, 1, 5.5, 4.4, 1, 2, 3.3, 3, 5.5]
+
+
+def test_ListArray_strings():
+    layout = ak._v2.operations.convert.from_iter(
+        ["one", "two", "three", "four", "five"], highlevel=False
+    )
+
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_ListArray_strings(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = (obj[0] == "one");
+  out[2] = (obj[1] == "two");
+  out[3] = (obj[2] == "three");
+  out[4] = (obj[3] == "four");
+  out[5] = (obj[4] == "five");
+}}
+"""
+    )
+    out = np.zeros(6, dtype=np.float64)
+    ROOT.roottest_ListArray_strings(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [5.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+
+def test_RegularArray_strings():
+    layout = ak._v2.operations.structure.to_regular(
+        ak._v2.operations.convert.from_iter(
+            ["onexx", "twoxx", "three", "fourx", "fivex"]
+        ),
+        axis=1,
+        highlevel=False,
+    )
+
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_RegularArray_strings(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = (obj[0] == "onexx");
+  out[2] = (obj[1] == "twoxx");
+  out[3] = (obj[2] == "three");
+  out[4] = (obj[3] == "fourx");
+  out[5] = (obj[4] == "fivex");
+}}
+"""
+    )
+    out = np.zeros(6, dtype=np.float64)
+    ROOT.roottest_RegularArray_strings(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [5.0, 1.0, 1.0, 1.0, 1.0, 1.0]

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -789,392 +789,43 @@ void roottest_UnmaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t*
     assert out.tolist() == [4.0, 1.1, 3.3]
 
 
-# def test_UnionArray_NumpyArray():
-#     v2a = ak._v2.contents.unionarray.UnionArray(
-#         ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),
-#         ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
-#         [
-#             ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3], np.int64)),
-#             ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
-#         ],
-#     )
+def test_UnionArray_NumpyArray():
+    v2a = ak._v2.contents.unionarray.UnionArray(
+        ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),
+        ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+    )
 
-#     layout = v2a
-#     generator = ak._v2._connect.cling.togenerator(layout.form)
-#     lookup = ak._v2._lookup.Lookup(layout)
-#     generator.generate(compiler)
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(debug_compiler)
 
-#     ROOT.gInterpreter.Declare(
-#         f"""
-# void roottest_UnmaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
-#   auto obj = {generator.entry()};
-#   out[0] = obj.size();
-#   out[1] = obj[1].has_value() ? obj[1].value() : 999.0;
-#   out[2] = obj[3].has_value() ? obj[3].value() : 999.0;
-# }}
-# """
-#     )
-#     out = np.zeros(3, dtype=np.float64)
-#     ROOT.roottest_UnmaskedArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
-#     assert out.tolist() == [4.0, 1.1, 3.3]
-
-
-# def test_RegularArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.regulararray.RegularArray(
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#         3,
-#     )
-
-#     v2b = ak._v2.contents.regulararray.RegularArray(
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(
-#                     np.dtype(np.float64)
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#         0,
-#         zeros_length=10,
-#     )
-
-
-# def test_ListArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.listarray.ListArray(
-#         ak._v2.index.Index(np.array([4, 100, 1], np.int64)),
-#         ak._v2.index.Index(np.array([7, 100, 3, 200], np.int64)),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#     )
-
-
-# def test_ListOffsetArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.listoffsetarray.ListOffsetArray(
-#         ak._v2.index.Index(np.array([1, 4, 4, 6], np.int64)),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     [6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#     )
-
-
-# def test_IndexedArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.indexedarray.IndexedArray(
-#         ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4], np.int64)),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#     )
-
-
-# def test_IndexedOptionArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
-#         ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#     )
-
-
-# def test_ByteMaskedArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
-#         ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#         valid_when=True,
-#     )
-
-#     v2b = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
-#         ak._v2.index.Index(np.array([0, 1, 0, 1, 0], np.int8)),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#         valid_when=False,
-#     )
-
-
-# def test_BitMaskedArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
-#         ak._v2.index.Index(
-#             np.packbits(
-#                 np.array(
-#                     [
-#                         True,
-#                         True,
-#                         True,
-#                         True,
-#                         False,
-#                         False,
-#                         False,
-#                         False,
-#                         True,
-#                         False,
-#                         True,
-#                         False,
-#                         True,
-#                     ]
-#                 )
-#             )
-#         ),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array(
-#                         [
-#                             0.0,
-#                             1.0,
-#                             2.0,
-#                             3.0,
-#                             4.0,
-#                             5.0,
-#                             6.0,
-#                             7.0,
-#                             1.1,
-#                             2.2,
-#                             3.3,
-#                             4.4,
-#                             5.5,
-#                             6.6,
-#                         ]
-#                     )
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#         valid_when=True,
-#         length=13,
-#         lsb_order=False,
-#     )
-
-#     v2b = ak._v2.contents.bitmaskedarray.BitMaskedArray(
-#         ak._v2.index.Index(
-#             np.packbits(
-#                 np.array(
-#                     [
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         1,
-#                         1,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                     ],
-#                     np.uint8,
-#                 )
-#             )
-#         ),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array(
-#                         [
-#                             0.0,
-#                             1.0,
-#                             2.0,
-#                             3.0,
-#                             4.0,
-#                             5.0,
-#                             6.0,
-#                             7.0,
-#                             1.1,
-#                             2.2,
-#                             3.3,
-#                             4.4,
-#                             5.5,
-#                             6.6,
-#                         ]
-#                     )
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#         valid_when=False,
-#         length=13,
-#         lsb_order=False,
-#     )
-
-#     v2c = ak._v2.contents.bitmaskedarray.BitMaskedArray(
-#         ak._v2.index.Index(
-#             np.packbits(
-#                 np.array(
-#                     [
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         1,
-#                         1,
-#                         1,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                     ],
-#                     np.uint8,
-#                 )
-#             )
-#         ),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array(
-#                         [
-#                             0.0,
-#                             1.0,
-#                             2.0,
-#                             3.0,
-#                             4.0,
-#                             5.0,
-#                             6.0,
-#                             7.0,
-#                             1.1,
-#                             2.2,
-#                             3.3,
-#                             4.4,
-#                             5.5,
-#                             6.6,
-#                         ]
-#                     )
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#         valid_when=True,
-#         length=13,
-#         lsb_order=True,
-#     )
-
-#     v2d = ak._v2.contents.bitmaskedarray.BitMaskedArray(
-#         ak._v2.index.Index(
-#             np.packbits(
-#                 np.array(
-#                     [
-#                         1,
-#                         1,
-#                         1,
-#                         1,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         0,
-#                         1,
-#                         0,
-#                         1,
-#                         0,
-#                     ],
-#                     np.uint8,
-#                 )
-#             )
-#         ),
-#         ak._v2.contents.recordarray.RecordArray(
-#             [
-#                 ak._v2.contents.numpyarray.NumpyArray(
-#                     np.array(
-#                         [
-#                             0.0,
-#                             1.0,
-#                             2.0,
-#                             3.0,
-#                             4.0,
-#                             5.0,
-#                             6.0,
-#                             7.0,
-#                             1.1,
-#                             2.2,
-#                             3.3,
-#                             4.4,
-#                             5.5,
-#                             6.6,
-#                         ]
-#                     )
-#                 )
-#             ],
-#             ["nest"],
-#         ),
-#         valid_when=False,
-#         length=13,
-#         lsb_order=True,
-#     )
-
-
-# def test_UnmaskedArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.unmaskedarray.UnmaskedArray(
-#         ak._v2.contents.recordarray.RecordArray(
-#             [ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3]))],
-#             ["nest"],
-#         )
-#     )
-
-
-# def test_UnionArray_RecordArray_NumpyArray():
-#     v2a = ak._v2.contents.unionarray.UnionArray(
-#         ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),
-#         ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
-#         [
-#             ak._v2.contents.recordarray.RecordArray(
-#                 [ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3], np.int64))],
-#                 ["nest"],
-#             ),
-#             ak._v2.contents.recordarray.RecordArray(
-#                 [
-#                     ak._v2.contents.numpyarray.NumpyArray(
-#                         np.array([1.1, 2.2, 3.3, 4.4, 5.5])
-#                     )
-#                 ],
-#                 ["nest"],
-#             ),
-#         ],
-#     )
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_UnionArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  out[0] = obj.size();
+  out[1] = obj[0].index();
+  out[2] = obj[1].index();
+  out[3] = obj[2].index();
+  out[4] = obj[3].index();
+  out[5] = obj[4].index();
+  out[6] = obj[5].index();
+  out[7] = obj[6].index();
+  out[8] = std::get<double>(obj[0]);
+  out[9] = std::get<double>(obj[1]);
+  out[10] = std::get<int64_t>(obj[2]);
+  out[11] = std::get<int64_t>(obj[3]);
+  out[12] = std::get<double>(obj[4]);
+  out[13] = std::get<int64_t>(obj[5]);
+  out[14] = std::get<double>(obj[6]);
+}}
+"""
+    )
+    out = np.zeros(15, dtype=np.float64)
+    ROOT.roottest_UnionArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [7, 1, 1, 0, 0, 1, 0, 1, 5.5, 4.4, 1, 2, 3.3, 3, 5.5]

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -94,7 +94,8 @@ void roottest_NumpyArray_shape_v2a(double* out, ssize_t length, ssize_t* ptrs) {
     assert out.tolist() == [2.0, 3.0, 5.0, 0.0, 1.0, 5.0, 6.0, 15.0, 21.0]
 
 
-def test_RegularArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_RegularArray_NumpyArray(flatlist_as_rvec):
     v2a = ak._v2.contents.regulararray.RegularArray(
         ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
         3,
@@ -103,11 +104,11 @@ def test_RegularArray_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(compiler)
+    generator.generate(debug_compiler, flatlist_as_rvec=flatlist_as_rvec)
 
     ROOT.gInterpreter.Declare(
         f"""
-void roottest_RegularArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+void roottest_RegularArray_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()};
   out[0] = obj.size();
   out[1] = obj[0][0];
@@ -119,9 +120,13 @@ void roottest_RegularArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* 
 """
     )
     out = np.zeros(6, dtype=np.float64)
-    ROOT.roottest_RegularArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    getattr(ROOT, f"roottest_RegularArray_NumpyArray_v2a_{flatlist_as_rvec}")(
+        out, len(layout), lookup.arrayptrs
+    )
     assert out.tolist() == [2.0, 0.0, 1.1, 3.3, 4.4, 3.0]
 
+
+def test_RegularArray_NumpyArray_v2b():
     v2b = ak._v2.contents.regulararray.RegularArray(
         ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(np.dtype(np.float64)),
         0,
@@ -148,7 +153,8 @@ void roottest_RegularArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* 
     assert out.tolist() == [10.0, 0.0, 0.0]
 
 
-def test_ListArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_ListArray_NumpyArray(flatlist_as_rvec):
     v2a = ak._v2.contents.listarray.ListArray(
         ak._v2.index.Index(np.array([4, 100, 1], np.int64)),
         ak._v2.index.Index(np.array([7, 100, 3, 200], np.int64)),
@@ -160,11 +166,11 @@ def test_ListArray_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(compiler)
+    generator.generate(compiler, flatlist_as_rvec=flatlist_as_rvec)
 
     ROOT.gInterpreter.Declare(
         f"""
-void roottest_ListArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+void roottest_ListArray_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()};
   out[0] = obj.size();
   out[1] = obj[0].size();
@@ -179,11 +185,14 @@ void roottest_ListArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptr
 """
     )
     out = np.zeros(9, dtype=np.float64)
-    ROOT.roottest_ListArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    getattr(ROOT, f"roottest_ListArray_NumpyArray_v2a_{flatlist_as_rvec}")(
+        out, len(layout), lookup.arrayptrs
+    )
     assert out.tolist() == [3.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5]
 
 
-def test_ListOffsetArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_ListOffsetArray_NumpyArray(flatlist_as_rvec):
     v2a = ak._v2.contents.listoffsetarray.ListOffsetArray(
         ak._v2.index.Index(np.array([1, 4, 4, 6, 7], np.int64)),
         ak._v2.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]),
@@ -192,11 +201,11 @@ def test_ListOffsetArray_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(compiler)
+    generator.generate(compiler, flatlist_as_rvec=flatlist_as_rvec)
 
     ROOT.gInterpreter.Declare(
         f"""
-void roottest_ListOffsetArray_NumpyArray(double* out, ssize_t length, ssize_t* ptrs) {{
+void roottest_ListOffsetArray_NumpyArray_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()};
   out[0] = obj.size();
   out[1] = obj[0].size();
@@ -213,7 +222,9 @@ void roottest_ListOffsetArray_NumpyArray(double* out, ssize_t length, ssize_t* p
 """
     )
     out = np.zeros(11, dtype=np.float64)
-    ROOT.roottest_ListOffsetArray_NumpyArray(out, len(layout), lookup.arrayptrs)
+    getattr(ROOT, f"roottest_ListOffsetArray_NumpyArray_{flatlist_as_rvec}")(
+        out, len(layout), lookup.arrayptrs
+    )
     assert out.tolist() == [4.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5, 1.0, 7.7]
 
 
@@ -833,7 +844,8 @@ void roottest_UnionArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* pt
     assert out.tolist() == [7, 1, 1, 0, 0, 1, 0, 1, 5.5, 4.4, 1, 2, 3.3, 3, 5.5]
 
 
-def test_nested_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_nested_NumpyArray(flatlist_as_rvec):
     v2a = ak._v2.contents.ListOffsetArray(
         ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
         ak._v2.contents.numpyarray.NumpyArray(
@@ -845,11 +857,11 @@ def test_nested_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(compiler)
+    generator.generate(compiler, flatlist_as_rvec=flatlist_as_rvec)
 
     ROOT.gInterpreter.Declare(
         f"""
-void roottest_nested_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+void roottest_nested_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()}[1];
   out[0] = obj.size();
   out[1] = obj[1];
@@ -858,7 +870,9 @@ void roottest_nested_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) 
 """
     )
     out = np.zeros(3, dtype=np.float64)
-    ROOT.roottest_nested_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    getattr(ROOT, f"roottest_nested_NumpyArray_v2a_{flatlist_as_rvec}")(
+        out, len(layout), lookup.arrayptrs
+    )
     assert out.tolist() == [4.0, 1.1, 3.3]
 
 
@@ -959,7 +973,8 @@ void roottest_nested_RegularArray_NumpyArray_v2b(double* out, ssize_t length, ss
     assert out.tolist() == [10.0, 0.0, 0.0]
 
 
-def test_nested_ListArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_nested_ListArray_NumpyArray(flatlist_as_rvec):
     v2a = ak._v2.contents.ListOffsetArray(
         ak._v2.index.Index64(np.array([0, 1, 4], dtype=np.int64)),
         ak._v2.contents.listarray.ListArray(
@@ -974,11 +989,11 @@ def test_nested_ListArray_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(compiler)
+    generator.generate(compiler, flatlist_as_rvec=flatlist_as_rvec)
 
     ROOT.gInterpreter.Declare(
         f"""
-void roottest_nested_ListArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+void roottest_nested_ListArray_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()}[1];
   out[0] = obj.size();
   out[1] = obj[0].size();
@@ -993,11 +1008,14 @@ void roottest_nested_ListArray_NumpyArray_v2a(double* out, ssize_t length, ssize
 """
     )
     out = np.zeros(9, dtype=np.float64)
-    ROOT.roottest_nested_ListArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    getattr(ROOT, f"roottest_nested_ListArray_NumpyArray_v2a_{flatlist_as_rvec}")(
+        out, len(layout), lookup.arrayptrs
+    )
     assert out.tolist() == [3.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5]
 
 
-def test_nested_ListOffsetArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_nested_ListOffsetArray_NumpyArray(flatlist_as_rvec):
     v2a = ak._v2.contents.ListOffsetArray(
         ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
         ak._v2.contents.listoffsetarray.ListOffsetArray(
@@ -1009,11 +1027,11 @@ def test_nested_ListOffsetArray_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(compiler)
+    generator.generate(compiler, flatlist_as_rvec=flatlist_as_rvec)
 
     ROOT.gInterpreter.Declare(
         f"""
-void roottest_nested_ListOffsetArray_NumpyArray(double* out, ssize_t length, ssize_t* ptrs) {{
+void roottest_nested_ListOffsetArray_NumpyArray_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()}[1];
   out[0] = obj.size();
   out[1] = obj[0].size();
@@ -1030,7 +1048,9 @@ void roottest_nested_ListOffsetArray_NumpyArray(double* out, ssize_t length, ssi
 """
     )
     out = np.zeros(11, dtype=np.float64)
-    ROOT.roottest_nested_ListOffsetArray_NumpyArray(out, len(layout), lookup.arrayptrs)
+    getattr(ROOT, f"roottest_nested_ListOffsetArray_NumpyArray_{flatlist_as_rvec}")(
+        out, len(layout), lookup.arrayptrs
+    )
     assert out.tolist() == [4.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5, 1.0, 7.7]
 
 

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -45,7 +45,7 @@ void roottest_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
 
 
 def test_EmptyArray():
-    v2a = ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(np.dtype(np.float64))
+    v2a = ak._v2.contents.emptyarray.EmptyArray()
 
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
@@ -297,6 +297,7 @@ void roottest_RecordArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* p
 void roottest_RecordArray_NumpyArray_v2c(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()};
   out[0] = obj.size();
+  obj[5];
 }}
 """
     )
@@ -316,6 +317,7 @@ void roottest_RecordArray_NumpyArray_v2c(double* out, ssize_t length, ssize_t* p
 void roottest_RecordArray_NumpyArray_v2d(double* out, ssize_t length, ssize_t* ptrs) {{
   auto obj = {generator.entry()};
   out[0] = obj.size();
+  obj[5];
 }}
 """
     )
@@ -802,7 +804,7 @@ def test_UnionArray_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(debug_compiler)
+    generator.generate(compiler)
 
     ROOT.gInterpreter.Declare(
         f"""
@@ -828,4 +830,961 @@ void roottest_UnionArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* pt
     )
     out = np.zeros(15, dtype=np.float64)
     ROOT.roottest_UnionArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [7, 1, 1, 0, 0, 1, 0, 1, 5.5, 4.4, 1, 2, 3.3, 3, 5.5]
+
+
+def test_nested_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array([999.0, 0.0, 1.1, 2.2, 3.3]),
+            parameters={"some": "stuff", "other": [1, 2, "three"]},
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[1];
+  out[2] = obj.at(3);
+}}
+"""
+    )
+    out = np.zeros(3, dtype=np.float64)
+    ROOT.roottest_nested_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [4.0, 1.1, 3.3]
+
+
+def test_nested_NumpyArray_shape():
+    data = np.full((3, 3, 5), 999, dtype=np.int64)
+    data[1:3] = np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
+
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(data),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_NumpyArray_shape_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].size();
+  out[2] = obj[0][0].size();
+  out[3] = obj[0][0][0];
+  out[4] = obj[0][0][1];
+  out[5] = obj[0][1][0];
+  out[6] = obj[0][1][1];
+  out[7] = obj[1][0][0];
+  out[8] = obj[1][1][1];
+}}
+"""
+    )
+    out = np.zeros(9, dtype=np.float64)
+    ROOT.roottest_nested_NumpyArray_shape_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [2.0, 3.0, 5.0, 0.0, 1.0, 5.0, 6.0, 15.0, 21.0]
+
+
+def test_nested_RegularArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
+        ak._v2.contents.regulararray.RegularArray(
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([999, 999, 999, 0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+            3,
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_RegularArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0][0];
+  out[2] = obj[0][1];
+  out[3] = obj[1][0];
+  out[4] = obj[1][1];
+  out[5] = obj[1].size();
+}}
+"""
+    )
+    out = np.zeros(6, dtype=np.float64)
+    ROOT.roottest_nested_RegularArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [2.0, 0.0, 1.1, 3.3, 4.4, 3.0]
+
+    v2b = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 11], dtype=np.int64)),
+        ak._v2.contents.regulararray.RegularArray(
+            ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(np.dtype(np.float64)),
+            0,
+            zeros_length=11,
+        ),
+    )
+
+    layout = v2b
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_RegularArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].size();
+  out[2] = obj[1].size();
+}}
+"""
+    )
+    out = np.zeros(3, dtype=np.float64)
+    ROOT.roottest_nested_RegularArray_NumpyArray_v2b(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [10.0, 0.0, 0.0]
+
+
+def test_nested_ListArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 4], dtype=np.int64)),
+        ak._v2.contents.listarray.ListArray(
+            ak._v2.index.Index(np.array([999, 4, 100, 1], np.int64)),
+            ak._v2.index.Index(np.array([999, 7, 100, 3, 200], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+            ),
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_ListArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].size();
+  out[2] = obj[0][0];
+  out[3] = obj[0][1];
+  out[4] = obj[0][2];
+  out[5] = obj[1].size();
+  out[6] = obj[2].size();
+  out[7] = obj[2][0];
+  out[8] = obj[2][1];
+}}
+"""
+    )
+    out = np.zeros(9, dtype=np.float64)
+    ROOT.roottest_nested_ListArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [3.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5]
+
+
+def test_nested_ListOffsetArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
+        ak._v2.contents.listoffsetarray.ListOffsetArray(
+            ak._v2.index.Index(np.array([1, 1, 4, 4, 6, 7], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]),
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_ListOffsetArray_NumpyArray(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].size();
+  out[2] = obj[0][0];
+  out[3] = obj[0][1];
+  out[4] = obj[0][2];
+  out[5] = obj[1].size();
+  out[6] = obj[2].size();
+  out[7] = obj[2][0];
+  out[8] = obj[2][1];
+  out[9] = obj[3].size();
+  out[10] = obj[3][0];
+}}
+"""
+    )
+    out = np.zeros(11, dtype=np.float64)
+    ROOT.roottest_nested_ListOffsetArray_NumpyArray(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [4.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5, 1.0, 7.7]
+
+
+def test_nested_RecordArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 6], dtype=np.int64)),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([999, 0, 1, 2, 3, 4], np.int64)
+                ),
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([999, 0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+                ),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Something"},
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_RecordArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  auto rec1 = obj[1];
+  auto rec4 = obj[4];
+  out[1] = rec1.x();
+  out[2] = rec1.y();
+  out[3] = rec4.x();
+  out[4] = rec4.y();
+}}
+"""
+    )
+    out = np.zeros(5, dtype=np.float64)
+    ROOT.roottest_nested_RecordArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [5.0, 1, 1.1, 4, 4.4]
+
+    v2b = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 6], dtype=np.int64)),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([999, 0, 1, 2, 3, 4], np.int64)
+                ),
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([999, 0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+                ),
+            ],
+            None,
+        ),
+    )
+
+    layout = v2b
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_RecordArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  auto rec1 = obj[1];
+  auto rec4 = obj[4];
+  out[1] = rec1.slot0();
+  out[2] = rec1.slot1();
+  out[3] = rec4.slot0();
+  out[4] = rec4.slot1();
+}}
+"""
+    )
+    out = np.zeros(5, dtype=np.float64)
+    ROOT.roottest_nested_RecordArray_NumpyArray_v2b(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [5.0, 1, 1.1, 4, 4.4]
+
+    v2c = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 11], dtype=np.int64)),
+        ak._v2.contents.recordarray.RecordArray([], [], 11),
+    )
+
+    layout = v2c
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_RecordArray_NumpyArray_v2c(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  obj[5];
+}}
+"""
+    )
+    out = np.zeros(1, dtype=np.float64)
+    ROOT.roottest_nested_RecordArray_NumpyArray_v2c(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [10.0]
+
+    v2d = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 11], dtype=np.int64)),
+        ak._v2.contents.recordarray.RecordArray([], None, 11),
+    )
+
+    layout = v2d
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_RecordArray_NumpyArray_v2d(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  obj[5];
+}}
+"""
+    )
+    out = np.zeros(1, dtype=np.float64)
+    ROOT.roottest_nested_RecordArray_NumpyArray_v2d(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [10.0]
+
+
+def test_nested_IndexedArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 8], dtype=np.int64)),
+        ak._v2.contents.indexedarray.IndexedArray(
+            ak._v2.index.Index(np.array([999, 2, 2, 0, 1, 4, 5, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_IndexedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0];
+  out[2] = obj[1];
+  out[3] = obj[2];
+  out[4] = obj[3];
+  out[5] = obj[4];
+  out[6] = obj[5];
+  out[7] = obj[6];
+}}
+"""
+    )
+    out = np.zeros(8, dtype=np.float64)
+    ROOT.roottest_nested_IndexedArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    assert out.tolist() == [7.0, 2.2, 2.2, 0.0, 1.1, 4.4, 5.5, 4.4]
+
+
+def test_nested_IndexedOptionArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 8], dtype=np.int64)),
+        ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+            ak._v2.index.Index(np.array([999, 2, 2, -1, 1, -1, 5, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_IndexedOptionArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(8, dtype=np.float64)
+    ROOT.roottest_nested_IndexedOptionArray_NumpyArray_v2a(
+        out, len(layout), lookup.arrayptrs
+    )
+    assert out.tolist() == [7.0, 2.2, 2.2, 999.0, 1.1, 999.0, 5.5, 4.4]
+
+
+def test_nested_ByteMaskedArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 6], dtype=np.int64)),
+        ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+            ak._v2.index.Index(np.array([123, 1, 0, 1, 0, 1], np.int8)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([999, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+            ),
+            valid_when=True,
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_ByteMaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(6, dtype=np.float64)
+    ROOT.roottest_nested_ByteMaskedArray_NumpyArray_v2a(
+        out, len(layout), lookup.arrayptrs
+    )
+    assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
+
+    v2b = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 6], dtype=np.int64)),
+        ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+            ak._v2.index.Index(np.array([123, 0, 1, 0, 1, 0], np.int8)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([999, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+            ),
+            valid_when=False,
+        ),
+    )
+
+    layout = v2b
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_ByteMaskedArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(6, dtype=np.float64)
+    ROOT.roottest_nested_ByteMaskedArray_NumpyArray_v2b(
+        out, len(layout), lookup.arrayptrs
+    )
+    assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
+
+
+def test_nested_BitMaskedArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 14], dtype=np.int64)),
+        ak._v2.contents.bitmaskedarray.BitMaskedArray(
+            ak._v2.index.Index(
+                np.packbits(
+                    np.array(
+                        [
+                            0,
+                            1,
+                            1,
+                            1,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                        ],
+                        np.uint8,
+                    )
+                )
+            ),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array(
+                    [
+                        999,
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4,
+                        5.5,
+                        6.6,
+                    ]
+                )
+            ),
+            valid_when=True,
+            length=14,
+            lsb_order=False,
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_BitMaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+  out[8] = obj[7].has_value() ? obj[7].value() : 999.0;
+  out[9] = obj[8].has_value() ? obj[8].value() : 999.0;
+  out[10] = obj[9].has_value() ? obj[9].value() : 999.0;
+  out[11] = obj[10].has_value() ? obj[10].value() : 999.0;
+  out[12] = obj[11].has_value() ? obj[11].value() : 999.0;
+  out[13] = obj[12].has_value() ? obj[12].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(14, dtype=np.float64)
+    ROOT.roottest_nested_BitMaskedArray_NumpyArray_v2a(
+        out, len(layout), lookup.arrayptrs
+    )
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2b = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 14], dtype=np.int64)),
+        ak._v2.contents.bitmaskedarray.BitMaskedArray(
+            ak._v2.index.Index(
+                np.packbits(
+                    np.array(
+                        [
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            1,
+                            1,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                        ],
+                        np.uint8,
+                    )
+                )
+            ),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array(
+                    [
+                        999,
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4,
+                        5.5,
+                        6.6,
+                    ]
+                )
+            ),
+            valid_when=False,
+            length=14,
+            lsb_order=False,
+        ),
+    )
+
+    layout = v2b
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_BitMaskedArray_NumpyArray_v2b(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+  out[8] = obj[7].has_value() ? obj[7].value() : 999.0;
+  out[9] = obj[8].has_value() ? obj[8].value() : 999.0;
+  out[10] = obj[9].has_value() ? obj[9].value() : 999.0;
+  out[11] = obj[10].has_value() ? obj[10].value() : 999.0;
+  out[12] = obj[11].has_value() ? obj[11].value() : 999.0;
+  out[13] = obj[12].has_value() ? obj[12].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(14, dtype=np.float64)
+    ROOT.roottest_nested_BitMaskedArray_NumpyArray_v2b(
+        out, len(layout), lookup.arrayptrs
+    )
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2c = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 14], dtype=np.int64)),
+        ak._v2.contents.bitmaskedarray.BitMaskedArray(
+            ak._v2.index.Index(
+                np.packbits(
+                    np.array(
+                        [
+                            0,
+                            0,
+                            0,
+                            1,
+                            1,
+                            1,
+                            1,
+                            0,
+                            0,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                            0,
+                        ],
+                        np.uint8,
+                    )
+                )
+            ),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array(
+                    [
+                        999,
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4,
+                        5.5,
+                        6.6,
+                    ]
+                )
+            ),
+            valid_when=True,
+            length=14,
+            lsb_order=True,
+        ),
+    )
+
+    layout = v2c
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_BitMaskedArray_NumpyArray_v2c(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+  out[8] = obj[7].has_value() ? obj[7].value() : 999.0;
+  out[9] = obj[8].has_value() ? obj[8].value() : 999.0;
+  out[10] = obj[9].has_value() ? obj[9].value() : 999.0;
+  out[11] = obj[10].has_value() ? obj[10].value() : 999.0;
+  out[12] = obj[11].has_value() ? obj[11].value() : 999.0;
+  out[13] = obj[12].has_value() ? obj[12].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(14, dtype=np.float64)
+    ROOT.roottest_nested_BitMaskedArray_NumpyArray_v2c(
+        out, len(layout), lookup.arrayptrs
+    )
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2d = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 14], dtype=np.int64)),
+        ak._v2.contents.bitmaskedarray.BitMaskedArray(
+            ak._v2.index.Index(
+                np.packbits(
+                    np.array(
+                        [
+                            1,
+                            1,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            1,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                            1,
+                        ],
+                        np.uint8,
+                    )
+                )
+            ),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array(
+                    [
+                        999,
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4,
+                        5.5,
+                        6.6,
+                    ]
+                )
+            ),
+            valid_when=False,
+            length=14,
+            lsb_order=True,
+        ),
+    )
+
+    layout = v2d
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_BitMaskedArray_NumpyArray_v2d(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].has_value() ? obj[0].value() : 999.0;
+  out[2] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[3] = obj[2].has_value() ? obj[2].value() : 999.0;
+  out[4] = obj[3].has_value() ? obj[3].value() : 999.0;
+  out[5] = obj[4].has_value() ? obj[4].value() : 999.0;
+  out[6] = obj[5].has_value() ? obj[5].value() : 999.0;
+  out[7] = obj[6].has_value() ? obj[6].value() : 999.0;
+  out[8] = obj[7].has_value() ? obj[7].value() : 999.0;
+  out[9] = obj[8].has_value() ? obj[8].value() : 999.0;
+  out[10] = obj[9].has_value() ? obj[9].value() : 999.0;
+  out[11] = obj[10].has_value() ? obj[10].value() : 999.0;
+  out[12] = obj[11].has_value() ? obj[11].value() : 999.0;
+  out[13] = obj[12].has_value() ? obj[12].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(14, dtype=np.float64)
+    ROOT.roottest_nested_BitMaskedArray_NumpyArray_v2d(
+        out, len(layout), lookup.arrayptrs
+    )
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+
+def test_nested_UnmaskedArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
+        ak._v2.contents.unmaskedarray.UnmaskedArray(
+            ak._v2.contents.numpyarray.NumpyArray(np.array([999, 0.0, 1.1, 2.2, 3.3]))
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_UnmaskedArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[1].has_value() ? obj[1].value() : 999.0;
+  out[2] = obj[3].has_value() ? obj[3].value() : 999.0;
+}}
+"""
+    )
+    out = np.zeros(3, dtype=np.float64)
+    ROOT.roottest_nested_UnmaskedArray_NumpyArray_v2a(
+        out, len(layout), lookup.arrayptrs
+    )
+    assert out.tolist() == [4.0, 1.1, 3.3]
+
+
+def test_nested_UnionArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 8], dtype=np.int64)),
+        ak._v2.contents.unionarray.UnionArray(
+            ak._v2.index.Index(np.array([123, 1, 1, 0, 0, 1, 0, 1], np.int8)),
+            ak._v2.index.Index(np.array([999, 4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
+            [
+                ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3], np.int64)),
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5])
+                ),
+            ],
+        ),
+    )
+
+    layout = v2a
+    generator = ak._v2._connect.cling.togenerator(layout.form)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_nested_UnionArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()}[1];
+  out[0] = obj.size();
+  out[1] = obj[0].index();
+  out[2] = obj[1].index();
+  out[3] = obj[2].index();
+  out[4] = obj[3].index();
+  out[5] = obj[4].index();
+  out[6] = obj[5].index();
+  out[7] = obj[6].index();
+  out[8] = std::get<double>(obj[0]);
+  out[9] = std::get<double>(obj[1]);
+  out[10] = std::get<int64_t>(obj[2]);
+  out[11] = std::get<int64_t>(obj[3]);
+  out[12] = std::get<double>(obj[4]);
+  out[13] = std::get<int64_t>(obj[5]);
+  out[14] = std::get<double>(obj[6]);
+}}
+"""
+    )
+    out = np.zeros(15, dtype=np.float64)
+    ROOT.roottest_nested_UnionArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
     assert out.tolist() == [7, 1, 1, 0, 0, 1, 0, 1, 5.5, 4.4, 1, 2, 3.3, 3, 5.5]

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -109,7 +109,7 @@ def test_RegularArray_NumpyArray(flatlist_as_rvec):
     ROOT.gInterpreter.Declare(
         f"""
 void roottest_RegularArray_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
-  auto obj = {generator.entry()};
+  auto obj = {generator.entry(flatlist_as_rvec=flatlist_as_rvec)};
   out[0] = obj.size();
   out[1] = obj[0][0];
   out[2] = obj[0][1];
@@ -171,7 +171,7 @@ def test_ListArray_NumpyArray(flatlist_as_rvec):
     ROOT.gInterpreter.Declare(
         f"""
 void roottest_ListArray_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
-  auto obj = {generator.entry()};
+  auto obj = {generator.entry(flatlist_as_rvec=flatlist_as_rvec)};
   out[0] = obj.size();
   out[1] = obj[0].size();
   out[2] = obj[0][0];
@@ -206,7 +206,7 @@ def test_ListOffsetArray_NumpyArray(flatlist_as_rvec):
     ROOT.gInterpreter.Declare(
         f"""
 void roottest_ListOffsetArray_NumpyArray_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
-  auto obj = {generator.entry()};
+  auto obj = {generator.entry(flatlist_as_rvec=flatlist_as_rvec)};
   out[0] = obj.size();
   out[1] = obj[0].size();
   out[2] = obj[0][0];
@@ -862,7 +862,7 @@ def test_nested_NumpyArray(flatlist_as_rvec):
     ROOT.gInterpreter.Declare(
         f"""
 void roottest_nested_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
-  auto obj = {generator.entry()}[1];
+  auto obj = {generator.entry(flatlist_as_rvec=flatlist_as_rvec)}[1];
   out[0] = obj.size();
   out[1] = obj[1];
   out[2] = obj.at(3);
@@ -911,7 +911,8 @@ void roottest_nested_NumpyArray_shape_v2a(double* out, ssize_t length, ssize_t* 
     assert out.tolist() == [2.0, 3.0, 5.0, 0.0, 1.0, 5.0, 6.0, 15.0, 21.0]
 
 
-def test_nested_RegularArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_nested_RegularArray_NumpyArray(flatlist_as_rvec):
     v2a = ak._v2.contents.ListOffsetArray(
         ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
         ak._v2.contents.regulararray.RegularArray(
@@ -925,12 +926,12 @@ def test_nested_RegularArray_NumpyArray():
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(compiler)
+    generator.generate(compiler, flatlist_as_rvec=flatlist_as_rvec)
 
     ROOT.gInterpreter.Declare(
         f"""
-void roottest_nested_RegularArray_NumpyArray_v2a(double* out, ssize_t length, ssize_t* ptrs) {{
-  auto obj = {generator.entry()}[1];
+void roottest_nested_RegularArray_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry(flatlist_as_rvec=flatlist_as_rvec)}[1];
   out[0] = obj.size();
   out[1] = obj[0][0];
   out[2] = obj[0][1];
@@ -941,7 +942,9 @@ void roottest_nested_RegularArray_NumpyArray_v2a(double* out, ssize_t length, ss
 """
     )
     out = np.zeros(6, dtype=np.float64)
-    ROOT.roottest_nested_RegularArray_NumpyArray_v2a(out, len(layout), lookup.arrayptrs)
+    getattr(ROOT, f"roottest_nested_RegularArray_NumpyArray_v2a_{flatlist_as_rvec}")(
+        out, len(layout), lookup.arrayptrs
+    )
     assert out.tolist() == [2.0, 0.0, 1.1, 3.3, 4.4, 3.0]
 
     v2b = ak._v2.contents.ListOffsetArray(
@@ -994,7 +997,7 @@ def test_nested_ListArray_NumpyArray(flatlist_as_rvec):
     ROOT.gInterpreter.Declare(
         f"""
 void roottest_nested_ListArray_NumpyArray_v2a_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
-  auto obj = {generator.entry()}[1];
+  auto obj = {generator.entry(flatlist_as_rvec=flatlist_as_rvec)}[1];
   out[0] = obj.size();
   out[1] = obj[0].size();
   out[2] = obj[0][0];
@@ -1027,12 +1030,12 @@ def test_nested_ListOffsetArray_NumpyArray(flatlist_as_rvec):
     layout = v2a
     generator = ak._v2._connect.cling.togenerator(layout.form)
     lookup = ak._v2._lookup.Lookup(layout)
-    generator.generate(compiler, flatlist_as_rvec=flatlist_as_rvec)
+    generator.generate(debug_compiler, flatlist_as_rvec=flatlist_as_rvec)
 
     ROOT.gInterpreter.Declare(
         f"""
 void roottest_nested_ListOffsetArray_NumpyArray_{flatlist_as_rvec}(double* out, ssize_t length, ssize_t* ptrs) {{
-  auto obj = {generator.entry()}[1];
+  auto obj = {generator.entry(flatlist_as_rvec=flatlist_as_rvec)}[1];
   out[0] = obj.size();
   out[1] = obj[0].size();
   out[2] = obj[0][0];

--- a/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/v2/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -1,0 +1,29 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+ROOT = pytest.importorskip("ROOT")
+
+import awkward._v2._lookup  # noqa: E402
+import awkward._v2._connect.cling  # noqa: E402
+
+
+def test():
+    array = ak._v2.Array([5, 4, 3, 2, 1])
+    generator = ak._v2._connect.cling.togenerator(array.layout.form)
+    lookup = ak._v2._lookup.Lookup(array.layout)
+
+    generator.generate(ROOT.gInterpreter.Declare)
+
+    ROOT.gInterpreter.Declare(
+        f"""
+void roottest_1(ssize_t length, ssize_t* ptrs) {{
+  auto obj = {generator.entry()};
+  std::cout << "HEY " << obj[0] << std::endl;
+}}
+"""
+    )
+
+    ROOT.roottest_1(len(array), lookup.arrayptrs)

--- a/tests/v2/test_1300b-same-for-numba.py
+++ b/tests/v2/test_1300b-same-for-numba.py
@@ -1,0 +1,1346 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+numba = pytest.importorskip("numba")
+
+ak_numba_arrayview = pytest.importorskip("awkward._v2._connect.numba.arrayview")
+
+ak._v2.numba.register_and_check()
+
+
+def test_NumpyArray():
+    v2a = ak._v2.contents.numpyarray.NumpyArray(
+        np.array([0.0, 1.1, 2.2, 3.3]),
+        parameters={"some": "stuff", "other": [1, 2, "three"]},
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[1]
+        out[2] = obj[3]
+
+    out = np.zeros(3, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [4.0, 1.1, 3.3]
+
+
+def test_EmptyArray():
+    v2a = ak._v2.contents.emptyarray.EmptyArray()
+
+    @numba.njit
+    def f(obj):
+        return len(obj)
+
+    assert f(ak._v2.highlevel.Array(v2a)) == 0
+
+
+def test_NumpyArray_shape():
+    v2a = ak._v2.contents.numpyarray.NumpyArray(
+        np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = len(obj[0])
+        out[2] = len(obj[0][0])
+        out[3] = obj[0][0][0]
+        out[4] = obj[0][0][1]
+        out[5] = obj[0][1][0]
+        out[6] = obj[0][1][1]
+        out[7] = obj[1][0][0]
+        out[8] = obj[1][1][1]
+
+    out = np.zeros(9, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [2.0, 3.0, 5.0, 0.0, 1.0, 5.0, 6.0, 15.0, 21.0]
+
+
+def test_RegularArray_NumpyArray():
+    v2a = ak._v2.contents.regulararray.RegularArray(
+        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+        3,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0][0]
+        out[2] = obj[0][1]
+        out[3] = obj[1][0]
+        out[4] = obj[1][1]
+        out[5] = len(obj[1])
+
+    out = np.zeros(6, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [2.0, 0.0, 1.1, 3.3, 4.4, 3.0]
+
+    v2b = ak._v2.contents.regulararray.RegularArray(
+        ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(np.dtype(np.float64)),
+        0,
+        zeros_length=10,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = len(obj[0])
+        out[2] = len(obj[1])
+
+    out = np.zeros(3, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2b))
+    assert out.tolist() == [10.0, 0.0, 0.0]
+
+
+def test_ListArray_NumpyArray():
+    v2a = ak._v2.contents.listarray.ListArray(
+        ak._v2.index.Index(np.array([4, 100, 1], np.int64)),
+        ak._v2.index.Index(np.array([7, 100, 3, 200], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+        ),
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = len(obj[0])
+        out[2] = obj[0][0]
+        out[3] = obj[0][1]
+        out[4] = obj[0][2]
+        out[5] = len(obj[1])
+        out[6] = len(obj[2])
+        out[7] = obj[2][0]
+        out[8] = obj[2][1]
+
+    out = np.zeros(9, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [3.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5]
+
+
+def test_ListOffsetArray_NumpyArray():
+    v2a = ak._v2.contents.listoffsetarray.ListOffsetArray(
+        ak._v2.index.Index(np.array([1, 4, 4, 6, 7], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]),
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = len(obj[0])
+        out[2] = obj[0][0]
+        out[3] = obj[0][1]
+        out[4] = obj[0][2]
+        out[5] = len(obj[1])
+        out[6] = len(obj[2])
+        out[7] = obj[2][0]
+        out[8] = obj[2][1]
+        out[9] = len(obj[3])
+        out[10] = obj[3][0]
+
+    out = np.zeros(11, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [4.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5, 1.0, 7.7]
+
+
+def test_RecordArray_NumpyArray():
+    v2a = ak._v2.contents.recordarray.RecordArray(
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ],
+        ["x", "y"],
+        parameters={"__record__": "Something"},
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        rec1 = obj[1]
+        rec4 = obj[4]
+        out[1] = rec1.x
+        out[2] = rec1.y
+        out[3] = rec4.x
+        out[4] = rec4.y
+
+    out = np.zeros(5, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [5.0, 1, 1.1, 4, 4.4]
+
+    v2b = ak._v2.contents.recordarray.RecordArray(
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ],
+        None,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        rec1 = obj[1]
+        rec4 = obj[4]
+        out[1] = rec1["0"]
+        out[2] = rec1["1"]
+        out[3] = rec4["0"]
+        out[4] = rec4["1"]
+
+    out = np.zeros(5, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2b))
+    assert out.tolist() == [5.0, 1, 1.1, 4, 4.4]
+
+    v2c = ak._v2.contents.recordarray.RecordArray([], [], 10)
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        obj[5]
+
+    out = np.zeros(1, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2c))
+    assert out.tolist() == [10.0]
+
+    v2d = ak._v2.contents.recordarray.RecordArray([], None, 10)
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        obj[5]
+
+    out = np.zeros(1, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2d))
+    assert out.tolist() == [10.0]
+
+
+def test_IndexedArray_NumpyArray():
+    v2a = ak._v2.contents.indexedarray.IndexedArray(
+        ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0]
+        out[2] = obj[1]
+        out[3] = obj[2]
+        out[4] = obj[3]
+        out[5] = obj[4]
+        out[6] = obj[5]
+        out[7] = obj[6]
+
+    out = np.zeros(8, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [7.0, 2.2, 2.2, 0.0, 1.1, 4.4, 5.5, 4.4]
+
+
+def test_IndexedOptionArray_NumpyArray():
+    v2a = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+        ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+
+    out = np.zeros(8, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [7.0, 2.2, 2.2, 999.0, 1.1, 999.0, 5.5, 4.4]
+
+
+def test_ByteMaskedArray_NumpyArray():
+    v2a = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=True,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+
+    out = np.zeros(6, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
+
+    v2b = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([0, 1, 0, 1, 0], np.int8)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=False,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+
+    out = np.zeros(6, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2b))
+    assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
+
+
+def test_BitMaskedArray_NumpyArray():
+    v2a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+        out[8] = obj[7] if obj[7] is not None else 999.0
+        out[9] = obj[8] if obj[8] is not None else 999.0
+        out[10] = obj[9] if obj[9] is not None else 999.0
+        out[11] = obj[10] if obj[10] is not None else 999.0
+        out[12] = obj[11] if obj[11] is not None else 999.0
+        out[13] = obj[12] if obj[12] is not None else 999.0
+
+    out = np.zeros(14, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2b = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=False,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+        out[8] = obj[7] if obj[7] is not None else 999.0
+        out[9] = obj[8] if obj[8] is not None else 999.0
+        out[10] = obj[9] if obj[9] is not None else 999.0
+        out[11] = obj[10] if obj[10] is not None else 999.0
+        out[12] = obj[11] if obj[11] is not None else 999.0
+        out[13] = obj[12] if obj[12] is not None else 999.0
+
+    out = np.zeros(14, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2b))
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2c = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=True,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+        out[8] = obj[7] if obj[7] is not None else 999.0
+        out[9] = obj[8] if obj[8] is not None else 999.0
+        out[10] = obj[9] if obj[9] is not None else 999.0
+        out[11] = obj[10] if obj[10] is not None else 999.0
+        out[12] = obj[11] if obj[11] is not None else 999.0
+        out[13] = obj[12] if obj[12] is not None else 999.0
+
+    out = np.zeros(14, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2c))
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2d = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=True,
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+        out[8] = obj[7] if obj[7] is not None else 999.0
+        out[9] = obj[8] if obj[8] is not None else 999.0
+        out[10] = obj[9] if obj[9] is not None else 999.0
+        out[11] = obj[10] if obj[10] is not None else 999.0
+        out[12] = obj[11] if obj[11] is not None else 999.0
+        out[13] = obj[12] if obj[12] is not None else 999.0
+
+    out = np.zeros(14, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2d))
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+
+def test_UnmaskedArray_NumpyArray():
+    v2a = ak._v2.contents.unmaskedarray.UnmaskedArray(
+        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3]))
+    )
+
+    @numba.njit
+    def f(out, obj):
+        out[0] = len(obj)
+        out[1] = obj[1] if obj[1] is not None else 999.0
+        out[2] = obj[3] if obj[3] is not None else 999.0
+
+    out = np.zeros(3, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [4.0, 1.1, 3.3]
+
+
+def test_nested_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array([999.0, 0.0, 1.1, 2.2, 3.3]),
+            parameters={"some": "stuff", "other": [1, 2, "three"]},
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[1]
+        out[2] = obj[3]
+
+    out = np.zeros(3, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [4.0, 1.1, 3.3]
+
+
+def test_nested_NumpyArray_shape():
+    data = np.full((3, 3, 5), 999, dtype=np.int64)
+    data[1:3] = np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
+
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(data),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = len(obj[0])
+        out[2] = len(obj[0][0])
+        out[3] = obj[0][0][0]
+        out[4] = obj[0][0][1]
+        out[5] = obj[0][1][0]
+        out[6] = obj[0][1][1]
+        out[7] = obj[1][0][0]
+        out[8] = obj[1][1][1]
+
+    out = np.zeros(9, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [2.0, 3.0, 5.0, 0.0, 1.0, 5.0, 6.0, 15.0, 21.0]
+
+
+def test_nested_RegularArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
+        ak._v2.contents.regulararray.RegularArray(
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([999, 999, 999, 0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+            3,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0][0]
+        out[2] = obj[0][1]
+        out[3] = obj[1][0]
+        out[4] = obj[1][1]
+        out[5] = len(obj[1])
+
+    out = np.zeros(6, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [2.0, 0.0, 1.1, 3.3, 4.4, 3.0]
+
+    v2b = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 11], dtype=np.int64)),
+        ak._v2.contents.regulararray.RegularArray(
+            ak._v2.contents.emptyarray.EmptyArray().toNumpyArray(np.dtype(np.float64)),
+            0,
+            zeros_length=11,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = len(obj[0])
+        out[2] = len(obj[1])
+
+    out = np.zeros(3, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2b))
+    assert out.tolist() == [10.0, 0.0, 0.0]
+
+
+def test_nested_ListArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 4], dtype=np.int64)),
+        ak._v2.contents.listarray.ListArray(
+            ak._v2.index.Index(np.array([999, 4, 100, 1], np.int64)),
+            ak._v2.index.Index(np.array([999, 7, 100, 3, 200], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+            ),
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = len(obj[0])
+        out[2] = obj[0][0]
+        out[3] = obj[0][1]
+        out[4] = obj[0][2]
+        out[5] = len(obj[1])
+        out[6] = len(obj[2])
+        out[7] = obj[2][0]
+        out[8] = obj[2][1]
+
+    out = np.zeros(9, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [3.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5]
+
+
+def test_nested_ListOffsetArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
+        ak._v2.contents.listoffsetarray.ListOffsetArray(
+            ak._v2.index.Index(np.array([1, 1, 4, 4, 6, 7], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]),
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = len(obj[0])
+        out[2] = obj[0][0]
+        out[3] = obj[0][1]
+        out[4] = obj[0][2]
+        out[5] = len(obj[1])
+        out[6] = len(obj[2])
+        out[7] = obj[2][0]
+        out[8] = obj[2][1]
+        out[9] = len(obj[3])
+        out[10] = obj[3][0]
+
+    out = np.zeros(11, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [4.0, 3.0, 1.1, 2.2, 3.3, 0.0, 2.0, 4.4, 5.5, 1.0, 7.7]
+
+
+def test_nested_RecordArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 6], dtype=np.int64)),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([999, 0, 1, 2, 3, 4], np.int64)
+                ),
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([999, 0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+                ),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Something"},
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        rec1 = obj[1]
+        rec4 = obj[4]
+        out[1] = rec1.x
+        out[2] = rec1.y
+        out[3] = rec4.x
+        out[4] = rec4.y
+
+    out = np.zeros(5, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [5.0, 1, 1.1, 4, 4.4]
+
+    v2b = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 6], dtype=np.int64)),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([999, 0, 1, 2, 3, 4], np.int64)
+                ),
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([999, 0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+                ),
+            ],
+            None,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        rec1 = obj[1]
+        rec4 = obj[4]
+        out[1] = rec1["0"]
+        out[2] = rec1["1"]
+        out[3] = rec4["0"]
+        out[4] = rec4["1"]
+
+    out = np.zeros(5, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2b))
+    assert out.tolist() == [5.0, 1, 1.1, 4, 4.4]
+
+    v2c = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 11], dtype=np.int64)),
+        ak._v2.contents.recordarray.RecordArray([], [], 11),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        obj[5]
+
+    out = np.zeros(1, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2c))
+    assert out.tolist() == [10.0]
+
+    v2d = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 11], dtype=np.int64)),
+        ak._v2.contents.recordarray.RecordArray([], None, 11),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        obj[5]
+
+    out = np.zeros(1, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2d))
+    assert out.tolist() == [10.0]
+
+
+def test_nested_IndexedArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 8], dtype=np.int64)),
+        ak._v2.contents.indexedarray.IndexedArray(
+            ak._v2.index.Index(np.array([999, 2, 2, 0, 1, 4, 5, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0]
+        out[2] = obj[1]
+        out[3] = obj[2]
+        out[4] = obj[3]
+        out[5] = obj[4]
+        out[6] = obj[5]
+        out[7] = obj[6]
+
+    out = np.zeros(8, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [7.0, 2.2, 2.2, 0.0, 1.1, 4.4, 5.5, 4.4]
+
+
+def test_nested_IndexedOptionArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 8], dtype=np.int64)),
+        ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+            ak._v2.index.Index(np.array([999, 2, 2, -1, 1, -1, 5, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+
+    out = np.zeros(8, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [7.0, 2.2, 2.2, 999.0, 1.1, 999.0, 5.5, 4.4]
+
+
+def test_nested_ByteMaskedArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 6], dtype=np.int64)),
+        ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+            ak._v2.index.Index(np.array([123, 1, 0, 1, 0, 1], np.int8)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([999, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+            ),
+            valid_when=True,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+
+    out = np.zeros(6, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
+
+    v2b = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 6], dtype=np.int64)),
+        ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+            ak._v2.index.Index(np.array([123, 0, 1, 0, 1, 0], np.int8)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([999, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+            ),
+            valid_when=False,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+
+    out = np.zeros(6, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2b))
+    assert out.tolist() == [5.0, 1.1, 999.0, 3.3, 999.0, 5.5]
+
+
+def test_nested_BitMaskedArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 14], dtype=np.int64)),
+        ak._v2.contents.bitmaskedarray.BitMaskedArray(
+            ak._v2.index.Index(
+                np.packbits(
+                    np.array(
+                        [
+                            0,
+                            1,
+                            1,
+                            1,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                        ],
+                        np.uint8,
+                    )
+                )
+            ),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array(
+                    [
+                        999,
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4,
+                        5.5,
+                        6.6,
+                    ]
+                )
+            ),
+            valid_when=True,
+            length=14,
+            lsb_order=False,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+        out[8] = obj[7] if obj[7] is not None else 999.0
+        out[9] = obj[8] if obj[8] is not None else 999.0
+        out[10] = obj[9] if obj[9] is not None else 999.0
+        out[11] = obj[10] if obj[10] is not None else 999.0
+        out[12] = obj[11] if obj[11] is not None else 999.0
+        out[13] = obj[12] if obj[12] is not None else 999.0
+
+    out = np.zeros(14, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2b = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 14], dtype=np.int64)),
+        ak._v2.contents.bitmaskedarray.BitMaskedArray(
+            ak._v2.index.Index(
+                np.packbits(
+                    np.array(
+                        [
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            1,
+                            1,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                        ],
+                        np.uint8,
+                    )
+                )
+            ),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array(
+                    [
+                        999,
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4,
+                        5.5,
+                        6.6,
+                    ]
+                )
+            ),
+            valid_when=False,
+            length=14,
+            lsb_order=False,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+        out[8] = obj[7] if obj[7] is not None else 999.0
+        out[9] = obj[8] if obj[8] is not None else 999.0
+        out[10] = obj[9] if obj[9] is not None else 999.0
+        out[11] = obj[10] if obj[10] is not None else 999.0
+        out[12] = obj[11] if obj[11] is not None else 999.0
+        out[13] = obj[12] if obj[12] is not None else 999.0
+
+    out = np.zeros(14, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2b))
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2c = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 14], dtype=np.int64)),
+        ak._v2.contents.bitmaskedarray.BitMaskedArray(
+            ak._v2.index.Index(
+                np.packbits(
+                    np.array(
+                        [
+                            0,
+                            0,
+                            0,
+                            1,
+                            1,
+                            1,
+                            1,
+                            0,
+                            0,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                            0,
+                        ],
+                        np.uint8,
+                    )
+                )
+            ),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array(
+                    [
+                        999,
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4,
+                        5.5,
+                        6.6,
+                    ]
+                )
+            ),
+            valid_when=True,
+            length=14,
+            lsb_order=True,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+        out[8] = obj[7] if obj[7] is not None else 999.0
+        out[9] = obj[8] if obj[8] is not None else 999.0
+        out[10] = obj[9] if obj[9] is not None else 999.0
+        out[11] = obj[10] if obj[10] is not None else 999.0
+        out[12] = obj[11] if obj[11] is not None else 999.0
+        out[13] = obj[12] if obj[12] is not None else 999.0
+
+    out = np.zeros(14, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2c))
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+    v2d = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 14], dtype=np.int64)),
+        ak._v2.contents.bitmaskedarray.BitMaskedArray(
+            ak._v2.index.Index(
+                np.packbits(
+                    np.array(
+                        [
+                            1,
+                            1,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            1,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                            0,
+                            1,
+                            1,
+                        ],
+                        np.uint8,
+                    )
+                )
+            ),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array(
+                    [
+                        999,
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4,
+                        5.5,
+                        6.6,
+                    ]
+                )
+            ),
+            valid_when=False,
+            length=14,
+            lsb_order=True,
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[0] if obj[0] is not None else 999.0
+        out[2] = obj[1] if obj[1] is not None else 999.0
+        out[3] = obj[2] if obj[2] is not None else 999.0
+        out[4] = obj[3] if obj[3] is not None else 999.0
+        out[5] = obj[4] if obj[4] is not None else 999.0
+        out[6] = obj[5] if obj[5] is not None else 999.0
+        out[7] = obj[6] if obj[6] is not None else 999.0
+        out[8] = obj[7] if obj[7] is not None else 999.0
+        out[9] = obj[8] if obj[8] is not None else 999.0
+        out[10] = obj[9] if obj[9] is not None else 999.0
+        out[11] = obj[10] if obj[10] is not None else 999.0
+        out[12] = obj[11] if obj[11] is not None else 999.0
+        out[13] = obj[12] if obj[12] is not None else 999.0
+
+    out = np.zeros(14, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2d))
+    assert out.tolist() == [
+        13.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        999.0,
+        999.0,
+        999.0,
+        999.0,
+        1.1,
+        999.0,
+        3.3,
+        999.0,
+        5.5,
+    ]
+
+
+def test_nested_UnmaskedArray_NumpyArray():
+    v2a = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
+        ak._v2.contents.unmaskedarray.UnmaskedArray(
+            ak._v2.contents.numpyarray.NumpyArray(np.array([999, 0.0, 1.1, 2.2, 3.3]))
+        ),
+    )
+
+    @numba.njit
+    def f(out, array):
+        obj = array[1]
+        out[0] = len(obj)
+        out[1] = obj[1] if obj[1] is not None else 999.0
+        out[2] = obj[3] if obj[3] is not None else 999.0
+
+    out = np.zeros(3, dtype=np.float64)
+    f(out, ak._v2.highlevel.Array(v2a))
+    assert out.tolist() == [4.0, 1.1, 3.3]


### PR DESCRIPTION
This is for the Awkward → RDataFrame step in ianna/awkward-to-rdf, but it won't include any RDataFrame-specific stuff (just Cling). @ianna will be able to use this, so it's a blocker for the to-RDF step, but it's not a blocker for the from-RDF step.

Things to do:

  - [x] Extract the `Lookup` class and `tolookup` function(s) from the Numba implementation to use them here. There's nothing Numba-specific about them, but those functions are spread throughout all the Numba Content Types as classmethods. Probably the right way to do it is to make a suite of LookupTypes that is independent of both Numba and C++, then the Numba Content Types would be subclasses. It's relevant because the LookupTypes are, in part, defined by the `cls.STARTS`, `cls.STOPS`, `cls.CONTENT` constants that define the order of the lookup table, and we want to keep that code together as a unit.
  - [x] Set up a test for development. This is all v2.
  - [x] Define a superclass `ak::ArrayView` with `start`, `stop`, `which_array`, and `array_ptrs` (32 bytes). All of the Awkward data will be subclasses of this, but they will add no member data and only the subclasses would ever get instantiated. (Find out if this means there will be an unwanted vtable or not.)
  - [x] Also an `ak::RecordView`, which doesn't derive from the above (sequences and scalars are distinct).
  - [x] Set up the abstract `ak::List<T>`, from which concrete types will derive. If `T` is a primitive type, the concrete type will either be another `ak::List<T>` or a `ROOT::RVec<T>`, depending on a user configuation. [This question](https://stackoverflow.com/q/5478866/1623645) prescribes the set of methods expected on an immutable sequence. Include a placeholder for a `to_RVec() const` method.
  - [x] Generate concrete record classes, deriving from `ak::RecordView`.
  - [x] Generate examples of [std::optional<T>](https://en.cppreference.com/w/cpp/utility/optional) to get a sense of how that works. No need for an Awkward-specific class.
  - [x] Generate examples of [std::variant<T>](https://en.cppreference.com/w/cpp/utility/variant) to get a sense of how that works. No need for an Awkward-specific class.
  - [x] Do NumpyArray (only real, 1-D arrays, no EmptyArray, multidimensional, or non-contiguous because the conversion to Lookup handles that).
  - [x] Do RegularArray.
  - [x] Do ListArray (no ListOffsetArray because the conversion to Lookup makes them all ListArray).
  - [x] Do IndexedArray.
  - [x] Do IndexedOptionArray.
  - [x] Do ByteMaskedArray.
  - [x] Do BitMaskedArray.
  - [x] Do UnmaskedArray.
  - [x] Do RecordArray.
  - [x] Do UnionArray (couldn't be done in Numba, but C++ has `std::variant`, so maybe).

That should do it. In the end, it should have a clean API for @ianna to use.