### PR TITLE
Feat: validate Array simplification

### DIFF
--- a/src/awkward/_v2/forms/indexedform.py
+++ b/src/awkward/_v2/forms/indexedform.py
@@ -133,6 +133,32 @@ class IndexedForm(Form):
             form_key=None,
         )
 
+    def simplify_optiontype(self):
+        if isinstance(
+            self._content,
+            (
+                ak._v2.forms.indexedoptionform.IndexedOptionForm,
+                ak._v2.forms.bytemaskedform.ByteMaskedForm,
+                ak._v2.forms.bitmaskedform.BitMaskedForm,
+                ak._v2.forms.unmaskedform.UnmaskedForm,
+            ),
+        ):
+            return ak._v2.forms.indexedoptionform.IndexedOptionForm(
+                "i64",
+                self._content.content,
+                has_identifier=self._has_identifier,
+                parameters=self._parameters,
+            ).simplify_optiontype()
+        elif isinstance(self._content, ak._v2.forms.indexedform.IndexedForm):
+            return ak._v2.forms.indexedform.IndexedForm(
+                "i64",
+                self._content.content,
+                has_identifier=self._has_identifier,
+                parameters=self._parameters,
+            ).simplify_optiontype()
+        else:
+            return self
+
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:
             return self._content.purelist_parameter(key)

--- a/src/awkward/_v2/operations/describe/__init__.py
+++ b/src/awkward/_v2/operations/describe/__init__.py
@@ -9,3 +9,4 @@ from awkward._v2.operations.describe.ak_parameters import parameters  # noqa: F4
 from awkward._v2.operations.describe.ak_fields import fields  # noqa: F401
 from awkward._v2.operations.describe.ak_backend import backend  # noqa: F401
 from awkward._v2.operations.describe.ak_to_backend import to_backend  # noqa: F401
+from awkward._v2.operations.describe.ak_is_simplified import is_simplified  # noqa: F401

--- a/src/awkward/_v2/operations/describe/ak_is_simplified.py
+++ b/src/awkward/_v2/operations/describe/ak_is_simplified.py
@@ -1,0 +1,43 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+
+def is_simplified(array, exception=False):
+    """
+    Args:
+        array (#ak.Array, #ak.layout.Content, #ak.ArrayBuilder, #ak.layout.ArrayBuilder,
+               #ak.layout.LayoutBuilder32, #ak.layout.LayoutBuilder64):
+            Array to check.
+        exception (bool): If True, unsimplified arrays raise exceptions.
+
+    Returns True if there the array is already simplified and False if not.
+
+    Checks for redundant layouts in the structure of the array, such as indexed types that wrap
+    another indexed or option type. Either an error is raised or the function returns a boolean.
+    """
+    layout = ak._v2.operations.convert.to_layout(
+        array, allow_record=False, allow_other=False
+    )
+
+    def visitor(layout, depth, **kwargs):
+        if layout.is_IndexedType or layout.is_OptionType:
+            simplified = layout.simplify_optiontype()
+        elif layout.is_UnionType:
+            simplified = layout.simplify_uniontype()
+        else:
+            return
+
+        if simplified.form != layout.form:
+            raise ValueError(
+                f"Form changed from\n{layout.form}\nto\n{simplified.form}\nafter simplification."
+            )
+
+    try:
+        layout.recursively_apply(visitor, numpy_to_regular=False, return_array=False)
+    except ValueError:
+        if exception:
+            raise
+        return False
+    else:
+        return True

