### PR TITLE
Refactor: cleanup reducer

### DIFF
--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -821,7 +821,7 @@ class IndexedArray(Content):
             if isinstance(unique, ak._v2.contents.RegularArray):
                 unique = unique.toListOffsetArray64(True)
 
-            elif isinstance(unique, ak._v2.contents.ListOffsetArray):
+            if isinstance(unique, ak._v2.contents.ListOffsetArray):
                 if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
                     raise ak._v2._util.error(
                         AssertionError(

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1173,9 +1173,11 @@ class IndexedOptionArray(Content):
         return nextshifts
 
     def _rearrange_next(self, parents):
+        assert self._index.nplike is self._nplike and parents.nplike is self._nplike
         index_length = self._index.length
         numnull = ak._v2.index.Index64.empty(1, self._nplike)
-        assert numnull.nplike is self._nplike and self._index.nplike is self._nplike
+        assert numnull.nplike is self._nplike
+
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_numnull",
@@ -1193,9 +1195,8 @@ class IndexedOptionArray(Content):
         outindex = ak._v2.index.Index64.empty(index_length, self._nplike)
         assert (
             nextcarry.nplike is self._nplike
+            and nextparents.nplike is self._nplike
             and outindex.nplike is self._nplike
-            and self._index.nplike is self._nplike
-            and parents.nplike is self._nplike
         )
         self._handle_error(
             self._nplike[
@@ -1220,6 +1221,7 @@ class IndexedOptionArray(Content):
     def _sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
+        assert starts.nplike is self._nplike and parents.nplike is self._nplike
         branch, depth = self.branch_depth
 
         next, nextparents, numnull, outindex = self._rearrange_next(parents)
@@ -1238,12 +1240,8 @@ class IndexedOptionArray(Content):
         )
 
         nextoutindex = ak._v2.index.Index64.empty(parents.length, self._nplike)
-        assert (
-            nextoutindex.nplike is self._nplike
-            and starts.nplike is self._nplike
-            and parents.nplike is self._nplike
-            and nextparents.nplike is self._nplike
-        )
+        assert nextoutindex.nplike is self._nplike
+
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_local_preparenext_64",

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1115,6 +1115,11 @@ class IndexedOptionArray(Content):
         kind,
         order,
     ):
+        assert (
+            starts.nplike is self._nplike
+            and parents.nplike is self._nplike
+            and self._index.nplike is self._nplike
+        )
         if self._index.length == 0:
             return ak._v2.contents.NumpyArray(
                 self._nplike.empty(0, np.int64), None, None, self._nplike
@@ -1128,10 +1133,6 @@ class IndexedOptionArray(Content):
             nextshifts = self._rearrange_nextshifts(nextparents, shifts)
         else:
             nextshifts = None
-
-        inject_nones = (
-            True if (numnull[0] > 0 and not branch and negaxis != depth) else False
-        )
 
         out = next._argsort_next(
             negaxis,
@@ -1151,12 +1152,7 @@ class IndexedOptionArray(Content):
         # their sublists
         nulls_merged = False
         nulls_index = ak._v2.index.Index64.empty(numnull[0], self._nplike)
-        assert (
-            nulls_index.nplike is self._nplike
-            and self._index.nplike is self._nplike
-            and parents.nplike is self._nplike
-            and starts.nplike is self._nplike
-        )
+        assert nulls_index.nplike is self._nplike
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_index_of_nulls",
@@ -1230,6 +1226,10 @@ class IndexedOptionArray(Content):
             self._nplike,
         ).simplify_optiontype()
 
+        inject_nones = (
+            True if (numnull[0] > 0 and not branch and negaxis != depth) else False
+        )
+
         return self._prepare_out(
             inject_nones, out, branch, negaxis, depth, parents, starts, outindex
         )
@@ -1241,8 +1241,6 @@ class IndexedOptionArray(Content):
         branch, depth = self.branch_depth
 
         next, nextparents, numnull, outindex = self._rearrange_next(parents)
-
-        inject_nones = True if not branch and negaxis != depth else False
 
         out = next._sort_next(
             negaxis,
@@ -1282,6 +1280,8 @@ class IndexedOptionArray(Content):
             self._parameters,
             self._nplike,
         ).simplify_optiontype()
+
+        inject_nones = True if not branch and negaxis != depth else False
 
         return self._prepare_out(
             inject_nones, out, branch, negaxis, depth, parents, starts, outindex

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1029,52 +1029,13 @@ class IndexedOptionArray(Content):
             )
 
         branch, depth = self.branch_depth
-
         index_length = self._index.length
         parents_length = parents.length
 
         next, nextparents, numnull, outindex = self._prepare_next(index_length, parents)
 
         if (not branch) and negaxis == depth:
-            nextshifts = ak._v2.index.Index64.empty(
-                nextparents.length,
-                self._nplike,
-            )
-            if shifts is None:
-                assert (
-                    nextshifts.nplike is self._nplike
-                    and self._index.nplike is self._nplike
-                )
-                self._handle_error(
-                    self._nplike[
-                        "awkward_IndexedArray_reduce_next_nonlocal_nextshifts_64",
-                        nextshifts.dtype.type,
-                        self._index.dtype.type,
-                    ](
-                        nextshifts.data,
-                        self._index.data,
-                        self._index.length,
-                    )
-                )
-            else:
-                assert (
-                    nextshifts.nplike is self._nplike
-                    and self._index.nplike is self._nplike
-                    and shifts.nplike is self._nplike
-                )
-                self._handle_error(
-                    self._nplike[
-                        "awkward_IndexedArray_reduce_next_nonlocal_nextshifts_fromshifts_64",
-                        nextshifts.dtype.type,
-                        self._index.dtype.type,
-                        shifts.dtype.type,
-                    ](
-                        nextshifts.data,
-                        self._index.data,
-                        self._index.length,
-                        shifts.data,
-                    )
-                )
+            nextshifts = self._prepare_nextshifts(nextparents, shifts)
         else:
             nextshifts = None
 
@@ -1168,6 +1129,47 @@ class IndexedOptionArray(Content):
         return self._prepare_out(
             inject_nones, out, branch, negaxis, depth, parents, starts, outindex
         )
+
+    def _prepare_nextshifts(self, nextparents, shifts):
+        nextshifts = ak._v2.index.Index64.empty(
+            nextparents.length,
+            self._nplike,
+        )
+        if shifts is None:
+            assert (
+                nextshifts.nplike is self._nplike and self._index.nplike is self._nplike
+            )
+            self._handle_error(
+                self._nplike[
+                    "awkward_IndexedArray_reduce_next_nonlocal_nextshifts_64",
+                    nextshifts.dtype.type,
+                    self._index.dtype.type,
+                ](
+                    nextshifts.data,
+                    self._index.data,
+                    self._index.length,
+                )
+            )
+        else:
+            assert (
+                nextshifts.nplike is self._nplike
+                and self._index.nplike is self._nplike
+                and shifts.nplike is self._nplike
+            )
+            self._handle_error(
+                self._nplike[
+                    "awkward_IndexedArray_reduce_next_nonlocal_nextshifts_fromshifts_64",
+                    nextshifts.dtype.type,
+                    self._index.dtype.type,
+                    shifts.dtype.type,
+                ](
+                    nextshifts.data,
+                    self._index.data,
+                    self._index.length,
+                    shifts.data,
+                )
+            )
+        return nextshifts
 
     def _prepare_next(self, index_length, parents):
         numnull = ak._v2.index.Index64.empty(1, self._nplike)
@@ -1373,47 +1375,12 @@ class IndexedOptionArray(Content):
         keepdims,
     ):
         branch, depth = self.branch_depth
-
         index_length = self._index.length
 
         next, nextparents, numnull, outindex = self._prepare_next(index_length, parents)
 
         if reducer.needs_position and (not branch and negaxis == depth):
-            nextshifts = ak._v2.index.Index64.empty(nextparents.length, self._nplike)
-            if shifts is None:
-                assert (
-                    nextshifts.nplike is self._nplike
-                    and self.index.nplike is self._nplike
-                )
-                self._handle_error(
-                    self._nplike[
-                        "awkward_IndexedArray_reduce_next_nonlocal_nextshifts_64",
-                        nextshifts.dtype.type,
-                        self.index.dtype.type,
-                    ](
-                        nextshifts.data,
-                        self.index.data,
-                        self.index.length,
-                    )
-                )
-            else:
-                assert (
-                    nextshifts.nplike is self._nplike
-                    and self.index.nplike is self._nplike
-                )
-                self._handle_error(
-                    self._nplike[
-                        "awkward_IndexedArray_reduce_next_nonlocal_nextshifts_fromshifts_64",
-                        nextshifts.dtype.type,
-                        self.index.dtype.type,
-                        shifts.dtype.type,
-                    ](
-                        nextshifts.data,
-                        self.index.data,
-                        self.index.length,
-                        shifts.data,
-                    )
-                )
+            nextshifts = self._prepare_nextshifts(nextparents, shifts)
         else:
             nextshifts = None
 

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1226,7 +1226,9 @@ class IndexedOptionArray(Content):
             self._nplike,
         ).simplify_optiontype()
 
-        inject_nones = True if (not branch and negaxis != depth) else False
+        inject_nones = (
+            True if (numnull[0] > 0 and not branch and negaxis != depth) else False
+        )
 
         # If we want the None's at this depth to be injected
         # into the dense ([x y z None None]) rearranger result.
@@ -1241,12 +1243,9 @@ class IndexedOptionArray(Content):
                 self._nplike,
             ).simplify_optiontype()
         # Otherwise, if we are rearranging (e.g sorting) the contents of this layout,
