### PR TITLE
Feat: add `depth_limit` to `ak.broadcast_arrays`

### DIFF
--- a/src/awkward/_v2/operations/structure/ak_broadcast_arrays.py
+++ b/src/awkward/_v2/operations/structure/ak_broadcast_arrays.py
@@ -16,6 +16,10 @@ def broadcast_arrays(*arrays, **kwargs):
             right-broadcasting, as described below.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.layout.Content subclass.
+        depth_limit (None or int, default is None): If None, attempt to fully
+            broadcast the `arrays` to all levels. If an int, limit the number
+            of dimensions that get broadcasted. The minimum value is `1`,
+            for no broadcasting.
 
     Like NumPy's
     [broadcast_arrays](https://docs.scipy.org/doc/numpy/reference/generated/numpy.broadcast_arrays.html)
@@ -108,6 +112,23 @@ def broadcast_arrays(*arrays, **kwargs):
     for all elements). This distinction is can be accessed through the
     #ak.Array.type, but it is lost when converting an array into JSON or
     Python objects.
+
+    If arrays have the same depth but different lengths of nested
+    lists, attempting to broadcast them together is a broadcasting error.
+
+        >>> one = ak.Array([[[1, 2, 3], [], [4, 5], [6]], [], [[7, 8]]])
+        >>> two = ak.Array([[[1.1, 2.2], [3.3], [4.4], [5.5]], [], [[6.6]]])
+        >>> ak.broadcast_arrays(one, two)
+        ValueError: in ListArray64, cannot broadcast nested list
+
+    For this, one can set the `depth_limit` to prevent the operation from
+    attempting to broadcast what can't be broadcasted.
+
+        >>> this, that = ak.broadcast_arrays(one, two, depth_limit=1)
+        >>> ak.to_list(this)
+        [[[1, 2, 3], [], [4, 5], [6]], [], [[7, 8]]]
+        >>> ak.to_list(that)
+        [[[1.1, 2.2], [3.3], [4.4], [5.5]], [], [[6.6]]]
     """
     with ak._v2._util.OperationErrorContext(
         "ak._v2.broadcast_arrays",
@@ -117,10 +138,15 @@ def broadcast_arrays(*arrays, **kwargs):
 
 
 def _impl(arrays, kwargs):
-    (highlevel, left_broadcast, right_broadcast) = ak._v2._util.extra(
+    (highlevel, depth_limit, left_broadcast, right_broadcast) = ak._v2._util.extra(
         (),
         kwargs,
-        [("highlevel", True), ("left_broadcast", True), ("right_broadcast", True)],
+        [
+            ("highlevel", True),
+            ("depth_limit", None),
+            ("left_broadcast", True),
+            ("right_broadcast", True),
+        ],
     )
 
     inputs = []
@@ -130,8 +156,11 @@ def _impl(arrays, kwargs):
             y = ak._v2.contents.NumpyArray(ak.nplike.of(*arrays).array([y]))
         inputs.append(y)
 
-    def action(inputs, **kwargs):
-        if all(isinstance(x, ak._v2.contents.NumpyArray) for x in inputs):
+    def action(inputs, depth, **kwargs):
+        if depth == depth_limit or (
+            depth_limit is None
+            and all(isinstance(x, ak._v2.contents.NumpyArray) for x in inputs)
+        ):
             return tuple(inputs)
         else:
             return None

--- a/src/awkward/operations/structure.py
+++ b/src/awkward/operations/structure.py
@@ -1424,6 +1424,23 @@ def broadcast_arrays(*arrays, **kwargs):
     for all elements). This distinction is can be accessed through the
     #ak.Array.type, but it is lost when converting an array into JSON or
     Python objects.
+
+    If arrays have the same depth but different lengths of nested
+    lists, attempting to broadcast them together is a broadcasting error.
+
+        >>> one = ak.Array([[[1, 2, 3], [], [4, 5], [6]], [], [[7, 8]]])
+        >>> two = ak.Array([[[1.1, 2.2], [3.3], [4.4], [5.5]], [], [[6.6]]])
+        >>> ak.broadcast_arrays(one, two)
+        ValueError: in ListArray64, cannot broadcast nested list
+
+    For this, one can set the `depth_limit` to prevent the operation from
+    attempting to broadcast what can't be broadcasted.
+
+        >>> this, that = ak.broadcast_arrays(one, two, depth_limit=1)
+        >>> ak.to_list(this)
+        [[[1, 2, 3], [], [4, 5], [6]], [], [[7, 8]]]
+        >>> ak.to_list(that)
+        [[[1.1, 2.2], [3.3], [4.4], [5.5]], [], [[6.6]]]
     """
     (highlevel, depth_limit, left_broadcast, right_broadcast) = ak._util.extra(
         (),

--- a/tests/test_1344-broadcast-arrays-depth-limit.py
+++ b/tests/test_1344-broadcast-arrays-depth-limit.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    x = ak.Array([[0, 1], [], [3], [5], [6, 8, 9]])
+    y = ak.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
+
+    with pytest.raises(ValueError):
+        ak.broadcast_arrays(x, y, depth_limit=None)
+
+    u, v = ak.broadcast_arrays(x, y, depth_limit=1)
+    assert ak.to_list(u) == [[0, 1], [], [3], [5], [6, 8, 9]]
+    assert ak.to_list(v) == [
+        [0.0, 1.1, 2.2],
+        [],
+        [3.3, 4.4],
+        [5.5],
+        [6.6, 7.7, 8.8, 9.9],
+    ]

--- a/tests/v2/test_1344-broadcast-arrays-depth-limit.py
+++ b/tests/v2/test_1344-broadcast-arrays-depth-limit.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    x = ak._v2.Array([[0, 1], [], [3], [5], [6, 8, 9]])
+    y = ak._v2.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
+
+    with pytest.raises(ValueError):
+        ak._v2.broadcast_arrays(x, y, depth_limit=None)
+
+    u, v = ak._v2.broadcast_arrays(x, y, depth_limit=1)
+    assert ak._v2.to_list(u) == [[0, 1], [], [3], [5], [6, 8, 9]]
+    assert ak._v2.to_list(v) == [
+        [0.0, 1.1, 2.2],
+        [],
+        [3.3, 4.4],
+        [5.5],
+        [6.6, 7.7, 8.8, 9.9],
+    ]


### PR DESCRIPTION
This behaves identically to the `depth_limit` argument of `ak.zip`, which arrests broadcasting at a given depth. Because most of the code is directly copied from `ak.zip`, it should be a fairly safe new feature.