### PR TITLE
Feat: add stack implementation

### DIFF
--- a/src/awkward/_v2/operations/structure/__init__.py
+++ b/src/awkward/_v2/operations/structure/__init__.py
@@ -23,6 +23,7 @@ from awkward._v2.operations.structure.ak_broadcast_arrays import (  # noqa: F401
     broadcast_arrays,
 )
 from awkward._v2.operations.structure.ak_concatenate import concatenate  # noqa: F401
+from awkward._v2.operations.structure.ak_stack import stack  # noqa: F401
 from awkward._v2.operations.structure.ak_where import where  # noqa: F401
 from awkward._v2.operations.structure.ak_flatten import flatten  # noqa: F401
 from awkward._v2.operations.structure.ak_unflatten import unflatten  # noqa: F401

--- a/src/awkward/_v2/operations/structure/ak_stack.py
+++ b/src/awkward/_v2/operations/structure/ak_stack.py
@@ -1,0 +1,200 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+from awkward._v2.operations.structure.ak_fill_none import fill_none
+
+np = ak.nplike.NumpyMetadata.instance()
+
+
+# @ak._v2._connect.numpy.implements("stack")
+def stack(arrays, axis=0, merge=True, mergebool=True, highlevel=True, behavior=None):
+    """
+    Args:
+        arrays: Arrays to concatenate along a new dimension.
+        axis (int): The dimension in the result at which the arrays are stacked.
+            The outermost dimension is `0`, followed by `1`, etc., and negative
+            values count backward from the innermost: `-1` is the innermost
+            dimension, `-2` is the next level up, etc.
+        merge (bool): If True, combine data into the same buffers wherever
+            possible, eliminating unnecessary #ak.layout.UnionArray8_64 types
+            at the expense of materializing #ak.layout.VirtualArray nodes.
+        mergebool (bool): If True, boolean and nummeric data can be combined
+            into the same buffer, losing information about False vs `0` and
+            True vs `1`; otherwise, they are kept in separate buffers with
+            distinct types (using an #ak.layout.UnionArray8_64).
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.layout.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Returns an array with `arrays` stacked along a new axis. Above the axis `arrays`
+    must be broadcastable.
+    """
+    with ak._v2._util.OperationErrorContext(
+        "ak._v2.stack",
+        dict(
+            arrays=arrays,
+            axis=axis,
+            merge=merge,
+            mergebool=mergebool,
+            highlevel=highlevel,
+            behavior=behavior,
+        ),
+    ):
+        return _impl(arrays, axis, merge, mergebool, highlevel, behavior)
+
+
+def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
+    layouts = [
+        ak._v2.operations.convert.to_layout(
+            x, allow_record=False if axis == 0 else True, allow_other=True
+        )
+        for x in arrays
+    ]
+    behavior = ak._v2._util.behavior_of(*arrays, behavior=behavior)
+    nplike = ak.nplike.of(*layouts)
+
+    contents = [x for x in layouts if isinstance(x, ak._v2.contents.Content)]
+    if not contents:
+        raise ak._v2._util.error(ValueError("need at least one array to concatenate"))
+
+    posaxis = contents[0].axis_wrap_if_negative(axis)
+    maxdepth = max(x.minmax_depth[1] for x in contents)
+    if not 0 <= posaxis <= maxdepth:
+        raise ak._v2._util.error(
+            ValueError(
+                "axis={} is beyond the depth of this array or the depth of this array "
+                "is ambiguous".format(axis)
+            )
+        )
+    if any(x.axis_wrap_if_negative(axis) != posaxis for x in contents):
+        raise ak._v2._util.error(
+            ValueError(
+                "arrays to concatenate do not have the same depth for negative "
+                "axis={}".format(axis)
+            )
+        )
+
+    if posaxis == 0:
+        layouts = [
+            x
+            if isinstance(x, ak._v2.contents.Content)
+            else ak._v2.operations.convert.to_layout([x])
+            for x in contents
+        ]
+        length = len(layouts[0])
+
+        tags = nplike.repeat(nplike.arange(len(layouts)), length)
+        index = nplike.broadcast_to(
+            nplike.arange(length), (len(layouts), length)
+        ).ravel()
+
+        inner = ak._v2.contents.UnionArray(
+            ak._v2.index.Index8(tags), ak._v2.index.Index64(index), layouts
+        ).simplify_uniontype(merge=merge, mergebool=mergebool)
+
+        offset = nplike.arange(0, len(index) + 1, length)
+        out = ak._v2.contents.ListOffsetArray(ak._v2.index.Index64(offset), inner)
+
+    else:
+
+        def stack_contents(contents, length):
+            tags = nplike.broadcast_to(
+                nplike.arange(len(contents)), (length, len(contents))
+            ).ravel()
+            index = nplike.repeat(nplike.arange(length), len(contents))
+
+            inner = ak._v2.contents.UnionArray(
+                ak._v2.index.Index8(tags), ak._v2.index.Index64(index), contents
+            ).simplify_uniontype(merge=merge, mergebool=mergebool)
+
+            offset = nplike.arange(0, len(index) + 1, len(contents))
+            return ak._v2.contents.ListOffsetArray(ak._v2.index.Index64(offset), inner)
+
+        def action(inputs, depth, **kwargs):
+
+            if depth == posaxis and any(
+                isinstance(x, ak._v2.contents.Content) and x.is_OptionType
+                for x in inputs
+            ):
+                nextinputs = []
+                for x in inputs:
+                    if x.is_OptionType and x.content.is_ListType:
+                        nextinputs.append(fill_none(x, [], axis=0, highlevel=False))
+                    else:
+                        nextinputs.append(x)
+                inputs = nextinputs
+
+            if depth == posaxis and all(
+                isinstance(x, ak._v2.contents.Content)
+                and x.is_ListType
+                or not isinstance(x, ak._v2.contents.Content)
+                for x in inputs
+            ):
+                length = max(
+                    len(x) for x in inputs if isinstance(x, ak._v2.contents.Content)
+                )
+                nextinputs = []
+                for x in inputs:
+                    if isinstance(x, ak._v2.contents.Content):
+                        nextinputs.append(x)
+                    else:
+                        nextinputs.append(
+                            ak._v2.contents.ListOffsetArray(
+                                ak._v2.index.Index64(
+                                    nplike.arange(length + 1, dtype=np.int64)
+                                ),
+                                ak._v2.contents.NumpyArray(
+                                    nplike.broadcast_to(nplike.array([x]), (length,))
+                                ),
+                            )
+                        )
+
+                return (stack_contents(nextinputs, length),)
+
+            # New axis at end
+            elif depth == posaxis and all(
+                isinstance(x, ak._v2.contents.NumpyArray)
+                or not isinstance(x, ak._v2.contents.Content)
+                for x in inputs
+            ):
+                length = max(
+                    len(x) for x in inputs if isinstance(x, ak._v2.contents.Content)
+                )
+                nextinputs = []
+                for x in inputs:
+                    if isinstance(x, ak._v2.contents.Content):
+                        nextinputs.append(x)
+                    else:
+                        nextinputs.append(
+                            ak._v2.contents.NumpyArray(
+                                nplike.broadcast_to(nplike.array([x]), (length,))
+                            )
+                        )
+                return (stack_contents(nextinputs, length),)
+
+            elif any(
+                x.purelist_depth == 1
+                for x in inputs
+                if isinstance(x, ak._v2.contents.Content)
+            ):
+                raise ak._v2._util.error(
+                    ValueError(
+                        "at least one array is not deep enough to concatenate at "
+                        "axis={}".format(axis)
+                    )
+                )
+
+            else:
+                return None
+
+        (out,) = ak._v2._broadcasting.broadcast_and_apply(
+            layouts,
+            action,
+            behavior=behavior,
+            numpy_to_regular=True,
+            right_broadcast=False,
+        )
+
+    return ak._v2._util.wrap(out, behavior, highlevel)