-        # then we do NOT want to return an optional layout
-        elif not branch and negaxis == depth:
-            return out
-        # Otherwise branching
+        # then we do NOT want to return an optional layout,
+        # OR we are branching
         else:
-            assert isinstance(out, ak._v2.contents.IndexedOptionArray)
             return out
 
     def _sort_next(
@@ -1311,11 +1310,8 @@ class IndexedOptionArray(Content):
             ).simplify_optiontype()
         # Otherwise, if we are rearranging (e.g sorting) the contents of this layout,
         # then we do NOT want to return an optional layout
-        elif not branch and negaxis == depth:
-            return out
-        # Otherwise branching
+        # OR we are branching
         else:
-            assert isinstance(out, ak._v2.contents.IndexedOptionArray)
             return out
 
     def _reduce_next(

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1231,7 +1231,7 @@ class IndexedOptionArray(Content):
         )
 
         return self._prepare_out(
-            inject_nones, out, branch, negaxis, depth, parents, starts, outindex
+            inject_nones, out, branch, negaxis, depth, starts, outindex
         )
 
     def _sort_next(
@@ -1284,13 +1284,16 @@ class IndexedOptionArray(Content):
         inject_nones = True if not branch and negaxis != depth else False
 
         return self._prepare_out(
-            inject_nones, out, branch, negaxis, depth, parents, starts, outindex
+            inject_nones, out, branch, negaxis, depth, starts, outindex
         )
 
-    def _prepare_out(
-        self, inject_nones, out, branch, negaxis, depth, parents, starts, outindex
-    ):
-        if inject_nones:
+    def _prepare_out(self, inject_nones, out, branch, negaxis, depth, starts, outindex):
+        # If we are rearranging (e.g sorting) the contents of this layout,
+        # then we do NOT want to return an optional layout
+        if not branch and negaxis == depth:
+            return out
+        # Otherwise, create an option type layout
+        elif inject_nones:
             return ak._v2.contents.IndexedOptionArray(
                 outindex,
                 out,
@@ -1298,10 +1301,7 @@ class IndexedOptionArray(Content):
                 self._parameters,
                 self._nplike,
             ).simplify_optiontype()
-
-        elif not branch and negaxis == depth:
-            assert not inject_nones
-            return out
+        # Otherwise
         else:
             if isinstance(out, ak._v2.contents.RegularArray):
                 out = out.toListOffsetArray64(True)
@@ -1407,9 +1407,7 @@ class IndexedOptionArray(Content):
             keepdims,
         )
 
