### PR TITLE
fix: no need to specify wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=42.0",
-    "wheel>=0.36.0",
     "cmake>=3.13",
     "PyYAML",
 ]


### PR DESCRIPTION
"wheel" is included with proper version by get_requires_for_build_wheel from PEP 517, and isn't required for making an sdist, and might not be required in the future at all (in which case setuptools will modify get_requires_for_build_wheel). It's available even in setuptools 40.8.