### PR TITLE
Fix: do not increment field index for nested lists

### DIFF
--- a/src/libawkward/layoutbuilder/RecordArrayBuilder.cpp
+++ b/src/libawkward/layoutbuilder/RecordArrayBuilder.cpp
@@ -1,8 +1,6 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)     \
-  FILENAME_FOR_EXCEPTIONS( \
-      "src/libawkward/layoutbuilder/RecordArrayBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/layoutbuilder/RecordArrayBuilder.cpp", line)
 
 #include "awkward/layoutbuilder/RecordArrayBuilder.h"
 #include "awkward/layoutbuilder/LayoutBuilder.h"
@@ -11,17 +9,16 @@ namespace awkward {
 
   ///
   template <typename T, typename I>
-  RecordArrayBuilder<T, I>::RecordArrayBuilder(
-      const std::vector<FormBuilderPtr<T, I>>& contents,
-      const util::RecordLookupPtr recordlookup,
-      const util::Parameters& parameters,
-      const std::string& form_key,
-      const std::string attribute,
-      const std::string partition)
-      : form_recordlookup_(recordlookup),
-        parameters_(parameters),
-        field_index_(0),
-        contents_size_((int64_t)contents.size()) {
+  RecordArrayBuilder<T, I>::RecordArrayBuilder(const std::vector<FormBuilderPtr<T, I>>& contents,
+                                               const util::RecordLookupPtr recordlookup,
+                                               const util::Parameters& parameters,
+                                               const std::string& form_key,
+                                               const std::string attribute,
+                                               const std::string partition)
+    : form_recordlookup_(recordlookup),
+      parameters_(parameters),
+      field_index_(0),
+      contents_size_((int64_t) contents.size()) {
     for (auto const& content : contents) {
       contents_.push_back(content);
       vm_output_.append(contents_.back().get()->vm_output());
@@ -32,12 +29,12 @@ namespace awkward {
 
     vm_func_name_ = std::string(form_key).append(attribute);
 
-    vm_func_.append(": ").append(vm_func_name_);
+    vm_func_.append(": ")
+      .append(vm_func_name_);
 
     for (auto const& content : contents_) {
-      vm_func_.append(" ")
-          .append(content.get()->vm_func_name())
-          .append(" pause");
+      vm_func_.append(" ").append(content.get()->vm_func_name())
+        .append(" pause");
     }
     // Remove the last pause
     vm_func_.erase(vm_func_.end() - 6, vm_func_.end());
@@ -95,14 +92,12 @@ namespace awkward {
   template <typename T, typename I>
   int64_t
   RecordArrayBuilder<T, I>::field_index() {
-    if (!list_field_index_.empty()) {
+    if (!list_field_index_.empty())
+    {
       return field_index_;
     }
-    auto index = field_index_;
-    field_index_ = (++field_index_ < contents_size_)
-                       ? field_index_
-                       : field_index_ % contents_size_;
-    return index;
+    return (field_index_ < contents_size_ - 1) ?
+      field_index_++ : (field_index_ = 0);
   }
 
   template <typename T, typename I>
@@ -125,22 +120,19 @@ namespace awkward {
 
   template <typename T, typename I>
   void
-  RecordArrayBuilder<T, I>::complex(std::complex<double> x,
-                                    LayoutBuilderPtr<T, I> builder) {
+  RecordArrayBuilder<T, I>::complex(std::complex<double> x, LayoutBuilderPtr<T, I> builder) {
     contents_[(size_t)field_index()].get()->complex(x, builder);
   }
 
   template <typename T, typename I>
   void
-  RecordArrayBuilder<T, I>::bytestring(const std::string& x,
-                                       LayoutBuilderPtr<T, I> builder) {
+  RecordArrayBuilder<T, I>::bytestring(const std::string& x, LayoutBuilderPtr<T, I> builder) {
     contents_[(size_t)field_index()].get()->bytestring(x, builder);
   }
 
   template <typename T, typename I>
   void
-  RecordArrayBuilder<T, I>::string(const std::string& x,
-                                   LayoutBuilderPtr<T, I> builder) {
+  RecordArrayBuilder<T, I>::string(const std::string& x, LayoutBuilderPtr<T, I> builder) {
     contents_[(size_t)field_index()].get()->string(x, builder);
   }
 
@@ -165,8 +157,9 @@ namespace awkward {
   RecordArrayBuilder<T, I>::active() {
     if (!list_field_index_.empty()) {
       return contents_[(size_t)list_field_index_.back()].get()->active();
-    } else {
-      for (auto content : contents_) {
+    }
+    else {
+      for(auto content : contents_) {
         if (content.get()->active()) {
           return true;
         }
@@ -178,4 +171,4 @@ namespace awkward {
   template class EXPORT_TEMPLATE_INST RecordArrayBuilder<int32_t, int32_t>;
   template class EXPORT_TEMPLATE_INST RecordArrayBuilder<int64_t, int32_t>;
 
-}  // namespace awkward
+}

--- a/src/libawkward/layoutbuilder/RecordArrayBuilder.cpp
+++ b/src/libawkward/layoutbuilder/RecordArrayBuilder.cpp
@@ -96,8 +96,11 @@ namespace awkward {
     {
       return field_index_;
     }
-    return (field_index_ < contents_size_ - 1) ?
-      field_index_++ : (field_index_ = 0);
+    auto index = field_index_;
+    field_index_ = (++field_index_ < contents_size_)
+                       ? field_index_
+                       : field_index_ % contents_size_;
+    return index;
   }
 
   template <typename T, typename I>

--- a/src/libawkward/layoutbuilder/RecordArrayBuilder.cpp
+++ b/src/libawkward/layoutbuilder/RecordArrayBuilder.cpp
@@ -1,6 +1,8 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/layoutbuilder/RecordArrayBuilder.cpp", line)
+#define FILENAME(line)     \
+  FILENAME_FOR_EXCEPTIONS( \
+      "src/libawkward/layoutbuilder/RecordArrayBuilder.cpp", line)
 
 #include "awkward/layoutbuilder/RecordArrayBuilder.h"
 #include "awkward/layoutbuilder/LayoutBuilder.h"
@@ -9,16 +11,17 @@ namespace awkward {
 
   ///
   template <typename T, typename I>
-  RecordArrayBuilder<T, I>::RecordArrayBuilder(const std::vector<FormBuilderPtr<T, I>>& contents,
-                                               const util::RecordLookupPtr recordlookup,
-                                               const util::Parameters& parameters,
-                                               const std::string& form_key,
-                                               const std::string attribute,
-                                               const std::string partition)
-    : form_recordlookup_(recordlookup),
-      parameters_(parameters),
-      field_index_(0),
-      contents_size_((int64_t) contents.size()) {
+  RecordArrayBuilder<T, I>::RecordArrayBuilder(
+      const std::vector<FormBuilderPtr<T, I>>& contents,
+      const util::RecordLookupPtr recordlookup,
+      const util::Parameters& parameters,
+      const std::string& form_key,
+      const std::string attribute,
+      const std::string partition)
+      : form_recordlookup_(recordlookup),
+        parameters_(parameters),
+        field_index_(0),
+        contents_size_((int64_t)contents.size()) {
     for (auto const& content : contents) {
       contents_.push_back(content);
       vm_output_.append(contents_.back().get()->vm_output());
@@ -29,12 +32,12 @@ namespace awkward {
 
     vm_func_name_ = std::string(form_key).append(attribute);
 
-    vm_func_.append(": ")
-      .append(vm_func_name_);
+    vm_func_.append(": ").append(vm_func_name_);
 
     for (auto const& content : contents_) {
-      vm_func_.append(" ").append(content.get()->vm_func_name())
-        .append(" pause");
+      vm_func_.append(" ")
+          .append(content.get()->vm_func_name())
+          .append(" pause");
     }
     // Remove the last pause
     vm_func_.erase(vm_func_.end() - 6, vm_func_.end());
@@ -92,12 +95,14 @@ namespace awkward {
   template <typename T, typename I>
   int64_t
   RecordArrayBuilder<T, I>::field_index() {
-    if (!list_field_index_.empty())
-    {
+    if (!list_field_index_.empty()) {
       return field_index_;
     }
-    return (field_index_ < contents_size_ - 1) ?
-      field_index_++ : (field_index_ = 0);
+    auto index = field_index_;
+    field_index_ = (++field_index_ < contents_size_)
+                       ? field_index_
+                       : field_index_ % contents_size_;
+    return index;
   }
 
   template <typename T, typename I>
@@ -120,19 +125,22 @@ namespace awkward {
 
   template <typename T, typename I>
   void
-  RecordArrayBuilder<T, I>::complex(std::complex<double> x, LayoutBuilderPtr<T, I> builder) {
+  RecordArrayBuilder<T, I>::complex(std::complex<double> x,
+                                    LayoutBuilderPtr<T, I> builder) {
     contents_[(size_t)field_index()].get()->complex(x, builder);
   }
 
   template <typename T, typename I>
   void
-  RecordArrayBuilder<T, I>::bytestring(const std::string& x, LayoutBuilderPtr<T, I> builder) {
+  RecordArrayBuilder<T, I>::bytestring(const std::string& x,
+                                       LayoutBuilderPtr<T, I> builder) {
     contents_[(size_t)field_index()].get()->bytestring(x, builder);
   }
 
   template <typename T, typename I>
   void
-  RecordArrayBuilder<T, I>::string(const std::string& x, LayoutBuilderPtr<T, I> builder) {
+  RecordArrayBuilder<T, I>::string(const std::string& x,
+                                   LayoutBuilderPtr<T, I> builder) {
     contents_[(size_t)field_index()].get()->string(x, builder);
   }
 
@@ -157,9 +165,8 @@ namespace awkward {
   RecordArrayBuilder<T, I>::active() {
     if (!list_field_index_.empty()) {
       return contents_[(size_t)list_field_index_.back()].get()->active();
-    }
-    else {
-      for(auto content : contents_) {
+    } else {
+      for (auto content : contents_) {
         if (content.get()->active()) {
           return true;
         }
@@ -171,4 +178,4 @@ namespace awkward {
   template class EXPORT_TEMPLATE_INST RecordArrayBuilder<int32_t, int32_t>;
   template class EXPORT_TEMPLATE_INST RecordArrayBuilder<int64_t, int32_t>;
 
-}
+}  // namespace awkward

--- a/src/libawkward/layoutbuilder/RecordArrayBuilder.cpp
+++ b/src/libawkward/layoutbuilder/RecordArrayBuilder.cpp
@@ -92,6 +92,10 @@ namespace awkward {
   template <typename T, typename I>
   int64_t
   RecordArrayBuilder<T, I>::field_index() {
+    if (!list_field_index_.empty())
+    {
+      return field_index_;
+    }
     return (field_index_ < contents_size_ - 1) ?
       field_index_++ : (field_index_ = 0);
   }

--- a/tests/test_1302-layout-builder-nested-list.py
+++ b/tests/test_1302-layout-builder-nested-list.py
@@ -35,7 +35,7 @@ def test():
             },
             "v": {
                 "class": "NumpyArray",
-                "primitive": "float64",
+                "primitive": "int64",
                 "form_key": "v"
             },
             "w": {
@@ -57,30 +57,33 @@ def test():
 
     builder.int64(1)  # i
     builder.begin_list()  # j
-    builder.int64(2)
+    builder.int64(9)
+    builder.int64(8)
+    builder.int64(7)
     builder.end_list()  # j
 
     builder.end_list()  # u
 
-    builder.float64(3.0)  # v
-    builder.int64(4)  # w
-    builder.int64(5)  # x
+    builder.int64(2)  # v
+    builder.int64(3)  # w
+    builder.int64(4)  # x
 
-    # Second pass
     builder.begin_list()  # u
 
     builder.int64(1)  # i
     builder.begin_list()  # j
-    builder.int64(2)
+    builder.int64(9)
+    builder.int64(8)
+    builder.int64(7)
     builder.end_list()  # j
 
     builder.end_list()  # u
 
-    builder.float64(3.0)  # v
-    builder.int64(4)  # w
-    builder.int64(5)  # x
+    builder.int64(2)  # v
+    builder.int64(3)  # w
+    builder.int64(4)  # x
 
     assert ak.to_list(builder.snapshot()) == [
-        {"u": [{"i": 1, "j": [2]}], "v": 3, "w": 4, "x": 5},
-        {"u": [{"i": 1, "j": [2]}], "v": 3, "w": 4, "x": 5},
+        {"u": [{"i": 1, "j": [9, 8, 7]}], "v": 2, "w": 3, "x": 4},
+        {"u": [{"i": 1, "j": [9, 8, 7]}], "v": 2, "w": 3, "x": 4},
     ]

--- a/tests/test_1302-layout-builder-nested-list.py
+++ b/tests/test_1302-layout-builder-nested-list.py
@@ -22,13 +22,13 @@ def test():
                         "i": {
                             "class": "NumpyArray",
                             "primitive": "int64",
-                            "form_key": "u-content.i"
+                            "form_key": "i"
                         },
                         "j": {
                             "class": "ListOffsetArray64",
                             "offsets": "i64",
                             "content": "int64",
-                            "form_key": "u-content.j"
+                            "form_key": "j"
                         }
                     }
                 }

--- a/tests/test_1302-layout-builder-nested-list.py
+++ b/tests/test_1302-layout-builder-nested-list.py
@@ -1,0 +1,71 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    builder = ak.layout.LayoutBuilder64(
+        """
+    {
+        "form_key": "root",
+        "class": "RecordArray",
+        "contents": {
+            "u": {
+                "form_key": "u",
+                "class": "ListOffsetArray64",
+                "offsets": "i64",
+                "content": {
+                    "form_key": "u-content",
+                    "class": "RecordArray",
+                    "contents": {
+                        "i": {
+                            "class": "NumpyArray",
+                            "primitive": "int64",
+                            "form_key": "u-content.i"
+                        },
+                        "j": {
+                            "class": "ListOffsetArray64",
+                            "offsets": "i64",
+                            "content": "int64",
+                            "form_key": "u-content.j"
+                        }
+                    }
+                }
+            },
+            "v": {
+                "class": "NumpyArray",
+                "primitive": "float64",
+                "form_key": "v"
+            },
+            "w": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "w"
+            },
+            "x": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "x"
+            }
+        }
+    }
+    """
+    )
+
+    builder.begin_list()  # u (0, 0)
+
+    builder.int64(1)  # i (1, 1)
+    builder.begin_list()  # j
+    builder.int64(2)
+    builder.end_list()  # j
+
+    builder.end_list()  # u
+
+    builder.float64(3.0)  # v
+    builder.int64(4)  # w
+    builder.int64(5)  # x
+
+    assert ak.to_list(builder.snapshot()) == [
+        {"u": [{"i": 1, "j": [2]}], "v": 3, "w": 4, "x": 5}
+    ]

--- a/tests/test_1302-layout-builder-nested-list.py
+++ b/tests/test_1302-layout-builder-nested-list.py
@@ -53,9 +53,23 @@ def test():
     """
     )
 
-    builder.begin_list()  # u (0, 0)
+    builder.begin_list()  # u
 
-    builder.int64(1)  # i (1, 1)
+    builder.int64(1)  # i
+    builder.begin_list()  # j
+    builder.int64(2)
+    builder.end_list()  # j
+
+    builder.end_list()  # u
+
+    builder.float64(3.0)  # v
+    builder.int64(4)  # w
+    builder.int64(5)  # x
+
+    # Second pass
+    builder.begin_list()  # u
+
+    builder.int64(1)  # i
     builder.begin_list()  # j
     builder.int64(2)
     builder.end_list()  # j
@@ -67,5 +81,6 @@ def test():
     builder.int64(5)  # x
 
     assert ak.to_list(builder.snapshot()) == [
-        {"u": [{"i": 1, "j": [2]}], "v": 3, "w": 4, "x": 5}
+        {"u": [{"i": 1, "j": [2]}], "v": 3, "w": 4, "x": 5},
+        {"u": [{"i": 1, "j": [2]}], "v": 3, "w": 4, "x": 5},
     ]


### PR DESCRIPTION
This would fix #1302 by holding the `field_index_` constant whilst in an `inside-list` state.