### PR TITLE
Keep as much length knowledge as possible in typetracers.

### DIFF
--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -130,7 +130,7 @@ def all_same_offsets(nplike, inputs):
             if x.size == 0:
                 my_offsets = nplike.empty(0, dtype=np.int64)
             else:
-                my_offsets = nplike.arange(0, x.content.length, x.size)
+                my_offsets = nplike.arange(0, x.content.length, x.size, dtype=np.int64)
 
             if offsets is None:
                 offsets = my_offsets
@@ -323,7 +323,9 @@ def apply_step(
                 for tag, combo in enumerate(all_combos):
                     mask = combos == combo
                     tags[mask] = tag
-                    index[mask] = nplike.arange(nplike.count_nonzero(mask))
+                    index[mask] = nplike.arange(
+                        nplike.count_nonzero(mask), dtype=np.int64
+                    )
                     nextinputs = []
                     i = 0
                     for x in inputs:

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -243,6 +243,9 @@ class TypeTracerArray:
     def ndim(self):
         return len(self._shape)
 
+    def forget_length(self):
+        return type(self)(self._dtype, (UnknownLength,) + self._shape[1:])
+
     def __iter__(self):
         raise AssertionError(
             "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -91,20 +91,29 @@ class ByteMaskedArray(Content):
 
     @property
     def typetracer(self):
+        tt = ak._v2._typetracer.TypeTracer.instance()
         return ByteMaskedArray(
-            ak._v2.index.Index(
-                self._mask.raw(ak._v2._typetracer.TypeTracer.instance())
-            ),
+            ak._v2.index.Index(self._mask.raw(tt)),
             self._content.typetracer,
             self._valid_when,
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._mask.length
+
+    def _forget_length(self):
+        return ByteMaskedArray(
+            self._mask.forget_length(),
+            self._content,
+            self._valid_when,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -173,7 +173,7 @@ class ByteMaskedArray(Content):
 
         if where < 0:
             where += self.length
-        if self._nplike.known_shape and not (0 <= where < self.length):
+        if self._nplike.known_shape and not 0 <= where < self.length:
             raise NestedIndexError(self, where)
         if self._mask[where] == self._valid_when:
             return self._content._getitem_at(where)

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -269,7 +269,7 @@ class ByteMaskedArray(Content):
         return nextcarry, outindex
 
     def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
-        if slicestarts.length != self.length:
+        if self._nplike.known_shape and slicestarts.length != self.length:
             raise NestedIndexError(
                 self,
                 ak._v2.contents.ListArray(

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1203,7 +1203,9 @@ at inner {} of length {}, using sub-slice {}.{}""".format(
 
     def rpad_axis0(self, target, clip):
         if not clip and target < self.length:
-            index = ak._v2.index.Index64(self._nplike.arange(self.length))
+            index = ak._v2.index.Index64(
+                self._nplike.arange(self.length, dtype=np.int64)
+            )
 
         else:
             index = ak._v2.index.Index64.empty(target, self._nplike)

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -104,6 +104,12 @@ class Content:
 
         return self._form_with_key(getkey)
 
+    def forget_length(self):
+        if not isinstance(self._nplike, ak._v2._typetracer.TypeTracer):
+            return self.typetracer._forget_length()
+        else:
+            return self._forget_length()
+
     def to_buffers(
         self,
         container=None,

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -335,7 +335,7 @@ class Content:
 
         index = ak._v2.index.Index64(head._index)
         content = that._getitem_at(0)
-        if content.length < index.length and self._nplike.known_shape:
+        if self._nplike.known_shape and content.length < index.length:
             raise NestedIndexError(
                 self,
                 head,

--- a/src/awkward/_v2/contents/emptyarray.py
+++ b/src/awkward/_v2/contents/emptyarray.py
@@ -99,7 +99,7 @@ class EmptyArray(Content):
     def _carry(self, carry, allow_lazy, exception):
         assert isinstance(carry, ak._v2.index.Index)
 
-        if carry.length == 0 or not carry.nplike.known_shape:
+        if not carry.nplike.known_shape or carry.length == 0:
             return self
         else:
             if issubclass(exception, NestedIndexError):

--- a/src/awkward/_v2/contents/emptyarray.py
+++ b/src/awkward/_v2/contents/emptyarray.py
@@ -33,15 +33,15 @@ class EmptyArray(Content):
 
     @property
     def typetracer(self):
-        return EmptyArray(
-            self._typetracer_identifier(),
-            self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
-        )
+        tt = ak._v2._typetracer.TypeTracer.instance()
+        return EmptyArray(self._typetracer_identifier(), self._parameters, tt)
 
     @property
     def length(self):
         return 0
+
+    def _forget_length(self):
+        return EmptyArray(self._identifier, self._parameters, self._nplike)
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -79,12 +79,21 @@ class IndexedArray(Content):
             self._content.typetracer,
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._index.length
+
+    def _forget_length(self):
+        return IndexedArray(
+            self._index.forget_length(),
+            self._content,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -130,7 +130,7 @@ class IndexedArray(Content):
 
         if where < 0:
             where += self.length
-        if not (0 <= where < self.length) and self._nplike.known_shape:
+        if self._nplike.known_shape and not (0 <= where < self.length):
             raise NestedIndexError(self, where)
         return self._content._getitem_at(self._index[where])
 
@@ -186,7 +186,7 @@ class IndexedArray(Content):
         )
 
     def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
-        if slicestarts.length != self.length and self._nplike.known_shape:
+        if self._nplike.known_shape and slicestarts.length != self.length:
             raise NestedIndexError(
                 self,
                 ak._v2.contents.ListArray(
@@ -270,7 +270,7 @@ class IndexedArray(Content):
 
     def project(self, mask=None):
         if mask is not None:
-            if self._index.length != mask.length:
+            if self._nplike.known_shape and self._index.length != mask.length:
                 raise ValueError(
                     "mask length ({}) is not equal to {} length ({})".format(
                         mask.length(), type(self).__name__, self._index.length
@@ -626,7 +626,7 @@ class IndexedArray(Content):
         )
 
     def fillna(self, value):
-        if value.length != 1:
+        if value.nplike.known_shape and value.length != 1:
             raise ValueError(f"fillna value length ({value.length}) is not equal to 1")
 
         return IndexedArray(

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -130,7 +130,7 @@ class IndexedArray(Content):
 
         if where < 0:
             where += self.length
-        if self._nplike.known_shape and not (0 <= where < self.length):
+        if self._nplike.known_shape and not 0 <= where < self.length:
             raise NestedIndexError(self, where)
         return self._content._getitem_at(self._index[where])
 

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -806,7 +806,7 @@ class IndexedArray(Content):
                 unique = unique.toListOffsetArray64(True)
 
             elif isinstance(unique, ak._v2.contents.ListOffsetArray):
-                if starts.length > 0 and starts[0] != 0:
+                if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
                     raise AssertionError(
                         "reduce_next with unbranching depth > negaxis expects a "
                         "ListOffsetArray64 whose offsets start at zero ({})".format(
@@ -987,7 +987,7 @@ class IndexedArray(Content):
                 out = out.toListOffsetArray64(True)
 
             elif isinstance(out, ak._v2.contents.ListOffsetArray):
-                if starts.length > 0 and starts[0] != 0:
+                if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
                     raise AssertionError(
                         "reduce_next with unbranching depth > negaxis expects a "
                         "ListOffsetArray64 whose offsets start at zero ({})".format(

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -140,7 +140,7 @@ class IndexedOptionArray(Content):
 
         if where < 0:
             where += self.length
-        if self._nplike.known_shape and not (0 <= where < self.length):
+        if self._nplike.known_shape and not 0 <= where < self.length:
             raise NestedIndexError(self, where)
         if self._index[where] < 0:
             return None

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -140,7 +140,7 @@ class IndexedOptionArray(Content):
 
         if where < 0:
             where += self.length
-        if not (0 <= where < self.length) and self._nplike.known_shape:
+        if self._nplike.known_shape and not (0 <= where < self.length):
             raise NestedIndexError(self, where)
         if self._index[where] < 0:
             return None
@@ -244,7 +244,7 @@ class IndexedOptionArray(Content):
         slicestarts = slicestarts._to_nplike(self.nplike)
         slicestops = slicestops._to_nplike(self.nplike)
 
-        if slicestarts.length != self.length and self._nplike.known_shape:
+        if self._nplike.known_shape and slicestarts.length != self.length:
             raise NestedIndexError(
                 self,
                 ak._v2.contents.ListArray(
@@ -335,7 +335,7 @@ class IndexedOptionArray(Content):
 
     def project(self, mask=None):
         if mask is not None:
-            if self._index.length != mask.length:
+            if self._nplike.known_shape and self._index.length != mask.length:
                 raise ValueError(
                     "mask length ({}) is not equal to {} length ({})".format(
                         mask.length(), type(self).__name__, self._index.length
@@ -729,7 +729,7 @@ class IndexedOptionArray(Content):
         )
 
     def fillna(self, value):
-        if value.length != 1:
+        if value.nplike.known_shape and value.length != 1:
             raise ValueError(f"fillna value length ({value.length}) is not equal to 1")
 
         contents = [self._content, value]
@@ -1251,7 +1251,7 @@ class IndexedOptionArray(Content):
                 out = out.toListOffsetArray64(True)
             if isinstance(out, ak._v2.contents.ListOffsetArray):
                 if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
-                    raise RuntimeError(
+                    raise AssertionError(
                         "sort_next with unbranching depth > negaxis expects a "
                         "ListOffsetArray64 whose offsets start at zero"
                     )
@@ -1292,7 +1292,7 @@ class IndexedOptionArray(Content):
             if isinstance(out, ak._v2.contents.IndexedOptionArray):
                 return out
             else:
-                raise RuntimeError(
+                raise AssertionError(
                     "argsort_next with unbranching depth > negaxis is only "
                     "expected to return RegularArray or ListOffsetArray or "
                     "IndexedOptionArray; "
@@ -1417,7 +1417,7 @@ class IndexedOptionArray(Content):
                 out = out.toListOffsetArray64(True)
             if isinstance(out, ak._v2.contents.ListOffsetArray):
                 if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
-                    raise RuntimeError(
+                    raise AssertionError(
                         "sort_next with unbranching depth > negaxis expects a "
                         "ListOffsetArray64 whose offsets start at zero"
                     )
@@ -1460,7 +1460,7 @@ class IndexedOptionArray(Content):
             if isinstance(out, ak._v2.contents.IndexedOptionArray):
                 return out
             else:
-                raise RuntimeError(
+                raise AssertionError(
                     "sort_next with unbranching depth > negaxis is only "
                     "expected to return RegularArray or ListOffsetArray or "
                     "IndexedOptionArray; "

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -75,16 +75,25 @@ class IndexedOptionArray(Content):
     def typetracer(self):
         tt = ak._v2._typetracer.TypeTracer.instance()
         return IndexedOptionArray(
-            ak._v2.index.Index(self._index.raw(tt), nplike=tt),
+            ak._v2.index.Index(self._index.raw(tt)),
             self._content.typetracer,
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._index.length
+
+    def _forget_length(self):
+        return IndexedOptionArray(
+            self._index.forget_length(),
+            self._content,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1250,7 +1250,7 @@ class IndexedOptionArray(Content):
             if isinstance(out, ak._v2.contents.RegularArray):
                 out = out.toListOffsetArray64(True)
             if isinstance(out, ak._v2.contents.ListOffsetArray):
-                if starts.length > 0 and starts[0] != 0:
+                if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
                     raise RuntimeError(
                         "sort_next with unbranching depth > negaxis expects a "
                         "ListOffsetArray64 whose offsets start at zero"
@@ -1416,7 +1416,7 @@ class IndexedOptionArray(Content):
             if isinstance(out, ak._v2.contents.RegularArray):
                 out = out.toListOffsetArray64(True)
             if isinstance(out, ak._v2.contents.ListOffsetArray):
-                if starts.length > 0 and starts[0] != 0:
+                if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
                     raise RuntimeError(
                         "sort_next with unbranching depth > negaxis expects a "
                         "ListOffsetArray64 whose offsets start at zero"

--- a/src/awkward/_v2/contents/listarray.py
+++ b/src/awkward/_v2/contents/listarray.py
@@ -101,12 +101,22 @@ class ListArray(Content):
             self._content.typetracer,
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._starts.length
+
+    def _forget_length(self):
+        return ListArray(
+            self._starts.forget_length(),
+            self._stops,
+            self._content,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/listarray.py
+++ b/src/awkward/_v2/contents/listarray.py
@@ -39,7 +39,11 @@ class ListArray(Content):
                     type(self).__name__, repr(content)
                 )
             )
-        if starts.length > stops.length:
+        if (
+            starts.nplike.known_shape
+            and stops.nplike.known_shape
+            and starts.length > stops.length
+        ):
             raise ValueError(
                 "{} len(starts) ({}) must be <= len(stops) ({})".format(
                     type(self).__name__, starts.length, stops.length
@@ -255,7 +259,7 @@ class ListArray(Content):
     def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
         slicestarts = slicestarts._to_nplike(self.nplike)
         slicestops = slicestops._to_nplike(self.nplike)
-        if slicestarts.length != self.length and self._nplike.known_shape:
+        if self._nplike.known_shape and slicestarts.length != self.length:
             raise NestedIndexError(
                 self,
                 ak._v2.contents.ListArray(
@@ -378,7 +382,7 @@ class ListArray(Content):
         elif isinstance(
             slicecontent, ak._v2.contents.indexedoptionarray.IndexedOptionArray
         ):
-            if self._starts.length < slicestarts.length and self._nplike.known_shape:
+            if self._nplike.known_shape and self._starts.length < slicestarts.length:
                 raise NestedIndexError(
                     self,
                     ak._v2.contents.ListArray(
@@ -1180,7 +1184,7 @@ class ListArray(Content):
         )
 
     def _validityerror(self, path):
-        if self.stops.length < self.starts.length:
+        if self._nplike.known_shape and self.stops.length < self.starts.length:
             return f'at {path} ("{type(self)}"): len(stops) < len(starts)'
         assert self.starts.nplike is self._nplike and self.stops.nplike is self._nplike
         error = self._nplike[

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -32,13 +32,12 @@ class ListOffsetArray(Content):
                     type(self).__name__, repr(content)
                 )
             )
-        if ak.nplike.of(offsets).known_shape:
-            if not offsets.length >= 1:
-                raise ValueError(
-                    "{} len(offsets) ({}) must be >= 1".format(
-                        type(self).__name__, offsets.length
-                    )
+        if offsets.nplike.known_shape and not offsets.length >= 1:
+            raise ValueError(
+                "{} len(offsets) ({}) must be >= 1".format(
+                    type(self).__name__, offsets.length
                 )
+            )
         if nplike is None:
             nplike = content.nplike
         if nplike is None:
@@ -876,7 +875,8 @@ class ListOffsetArray(Content):
             ):
                 raise np.AxisError("array with strings can only be sorted with axis=-1")
 
-            assert self._offsets.length - 1 == parents.length
+            if self._nplike.known_shape and parents.nplike.known_shape:
+                assert self._offsets.length - 1 == parents.length
 
             nextlen = self._offsets[-1] - self._offsets[0]
             maxcount = ak._v2.index.Index64.empty(1, self._nplike)
@@ -1096,7 +1096,8 @@ class ListOffsetArray(Content):
             ):
                 raise np.AxisError("array with strings can only be sorted with axis=-1")
 
-            assert self._offsets.length - 1 == parents.length
+            if self._nplike.known_shape and parents.nplike.known_shape:
+                assert self._offsets.length - 1 == parents.length
 
             maxcount = ak._v2.index.Index64.empty(1, self._nplike)
             offsetscopy = ak._v2.index.Index64.empty(self._offsets.length, self._nplike)

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -89,12 +89,21 @@ class ListOffsetArray(Content):
             self._content.typetracer,
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._offsets.length - 1
+
+    def _forget_length(self):
+        return ListOffsetArray(
+            self._offsets.forget_length(),
+            self._content,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -1349,7 +1349,8 @@ class ListOffsetArray(Content):
             ):
                 raise np.AxisError("array with strings can only be sorted with axis=-1")
 
-            assert self._offsets.length - 1 == parents.length
+            if self._nplike.known_shape and parents.nplike.known_shape:
+                assert self._offsets.length - 1 == parents.length
 
             nextlen = self._offsets[-1] - self._offsets[0]
             maxcount = ak._v2.index.Index64.empty(1, self._nplike)

--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -76,16 +76,25 @@ class NumpyArray(Content):
 
     @property
     def typetracer(self):
+        tt = ak._v2._typetracer.TypeTracer.instance()
         return NumpyArray(
-            self.raw(ak._v2._typetracer.TypeTracer.instance()),
+            self.raw(tt),
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._data.shape[0]
+
+    def _forget_length(self):
+        return NumpyArray(
+            self._data.forget_length(),
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/recordarray.py
+++ b/src/awkward/_v2/contents/recordarray.py
@@ -164,18 +164,29 @@ class RecordArray(Content):
 
     @property
     def typetracer(self):
+        tt = ak._v2._typetracer.TypeTracer.instance()
         return RecordArray(
             [x.typetracer for x in self._contents],
             self._fields,
             self._length,
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._length
+
+    def _forget_length(self):
+        return RecordArray(
+            [x._forget_length() for x in self._contents],
+            self._fields,
+            ak._v2._typetracer.UnknownLength,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/recordarray.py
+++ b/src/awkward/_v2/contents/recordarray.py
@@ -44,7 +44,13 @@ class RecordArray(Content):
                 )
             )
         elif length is None:
-            length = min(x.length for x in contents)
+            lengths = [x.length for x in contents]
+            if any(
+                isinstance(x, ak._v2._typetracer.UnknownLengthType) for x in contents
+            ):
+                length = ak._v2._typetracer.UnknownLength
+            else:
+                length = min(lengths)
         if not isinstance(length, ak._v2._typetracer.UnknownLengthType) and not (
             ak._util.isint(length) and length >= 0
         ):
@@ -452,7 +458,7 @@ class RecordArray(Content):
             for content in self._contents:
                 trimmed = content._getitem_range(slice(0, self.length))
                 offsets, flattened = trimmed._offsets_and_flattened(posaxis, depth)
-                if offsets.length != 0:
+                if self._nplike.known_shape and offsets.length != 0:
                     raise AssertionError(
                         "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
                     )

--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -84,18 +84,29 @@ class RegularArray(Content):
 
     @property
     def typetracer(self):
+        tt = ak._v2._typetracer.TypeTracer.instance()
         return RegularArray(
             self._content.typetracer,
             self._size,
             self._length,
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._length
+
+    def _forget_length(self):
+        return RegularArray(
+            self._content._forget_length(),
+            self._size,
+            ak._v2._typetracer.UnknownLength,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -545,7 +545,7 @@ class RegularArray(Content):
                     "cannot mix jagged slice with NumPy-style advanced indexing",
                 )
 
-            if head.length != self._size and self._nplike.known_shape:
+            if self._nplike.known_shape and head.length != self._size:
                 raise NestedIndexError(
                     self,
                     head,

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -136,12 +136,22 @@ class UnionArray(Content):
             [x.typetracer for x in self._contents],
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._tags.length
+
+    def _forget_length(self):
+        return UnionArray(
+            self._tags.forget_length(),
+            self._index,
+            self._contents,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -59,7 +59,11 @@ class UnionArray(Content):
                     )
                 )
 
-        if tags.length > index.length:
+        if (
+            tags.nplike.known_shape
+            and index.nplike.known_shape
+            and tags.length > index.length
+        ):
             raise ValueError(
                 "{} len(tags) ({}) must be <= len(index) ({})".format(
                     type(self).__name__, tags.length, index.length
@@ -181,7 +185,7 @@ class UnionArray(Content):
 
         if where < 0:
             where += self.length
-        if not (0 <= where < self.length) and self._nplike.known_shape:
+        if self._nplike.known_shape and not (0 <= where < self.length):
             raise NestedIndexError(self, where)
         tag, index = self._tags[where], self._index[where]
         return self._contents[tag]._getitem_at(index)
@@ -427,7 +431,7 @@ class UnionArray(Content):
             raise AssertionError(repr(head))
 
     def simplify_uniontype(self, merge=True, mergebool=False):
-        if self._index.length < self._tags.length:
+        if self._nplike.known_shape and self._index.length < self._tags.length:
             raise ValueError("invalid UnionArray: len(index) < len(tags)")
 
         length = self._tags.length
@@ -1098,7 +1102,7 @@ class UnionArray(Content):
                 return "{} contains {}, the operation that made it might have forgotten to call 'simplify_uniontype'".format(
                     type(self), type(self.contents[i])
                 )
-            if self.index.length < self.tags.length:
+            if self._nplike.known_shape and self.index.length < self.tags.length:
                 return f'at {path} ("{type(self)}"): len(index) < len(tags)'
 
             lencontents = self._nplike.empty(len(self.contents), dtype=np.int64)

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -185,7 +185,7 @@ class UnionArray(Content):
 
         if where < 0:
             where += self.length
-        if self._nplike.known_shape and not (0 <= where < self.length):
+        if self._nplike.known_shape and not 0 <= where < self.length:
             raise NestedIndexError(self, where)
         tag, index = self._tags[where], self._index[where]
         return self._contents[tag]._getitem_at(index)

--- a/src/awkward/_v2/contents/unmaskedarray.py
+++ b/src/awkward/_v2/contents/unmaskedarray.py
@@ -47,16 +47,25 @@ class UnmaskedArray(Content):
 
     @property
     def typetracer(self):
+        tt = ak._v2._typetracer.TypeTracer.instance()
         return UnmaskedArray(
             self._content.typetracer,
             self._typetracer_identifier(),
             self._parameters,
-            ak._v2._typetracer.TypeTracer.instance(),
+            tt,
         )
 
     @property
     def length(self):
         return self._content.length
+
+    def _forget_length(self):
+        return UnmaskedArray(
+            self._content._forget_length(),
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/_v2/index.py
+++ b/src/awkward/_v2/index.py
@@ -86,6 +86,14 @@ class Index:
     def length(self):
         return self._data.shape[0]
 
+    def forget_length(self):
+        tt = ak._v2._typetracer.TypeTracer.instance()
+        if isinstance(self._nplike, type(tt)):
+            data = self._data
+        else:
+            data = self.raw(tt)
+        return type(self)(data.forget_length(), self._metadata, tt)
+
     def raw(self, nplike):
         return self.nplike.raw(self.data, nplike)
 

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -130,9 +130,6 @@ class NumpyLike(Singleton):
         # data[, dtype=[, copy=]]
         return self._module.array(*args, **kwargs)
 
-    def raw(self, *args, **kwargs):
-        return self._module.raw(*args, **kwargs)
-
     def asarray(self, *args, **kwargs):
         # array[, dtype=][, order=]
         return self._module.asarray(*args, **kwargs)

--- a/tests/v2/test_1110-type-tracer-1.py
+++ b/tests/v2/test_1110-type-tracer-1.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
+
+from awkward._v2._typetracer import UnknownLength
 
 typetracer = ak._v2._typetracer.TypeTracer.instance()
 
@@ -22,3 +23,747 @@ def test_getitem_at():
 
     assert abstract[0].form == concrete[0].form
     assert abstract[0].form.type == concrete[0].form.type
+
+
+def test_EmptyArray():
+    a = ak._v2.contents.emptyarray.EmptyArray()
+    assert a.typetracer.form == a.forget_length().form
+
+
+def test_NumpyArray():
+    a = ak._v2.contents.numpyarray.NumpyArray(
+        np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+    b = ak._v2.contents.numpyarray.NumpyArray(
+        np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
+    )
+    assert b.typetracer.form == b.forget_length().form
+    assert b.forget_length().length is UnknownLength
+    assert b.forget_length().data.shape[1:] == (3, 5)
+
+
+def test_RegularArray_NumpyArray():
+    # 6.6 is inaccessible
+    a = ak._v2.contents.regulararray.RegularArray(
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+        ),
+        3,
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+    b = ak._v2.contents.regulararray.RegularArray(
+        ak._v2.contents.emptyarray.EmptyArray(), 0, zeros_length=10
+    )
+    assert b.typetracer.form == b.forget_length().form
+    assert b.forget_length().length is UnknownLength
+
+
+def test_ListArray_NumpyArray():
+    # 200 is inaccessible in stops
+    # 6.6, 7.7, and 8.8 are inaccessible in content
+    a = ak._v2.contents.listarray.ListArray(
+        ak._v2.index.Index(np.array([4, 100, 1], dtype=np.int64)),
+        ak._v2.index.Index(np.array([7, 100, 3, 200], dtype=np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+        ),
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_ListOffsetArray_NumpyArray():
+    # 6.6 and 7.7 are inaccessible
+    a = ak._v2.contents.listoffsetarray.ListOffsetArray(
+        ak._v2.index.Index(np.array([1, 4, 4, 6])),
+        ak._v2.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]),
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_RecordArray_NumpyArray():
+    # 5.5 is inaccessible
+    a = ak._v2.contents.recordarray.RecordArray(
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4])),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ],
+        ["x", "y"],
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+    # 5.5 is inaccessible
+    b = ak._v2.contents.recordarray.RecordArray(
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4])),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ],
+        None,
+    )
+    assert b.typetracer.form == b.forget_length().form
+    assert b.forget_length().length is UnknownLength
+
+    c = ak._v2.contents.recordarray.RecordArray([], [], 10)
+    assert c.typetracer.form == c.forget_length().form
+    assert c.forget_length().length is UnknownLength
+
+    d = ak._v2.contents.recordarray.RecordArray([], None, 10)
+    assert d.typetracer.form == d.forget_length().form
+    assert d.forget_length().length is UnknownLength
+
+
+def test_IndexedArray_NumpyArray():
+    # 4.4 is inaccessible; 3.3 and 5.5 appear twice
+    a = ak._v2.contents.indexedarray.IndexedArray(
+        ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_IndexedOptionArray_NumpyArray():
+    # 1.1 and 4.4 are inaccessible; 3.3 appears twice
+    a = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+        ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_ByteMaskedArray_NumpyArray():
+    # 2.2, 4.4, and 6.6 are inaccessible
+    a = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=True,
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+    # 2.2, 4.4, and 6.6 are inaccessible
+    b = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=False,
+    )
+    assert b.typetracer.form == b.forget_length().form
+    assert b.forget_length().length is UnknownLength
+
+
+def test_BitMaskedArray_NumpyArray():
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    b = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=False,
+    )
+    assert b.typetracer.form == b.forget_length().form
+    assert b.forget_length().length is UnknownLength
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    c = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=True,
+    )
+    assert c.typetracer.form == c.forget_length().form
+    assert c.forget_length().length is UnknownLength
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    d = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=True,
+    )
+    assert d.typetracer.form == d.forget_length().form
+    assert d.forget_length().length is UnknownLength
+
+
+def test_UnmaskedArray_NumpyArray():
+    a = ak._v2.contents.unmaskedarray.UnmaskedArray(
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+        )
+    )
+    assert a.typetracer.form == a.form
+    assert a.typetracer.form.type == a.form.type
+    assert len(a) == 4
+    assert a[2] == 2.2
+    assert a[-2] == 2.2
+    assert type(a[2]) is np.float64
+    with pytest.raises(IndexError):
+        a[4]
+    with pytest.raises(IndexError):
+        a[-5]
+    assert isinstance(a[2:], ak._v2.contents.unmaskedarray.UnmaskedArray)
+    assert a[2:][0] == 2.2
+    assert len(a[2:]) == 2
+    with pytest.raises(IndexError):
+        a["bad"]
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_UnionArray_NumpyArray():
+    # 100 is inaccessible in index
+    # 1.1 is inaccessible in contents[1]
+    a = ak._v2.contents.unionarray.UnionArray(
+        ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
+        ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3])),
+            ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_RegularArray_RecordArray_NumpyArray():
+    # 6.6 is inaccessible
+    a = ak._v2.contents.regulararray.RegularArray(
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        3,
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+    b = ak._v2.contents.regulararray.RegularArray(
+        ak._v2.contents.recordarray.RecordArray(
+            [ak._v2.contents.emptyarray.EmptyArray()], ["nest"]
+        ),
+        0,
+        zeros_length=10,
+    )
+    assert b.typetracer.form == b.form
+    assert b.typetracer.form.type == b.form.type
+    assert len(b["nest"]) == 10
+    assert b.typetracer["nest"].form == b["nest"].form
+    assert isinstance(b["nest"][5], ak._v2.contents.emptyarray.EmptyArray)
+    assert b.typetracer["nest"][5].form == b["nest"][5].form
+    assert len(b["nest"][5]) == 0
+    assert isinstance(b["nest"][7:], ak._v2.contents.regulararray.RegularArray)
+    assert b.typetracer["nest"][7:].form == b["nest"][7:].form
+    assert len(b["nest"][7:]) == 3
+    assert len(b["nest"][7:100]) == 3
+    with pytest.raises(IndexError):
+        b["nest"]["bad"]
+    assert b.typetracer.form == b.forget_length().form
+    assert b.forget_length().length is UnknownLength
+
+
+def test_ListArray_RecordArray_NumpyArray():
+    # 200 is inaccessible in stops
+    # 6.6, 7.7, and 8.8 are inaccessible in content
+    a = ak._v2.contents.listarray.ListArray(
+        ak._v2.index.Index(np.array([4, 100, 1])),
+        ak._v2.index.Index(np.array([7, 100, 3, 200])),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_ListOffsetArray_RecordArray_NumpyArray():
+    # 6.6 and 7.7 are inaccessible
+    a = ak._v2.contents.listoffsetarray.ListOffsetArray(
+        ak._v2.index.Index(np.array([1, 4, 4, 6])),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    [6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7]
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_IndexedArray_RecordArray_NumpyArray():
+    # 4.4 is inaccessible; 3.3 and 5.5 appear twice
+    a = ak._v2.contents.indexedarray.IndexedArray(
+        ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_IndexedOptionArray_RecordArray_NumpyArray():
+    # 1.1 and 4.4 are inaccessible; 3.3 appears twice
+    a = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+        ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_ByteMaskedArray_RecordArray_NumpyArray():
+    # 2.2, 4.4, and 6.6 are inaccessible
+    a = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+    # 2.2, 4.4, and 6.6 are inaccessible
+    b = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+    )
+    assert b.typetracer.form == b.forget_length().form
+    assert b.forget_length().length is UnknownLength
+
+
+def test_BitMaskedArray_RecordArray_NumpyArray():
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        True,
+                        True,
+                        True,
+                        True,
+                        False,
+                        False,
+                        False,
+                        False,
+                        True,
+                        False,
+                        True,
+                        False,
+                        True,
+                    ]
+                )
+            )
+        ),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    b = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=False,
+    )
+    assert b.typetracer.form == b.forget_length().form
+    assert b.forget_length().length is UnknownLength
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    c = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=True,
+    )
+    assert c.typetracer.form == c.forget_length().form
+    assert c.forget_length().length is UnknownLength
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    d = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=True,
+    )
+    assert d.typetracer.form == d.forget_length().form
+    assert d.forget_length().length is UnknownLength
+
+
+def test_UnmaskedArray_RecordArray_NumpyArray():
+    a = ak._v2.contents.unmaskedarray.UnmaskedArray(
+        ak._v2.contents.recordarray.RecordArray(
+            [
+                ak._v2.contents.numpyarray.NumpyArray(
+                    np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+                )
+            ],
+            ["nest"],
+        )
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength
+
+
+def test_UnionArray_RecordArray_NumpyArray():
+    # 100 is inaccessible in index
+    # 1.1 is inaccessible in contents[1]
+    a = ak._v2.contents.unionarray.UnionArray(
+        ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
+        ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
+        [
+            ak._v2.contents.recordarray.RecordArray(
+                [ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3]))], ["nest"]
+            ),
+            ak._v2.contents.recordarray.RecordArray(
+                [
+                    ak._v2.contents.numpyarray.NumpyArray(
+                        np.array([1.1, 2.2, 3.3, 4.4, 5.5])
+                    )
+                ],
+                ["nest"],
+            ),
+        ],
+    )
+    assert a.typetracer.form == a.forget_length().form
+    assert a.forget_length().length is UnknownLength

--- a/tests/v2/test_1110-type-tracer-1.py
+++ b/tests/v2/test_1110-type-tracer-1.py
@@ -5,8 +5,6 @@ import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
-from awkward._v2._typetracer import UnknownLength
-
 typetracer = ak._v2._typetracer.TypeTracer.instance()
 
 
@@ -15,9 +13,9 @@ def test_getitem_at():
     abstract = ak._v2.contents.NumpyArray(concrete.raw(typetracer))
 
     assert concrete.shape == (2, 3, 5)
-    assert abstract.shape == (UnknownLength, 3, 5)
-    assert abstract[0].shape == (UnknownLength, 5)
-    assert abstract[0][0].shape == (UnknownLength,)
+    assert abstract.shape[1:] == (3, 5)
+    assert abstract[0].shape[1:] == (5,)
+    assert abstract[0][0].shape[1:] == ()
 
     assert abstract.form == concrete.form
     assert abstract.form.type == concrete.form.type


### PR DESCRIPTION
I have no idea whether this addresses #1311, @douglasdavis, but it does maximize the amount of length information available by turning concrete arrays of length `N` into typetracer arrays of length `N`, rather than `UnknownLength`. It will definitely happen that intermediate calculations will create arrays of unknown length, which could legitimately result in the final array having unknown length. This PR should just make that happen less often, in fewer circumstances.