-        return self._prepare_out(
-            False, out, branch, negaxis, depth, parents, starts, outindex
-        )
+        return self._prepare_out(False, out, branch, negaxis, depth, starts, outindex)
 
     def _validityerror(self, path):
         assert self.index.nplike is self._nplike

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1078,7 +1078,7 @@ class IndexedOptionArray(Content):
 
         ind = ak._v2.contents.NumpyArray(nulls_index, None, None, self._nplike)
 
-        if self.mergeable(ind, True):
+        if out.mergeable(ind, True):
             out = out.merge(ind)
             nulls_merged = True
 

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1246,6 +1246,7 @@ class IndexedOptionArray(Content):
         # Otherwise branching?
         else:
             assert isinstance(out, ak._v2.contents.IndexedOptionArray)
+            return out
 
     def _sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -978,8 +978,7 @@ class IndexedOptionArray(Content):
             )
 
         if isinstance(out, ak._v2.contents.NumpyArray):
-            # Overallocate nextoutindex to support typetracer 0-sized arrays
-            nextoutindex = ak._v2.index.Index64.empty(out.length + 1, self._nplike)
+            nextoutindex = ak._v2.index.Index64.empty(out.length, self._nplike)
             assert nextoutindex.nplike is self._nplike
             self._handle_error(
                 self._nplike[

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1291,16 +1291,16 @@ class IndexedOptionArray(Content):
         self, inject_nones, out, branch, negaxis, depth, parents, starts, outindex
     ):
         if inject_nones:
-            out = ak._v2.contents.RegularArray(
+            return ak._v2.contents.IndexedOptionArray(
+                outindex,
                 out,
-                parents.length if self._nplike.known_shape else 1,
-                0,
                 None,
                 self._parameters,
                 self._nplike,
-            )
+            ).simplify_optiontype()
 
-        if not branch and negaxis == depth:
+        elif not branch and negaxis == depth:
+            assert not inject_nones
             return out
         else:
             if isinstance(out, ak._v2.contents.RegularArray):
@@ -1337,9 +1337,6 @@ class IndexedOptionArray(Content):
                     self._parameters,
                     self._nplike,
                 ).simplify_optiontype()
-
-                if inject_nones:
-                    return tmp
 
                 return ak._v2.contents.ListOffsetArray(
                     outoffsets,

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1107,6 +1107,10 @@ class IndexedOptionArray(Content):
         )
 
         if nulls_merged:
+            # awkward_IndexedArray_local_preparenext_64 uses -1 to indicate None values
+            # We don't want to return None, instead we want to return their locations
+            # We can do this by mapping the -1 values to monotonic increasing values
+            # after the maximum index.
             assert nextoutindex.nplike is self._nplike
             self._handle_error(
                 self._nplike["awkward_Index_nones_as_index", nextoutindex.dtype.type](

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1226,9 +1226,7 @@ class IndexedOptionArray(Content):
             self._nplike,
         ).simplify_optiontype()
 
-        inject_nones = (
-            True if (numnull[0] > 0 and not branch and negaxis != depth) else False
-        )
+        inject_nones = True if (not branch and negaxis != depth) else False
 
         return self._prepare_out(
             inject_nones, out, branch, negaxis, depth, starts, outindex

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -872,7 +872,7 @@ class IndexedOptionArray(Content):
         index_length = self._index.length
         parents_length = parents.length
 
-        next, nextparents, numnull, outindex = self._prepare_next(index_length, parents)
+        next, nextparents, numnull, outindex = self._rearrange_next(parents)
 
         out = next._unique(
             negaxis,
@@ -1029,13 +1029,12 @@ class IndexedOptionArray(Content):
             )
 
         branch, depth = self.branch_depth
-        index_length = self._index.length
         parents_length = parents.length
 
-        next, nextparents, numnull, outindex = self._prepare_next(index_length, parents)
+        next, nextparents, numnull, outindex = self._rearrange_next(parents)
 
         if (not branch) and negaxis == depth:
-            nextshifts = self._prepare_nextshifts(nextparents, shifts)
+            nextshifts = self._rearrange_nextshifts(nextparents, shifts)
         else:
             nextshifts = None
 
@@ -1130,7 +1129,7 @@ class IndexedOptionArray(Content):
             inject_nones, out, branch, negaxis, depth, parents, starts, outindex
         )
 
-    def _prepare_nextshifts(self, nextparents, shifts):
+    def _rearrange_nextshifts(self, nextparents, shifts):
         nextshifts = ak._v2.index.Index64.empty(
             nextparents.length,
             self._nplike,
@@ -1171,7 +1170,8 @@ class IndexedOptionArray(Content):
             )
         return nextshifts
 
-    def _prepare_next(self, index_length, parents):
+    def _rearrange_next(self, parents):
+        index_length = self._index.length
         numnull = ak._v2.index.Index64.empty(1, self._nplike)
         assert numnull.nplike is self._nplike and self._index.nplike is self._nplike
         self._handle_error(
@@ -1220,10 +1220,9 @@ class IndexedOptionArray(Content):
     ):
         branch, depth = self.branch_depth
 
-        index_length = self._index.length
         parents_length = parents.length
 
-        next, nextparents, numnull, outindex = self._prepare_next(index_length, parents)
+        next, nextparents, numnull, outindex = self._rearrange_next(parents)
 
         inject_nones = True if not branch and negaxis != depth else False
 
@@ -1375,12 +1374,11 @@ class IndexedOptionArray(Content):
         keepdims,
     ):
         branch, depth = self.branch_depth
