### PR TITLE
chore: wheel not required for setuptools PEP 517 (all-repos)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=42.0",
-    "wheel>=0.36.0",
     "cmake>=3.13",
     "PyYAML",
 ]


### PR DESCRIPTION
@henryiii I'm following the example of https://github.com/scikit-hep/uproot4/pull/565 and the other Scikit-HEP packages. I think this one didn't match your `sed` string because it specifies a version.

If this is the right thing to do for Awkward as well, go ahead and merge this PR.

Closes #1315.