--- a/src/awkward/_v2/operations/structure/ak_stack.py
+++ b/src/awkward/_v2/operations/structure/ak_stack.py
@@ -96,7 +96,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
 
         inner = ak._v2.contents.UnionArray(
             ak._v2.index.Index8(tags), ak._v2.index.Index64(index), nextinputs
-        ).simplify_optiontype(merge=merge, mergebool=mergebool)
+        ).simplify_uniontype(merge=merge, mergebool=mergebool)
 
         offset = nplike.empty(len(lengths) + 1, dtype=np.int64)
         offset[0] = 0

--- a/src/awkward/_v2/operations/structure/ak_stack.py
+++ b/src/awkward/_v2/operations/structure/ak_stack.py
@@ -131,6 +131,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                         nextinputs.append(x)
                 inputs = nextinputs
 
+            # New axis above existing
             if depth == posaxis and all(
                 isinstance(x, ak._v2.contents.Content)
                 and x.is_ListType


### PR DESCRIPTION
### Feature :sparkles: 
This PR adds an implementation of `np.stack`. This can already be done by users without *too* much difficulty, using `np.concatenate` and `np.newaxis`, but I think it's a fundamental enough function to warrant inclusion.

### Method :blue_book: 
The approach taken for `posaxis > 0` is to build a union over the existing lists, re-index their sublists, and then add a new list layout i.e.
`[A1 A2 A3 ... An]`, `[B1 B2 B3 ... Bn]` → `Union[A1 B1 A2 B2 A3 B3 ... An Bn]` →`List[[A1 B1] [A2 B2] [A3 B3] ... [An Bn]]`
For `posaxis == 0 `, we merge the contents into a single `Content`, and then create a new list layout over this content. This is simpler because we do not need to re-order the sublists as we do for `posaxis>0`

### Discussion :left_speech_bubble:  
I have not used `RegularArray` for the `posaxis > 0` case here, despite the fact that we *know* that the layout is regular. This is because I would like some input from the rest of the team as to what *should* happen. As we've discussed previously, the `RegularArray` layouts often introduce two sometimes conflicting behaviors - maintaining length information and informing behaviour of broadcasting, indexing.

My gut feeling is that we _should_ introduce a `RegularArray` layout, because we *know* it will always have a guaranteed constant length. 

I'd also be interested to know whether people think I should write a kernel for generating the tags and indices. 