-        index_length = self._index.length
 
-        next, nextparents, numnull, outindex = self._prepare_next(index_length, parents)
+        next, nextparents, numnull, outindex = self._rearrange_next(parents)
 
         if reducer.needs_position and (not branch and negaxis == depth):
-            nextshifts = self._prepare_nextshifts(nextparents, shifts)
+            nextshifts = self._rearrange_nextshifts(nextparents, shifts)
         else:
             nextshifts = None
 

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1272,7 +1272,6 @@ class IndexedOptionArray(Content):
                 nextparents.length,
             )
         )
-
         out = ak._v2.contents.IndexedOptionArray(
             nextoutindex,
             out,
@@ -1292,7 +1291,9 @@ class IndexedOptionArray(Content):
         # then we do NOT want to return an optional layout
         if not branch and negaxis == depth:
             return out
-        # Otherwise, create an option type layout
+        # Otherwise, we want the None's to be in the right place.
+        # Here, we index the dense ([x y z None None]) content with an index
+        # that maps the values to the correct locations
         elif inject_nones:
             return ak._v2.contents.IndexedOptionArray(
                 outindex,
@@ -1301,7 +1302,7 @@ class IndexedOptionArray(Content):
                 self._parameters,
                 self._nplike,
             ).simplify_optiontype()
-        # Otherwise
+        # Otherwise branching?
         else:
             if isinstance(out, ak._v2.contents.RegularArray):
                 out = out.toListOffsetArray64(True)

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1361,10 +1361,19 @@ class IndexedOptionArray(Content):
                 out = out.toListOffsetArray64(True)
 
             # If the result of `_reduce_next` is a list, and we're not applying at this
-            # depth,  then it will have offsets given by the boundaries in parents.
+            # depth, then it will have offsets given by the boundaries in parents.
             # This means that we need to look at the _contents_ to which the `outindex`
             # belongs to add the option type
             if isinstance(out, ak._v2.contents.ListOffsetArray):
+                if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
+                    raise ak._v2._util.error(
+                        AssertionError(
+                            "reduce_next with unbranching depth > negaxis expects a "
+                            "ListOffsetArray whose offsets start at zero ({})".format(
+                                starts[0]
+                            )
+                        )
+                    )
                 outoffsets = ak._v2.index.Index64.empty(starts.length + 1, self._nplike)
                 assert (
                     outoffsets.nplike is self._nplike and starts.nplike is self._nplike
@@ -1400,8 +1409,6 @@ class IndexedOptionArray(Content):
                     self._nplike,
                 )
 
-            if isinstance(out, ak._v2.contents.IndexedOptionArray):
-                return out
             else:
                 raise ak._v2._util.error(
                     AssertionError(

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -978,6 +978,7 @@ class IndexedOptionArray(Content):
             )
 
         if isinstance(out, ak._v2.contents.NumpyArray):
+            # Overallocate nextoutindex to support typetracer 0-sized arrays
             nextoutindex = ak._v2.index.Index64.empty(out.length + 1, self._nplike)
             assert nextoutindex.nplike is self._nplike
             self._handle_error(
@@ -1001,7 +1002,7 @@ class IndexedOptionArray(Content):
         if inject_nones:
             out = ak._v2.contents.RegularArray(
                 out,
-                nextoutindex.length,
+                out.length,
                 0,
                 None,
                 self._parameters,

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -870,7 +870,6 @@ class IndexedOptionArray(Content):
         )
 
         index_length = self._index.length
-        parents_length = parents.length
 
         next, nextparents, numnull, outindex = self._rearrange_next(parents)
 
@@ -882,7 +881,7 @@ class IndexedOptionArray(Content):
         )
 
         if branch or (negaxis is not None and negaxis != depth):
-            nextoutindex = ak._v2.index.Index64.empty(parents_length, self._nplike)
+            nextoutindex = ak._v2.index.Index64.empty(parents.length, self._nplike)
             assert (
                 nextoutindex.nplike is self._nplike
                 and starts.nplike is self._nplike
@@ -900,7 +899,7 @@ class IndexedOptionArray(Content):
                     nextoutindex.data,
                     starts.data,
                     parents.data,
-                    parents_length,
+                    parents.length,
                     nextparents.data,
                     nextparents.length,
                 )
@@ -1029,7 +1028,6 @@ class IndexedOptionArray(Content):
             )
 
         branch, depth = self.branch_depth
-        parents_length = parents.length
 
         next, nextparents, numnull, outindex = self._rearrange_next(parents)
 
@@ -1084,7 +1082,7 @@ class IndexedOptionArray(Content):
             out = out.merge(ind)
             nulls_merged = True
 
-        nextoutindex = ak._v2.index.Index64.empty(parents_length, self._nplike)
+        nextoutindex = ak._v2.index.Index64.empty(parents.length, self._nplike)
         assert (
             nextoutindex.nplike is self._nplike
             and starts.nplike is self._nplike
@@ -1102,7 +1100,7 @@ class IndexedOptionArray(Content):
                 nextoutindex.data,
                 starts.data,
                 parents.data,
-                parents_length,
+                parents.length,
                 nextparents.data,
                 nextparents.length,
             )
@@ -1220,8 +1218,6 @@ class IndexedOptionArray(Content):
     ):
         branch, depth = self.branch_depth
 
