### PR TITLE
Docs: fix typo in documentation

### DIFF
--- a/docs-sphinx/ak.layout.ArrayBuilder.rst
+++ b/docs-sphinx/ak.layout.ArrayBuilder.rst
@@ -33,11 +33,6 @@ ak.layout.ArrayBuilder.__repr__
 
 .. py:method:: ak.layout.ArrayBuilder.__repr__()
 
-ak.layout.ArrayBuilder.append
-=============================
-
-.. py:method:: ak.layout.ArrayBuilder.append(arg0, arg1)
-
 ak.layout.ArrayBuilder.beginlist
 ================================
 
@@ -83,10 +78,6 @@ ak.layout.ArrayBuilder.endtuple
 
 .. py:method:: ak.layout.ArrayBuilder.endtuple()
 
-ak.layout.ArrayBuilder.extend
-=============================
-
-.. py:method:: ak.layout.ArrayBuilder.extend(arg0)
 
 ak.layout.ArrayBuilder.field
 ============================

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2229,7 +2229,7 @@ class ArrayBuilder(Iterable, Sized):
                 this ArrayBuilder.
 
         Wraps a low-level #ak.layout.ArrayBuilder as a high-level
-        #ak.ArrayBulider.
+        #ak.ArrayBuilder.
 
         The #ak.ArrayBuilder constructor creates a new #ak.layout.ArrayBuilder
         with no accumulated data, but Numba needs to wrap existing data

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2168,7 +2168,6 @@ class ArrayBuilder(Iterable, Sized):
          #bytestring, #string, #ak.Array, #ak.Record, or arbitrary Python data.
          When filling from #ak.Array or #ak.Record, the output holds references
          to the original data, rather than copying.
-       * #extend: appends all the items from an #ak.Array (by reference).
        * #list: context manager for #begin_list and #end_list.
        * #tuple: context manager for #begin_tuple and #end_tuple.
        * #record: context manager for #begin_record and #end_record.


### PR DESCRIPTION
- [x] Drop documentation of `ak.highlevel.ArrayBuilder.extend`
- [x] Drop documentation of `ak.layout.ArrayBuilder.extend`
- [x] Drop documentation of `ak.layout.ArrayBuilder.append`
- [x] Fix typo of `ArrayBuilder`