### PR TITLE
Feat: add `is_tuple` describe operation

### DIFF
--- a/include/awkward/Content.h
+++ b/include/awkward/Content.h
@@ -184,6 +184,10 @@ namespace awkward {
     virtual const std::vector<std::string>
       keys() const = 0;
 
+    /// @brief Returns `true` if the outermost RecordArray is a tuple
+    virtual bool
+      istuple() const = 0;
+
     /// @brief Returns a string representation of this Form (#tojson with
     /// `pretty = true` and `verbose = false`).
     virtual const std::string
@@ -622,6 +626,10 @@ namespace awkward {
     /// array does not contain a RecordArray.
     virtual const std::vector<std::string>
       keys() const = 0;
+
+    /// @brief Returns `true` if the outermost RecordArray is a tuple
+    virtual bool
+      istuple() const = 0;
 
     /// @brief Returns an error message if this array is invalid; otherwise,
     /// returns an empty string.

--- a/include/awkward/array/BitMaskedArray.h
+++ b/include/awkward/array/BitMaskedArray.h
@@ -90,6 +90,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -332,6 +335,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/ByteMaskedArray.h
+++ b/include/awkward/array/ByteMaskedArray.h
@@ -84,6 +84,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -298,6 +301,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/EmptyArray.h
+++ b/include/awkward/array/EmptyArray.h
@@ -70,6 +70,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -210,6 +213,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/IndexedArray.h
+++ b/include/awkward/array/IndexedArray.h
@@ -78,6 +78,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -158,6 +161,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     bool
       equal(const FormPtr& other,
@@ -381,6 +387,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/ListArray.h
+++ b/include/awkward/array/ListArray.h
@@ -80,6 +80,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -322,6 +325,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/ListOffsetArray.h
+++ b/include/awkward/array/ListOffsetArray.h
@@ -76,6 +76,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -310,6 +313,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/None.h
+++ b/include/awkward/array/None.h
@@ -156,6 +156,10 @@ namespace awkward {
     const std::vector<std::string>
       keys() const override;
 
+    /// @exception std::runtime_error is always thrown
+    bool
+      istuple() const override;
+
     // operations
 
     /// @exception std::runtime_error is always thrown

--- a/include/awkward/array/NumpyArray.h
+++ b/include/awkward/array/NumpyArray.h
@@ -96,6 +96,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -415,6 +418,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/RegularArray.h
+++ b/include/awkward/array/RegularArray.h
@@ -76,6 +76,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -279,6 +282,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/UnionArray.h
+++ b/include/awkward/array/UnionArray.h
@@ -88,6 +88,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -318,6 +321,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/UnmaskedArray.h
+++ b/include/awkward/array/UnmaskedArray.h
@@ -76,6 +76,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -256,6 +259,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/include/awkward/array/VirtualArray.h
+++ b/include/awkward/array/VirtualArray.h
@@ -81,6 +81,9 @@ namespace awkward {
       keys() const override;
 
     bool
+      istuple() const override;
+
+    bool
       equal(const FormPtr& other,
             bool check_identities,
             bool check_parameters,
@@ -279,6 +282,9 @@ namespace awkward {
 
     const std::vector<std::string>
       keys() const override;
+
+    bool
+      istuple() const override;
 
     // operations
     const std::string

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1219,6 +1219,10 @@ class Content:
         return self.Form.fields.__get__(self)
 
     @property
+    def is_tuple(self):
+        return self.Form.is_tuple.__get__(self)
+
+    @property
     def dimension_optiontype(self):
         return self.Form.dimension_optiontype.__get__(self)
 

--- a/src/awkward/_v2/forms/bitmaskedform.py
+++ b/src/awkward/_v2/forms/bitmaskedform.py
@@ -220,5 +220,9 @@ class BitMaskedForm(Form):
         return self._content.fields
 
     @property
+    def is_tuple(self):
+        return self._content.is_tuple
+
+    @property
     def dimension_optiontype(self):
         return True

--- a/src/awkward/_v2/forms/bytemaskedform.py
+++ b/src/awkward/_v2/forms/bytemaskedform.py
@@ -199,5 +199,9 @@ class ByteMaskedForm(Form):
         return self._content.fields
 
     @property
+    def is_tuple(self):
+        return self._content.is_tuple
+
+    @property
     def dimension_optiontype(self):
         return True

--- a/src/awkward/_v2/forms/emptyform.py
+++ b/src/awkward/_v2/forms/emptyform.py
@@ -91,5 +91,9 @@ class EmptyForm(Form):
         return []
 
     @property
+    def is_tuple(self):
+        return False
+
+    @property
     def dimension_optiontype(self):
         return False

--- a/src/awkward/_v2/forms/indexedform.py
+++ b/src/awkward/_v2/forms/indexedform.py
@@ -164,5 +164,9 @@ class IndexedForm(Form):
         return self._content.fields
 
     @property
+    def is_tuple(self):
+        return self._content.is_tuple
+
+    @property
     def dimension_optiontype(self):
         return False

--- a/src/awkward/_v2/forms/indexedoptionform.py
+++ b/src/awkward/_v2/forms/indexedoptionform.py
@@ -181,5 +181,9 @@ class IndexedOptionForm(Form):
         return self._content.fields
 
     @property
+    def is_tuple(self):
+        return self._content.is_tuple
+
+    @property
     def dimension_optiontype(self):
         return True

--- a/src/awkward/_v2/forms/listform.py
+++ b/src/awkward/_v2/forms/listform.py
@@ -190,5 +190,9 @@ class ListForm(Form):
         return self._content.fields
 
     @property
+    def is_tuple(self):
+        return self._content.is_tuple
+
+    @property
     def dimension_optiontype(self):
         return False

--- a/src/awkward/_v2/forms/listoffsetform.py
+++ b/src/awkward/_v2/forms/listoffsetform.py
@@ -157,5 +157,9 @@ class ListOffsetForm(Form):
         return self._content.fields
 
     @property
+    def is_tuple(self):
+        return self._content.is_tuple
+
+    @property
     def dimension_optiontype(self):
         return False

--- a/src/awkward/_v2/forms/numpyform.py
+++ b/src/awkward/_v2/forms/numpyform.py
@@ -200,5 +200,9 @@ class NumpyForm(Form):
         return []
 
     @property
+    def is_tuple(self):
+        return False
+
+    @property
     def dimension_optiontype(self):
         return False

--- a/src/awkward/_v2/forms/regularform.py
+++ b/src/awkward/_v2/forms/regularform.py
@@ -162,5 +162,9 @@ class RegularForm(Form):
         return self._content.fields
 
     @property
+    def is_tuple(self):
+        return self._content.is_tuple
+
+    @property
     def dimension_optiontype(self):
         return False

--- a/src/awkward/_v2/forms/unionform.py
+++ b/src/awkward/_v2/forms/unionform.py
@@ -235,6 +235,10 @@ class UnionForm(Form):
         return list(set.intersection(*[set(x) for x in fieldslists]))
 
     @property
+    def is_tuple(self):
+        return all(x.is_tuple for x in self._contents)
+
+    @property
     def dimension_optiontype(self):
         for content in self._contents:
             if content.dimension_optiontype:

--- a/src/awkward/_v2/forms/unionform.py
+++ b/src/awkward/_v2/forms/unionform.py
@@ -236,7 +236,7 @@ class UnionForm(Form):
 
     @property
     def is_tuple(self):
-        return all(x.is_tuple for x in self._contents)
+        return all(x.is_tuple for x in self._contents) and (len(self._contents) > 0)
 
     @property
     def dimension_optiontype(self):

--- a/src/awkward/_v2/forms/unmaskedform.py
+++ b/src/awkward/_v2/forms/unmaskedform.py
@@ -147,5 +147,9 @@ class UnmaskedForm(Form):
         return self._content.fields
 
     @property
+    def is_tuple(self):
+        return self._content.is_tuple
+
+    @property
     def dimension_optiontype(self):
         return True

--- a/src/awkward/_v2/operations/describe/__init__.py
+++ b/src/awkward/_v2/operations/describe/__init__.py
@@ -9,3 +9,4 @@ from awkward._v2.operations.describe.ak_parameters import parameters  # noqa: F4
 from awkward._v2.operations.describe.ak_fields import fields  # noqa: F401
 from awkward._v2.operations.describe.ak_backend import backend  # noqa: F401
 from awkward._v2.operations.describe.ak_to_backend import to_backend  # noqa: F401
+from awkward._v2.operations.describe.ak_is_tuple import is_tuple  # noqa: F401

--- a/src/awkward/_v2/operations/describe/ak_is_tuple.py
+++ b/src/awkward/_v2/operations/describe/ak_is_tuple.py
@@ -22,21 +22,4 @@ def is_tuple(array):
 def _impl(array):
     layout = ak._v2.to_layout(array, allow_record=True)
 
-    if isinstance(layout, ak._v2.record.Record):
-        return layout.is_tuple
-
-    def visitor(form):
-        if form.is_RecordType:
-            return form.is_tuple
-        elif form.is_ListType or form.is_OptionType or form.is_IndexedType:
-            return visitor(form.content)
-        elif form.is_UnionType:
-            return all(visitor(x) for x in form.contents)
-        elif form.is_NumpyType or form.is_UnknownType:
-            return False
-        else:
-            raise ak._v2._util.error(
-                ValueError(f"Unexpected layout type {type(layout).__name__}")
-            )
-
-    return visitor(layout.form)
+    return layout.is_tuple

--- a/src/awkward/_v2/operations/describe/ak_is_tuple.py
+++ b/src/awkward/_v2/operations/describe/ak_is_tuple.py
@@ -1,0 +1,39 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+
+def is_tuple(array):
+    """
+    Args:
+        array (#ak.Array, #ak.Record, #ak.layout.Content, #ak.layout.Record, #ak.ArrayBuilder, #ak.layout.ArrayBuilder):
+            Array or record to check.
+
+    If `array` is a record, this returns True if the record is a tuple.
+    If `array` is an array, this returns True if the outermost record is a tuple.
+    """
+    with ak._v2._util.OperationErrorContext(
+        "ak._v2.is_tuple",
+        dict(array=array),
+    ):
+        return _impl(array)
+
+
+def _impl(array):
+    layout = ak._v2.to_layout(array, allow_record=True)
+
+    def visitor(layout):
+        if isinstance(layout, ak._v2.record.Record) or layout.is_RecordType:
+            return layout.is_tuple
+        elif layout.is_ListType or layout.is_OptionType or layout.is_IndexedType:
+            return visitor(layout.content)
+        elif layout.is_UnionType:
+            return all(visitor(x) for x in layout.contents)
+        elif layout.is_NumpyType:
+            return False
+        else:
+            raise ak._v2._util.error(
+                ValueError(f"Unexpected layout type {type(layout).__name__}")
+            )
+
+    return visitor(layout)

--- a/src/awkward/_v2/operations/describe/ak_is_tuple.py
+++ b/src/awkward/_v2/operations/describe/ak_is_tuple.py
@@ -22,18 +22,21 @@ def is_tuple(array):
 def _impl(array):
     layout = ak._v2.to_layout(array, allow_record=True)
 
-    def visitor(layout):
-        if isinstance(layout, ak._v2.record.Record) or layout.is_RecordType:
-            return layout.is_tuple
-        elif layout.is_ListType or layout.is_OptionType or layout.is_IndexedType:
-            return visitor(layout.content)
-        elif layout.is_UnionType:
-            return all(visitor(x) for x in layout.contents)
-        elif layout.is_NumpyType or layout.is_UnknownType:
+    if isinstance(layout, ak._v2.record.Record):
+        return layout.is_tuple
+
+    def visitor(form):
+        if form.is_RecordType:
+            return form.is_tuple
+        elif form.is_ListType or form.is_OptionType or form.is_IndexedType:
+            return visitor(form.content)
+        elif form.is_UnionType:
+            return all(visitor(x) for x in form.contents)
+        elif form.is_NumpyType or form.is_UnknownType:
             return False
         else:
             raise ak._v2._util.error(
                 ValueError(f"Unexpected layout type {type(layout).__name__}")
             )
 
-    return visitor(layout)
+    return visitor(layout.form)

--- a/src/awkward/_v2/operations/describe/ak_is_tuple.py
+++ b/src/awkward/_v2/operations/describe/ak_is_tuple.py
@@ -29,7 +29,7 @@ def _impl(array):
             return visitor(layout.content)
         elif layout.is_UnionType:
             return all(visitor(x) for x in layout.contents)
-        elif layout.is_NumpyType:
+        elif layout.is_NumpyType or layout.is_UnknownType:
             return False
         else:
             raise ak._v2._util.error(

--- a/src/awkward/operations/describe.py
+++ b/src/awkward/operations/describe.py
@@ -266,6 +266,22 @@ def fields(array):
     return layout.keys()
 
 
+def is_tuple(array):
+    """
+    Args:
+        array (#ak.Array, #ak.Record, #ak.layout.Content, #ak.layout.Record,
+               #ak.ArrayBuilder, #ak.layout.ArrayBuilder):
+            Array or record to check.
+
+    If `array` is a record, this returns True if the record is a tuple.
+    If `array` is an array, this returns True if the outermost record is a tuple.
+    """
+    layout = ak.operations.convert.to_layout(
+        array, allow_record=True, allow_other=False
+    )
+    return layout.istuple()
+
+
 __all__ = [
     x
     for x in list(globals())

--- a/src/awkward/operations/describe.py
+++ b/src/awkward/operations/describe.py
@@ -279,7 +279,7 @@ def is_tuple(array):
     layout = ak.operations.convert.to_layout(
         array, allow_record=True, allow_other=False
     )
-    return layout.istuple()
+    return layout.istuple
 
 
 __all__ = [

--- a/src/libawkward/array/BitMaskedArray.cpp
+++ b/src/libawkward/array/BitMaskedArray.cpp
@@ -171,6 +171,11 @@ namespace awkward {
   }
 
   bool
+  BitMaskedForm::istuple() const {
+    return content_.get()->istuple();
+  }
+
+  bool
   BitMaskedForm::equal(const FormPtr& other,
                        bool check_identities,
                        bool check_parameters,
@@ -787,6 +792,11 @@ namespace awkward {
   const std::vector<std::string>
   BitMaskedArray::keys() const {
     return content_.get()->keys();
+  }
+
+  bool
+  BitMaskedArray::istuple() const {
+    return content_.get()->istuple();
   }
 
   const std::string

--- a/src/libawkward/array/ByteMaskedArray.cpp
+++ b/src/libawkward/array/ByteMaskedArray.cpp
@@ -163,6 +163,11 @@ namespace awkward {
   }
 
   bool
+  ByteMaskedForm::istuple() const {
+    return content_.get()->istuple();
+  }
+
+  bool
   ByteMaskedForm::equal(const FormPtr& other,
                         bool check_identities,
                         bool check_parameters,
@@ -819,6 +824,11 @@ namespace awkward {
   const std::vector<std::string>
   ByteMaskedArray::keys() const {
     return content_.get()->keys();
+  }
+
+  bool
+  ByteMaskedArray::istuple() const {
+    return content_.get()->istuple();
   }
 
   const std::string

--- a/src/libawkward/array/EmptyArray.cpp
+++ b/src/libawkward/array/EmptyArray.cpp
@@ -120,6 +120,11 @@ namespace awkward {
   }
 
   bool
+  EmptyForm::istuple() const {
+    return false;
+  }
+
+  bool
   EmptyForm::equal(const FormPtr& other,
                    bool check_identities,
                    bool check_parameters,
@@ -425,6 +430,11 @@ namespace awkward {
   const std::vector<std::string>
   EmptyArray::keys() const {
     return std::vector<std::string>();
+  }
+
+  bool
+  EmptyArray::istuple() const {
+    return false;
   }
 
   const std::string

--- a/src/libawkward/array/IndexedArray.cpp
+++ b/src/libawkward/array/IndexedArray.cpp
@@ -180,6 +180,11 @@ namespace awkward {
   }
 
   bool
+  IndexedForm::istuple() const {
+    return content_.get()->istuple();
+  }
+
+  bool
   IndexedForm::equal(const FormPtr& other,
                      bool check_identities,
                      bool check_parameters,
@@ -423,6 +428,11 @@ namespace awkward {
   const std::vector<std::string>
   IndexedOptionForm::keys() const {
     return content_.get()->keys();
+  }
+
+  bool
+  IndexedOptionForm::istuple() const {
+    return content_.get()->istuple();
   }
 
   bool
@@ -1514,6 +1524,12 @@ namespace awkward {
   const std::vector<std::string>
   IndexedArrayOf<T, ISOPTION>::keys() const {
     return content_.get()->keys();
+  }
+
+  template <typename T, bool ISOPTION>
+  bool
+  IndexedArrayOf<T, ISOPTION>::istuple() const {
+    return content_.get()->istuple();
   }
 
   template <typename T, bool ISOPTION>

--- a/src/libawkward/array/ListArray.cpp
+++ b/src/libawkward/array/ListArray.cpp
@@ -192,6 +192,11 @@ namespace awkward {
   }
 
   bool
+  ListForm::istuple() const {
+    return content_.get()->istuple();
+  }
+
+  bool
   ListForm::equal(const FormPtr& other,
                   bool check_identities,
                   bool check_parameters,
@@ -898,6 +903,12 @@ namespace awkward {
   const std::vector<std::string>
   ListArrayOf<T>::keys() const {
     return content_.get()->keys();
+  }
+
+  template <typename T>
+  bool
+  ListArrayOf<T>::istuple() const {
+    return content_.get()->istuple();
   }
 
   template <typename T>

--- a/src/libawkward/array/ListOffsetArray.cpp
+++ b/src/libawkward/array/ListOffsetArray.cpp
@@ -182,6 +182,11 @@ namespace awkward {
   }
 
   bool
+  ListOffsetForm::istuple() const {
+    return content_.get()->istuple();
+  }
+
+  bool
   ListOffsetForm::equal(const FormPtr& other,
                         bool check_identities,
                         bool check_parameters,
@@ -909,6 +914,12 @@ namespace awkward {
   const std::vector<std::string>
   ListOffsetArrayOf<T>::keys() const {
     return content_.get()->keys();
+  }
+
+  template <typename T>
+  bool
+  ListOffsetArrayOf<T>::istuple() const {
+    return content_.get()->istuple();
   }
 
   template <typename T>

--- a/src/libawkward/array/None.cpp
+++ b/src/libawkward/array/None.cpp
@@ -238,6 +238,13 @@ namespace awkward {
       + FILENAME(__LINE__));
   }
 
+  bool
+  None::istuple() const {
+    throw std::runtime_error(
+      std::string("undefined operation: None::istuple")
+      + FILENAME(__LINE__));
+  }
+
   const std::string
   None::validityerror(const std::string& path) const {
     throw std::runtime_error(

--- a/src/libawkward/array/NumpyArray.cpp
+++ b/src/libawkward/array/NumpyArray.cpp
@@ -251,6 +251,11 @@ namespace awkward {
   }
 
   bool
+  NumpyForm::istuple() const {
+    return false;
+  }
+
+  bool
   NumpyForm::equal(const FormPtr& other,
                    bool check_identities,
                    bool check_parameters,
@@ -1538,6 +1543,11 @@ namespace awkward {
   const std::vector<std::string>
   NumpyArray::keys() const {
     return std::vector<std::string>();
+  }
+
+  bool
+  NumpyArray::istuple() const {
+    return false;
   }
 
   const std::string

--- a/src/libawkward/array/RegularArray.cpp
+++ b/src/libawkward/array/RegularArray.cpp
@@ -169,6 +169,11 @@ namespace awkward {
   }
 
   bool
+  RegularForm::istuple() const {
+    return content_.get()->istuple();
+  }
+
+  bool
   RegularForm::equal(const FormPtr& other,
                      bool check_identities,
                      bool check_parameters,
@@ -781,6 +786,11 @@ namespace awkward {
   const std::vector<std::string>
   RegularArray::keys() const {
     return content_.get()->keys();
+  }
+
+  bool
+  RegularArray::istuple() const {
+    return content_.get()->istuple();
   }
 
   const std::string

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -272,11 +272,12 @@ namespace awkward {
 
   bool
   UnionForm::istuple() const {
-  bool is_tuple = false;
+    bool all_contents_are_tuple = true;
     for (auto content : contents_) {
-        is_tuple = is_tuple && content.get()->istuple();
+        all_contents_are_tuple = all_contents_are_tuple && content.get()->istuple();
     }
-    return is_tuple;
+    //
+    return all_contents_are_tuple && (!contents_.empty());
   }
 
   bool
@@ -1456,11 +1457,12 @@ namespace awkward {
   template <typename T, typename I>
   bool
   UnionArrayOf<T, I>::istuple() const {
-  bool is_tuple = false;
+    bool all_contents_are_tuple = true;
     for (auto content : contents_) {
-        is_tuple = is_tuple && content.get()->istuple();
+        all_contents_are_tuple = all_contents_are_tuple && content.get()->istuple();
     }
-    return is_tuple;
+    //
+    return all_contents_are_tuple && (!contents_.empty());
   }
 
   template <typename T, typename I>

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -276,7 +276,6 @@ namespace awkward {
     for (auto content : contents_) {
         all_contents_are_tuple = all_contents_are_tuple && content.get()->istuple();
     }
-    //
     return all_contents_are_tuple && (!contents_.empty());
   }
 
@@ -1461,7 +1460,6 @@ namespace awkward {
     for (auto content : contents_) {
         all_contents_are_tuple = all_contents_are_tuple && content.get()->istuple();
     }
-    //
     return all_contents_are_tuple && (!contents_.empty());
   }
 

--- a/src/libawkward/array/UnionArray.cpp
+++ b/src/libawkward/array/UnionArray.cpp
@@ -271,6 +271,15 @@ namespace awkward {
   }
 
   bool
+  UnionForm::istuple() const {
+  bool is_tuple = false;
+    for (auto content : contents_) {
+        is_tuple = is_tuple && content.get()->istuple();
+    }
+    return is_tuple;
+  }
+
+  bool
   UnionForm::equal(const FormPtr& other,
                    bool check_identities,
                    bool check_parameters,
@@ -1442,6 +1451,16 @@ namespace awkward {
       }
     }
     return out;
+  }
+
+  template <typename T, typename I>
+  bool
+  UnionArrayOf<T, I>::istuple() const {
+  bool is_tuple = false;
+    for (auto content : contents_) {
+        is_tuple = is_tuple && content.get()->istuple();
+    }
+    return is_tuple;
   }
 
   template <typename T, typename I>

--- a/src/libawkward/array/UnmaskedArray.cpp
+++ b/src/libawkward/array/UnmaskedArray.cpp
@@ -138,6 +138,11 @@ namespace awkward {
   }
 
   bool
+  UnmaskedForm::istuple() const {
+    return content_.get()->istuple();
+  }
+
+  bool
   UnmaskedForm::equal(const FormPtr& other,
                       bool check_identities,
                       bool check_parameters,
@@ -687,6 +692,11 @@ namespace awkward {
   const std::vector<std::string>
   UnmaskedArray::keys() const {
     return content_.get()->keys();
+  }
+
+  bool
+  UnmaskedArray::istuple() const {
+    return content_.get()->istuple();
   }
 
   const std::string

--- a/src/libawkward/array/VirtualArray.cpp
+++ b/src/libawkward/array/VirtualArray.cpp
@@ -225,6 +225,17 @@ namespace awkward {
     }
   }
 
+  bool VirtualForm::istuple() const {
+    if (form_.get() == nullptr) {
+      throw std::invalid_argument(
+        std::string("VirtualForm cannot determine its type without an expected Form")
+        + FILENAME(__LINE__));
+    }
+    else {
+      return form_.get()->istuple();
+    }
+  }
+
   bool
   VirtualForm::equal(const FormPtr& other,
                      bool check_identities,
@@ -782,6 +793,11 @@ namespace awkward {
   const std::vector<std::string>
   VirtualArray::keys() const {
     return form(true).get()->keys();
+  }
+
+  bool
+  VirtualArray::istuple() const {
+    return form(true).get()->istuple();
   }
 
   const std::string

--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -1880,6 +1880,7 @@ content_methods(py::class_<T, std::shared_ptr<T>, ak::Content>& x) {
           .def("key", &T::key)
           .def("haskey", &T::haskey)
           .def("keys", &T::keys)
+          .def_property_readonly("istuple", &T::istuple)
           .def_property_readonly("purelist_isregular", &T::purelist_isregular)
           .def_property_readonly("purelist_depth", &T::purelist_depth)
           .def_property_readonly("branch_depth", [](const T& self)
@@ -3206,7 +3207,6 @@ make_RecordArray(const py::handle& m, const std::string& name) {
           return out;
         }
       })
-      .def_property_readonly("istuple", &ak::RecordArray::istuple)
       .def_property_readonly("contents", &ak::RecordArray::contents)
       .def("setitem_field",
            [](const ak::RecordArray& self,

--- a/tests/test_1351-is-tuple.py
+++ b/tests/test_1351-is-tuple.py
@@ -1,0 +1,81 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_record():
+    array = ak.Array(
+        [
+            {"x": 10},
+            {"x": 11},
+            {"x": 12},
+        ]
+    )
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+
+def test_record_list():
+    array = ak.Array(
+        [
+            [
+                {"x": 10},
+                {"x": 11},
+                {"x": 12},
+            ]
+        ]
+    )
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+
+def test_tuple():
+    array = ak.Array(
+        [
+            (10,),
+            (11,),
+            (12,),
+        ]
+    )
+
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
+
+
+def test_tuple_list():
+    array = ak.Array(
+        [
+            [
+                (10,),
+                (11,),
+                (12,),
+            ]
+        ]
+    )
+
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
+
+
+def test_list():
+    array = ak.Array([[10, 11, 12]])
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+
+def test_record_tuple():
+    array = ak.Array([{"x": (10,)}])
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+
+def test_tuple_record():
+    array = ak.Array([({"x": 10},)])
+
+    assert ak.is_tuple(array)
+    assert array.layout.istuple

--- a/tests/test_1351-is-tuple.py
+++ b/tests/test_1351-is-tuple.py
@@ -79,3 +79,17 @@ def test_tuple_record():
 
     assert ak.is_tuple(array)
     assert array.layout.istuple
+
+
+def test_union_tuple_int():
+    array = ak.Array([(10,), 20])
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+
+def test_union_tuple_tuple():
+    array = ak.Array([(10,), (20, 30)])
+
+    assert ak.is_tuple(array)
+    assert array.layout.istuple

--- a/tests/test_1351-is-tuple.py
+++ b/tests/test_1351-is-tuple.py
@@ -4,28 +4,19 @@ import pytest  # noqa: F401
 import awkward as ak  # noqa: F401
 import numpy as np
 
+tuple = ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None)
+record = ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"])
+
 
 def test_record():
-    array = ak.Array(
-        [
-            {"x": 10},
-            {"x": 11},
-            {"x": 12},
-        ]
-    )
+    array = ak.Array(record)
 
     assert not ak.is_tuple(array)
     assert not array.layout.istuple
 
 
 def test_tuple():
-    array = ak.Array(
-        [
-            (10,),
-            (11,),
-            (12,),
-        ]
-    )
+    array = ak.Array(tuple)
 
     assert ak.is_tuple(array)
     assert array.layout.istuple
@@ -39,128 +30,135 @@ def test_numpy():
 
 
 def test_list():
-    tuple = ak.Array(
+    array = ak.Array(
         ak.layout.ListArray64(
             ak.layout.Index64(np.array([0, 2], dtype=np.int64)),
             ak.layout.Index64(np.array([2, 4], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+            tuple,
         )
     )
 
-    assert ak.is_tuple(tuple)
-    assert tuple.layout.istuple
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
 
-    record = ak.Array(
+    array = ak.Array(
         ak.layout.ListArray64(
             ak.layout.Index64(np.array([0, 2], dtype=np.int64)),
             ak.layout.Index64(np.array([2, 4], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+            record,
         )
     )
 
-    assert not ak.is_tuple(record)
-    assert not record.layout.istuple
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
 
 
 def test_listoffset():
-    tuple = ak.Array(
+    array = ak.Array(
         ak.layout.ListOffsetArray64(
             ak.layout.Index64(np.array([0, 2, 4], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+            tuple,
         )
     )
 
-    assert ak.is_tuple(tuple)
-    assert tuple.layout.istuple
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
 
-    record = ak.Array(
+    array = ak.Array(
         ak.layout.ListOffsetArray64(
-            ak.layout.Index64(np.array([0, 2, 4], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+            ak.layout.Index64(np.array([0, 2, 4], dtype=np.int64)), record
         )
     )
 
-    assert not ak.is_tuple(record)
-    assert not record.layout.istuple
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
 
 
-def test_layouted():
-    tuple = ak.Array(
+def test_indexed():
+    array = ak.Array(
         ak.layout.IndexedArray64(
-            ak.layout.Index64(np.array([0, 1, 3], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+            ak.layout.Index64(np.array([0, 1, 3], dtype=np.int64)), tuple
         )
     )
 
-    assert ak.is_tuple(tuple)
-    assert tuple.layout.istuple
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
 
-    record = ak.Array(
+    array = ak.Array(
         ak.layout.IndexedArray64(
-            ak.layout.Index64(np.array([0, 1, 3], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+            ak.layout.Index64(np.array([0, 1, 3], dtype=np.int64)), record
         )
     )
 
-    assert not ak.is_tuple(record)
-    assert not record.layout.istuple
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+
+def test_regular():
+    array = ak.Array(ak.layout.RegularArray(tuple, 5))
+
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
+
+    array = ak.Array(ak.layout.RegularArray(record, 5))
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
 
 
 def test_bytemasked():
-    tuple = ak.Array(
+    array = ak.Array(
         ak.layout.ByteMaskedArray(
             ak.layout.Index8(np.array([0, 1, 0, 1], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+            tuple,
             valid_when=True,
         )
     )
 
-    assert ak.is_tuple(tuple)
-    assert tuple.layout.istuple
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
 
-    record = ak.Array(
+    array = ak.Array(
         ak.layout.ByteMaskedArray(
             ak.layout.Index8(np.array([0, 1, 0, 1], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+            record,
             valid_when=True,
         )
     )
 
-    assert not ak.is_tuple(record)
-    assert not record.layout.istuple
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
 
 
 def test_bitmasked():
-    tuple = ak.Array(
+    array = ak.Array(
         ak.layout.BitMaskedArray(
             ak.layout.IndexU8(np.array([0, 1, 0, 1], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+            tuple,
             valid_when=True,
             length=4,
             lsb_order=True,
         )
     )
 
-    assert ak.is_tuple(tuple)
-    assert tuple.layout.istuple
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
 
-    record = ak.Array(
+    array = ak.Array(
         ak.layout.BitMaskedArray(
             ak.layout.IndexU8(np.array([0, 1, 0, 1], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+            record,
             valid_when=True,
             length=4,
             lsb_order=True,
         )
     )
 
-    assert not ak.is_tuple(record)
-    assert not record.layout.istuple
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
 
 
 def test_union():
-    tuple = ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None)
-
     array = ak.Array(
         ak.layout.UnionArray8_64(
             ak.layout.Index8([0, 0, 1, 1]),
@@ -182,8 +180,6 @@ def test_union():
 
     assert ak.is_tuple(array)
     assert array.layout.istuple
-
-    record = ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"])
 
     array = ak.Array(
         ak.layout.UnionArray8_64(

--- a/tests/test_1351-is-tuple.py
+++ b/tests/test_1351-is-tuple.py
@@ -18,21 +18,6 @@ def test_record():
     assert not array.layout.istuple
 
 
-def test_record_list():
-    array = ak.Array(
-        [
-            [
-                {"x": 10},
-                {"x": 11},
-                {"x": 12},
-            ]
-        ]
-    )
-
-    assert not ak.is_tuple(array)
-    assert not array.layout.istuple
-
-
 def test_tuple():
     array = ak.Array(
         [
@@ -46,63 +31,189 @@ def test_tuple():
     assert array.layout.istuple
 
 
-def test_tuple_list():
-    array = ak.Array(
-        [
-            [
-                (10,),
-                (11,),
-                (12,),
-            ]
-        ]
-    )
+def test_numpy():
+    array = ak.Array(ak.layout.NumpyArray(np.arange(10)))
 
-    assert ak.is_tuple(array)
-    assert array.layout.istuple
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
 
 
 def test_list():
-    array = ak.Array([[10, 11, 12]])
+    tuple = ak.Array(
+        ak.layout.ListArray64(
+            ak.layout.Index64(np.array([0, 2], dtype=np.int64)),
+            ak.layout.Index64(np.array([2, 4], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+        )
+    )
 
-    assert not ak.is_tuple(array)
-    assert not array.layout.istuple
+    assert ak.is_tuple(tuple)
+    assert tuple.layout.istuple
 
+    record = ak.Array(
+        ak.layout.ListArray64(
+            ak.layout.Index64(np.array([0, 2], dtype=np.int64)),
+            ak.layout.Index64(np.array([2, 4], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+        )
+    )
 
-def test_record_tuple():
-    array = ak.Array([{"x": (10,)}])
-
-    assert not ak.is_tuple(array)
-    assert not array.layout.istuple
-
-
-def test_tuple_record():
-    array = ak.Array([({"x": 10},)])
-
-    assert ak.is_tuple(array)
-    assert array.layout.istuple
-
-
-def test_union_tuple_int():
-    array = ak.Array([(10,), 20])
-
-    assert not ak.is_tuple(array)
-    assert not array.layout.istuple
+    assert not ak.is_tuple(record)
+    assert not record.layout.istuple
 
 
-def test_union_tuple_tuple():
-    array = ak.Array([(10,), (20, 30)])
+def test_listoffset():
+    tuple = ak.Array(
+        ak.layout.ListOffsetArray64(
+            ak.layout.Index64(np.array([0, 2, 4], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+        )
+    )
 
-    assert ak.is_tuple(array)
-    assert array.layout.istuple
+    assert ak.is_tuple(tuple)
+    assert tuple.layout.istuple
+
+    record = ak.Array(
+        ak.layout.ListOffsetArray64(
+            ak.layout.Index64(np.array([0, 2, 4], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+        )
+    )
+
+    assert not ak.is_tuple(record)
+    assert not record.layout.istuple
 
 
-def test_indexed_tuple():
-    array = ak.Array(
+def test_layouted():
+    tuple = ak.Array(
         ak.layout.IndexedArray64(
             ak.layout.Index64(np.array([0, 1, 3], dtype=np.int64)),
-            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))]),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+        )
+    )
+
+    assert ak.is_tuple(tuple)
+    assert tuple.layout.istuple
+
+    record = ak.Array(
+        ak.layout.IndexedArray64(
+            ak.layout.Index64(np.array([0, 1, 3], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+        )
+    )
+
+    assert not ak.is_tuple(record)
+    assert not record.layout.istuple
+
+
+def test_bytemasked():
+    tuple = ak.Array(
+        ak.layout.ByteMaskedArray(
+            ak.layout.Index8(np.array([0, 1, 0, 1], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+            valid_when=True,
+        )
+    )
+
+    assert ak.is_tuple(tuple)
+    assert tuple.layout.istuple
+
+    record = ak.Array(
+        ak.layout.ByteMaskedArray(
+            ak.layout.Index8(np.array([0, 1, 0, 1], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+            valid_when=True,
+        )
+    )
+
+    assert not ak.is_tuple(record)
+    assert not record.layout.istuple
+
+
+def test_bitmasked():
+    tuple = ak.Array(
+        ak.layout.BitMaskedArray(
+            ak.layout.IndexU8(np.array([0, 1, 0, 1], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None),
+            valid_when=True,
+            length=4,
+            lsb_order=True,
+        )
+    )
+
+    assert ak.is_tuple(tuple)
+    assert tuple.layout.istuple
+
+    record = ak.Array(
+        ak.layout.BitMaskedArray(
+            ak.layout.IndexU8(np.array([0, 1, 0, 1], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"]),
+            valid_when=True,
+            length=4,
+            lsb_order=True,
+        )
+    )
+
+    assert not ak.is_tuple(record)
+    assert not record.layout.istuple
+
+
+def test_union():
+    tuple = ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], None)
+
+    array = ak.Array(
+        ak.layout.UnionArray8_64(
+            ak.layout.Index8([0, 0, 1, 1]),
+            ak.layout.Index64([0, 1, 0, 1]),
+            [tuple, ak.layout.NumpyArray(np.arange(10))],
+        )
+    )
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+    array = ak.Array(
+        ak.layout.UnionArray8_64(
+            ak.layout.Index8([0, 0, 1, 1]),
+            ak.layout.Index64([0, 1, 0, 1]),
+            [tuple, tuple],
         )
     )
 
     assert ak.is_tuple(array)
     assert array.layout.istuple
+
+    record = ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))], ["x"])
+
+    array = ak.Array(
+        ak.layout.UnionArray8_64(
+            ak.layout.Index8([0, 0, 1, 1]),
+            ak.layout.Index64([0, 1, 0, 1]),
+            [record, ak.layout.NumpyArray(np.arange(10))],
+        )
+    )
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+    array = ak.Array(
+        ak.layout.UnionArray8_64(
+            ak.layout.Index8([0, 0, 1, 1]),
+            ak.layout.Index64([0, 1, 0, 1]),
+            [record, tuple],
+        )
+    )
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple
+
+    array = ak.Array(
+        ak.layout.UnionArray8_64(
+            ak.layout.Index8([0, 0, 1, 1]),
+            ak.layout.Index64([0, 1, 0, 1]),
+            [record, record],
+        )
+    )
+
+    assert not ak.is_tuple(array)
+    assert not array.layout.istuple

--- a/tests/test_1351-is-tuple.py
+++ b/tests/test_1351-is-tuple.py
@@ -2,6 +2,7 @@
 
 import pytest  # noqa: F401
 import awkward as ak  # noqa: F401
+import numpy as np
 
 
 def test_record():
@@ -90,6 +91,18 @@ def test_union_tuple_int():
 
 def test_union_tuple_tuple():
     array = ak.Array([(10,), (20, 30)])
+
+    assert ak.is_tuple(array)
+    assert array.layout.istuple
+
+
+def test_indexed_tuple():
+    array = ak.Array(
+        ak.layout.IndexedArray64(
+            ak.layout.Index64(np.array([0, 1, 3], dtype=np.int64)),
+            ak.layout.RecordArray([ak.layout.NumpyArray(np.arange(10))]),
+        )
+    )
 
     assert ak.is_tuple(array)
     assert array.layout.istuple

--- a/tests/test_1351-is-tuple.py
+++ b/tests/test_1351-is-tuple.py
@@ -12,21 +12,18 @@ def test_record():
     array = ak.Array(record)
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
 
 def test_tuple():
     array = ak.Array(tuple)
 
     assert ak.is_tuple(array)
-    assert array.layout.istuple
 
 
 def test_numpy():
     array = ak.Array(ak.layout.NumpyArray(np.arange(10)))
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
 
 def test_list():
@@ -39,7 +36,6 @@ def test_list():
     )
 
     assert ak.is_tuple(array)
-    assert array.layout.istuple
 
     array = ak.Array(
         ak.layout.ListArray64(
@@ -50,7 +46,6 @@ def test_list():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
 
 def test_listoffset():
@@ -62,7 +57,6 @@ def test_listoffset():
     )
 
     assert ak.is_tuple(array)
-    assert array.layout.istuple
 
     array = ak.Array(
         ak.layout.ListOffsetArray64(
@@ -71,7 +65,6 @@ def test_listoffset():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
 
 def test_indexed():
@@ -82,7 +75,6 @@ def test_indexed():
     )
 
     assert ak.is_tuple(array)
-    assert array.layout.istuple
 
     array = ak.Array(
         ak.layout.IndexedArray64(
@@ -91,19 +83,16 @@ def test_indexed():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
 
 def test_regular():
     array = ak.Array(ak.layout.RegularArray(tuple, 5))
 
     assert ak.is_tuple(array)
-    assert array.layout.istuple
 
     array = ak.Array(ak.layout.RegularArray(record, 5))
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
 
 def test_bytemasked():
@@ -116,7 +105,6 @@ def test_bytemasked():
     )
 
     assert ak.is_tuple(array)
-    assert array.layout.istuple
 
     array = ak.Array(
         ak.layout.ByteMaskedArray(
@@ -127,7 +115,6 @@ def test_bytemasked():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
 
 def test_bitmasked():
@@ -142,7 +129,6 @@ def test_bitmasked():
     )
 
     assert ak.is_tuple(array)
-    assert array.layout.istuple
 
     array = ak.Array(
         ak.layout.BitMaskedArray(
@@ -155,7 +141,6 @@ def test_bitmasked():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
 
 def test_union():
@@ -168,7 +153,6 @@ def test_union():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
     array = ak.Array(
         ak.layout.UnionArray8_64(
@@ -179,7 +163,6 @@ def test_union():
     )
 
     assert ak.is_tuple(array)
-    assert array.layout.istuple
 
     array = ak.Array(
         ak.layout.UnionArray8_64(
@@ -190,7 +173,6 @@ def test_union():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
     array = ak.Array(
         ak.layout.UnionArray8_64(
@@ -201,7 +183,6 @@ def test_union():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple
 
     array = ak.Array(
         ak.layout.UnionArray8_64(
@@ -212,4 +193,3 @@ def test_union():
     )
 
     assert not ak.is_tuple(array)
-    assert not array.layout.istuple

--- a/tests/v2/test_1351-is-tuple.py
+++ b/tests/v2/test_1351-is-tuple.py
@@ -12,21 +12,18 @@ def test_record():
     array = ak._v2.Array(record)
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
 
 def test_tuple():
     array = ak._v2.Array(tuple)
 
     assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
 
 
 def test_numpy():
     array = ak._v2.Array(ak._v2.contents.NumpyArray(np.arange(10)))
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
 
 def test_list():
@@ -39,7 +36,6 @@ def test_list():
     )
 
     assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.ListArray(
@@ -50,7 +46,6 @@ def test_list():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
 
 def test_listoffset():
@@ -62,7 +57,6 @@ def test_listoffset():
     )
 
     assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.ListOffsetArray(
@@ -71,7 +65,6 @@ def test_listoffset():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
 
 def test_indexed():
@@ -82,7 +75,6 @@ def test_indexed():
     )
 
     assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.IndexedArray(
@@ -91,19 +83,16 @@ def test_indexed():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
 
 def test_regular():
     array = ak._v2.Array(ak._v2.contents.RegularArray(tuple, 5))
 
     assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
 
     array = ak._v2.Array(ak._v2.contents.RegularArray(record, 5))
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
 
 def test_bytemasked():
@@ -116,7 +105,6 @@ def test_bytemasked():
     )
 
     assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.ByteMaskedArray(
@@ -127,7 +115,6 @@ def test_bytemasked():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
 
 def test_bitmasked():
@@ -142,7 +129,6 @@ def test_bitmasked():
     )
 
     assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.BitMaskedArray(
@@ -155,7 +141,6 @@ def test_bitmasked():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
 
 def test_union():
@@ -168,7 +153,6 @@ def test_union():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.UnionArray(
@@ -179,7 +163,6 @@ def test_union():
     )
 
     assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.UnionArray(
@@ -190,7 +173,6 @@ def test_union():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.UnionArray(
@@ -201,7 +183,6 @@ def test_union():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
 
     array = ak._v2.Array(
         ak._v2.contents.UnionArray(
@@ -212,4 +193,3 @@ def test_union():
     )
 
     assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple

--- a/tests/v2/test_1351-is-tuple.py
+++ b/tests/v2/test_1351-is-tuple.py
@@ -14,6 +14,7 @@ def test_record():
     )
 
     assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_record_list():
@@ -28,6 +29,7 @@ def test_record_list():
     )
 
     assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_tuple():
@@ -40,6 +42,7 @@ def test_tuple():
     )
 
     assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
 
 
 def test_tuple_list():
@@ -54,21 +57,25 @@ def test_tuple_list():
     )
 
     assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
 
 
 def test_list():
     array = ak._v2.Array([[10, 11, 12]])
 
     assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_record_tuple():
     array = ak._v2.Array([{"x": (10,)}])
 
     assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_tuple_record():
     array = ak._v2.Array([({"x": 10},)])
 
     assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple

--- a/tests/v2/test_1351-is-tuple.py
+++ b/tests/v2/test_1351-is-tuple.py
@@ -1,0 +1,74 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_record():
+    array = ak._v2.Array(
+        [
+            {"x": 10},
+            {"x": 11},
+            {"x": 12},
+        ]
+    )
+
+    assert not ak._v2.is_tuple(array)
+
+
+def test_record_list():
+    array = ak._v2.Array(
+        [
+            [
+                {"x": 10},
+                {"x": 11},
+                {"x": 12},
+            ]
+        ]
+    )
+
+    assert not ak._v2.is_tuple(array)
+
+
+def test_tuple():
+    array = ak._v2.Array(
+        [
+            (10,),
+            (11,),
+            (12,),
+        ]
+    )
+
+    assert ak._v2.is_tuple(array)
+
+
+def test_tuple_list():
+    array = ak._v2.Array(
+        [
+            [
+                (10,),
+                (11,),
+                (12,),
+            ]
+        ]
+    )
+
+    assert ak._v2.is_tuple(array)
+
+
+def test_list():
+    array = ak._v2.Array([[10, 11, 12]])
+
+    assert not ak._v2.is_tuple(array)
+
+
+def test_record_tuple():
+    array = ak._v2.Array([{"x": (10,)}])
+
+    assert not ak._v2.is_tuple(array)
+
+
+def test_tuple_record():
+    array = ak._v2.Array([({"x": 10},)])
+
+    assert ak._v2.is_tuple(array)

--- a/tests/v2/test_1351-is-tuple.py
+++ b/tests/v2/test_1351-is-tuple.py
@@ -79,3 +79,17 @@ def test_tuple_record():
 
     assert ak._v2.is_tuple(array)
     assert array.layout.is_tuple
+
+
+def test_union_tuple_int():
+    array = ak._v2.Array([(10,), 20])
+
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
+
+
+def test_union_tuple_tuple():
+    array = ak._v2.Array([(10,), (20, 30)])
+
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple

--- a/tests/v2/test_1351-is-tuple.py
+++ b/tests/v2/test_1351-is-tuple.py
@@ -4,28 +4,19 @@ import pytest  # noqa: F401
 import awkward as ak  # noqa: F401
 import numpy as np
 
+tuple = ak._v2.contents.RecordArray([ak._v2.contents.NumpyArray(np.arange(10))], None)
+record = ak._v2.contents.RecordArray([ak._v2.contents.NumpyArray(np.arange(10))], ["x"])
+
 
 def test_record():
-    array = ak._v2.Array(
-        [
-            {"x": 10},
-            {"x": 11},
-            {"x": 12},
-        ]
-    )
+    array = ak._v2.Array(record)
 
     assert not ak._v2.is_tuple(array)
     assert not array.layout.is_tuple
 
 
 def test_tuple():
-    array = ak._v2.Array(
-        [
-            (10,),
-            (11,),
-            (12,),
-        ]
-    )
+    array = ak._v2.Array(tuple)
 
     assert ak._v2.is_tuple(array)
     assert array.layout.is_tuple
@@ -39,150 +30,135 @@ def test_numpy():
 
 
 def test_list():
-    tuple = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.ListArray(
             ak._v2.index.Index64(np.array([0, 2], dtype=np.int64)),
             ak._v2.index.Index64(np.array([2, 4], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], None
-            ),
+            tuple,
         )
     )
 
-    assert ak._v2.is_tuple(tuple)
-    assert tuple.layout.is_tuple
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
 
-    record = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.ListArray(
             ak._v2.index.Index64(np.array([0, 2], dtype=np.int64)),
             ak._v2.index.Index64(np.array([2, 4], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
-            ),
+            record,
         )
     )
 
-    assert not ak._v2.is_tuple(record)
-    assert not record.layout.is_tuple
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_listoffset():
-    tuple = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.ListOffsetArray(
             ak._v2.index.Index64(np.array([0, 2, 4], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], None
-            ),
+            tuple,
         )
     )
 
-    assert ak._v2.is_tuple(tuple)
-    assert tuple.layout.is_tuple
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
 
-    record = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.ListOffsetArray(
-            ak._v2.index.Index64(np.array([0, 2, 4], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
-            ),
+            ak._v2.index.Index64(np.array([0, 2, 4], dtype=np.int64)), record
         )
     )
 
-    assert not ak._v2.is_tuple(record)
-    assert not record.layout.is_tuple
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_indexed():
-    tuple = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.IndexedArray(
-            ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], None
-            ),
+            ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)), tuple
         )
     )
 
-    assert ak._v2.is_tuple(tuple)
-    assert tuple.layout.is_tuple
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
 
-    record = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.IndexedArray(
-            ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
-            ),
+            ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)), record
         )
     )
 
-    assert not ak._v2.is_tuple(record)
-    assert not record.layout.is_tuple
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
+
+
+def test_regular():
+    array = ak._v2.Array(ak._v2.contents.RegularArray(tuple, 5))
+
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
+
+    array = ak._v2.Array(ak._v2.contents.RegularArray(record, 5))
+
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_bytemasked():
-    tuple = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.ByteMaskedArray(
             ak._v2.index.Index8(np.array([0, 1, 0, 1], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], None
-            ),
+            tuple,
             valid_when=True,
         )
     )
 
-    assert ak._v2.is_tuple(tuple)
-    assert tuple.layout.is_tuple
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
 
-    record = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.ByteMaskedArray(
             ak._v2.index.Index8(np.array([0, 1, 0, 1], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
-            ),
+            record,
             valid_when=True,
         )
     )
 
-    assert not ak._v2.is_tuple(record)
-    assert not record.layout.is_tuple
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_bitmasked():
-    tuple = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.BitMaskedArray(
             ak._v2.index.IndexU8(np.array([0, 1, 0, 1], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], None
-            ),
+            tuple,
             valid_when=True,
             length=4,
             lsb_order=True,
         )
     )
 
-    assert ak._v2.is_tuple(tuple)
-    assert tuple.layout.is_tuple
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
 
-    record = ak._v2.Array(
+    array = ak._v2.Array(
         ak._v2.contents.BitMaskedArray(
             ak._v2.index.IndexU8(np.array([0, 1, 0, 1], dtype=np.int64)),
-            ak._v2.contents.RecordArray(
-                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
-            ),
+            record,
             valid_when=True,
             length=4,
             lsb_order=True,
         )
     )
 
-    assert not ak._v2.is_tuple(record)
-    assert not record.layout.is_tuple
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_union():
-    tuple = ak._v2.contents.RecordArray(
-        [ak._v2.contents.NumpyArray(np.arange(10))], None
-    )
-
     array = ak._v2.Array(
         ak._v2.contents.UnionArray(
             ak._v2.index.Index8([0, 0, 1, 1]),
@@ -204,10 +180,6 @@ def test_union():
 
     assert ak._v2.is_tuple(array)
     assert array.layout.is_tuple
-
-    record = ak._v2.contents.RecordArray(
-        [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
-    )
 
     array = ak._v2.Array(
         ak._v2.contents.UnionArray(

--- a/tests/v2/test_1351-is-tuple.py
+++ b/tests/v2/test_1351-is-tuple.py
@@ -2,6 +2,7 @@
 
 import pytest  # noqa: F401
 import awkward as ak  # noqa: F401
+import numpy as np
 
 
 def test_record():
@@ -93,3 +94,31 @@ def test_union_tuple_tuple():
 
     assert ak._v2.is_tuple(array)
     assert array.layout.is_tuple
+
+
+def test_indexed_tuple():
+    array = ak._v2.Array(
+        ak._v2.contents.IndexedArray(
+            ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], None
+            ),
+        )
+    )
+
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
+
+
+def test_indexed_record():
+    array = ak._v2.Array(
+        ak._v2.contents.IndexedArray(
+            ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
+            ),
+        )
+    )
+
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple

--- a/tests/v2/test_1351-is-tuple.py
+++ b/tests/v2/test_1351-is-tuple.py
@@ -18,21 +18,6 @@ def test_record():
     assert not array.layout.is_tuple
 
 
-def test_record_list():
-    array = ak._v2.Array(
-        [
-            [
-                {"x": 10},
-                {"x": 11},
-                {"x": 12},
-            ]
-        ]
-    )
-
-    assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
-
-
 def test_tuple():
     array = ak._v2.Array(
         [
@@ -46,58 +31,69 @@ def test_tuple():
     assert array.layout.is_tuple
 
 
-def test_tuple_list():
-    array = ak._v2.Array(
-        [
-            [
-                (10,),
-                (11,),
-                (12,),
-            ]
-        ]
-    )
+def test_numpy():
+    array = ak._v2.Array(ak._v2.contents.NumpyArray(np.arange(10)))
 
-    assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
 
 
 def test_list():
-    array = ak._v2.Array([[10, 11, 12]])
+    tuple = ak._v2.Array(
+        ak._v2.contents.ListArray(
+            ak._v2.index.Index64(np.array([0, 2], dtype=np.int64)),
+            ak._v2.index.Index64(np.array([2, 4], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], None
+            ),
+        )
+    )
 
-    assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
+    assert ak._v2.is_tuple(tuple)
+    assert tuple.layout.is_tuple
 
+    record = ak._v2.Array(
+        ak._v2.contents.ListArray(
+            ak._v2.index.Index64(np.array([0, 2], dtype=np.int64)),
+            ak._v2.index.Index64(np.array([2, 4], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
+            ),
+        )
+    )
 
-def test_record_tuple():
-    array = ak._v2.Array([{"x": (10,)}])
-
-    assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
-
-
-def test_tuple_record():
-    array = ak._v2.Array([({"x": 10},)])
-
-    assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
-
-
-def test_union_tuple_int():
-    array = ak._v2.Array([(10,), 20])
-
-    assert not ak._v2.is_tuple(array)
-    assert not array.layout.is_tuple
-
-
-def test_union_tuple_tuple():
-    array = ak._v2.Array([(10,), (20, 30)])
-
-    assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
+    assert not ak._v2.is_tuple(record)
+    assert not record.layout.is_tuple
 
 
-def test_indexed_tuple():
-    array = ak._v2.Array(
+def test_listoffset():
+    tuple = ak._v2.Array(
+        ak._v2.contents.ListOffsetArray(
+            ak._v2.index.Index64(np.array([0, 2, 4], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], None
+            ),
+        )
+    )
+
+    assert ak._v2.is_tuple(tuple)
+    assert tuple.layout.is_tuple
+
+    record = ak._v2.Array(
+        ak._v2.contents.ListOffsetArray(
+            ak._v2.index.Index64(np.array([0, 2, 4], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
+            ),
+        )
+    )
+
+    assert not ak._v2.is_tuple(record)
+    assert not record.layout.is_tuple
+
+
+def test_indexed():
+    tuple = ak._v2.Array(
         ak._v2.contents.IndexedArray(
             ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
             ak._v2.contents.RecordArray(
@@ -106,17 +102,140 @@ def test_indexed_tuple():
         )
     )
 
-    assert ak._v2.is_tuple(array)
-    assert array.layout.is_tuple
+    assert ak._v2.is_tuple(tuple)
+    assert tuple.layout.is_tuple
 
-
-def test_indexed_record():
-    array = ak._v2.Array(
+    record = ak._v2.Array(
         ak._v2.contents.IndexedArray(
             ak._v2.index.Index64(np.array([0, 1, 3], dtype=np.int64)),
             ak._v2.contents.RecordArray(
                 [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
             ),
+        )
+    )
+
+    assert not ak._v2.is_tuple(record)
+    assert not record.layout.is_tuple
+
+
+def test_bytemasked():
+    tuple = ak._v2.Array(
+        ak._v2.contents.ByteMaskedArray(
+            ak._v2.index.Index8(np.array([0, 1, 0, 1], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], None
+            ),
+            valid_when=True,
+        )
+    )
+
+    assert ak._v2.is_tuple(tuple)
+    assert tuple.layout.is_tuple
+
+    record = ak._v2.Array(
+        ak._v2.contents.ByteMaskedArray(
+            ak._v2.index.Index8(np.array([0, 1, 0, 1], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
+            ),
+            valid_when=True,
+        )
+    )
+
+    assert not ak._v2.is_tuple(record)
+    assert not record.layout.is_tuple
+
+
+def test_bitmasked():
+    tuple = ak._v2.Array(
+        ak._v2.contents.BitMaskedArray(
+            ak._v2.index.IndexU8(np.array([0, 1, 0, 1], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], None
+            ),
+            valid_when=True,
+            length=4,
+            lsb_order=True,
+        )
+    )
+
+    assert ak._v2.is_tuple(tuple)
+    assert tuple.layout.is_tuple
+
+    record = ak._v2.Array(
+        ak._v2.contents.BitMaskedArray(
+            ak._v2.index.IndexU8(np.array([0, 1, 0, 1], dtype=np.int64)),
+            ak._v2.contents.RecordArray(
+                [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
+            ),
+            valid_when=True,
+            length=4,
+            lsb_order=True,
+        )
+    )
+
+    assert not ak._v2.is_tuple(record)
+    assert not record.layout.is_tuple
+
+
+def test_union():
+    tuple = ak._v2.contents.RecordArray(
+        [ak._v2.contents.NumpyArray(np.arange(10))], None
+    )
+
+    array = ak._v2.Array(
+        ak._v2.contents.UnionArray(
+            ak._v2.index.Index8([0, 0, 1, 1]),
+            ak._v2.index.Index64([0, 1, 0, 1]),
+            [tuple, ak._v2.contents.NumpyArray(np.arange(10))],
+        )
+    )
+
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
+
+    array = ak._v2.Array(
+        ak._v2.contents.UnionArray(
+            ak._v2.index.Index8([0, 0, 1, 1]),
+            ak._v2.index.Index64([0, 1, 0, 1]),
+            [tuple, tuple],
+        )
+    )
+
+    assert ak._v2.is_tuple(array)
+    assert array.layout.is_tuple
+
+    record = ak._v2.contents.RecordArray(
+        [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
+    )
+
+    array = ak._v2.Array(
+        ak._v2.contents.UnionArray(
+            ak._v2.index.Index8([0, 0, 1, 1]),
+            ak._v2.index.Index64([0, 1, 0, 1]),
+            [record, ak._v2.contents.NumpyArray(np.arange(10))],
+        )
+    )
+
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
+
+    array = ak._v2.Array(
+        ak._v2.contents.UnionArray(
+            ak._v2.index.Index8([0, 0, 1, 1]),
+            ak._v2.index.Index64([0, 1, 0, 1]),
+            [record, tuple],
+        )
+    )
+
+    assert not ak._v2.is_tuple(array)
+    assert not array.layout.is_tuple
+
+    array = ak._v2.Array(
+        ak._v2.contents.UnionArray(
+            ak._v2.index.Index8([0, 0, 1, 1]),
+            ak._v2.index.Index64([0, 1, 0, 1]),
+            [record, record],
         )
     )
 


### PR DESCRIPTION
### Feature :sparkles: 
This PR 
- adds a `ak.is_tuple` function to test whether a layout behaves as a tuple or a record.  
- adds `is_tuple`/`istuple` to all `Form` and `Content` types (C++ and Python) to handle recursion.

### Method :blue_book: 
To keep things simple, this just uses a recursive layout visitor. There is now a `_recursively_apply` API that supports early termination (by returning the same layout), but it doesn't support return values. The boilerplate to do this (`nonlocal` et al.) seems more indirected than a direct recursive visitor.

### Discussion :left_speech_bubble: 
I don't think we should add an `is_tuple` property to `ak.Array`, for the same reason that most of the Awkward API is in the form of free functions. 