-        parents_length = parents.length
-
         next, nextparents, numnull, outindex = self._rearrange_next(parents)
 
         inject_nones = True if not branch and negaxis != depth else False
@@ -1237,7 +1233,7 @@ class IndexedOptionArray(Content):
             order,
         )
 
-        nextoutindex = ak._v2.index.Index64.empty(parents_length, self._nplike)
+        nextoutindex = ak._v2.index.Index64.empty(parents.length, self._nplike)
         assert (
             nextoutindex.nplike is self._nplike
             and starts.nplike is self._nplike
@@ -1255,7 +1251,7 @@ class IndexedOptionArray(Content):
                 nextoutindex.data,
                 starts.data,
                 parents.data,
-                parents_length,
+                parents.length,
                 nextparents.data,
                 nextparents.length,
             )

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -899,82 +899,14 @@ class ListOffsetArray(Content):
             if self._nplike.known_shape and parents.nplike.known_shape:
                 assert self._offsets.length - 1 == parents.length
 
-            nextlen = self._offsets[-1] - self._offsets[0]
-            maxcount = ak._v2.index.Index64.empty(1, self._nplike)
-            offsetscopy = ak._v2.index.Index64.empty(self._offsets.length, self._nplike)
-            assert (
-                maxcount.nplike is self._nplike
-                and offsetscopy.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64",
-                    maxcount.dtype.type,
-                    offsetscopy.dtype.type,
-                    self._offsets.dtype.type,
-                ](
-                    maxcount.data,
-                    offsetscopy.data,
-                    self._offsets.data,
-                    self._offsets.length - 1,
-                )
-            )
-
-            distincts_length = outlength * maxcount[0]
-            nextcarry = ak._v2.index.Index64.empty(nextlen, self._nplike)
-            nextparents = ak._v2.index.Index64.empty(nextlen, self._nplike)
-            maxnextparents = ak._v2.index.Index64.empty(1, self._nplike)
-            distincts = ak._v2.index.Index64.empty(distincts_length, self._nplike)
-            assert (
-                nextcarry.nplike is self._nplike
-                and nextparents.nplike is self._nplike
-                and maxnextparents.nplike is self._nplike
-                and distincts.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-                and offsetscopy.nplike is self._nplike
-                and parents.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_preparenext_64",
-                    nextcarry.dtype.type,
-                    nextparents.dtype.type,
-                    maxnextparents.dtype.type,
-                    distincts.dtype.type,
-                    self._offsets.dtype.type,
-                    offsetscopy.dtype.type,
-                    parents.dtype.type,
-                ](
-                    nextcarry.data,
-                    nextparents.data,
-                    nextlen,
-                    maxnextparents.data,
-                    distincts.data,
-                    distincts_length,
-                    offsetscopy.data,
-                    self._offsets.data,
-                    self._offsets.length - 1,
-                    parents.data,
-                    maxcount[0],
-                )
-            )
-
-            nextstarts = ak._v2.index.Index64.empty(maxnextparents[0] + 1, self._nplike)
-            assert (
-                nextstarts.nplike is self._nplike and nextparents.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
-                    nextstarts.dtype.type,
-                    nextparents.dtype.type,
-                ](
-                    nextstarts.data,
-                    nextparents.data,
-                    nextlen,
-                )
-            )
+            (
+                distincts,
+                maxcount,
+                maxnextparents,
+                nextcarry,
+                nextparents,
+                nextstarts,
+            ) = self._rearrange_prepare_next(outlength, parents)
 
             nextcontent = self._content._carry(nextcarry, False)
             outcontent = nextcontent._unique(
@@ -984,7 +916,7 @@ class ListOffsetArray(Content):
                 maxnextparents[0] + 1,
             )
 
-            outcarry = ak._v2.index.Index64.empty(nextlen, self._nplike)
+            outcarry = ak._v2.index.Index64.empty(nextcarry.length, self._nplike)
             assert outcarry.nplike is self._nplike and nextcarry.nplike is self._nplike
             self._handle_error(
                 self._nplike[
@@ -994,7 +926,7 @@ class ListOffsetArray(Content):
                 ](
                     outcarry.data,
                     nextcarry.data,
-                    nextlen,
+                    nextcarry.length,
                 )
             )
 
@@ -1124,90 +1056,18 @@ class ListOffsetArray(Content):
             if self._nplike.known_shape and parents.nplike.known_shape:
                 assert self._offsets.length - 1 == parents.length
 