--- a/tests/v2/test_1333-is-simplified.py
+++ b/tests/v2/test_1333-is-simplified.py
@@ -1,0 +1,117 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_indexed():
+    layout = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index(np.array([0, 3], dtype=np.int64)),
+        ak._v2.contents.IndexedArray(
+            ak._v2.index.Index(np.array([0, 1, 2], dtype=np.int64)),
+            ak._v2.contents.NumpyArray(np.array([4, 5, 6], dtype=np.int64)),
+        ),
+    )
+
+    assert ak._v2.operations.describe.is_simplified(layout)
+
+
+def test_indexedoption():
+    layout = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index(np.array([0, 3], dtype=np.int64)),
+        ak._v2.contents.IndexedOptionArray(
+            ak._v2.index.Index(np.array([0, 1, -1], dtype=np.int64)),
+            ak._v2.contents.NumpyArray(np.array([4, 5, 6], dtype=np.int64)),
+        ),
+    )
+
+    assert ak._v2.operations.describe.is_simplified(layout)
+
+
+def test_indexed_indexedoption():
+    layout = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index(np.array([0, 3], dtype=np.int64)),
+        ak._v2.contents.IndexedArray(
+            ak._v2.index.Index(np.array([0, 1, 2], dtype=np.int64)),
+            ak._v2.contents.IndexedOptionArray(
+                ak._v2.index.Index(np.array([0, 1, -1], dtype=np.int64)),
+                ak._v2.contents.NumpyArray(np.array([4, 5, 6], dtype=np.int64)),
+            ),
+        ),
+    )
+
+    assert not ak._v2.operations.describe.is_simplified(layout)
+
+
+def test_indexedoption_indexed():
+    layout = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index(np.array([0, 3], dtype=np.int64)),
+        ak._v2.contents.IndexedOptionArray(
+            ak._v2.index.Index(np.array([-1, 1, 2], dtype=np.int64)),
+            ak._v2.contents.IndexedArray(
+                ak._v2.index.Index(np.array([0, 1, 2], dtype=np.int64)),
+                ak._v2.contents.NumpyArray(np.array([4, 5, 6], dtype=np.int64)),
+            ),
+        ),
+    )
+
+    assert not ak._v2.operations.describe.is_simplified(layout)
+
+
+def test_indexedoption_indexedoption():
+    layout = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index(np.array([0, 3], dtype=np.int64)),
+        ak._v2.contents.IndexedOptionArray(
+            ak._v2.index.Index(np.array([-1, 1, 2], dtype=np.int64)),
+            ak._v2.contents.IndexedOptionArray(
+                ak._v2.index.Index(np.array([0, 1, -1], dtype=np.int64)),
+                ak._v2.contents.NumpyArray(np.array([4, 5, 6], dtype=np.int64)),
+            ),
+        ),
+    )
+
+    assert not ak._v2.operations.describe.is_simplified(layout)
+
+
+def test_indexed_indexed():
+    layout = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index(np.array([0, 3], dtype=np.int64)),
+        ak._v2.contents.IndexedArray(
+            ak._v2.index.Index(np.array([0, 1, 2], dtype=np.int64)),
+            ak._v2.contents.IndexedArray(
+                ak._v2.index.Index(np.array([0, 2, 1], dtype=np.int64)),
+                ak._v2.contents.NumpyArray(np.array([4, 5, 6], dtype=np.int64)),
+            ),
+        ),
+    )
+
+    assert not ak._v2.operations.describe.is_simplified(layout)
+
+
+def test_union_mergeable():
+    layout = ak._v2.contents.UnionArray(
+        ak._v2.index.Index(np.array([0, 0, 0, 0], dtype=np.int8)),
+        ak._v2.index.Index(np.array([0, 1, 0, 1], dtype=np.int64)),
+        [
+            ak._v2.contents.NumpyArray(np.array([0, 1, 2, 3], dtype=np.int64)),
+            ak._v2.contents.NumpyArray(np.array([9, 8, 7, 6], dtype=np.int64)),
+        ],
+    )
+
+    assert not ak._v2.operations.describe.is_simplified(layout)
+
+
+def test_union_unmergeable():
+    layout = ak._v2.contents.UnionArray(
+        ak._v2.index.Index(np.array([0, 0, 0, 0], dtype=np.int8)),
+        ak._v2.index.Index(np.array([0, 1, 0, 1], dtype=np.int64)),
+        [
+            ak._v2.contents.NumpyArray(np.array([0, 1, 2, 3], dtype=np.int64)),
+            ak._v2.contents.RegularArray(
+                ak._v2.contents.NumpyArray(np.array([9, 8, 7, 6], dtype=np.int64)), 1
+            ),
+        ],
+    )
+    assert ak._v2.operations.describe.is_simplified(layout)


### PR DESCRIPTION
As outlined in #1333, I think it would be useful to make it safer for users of the middle layer `ak._v2.contents` to create layouts. At present, it's possible (and not altogether hard) to create layouts that are _not_ simplified. This PR will not solve the problem of layouts with invalid offsets, but these sorts of mistakes are usually much easier to discover because things tend to fail quite noisily.

The purpose of this PR is to look at what this API might look like.