### PR TITLE
chore: remove extra files from the wheels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,7 @@ if(PYBUILD)
   target_link_libraries(_ext PRIVATE awkward-static)
 
   install(
-    TARGETS awkward-static awkward awkward-parent awkward-cpu-kernels awkward-cpu-kernels-static
-            _ext
+    TARGETS awkward awkward-parent awkward-cpu-kernels _ext
     LIBRARY DESTINATION awkward
     ARCHIVE DESTINATION awkward)
 


### PR DESCRIPTION
Currently, this leaves the "non-Python" install alone, and doesn't restructure this; in theory this should just slim up the wheels a bit.