-            maxcount = ak._v2.index.Index64.empty(1, self._nplike)
-            offsetscopy = ak._v2.index.Index64.empty(self._offsets.length, self._nplike)
-            assert (
-                maxcount.nplike is self._nplike
-                and offsetscopy.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64",
-                    maxcount.dtype.type,
-                    offsetscopy.dtype.type,
-                    self._offsets.dtype.type,
-                ](
-                    maxcount.data,
-                    offsetscopy.data,
-                    self._offsets.data,
-                    self._offsets.length - 1,
-                )
-            )
-
-            maxcount = maxcount[0]
-            nextlen = self._offsets[-1] - self._offsets[0]
-
-            nextcarry = ak._v2.index.Index64.empty(nextlen, self._nplike)
-            nextparents = ak._v2.index.Index64.empty(nextlen, self._nplike)
-            maxnextparents = ak._v2.index.Index64.empty(1, self._nplike)
-            distincts = ak._v2.index.Index64.empty(maxcount * outlength, self._nplike)
-            assert (
-                nextcarry.nplike is self._nplike
-                and nextparents.nplike is self._nplike
-                and maxnextparents.nplike is self._nplike
-                and distincts.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-                and offsetscopy.nplike is self._nplike
-                and parents.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_preparenext_64",
-                    nextcarry.dtype.type,
-                    nextparents.dtype.type,
-                    maxnextparents.dtype.type,
-                    distincts.dtype.type,
-                    self._offsets.dtype.type,
-                    offsetscopy.dtype.type,
-                    parents.dtype.type,
-                ](
-                    nextcarry.data,
-                    nextparents.data,
-                    nextlen,
-                    maxnextparents.data,
-                    distincts.data,
-                    maxcount * outlength,
-                    offsetscopy.data,
-                    self._offsets.data,
-                    self._offsets.length - 1,
-                    parents.data,
-                    maxcount,
-                )
-            )
-
-            nextstarts_length = maxnextparents[0] + 1
-            nextstarts = ak._v2.index.Index64.empty(
-                nextstarts_length, self._nplike, np.int64
-            )
-            assert (
-                nextstarts.nplike is self._nplike and nextparents.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
-                    nextstarts.dtype.type,
-                    nextparents.dtype.type,
-                ](
-                    nextstarts.data,
-                    nextparents.data,
-                    nextlen,
-                )
-            )
+            (
+                distincts,
+                maxcount,
+                maxnextparents,
+                nextcarry,
+                nextparents,
+                nextstarts,
+            ) = self._rearrange_prepare_next(outlength, parents)
 
             nummissing = ak._v2.index.Index64.empty(maxcount, self._nplike)
             missing = ak._v2.index.Index64.empty(self._offsets[-1], self._nplike)
-            nextshifts = ak._v2.index.Index64.empty(nextlen, self._nplike)
+            nextshifts = ak._v2.index.Index64.empty(nextcarry.length, self._nplike)
             assert (
                 nummissing.nplike is self._nplike
                 and missing.nplike is self._nplike
@@ -1217,6 +1077,7 @@ class ListOffsetArray(Content):
                 and parents.nplike is self._nplike
                 and nextcarry.nplike is self._nplike
             )
+
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_reduce_nonlocal_nextshifts_64",
@@ -1236,7 +1097,7 @@ class ListOffsetArray(Content):
                     starts.data,
                     parents.data,
                     maxcount,
-                    nextlen,
+                    nextcarry.length,
                     nextcarry.data,
                 )
             )
@@ -1247,14 +1108,14 @@ class ListOffsetArray(Content):
                 nextstarts,
                 nextshifts,
                 nextparents,
-                nextstarts_length,
+                nextstarts.length,
                 ascending,
                 stable,
                 kind,
                 order,
             )
 
-            outcarry = ak._v2.index.Index64.empty(nextlen, self._nplike)
+            outcarry = ak._v2.index.Index64.empty(nextcarry.length, self._nplike)
             assert outcarry.nplike is self._nplike and nextcarry.nplike is self._nplike
             self._handle_error(
                 self._nplike[
@@ -1264,7 +1125,7 @@ class ListOffsetArray(Content):
                 ](
                     outcarry.data,
                     nextcarry.data,
-                    nextlen,
+                    nextcarry.length,
                 )
             )
 
@@ -1382,82 +1243,14 @@ class ListOffsetArray(Content):
             if self._nplike.known_shape and parents.nplike.known_shape:
                 assert self._offsets.length - 1 == parents.length
 
