### PR TITLE
Fixed ak.num with axis=0 in typetracer.

### DIFF
--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -482,11 +482,11 @@ class ByteMaskedArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         else:
             numnull = ak._v2.index.Index64.empty(1, self._nplike, dtype=np.int64)
             nextcarry, outindex = self._nextcarry_outindex(numnull)

--- a/src/awkward/_v2/contents/emptyarray.py
+++ b/src/awkward/_v2/contents/emptyarray.py
@@ -145,11 +145,11 @@ class EmptyArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
 
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         else:
             out = ak._v2.index.Index64.empty(0, self._nplike)
             return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -416,11 +416,11 @@ class IndexedArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         else:
             return self.project().num(posaxis, depth)
 

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -480,11 +480,11 @@ class IndexedOptionArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         _, nextcarry, outindex = self._nextcarry_outindex(self._nplike)
         next = self._content._carry(nextcarry, False, NestedIndexError)
         out = next.num(posaxis, depth)

--- a/src/awkward/_v2/contents/listarray.py
+++ b/src/awkward/_v2/contents/listarray.py
@@ -840,11 +840,11 @@ class ListArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         elif posaxis == depth + 1:
             tonum = ak._v2.index.Index64.empty(self.length, self._nplike)
             assert (

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -593,11 +593,11 @@ class ListOffsetArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         elif posaxis == depth + 1:
             tonum = ak._v2.index.Index64.empty(self.length, self._nplike)
             assert (

--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -354,11 +354,11 @@ class NumpyArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         shape = []
         reps = 1
         size = self.length

--- a/src/awkward/_v2/contents/recordarray.py
+++ b/src/awkward/_v2/contents/recordarray.py
@@ -430,13 +430,12 @@ class RecordArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            single = ak._v2.index.Index64.empty(1, self._nplike)
-            single[0] = self.length
+            npsingle = self._nplike.full((1,), self.length, np.int64)
+            single = ak._v2.index.Index64(npsingle, nplike=self._nplike)
             singleton = ak._v2.contents.numpyarray.NumpyArray(
                 single, None, None, self._nplike
             )
             contents = [singleton] * len(self._contents)
-
             record = ak._v2.contents.recordarray.RecordArray(
                 contents, self._fields, 1, None, self._parameters, self._nplike
             )

--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -606,11 +606,11 @@ class RegularArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         elif posaxis == depth + 1:
             tonum = ak._v2.index.Index64.empty(self.length, self._nplike)
             assert tonum.nplike is self._nplike

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -631,11 +631,11 @@ class UnionArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self.nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         else:
             contents = []
             for content in self._contents:

--- a/src/awkward/_v2/contents/unmaskedarray.py
+++ b/src/awkward/_v2/contents/unmaskedarray.py
@@ -228,11 +228,11 @@ class UnmaskedArray(Content):
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            out = ak._v2.index.Index64.empty(1, self._nplike)
-            out[0] = self.length
-            return ak._v2.contents.numpyarray.NumpyArray(out, None, None, self._nplike)[
-                0
-            ]
+            out = self.length
+            if ak._v2._util.isint(out):
+                return np.int64(out)
+            else:
+                return out
         else:
             return ak._v2.contents.unmaskedarray.UnmaskedArray(
                 self._content.num(posaxis, depth), None, self._parameters, self._nplike


### PR DESCRIPTION
@douglasdavis, this fixes #1328. I'll merge it into main after 1.8.0 is released.