-            nextlen = self._offsets[-1] - self._offsets[0]
-            maxcount = ak._v2.index.Index64.empty(1, self._nplike)
-            offsetscopy = ak._v2.index.Index64.empty(self._offsets.length, self._nplike)
-            assert (
-                maxcount.nplike is self._nplike
-                and offsetscopy.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64",
-                    maxcount.dtype.type,
-                    offsetscopy.dtype.type,
-                    self._offsets.dtype.type,
-                ](
-                    maxcount.data,
-                    offsetscopy.data,
-                    self._offsets.data,
-                    self._offsets.length - 1,
-                )
-            )
-
-            distincts_length = outlength * maxcount[0]
-            nextcarry = ak._v2.index.Index64.empty(nextlen, self._nplike)
-            nextparents = ak._v2.index.Index64.empty(nextlen, self._nplike)
-            maxnextparents = ak._v2.index.Index64.empty(1, self._nplike)
-            distincts = ak._v2.index.Index64.empty(distincts_length, self._nplike)
-            assert (
-                nextcarry.nplike is self._nplike
-                and nextparents.nplike is self._nplike
-                and maxnextparents.nplike is self._nplike
-                and distincts.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-                and offsetscopy.nplike is self._nplike
-                and parents.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_preparenext_64",
-                    nextcarry.dtype.type,
-                    nextparents.dtype.type,
-                    maxnextparents.dtype.type,
-                    distincts.dtype.type,
-                    self._offsets.dtype.type,
-                    offsetscopy.dtype.type,
-                    parents.dtype.type,
-                ](
-                    nextcarry.data,
-                    nextparents.data,
-                    nextlen,
-                    maxnextparents.data,
-                    distincts.data,
-                    distincts_length,
-                    offsetscopy.data,
-                    self._offsets.data,
-                    self._offsets.length - 1,
-                    parents.data,
-                    maxcount[0],
-                )
-            )
-
-            nextstarts = ak._v2.index.Index64.empty(maxnextparents[0] + 1, self._nplike)
-            assert (
-                nextstarts.nplike is self._nplike and nextparents.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
-                    nextstarts.dtype.type,
-                    nextparents.dtype.type,
-                ](
-                    nextstarts.data,
-                    nextparents.data,
-                    nextlen,
-                )
-            )
+            (
+                distincts,
+                maxcount,
+                maxnextparents,
+                nextcarry,
+                nextparents,
+                nextstarts,
+            ) = self._rearrange_prepare_next(outlength, parents)
 
             nextcontent = self._content._carry(nextcarry, False)
             outcontent = nextcontent._sort_next(
@@ -1471,7 +1264,7 @@ class ListOffsetArray(Content):
                 order,
             )
 
-            outcarry = ak._v2.index.Index64.empty(nextlen, self._nplike)
+            outcarry = ak._v2.index.Index64.empty(nextcarry.length, self._nplike)
             assert outcarry.nplike is self._nplike and nextcarry.nplike is self._nplike
             self._handle_error(
                 self._nplike[
@@ -1481,7 +1274,7 @@ class ListOffsetArray(Content):
                 ](
                     outcarry.data,
                     nextcarry.data,
-                    nextlen,
+                    nextcarry.length,
                 )
             )
 
@@ -1663,87 +1456,16 @@ class ListOffsetArray(Content):
         branch, depth = self.branch_depth
         globalstarts_length = self._offsets.length - 1
         parents_length = parents.length
-        nextlen = self._offsets[-1] - self._offsets[0]
 
         if not branch and negaxis == depth:
-            maxcount = ak._v2.index.Index64.empty(1, self._nplike)
-            offsetscopy = ak._v2.index.Index64.empty(self.offsets.length, self._nplike)
-            assert (
-                maxcount.nplike is self._nplike
-                and offsetscopy.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64",
-                    maxcount.dtype.type,
-                    offsetscopy.dtype.type,
-                    self._offsets.dtype.type,
-                ](
-                    maxcount.data,
-                    offsetscopy.data,
-                    self._offsets.data,
-                    globalstarts_length,
-                )
-            )
-
-            distincts_length = outlength * maxcount[0]
-            np_nextcarry = self._nplike.empty(nextlen, dtype=np.int64)
-            np_nextparents = self._nplike.empty(nextlen, dtype=np.int64)
-            maxnextparents = ak._v2.index.Index64.empty(1, self._nplike)
-            distincts = ak._v2.index.Index64.empty(distincts_length, self._nplike)
-            assert (
-                maxnextparents.nplike is self._nplike
-                and distincts.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-                and offsetscopy.nplike is self._nplike
-                and parents.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_preparenext_64",
-                    np_nextcarry.dtype.type,
-                    np_nextparents.dtype.type,
-                    maxnextparents.dtype.type,
-                    distincts.dtype.type,
-                    self._offsets.dtype.type,
-                    offsetscopy.dtype.type,
-                    parents.dtype.type,
-                ](
-                    np_nextcarry,
-                    np_nextparents,
-                    nextlen,
-                    maxnextparents.data,
-                    distincts.data,
-                    distincts_length,
-                    offsetscopy.data,
-                    self._offsets.data,
-                    globalstarts_length,
-                    parents.data,
-                    maxcount[0],
-                )
-            )
-
-            # A "stable" sort is essential for the subsequent steps.
-            reorder = self._nplike.argsort(np_nextparents, kind="stable")
-            nextcarry = ak._v2.index.Index64(np_nextcarry[reorder])
-            nextparents = ak._v2.index.Index64(np_nextparents[reorder])
-
-            nextstarts = ak._v2.index.Index64.empty(maxnextparents[0] + 1, self._nplike)
-            assert (
-                nextstarts.nplike is self._nplike and nextparents.nplike is self._nplike
-            )
-            self._handle_error(
-                self._nplike[
-                    "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
-                    nextstarts.dtype.type,
-                    nextparents.dtype.type,
-                ](
-                    nextstarts.data,
-                    nextparents.data,
-                    nextlen,
-                )
-            )
+            (
+                distincts,
+                maxcount,
+                maxnextparents,
+                nextcarry,
+                nextparents,
+                nextstarts,
+            ) = self._rearrange_prepare_next(outlength, parents)
 
             gaps = ak._v2.index.Index64.empty(outlength, self._nplike)
             assert gaps.nplike is self._nplike and parents.nplike is self._nplike
@@ -1778,15 +1500,15 @@ class ListOffsetArray(Content):
                     outstarts.data,
                     outstops.data,
                     distincts.data,
-                    distincts_length,
+                    distincts.length,
                     gaps.data,
                     outlength,
                 )
             )
 
             if reducer.needs_position:
-                nextshifts = ak._v2.index.Index64.empty(nextlen, self._nplike)
-                nummissing = ak._v2.index.Index64.empty(maxcount[0], self._nplike)
+                nextshifts = ak._v2.index.Index64.empty(nextcarry.length, self._nplike)
+                nummissing = ak._v2.index.Index64.empty(maxcount, self._nplike)
                 missing = ak._v2.index.Index64.empty(self._offsets[-1], self._nplike)
                 assert (
                     nummissing.nplike is self._nplike
@@ -1797,6 +1519,7 @@ class ListOffsetArray(Content):
                     and parents.nplike is self._nplike
                     and nextcarry.nplike is self._nplike
                 )
+
                 self._handle_error(
                     self._nplike[
                         "awkward_ListOffsetArray_reduce_nonlocal_nextshifts_64",
@@ -1815,8 +1538,8 @@ class ListOffsetArray(Content):
                         globalstarts_length,
                         starts.data,
                         parents.data,
-                        maxcount[0],
-                        nextlen,
+                        maxcount,
+                        nextcarry.length,
                         nextcarry.data,
                     )
                 )
@@ -1857,6 +1580,7 @@ class ListOffsetArray(Content):
             return out
 
         else:
+            nextlen = self._offsets[-1] - self._offsets[0]
             nextparents = ak._v2.index.Index64.empty(nextlen, self._nplike)
 
             assert (
@@ -1919,6 +1643,90 @@ class ListOffsetArray(Content):
                 None,
                 self._nplike,
             )
+
+    def _rearrange_prepare_next(self, outlength, parents):
+        nextlen = self._offsets[-1] - self._offsets[0]
+        maxcount = ak._v2.index.Index64.empty(1, self._nplike)
+        offsetscopy = ak._v2.index.Index64.empty(self.offsets.length, self._nplike)
+        assert (
+            maxcount.nplike is self._nplike
+            and offsetscopy.nplike is self._nplike
+            and self._offsets.nplike is self._nplike
+        )
+        self._handle_error(
+            self._nplike[
+                "awkward_ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64",
+                maxcount.dtype.type,
+                offsetscopy.dtype.type,
+                self._offsets.dtype.type,
+            ](
+                maxcount.data,
+                offsetscopy.data,
+                self._offsets.data,
+                self._offsets.length - 1,
+            )
+        )
+
+        np_nextcarry = self._nplike.empty(nextlen, dtype=np.int64)
+        np_nextparents = self._nplike.empty(nextlen, dtype=np.int64)
+        maxnextparents = ak._v2.index.Index64.empty(1, self._nplike)
+        distincts = ak._v2.index.Index64.empty(outlength * maxcount[0], self._nplike)
+        assert (
+            maxnextparents.nplike is self._nplike
+            and distincts.nplike is self._nplike
+            and self._offsets.nplike is self._nplike
+            and offsetscopy.nplike is self._nplike
+            and parents.nplike is self._nplike
+        )
+        self._handle_error(
+            self._nplike[
+                "awkward_ListOffsetArray_reduce_nonlocal_preparenext_64",
+                np_nextcarry.dtype.type,
+                np_nextparents.dtype.type,
+                maxnextparents.dtype.type,
+                distincts.dtype.type,
+                self._offsets.dtype.type,
+                offsetscopy.dtype.type,
+                parents.dtype.type,
+            ](
+                np_nextcarry,
+                np_nextparents,
+                nextlen,
+                maxnextparents.data,
+                distincts.data,
+                distincts.length,
+                offsetscopy.data,
+                self._offsets.data,
+                self._offsets.length - 1,
+                parents.data,
+                maxcount[0],
+            )
+        )
+        # A "stable" sort is essential for the subsequent steps.
+        reorder = self._nplike.argsort(np_nextparents, kind="stable")
+        nextcarry = ak._v2.index.Index64(np_nextcarry[reorder])
+        nextparents = ak._v2.index.Index64(np_nextparents[reorder])
+        nextstarts = ak._v2.index.Index64.empty(maxnextparents[0] + 1, self._nplike)
+        assert nextstarts.nplike is self._nplike and nextparents.nplike is self._nplike
+        self._handle_error(
+            self._nplike[
+                "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
+                nextstarts.dtype.type,
+                nextparents.dtype.type,
+            ](
+                nextstarts.data,
+                nextparents.data,
+                nextlen,
+            )
+        )
+        return (
+            distincts,
+            maxcount[0],
+            maxnextparents,
+            nextcarry,
+            nextparents,
+            nextstarts,
+        )
 
     def _validityerror(self, path):
         if self.offsets.length < 1:

--- a/src/awkward/operations/describe.py
+++ b/src/awkward/operations/describe.py
@@ -269,8 +269,7 @@ def fields(array):
 def is_tuple(array):
     """
     Args:
-        array (#ak.Array, #ak.Record, #ak.layout.Content, #ak.layout.Record,
-               #ak.ArrayBuilder, #ak.layout.ArrayBuilder):
+        array (#ak.Array, #ak.Record, #ak.layout.Content, #ak.layout.Record, #ak.ArrayBuilder, #ak.layout.ArrayBuilder):
             Array or record to check.
 
     If `array` is a record, this returns True if the record is a tuple.


### PR DESCRIPTION
`ListOffsetArray` and the `Indexed[Option]Array` types have a non-negligible amount of boilerplate from v1 that we can eliminate. In addition, there is a reasonable overlap between the `reduce`, `[arg]sort`, and `unique` pathways that we can move into preparatory functions.

I've changed the logic here quite substantially (in the case of `IndexedOptionArray`), so it would be good to validate that the test suite is covering these changes.
