### PR TITLE
Fix _prettyprint after 'for i in range' changed to 'for i, val in enumerate'.

### DIFF
--- a/src/awkward/_v2/_prettyprint.py
+++ b/src/awkward/_v2/_prettyprint.py
@@ -180,13 +180,14 @@ def valuestr(data, limit_rows, limit_cols):
         out = front + back
         for i, val in enumerate(out):
             if i > 0:
-                out[i] = " " + val
+                val = out[i] = " " + val
             else:
-                out[i] = "[" + val
+                val = out[i] = "[" + val
             if i < len(out) - 1:
                 out[i] = val + ","
             else:
                 out[i] = val + "]"
+
         return "\n".join(out)
 
     elif isinstance(data, ak._v2.highlevel.Record):
@@ -220,11 +221,11 @@ def valuestr(data, limit_rows, limit_cols):
         out = front
         for i, val in enumerate(out):
             if i > 0:
-                out[i] = " " + val
+                val = out[i] = " " + val
             elif data.is_tuple:
-                out[i] = "(" + val
+                val = out[i] = "(" + val
             else:
-                out[i] = "{" + val
+                val = out[i] = "{" + val
             if i < len(out) - 1:
                 out[i] = val + ","
             elif data.is_tuple:

--- a/src/awkward/_v2/operations/structure/ak_strings_astype.py
+++ b/src/awkward/_v2/operations/structure/ak_strings_astype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import awkward as ak
 
 np = ak.nplike.NumpyMetadata.instance()

--- a/tests/test_0001-refcount.py
+++ b/tests/test_0001-refcount.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import sys
 import itertools
 

--- a/tests/test_0002-minimal-listarray.py
+++ b/tests/test_0002-minimal-listarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0004-design-surrogate-key.py
+++ b/tests/test_0004-design-surrogate-key.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import sys
 import gc
 

--- a/tests/test_0006-deep-iteration.py
+++ b/tests/test_0006-deep-iteration.py
@@ -1,8 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import sys
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0008-slices-and-getitem.py
+++ b/tests/test_0008-slices-and-getitem.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0009-identity-and-getitem.py
+++ b/tests/test_0009-identity-and-getitem.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0011-listarray.py
+++ b/tests/test_0011-listarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0013-error-handling-struct.py
+++ b/tests/test_0013-error-handling-struct.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0014-finish-up-getitem.py
+++ b/tests/test_0014-finish-up-getitem.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import itertools
 
 import pytest  # noqa: F401

--- a/tests/test_0018-fromiter-fillable.py
+++ b/tests/test_0018-fromiter-fillable.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0019-use-json-library.py
+++ b/tests/test_0019-use-json-library.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 import json
 

--- a/tests/test_0020-support-unsigned-indexes.py
+++ b/tests/test_0020-support-unsigned-indexes.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0021-emptyarray.py
+++ b/tests/test_0021-emptyarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0023-regular-array.py
+++ b/tests/test_0023-regular-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import itertools
 
 import pytest  # noqa: F401

--- a/tests/test_0024-use-regular-array.py
+++ b/tests/test_0024-use-regular-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0025-record-array.py
+++ b/tests/test_0025-record-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0028-add-dressed-types.py
+++ b/tests/test_0028-add-dressed-types.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0031-pickle-types.py
+++ b/tests/test_0031-pickle-types.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pickle
 
 import pytest  # noqa: F401

--- a/tests/test_0032-replace-dressedtype.py
+++ b/tests/test_0032-replace-dressedtype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0038-emptyarray-astype.py
+++ b/tests/test_0038-emptyarray-astype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0039-no-hanging-types.py
+++ b/tests/test_0039-no-hanging-types.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0042-stubs-for-flatten-operation.py
+++ b/tests/test_0042-stubs-for-flatten-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0043-strings-vs-bytes.py
+++ b/tests/test_0043-strings-vs-bytes.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0046-start-indexedarray.py
+++ b/tests/test_0046-start-indexedarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0047-missing-odd-fields-in-fillablearray.py
+++ b/tests/test_0047-missing-odd-fields-in-fillablearray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0049-distinguish-record-and-recordarray-behaviors.py
+++ b/tests/test_0049-distinguish-record-and-recordarray-behaviors.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0056-partitioned-array.py
+++ b/tests/test_0056-partitioned-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0056b-partitioned-array-numba.py
+++ b/tests/test_0056b-partitioned-array-numba.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import sys
 
 import pytest  # noqa: F401

--- a/tests/test_0057-virtual-array.py
+++ b/tests/test_0057-virtual-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pickle

--- a/tests/test_0057b-virtual-array-numba.py
+++ b/tests/test_0057b-virtual-array-numba.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0070-argmin-and-argmax.py
+++ b/tests/test_0070-argmin-and-argmax.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0072-fillna-operation.py
+++ b/tests/test_0072-fillna-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0077-zip-operation.py
+++ b/tests/test_0077-zip-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0078-argcross-and-cross.py
+++ b/tests/test_0078-argcross-and-cross.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0079-argchoose-and-choose.py
+++ b/tests/test_0079-argchoose-and-choose.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0080-flatpandas-multiindex-rows-and-columns.py
+++ b/tests/test_0080-flatpandas-multiindex-rows-and-columns.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 import setuptools
 

--- a/tests/test_0082-indexedarray-setidentities.py
+++ b/tests/test_0082-indexedarray-setidentities.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0084-start-unionarray.py
+++ b/tests/test_0084-start-unionarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0086-nep13-ufunc.py
+++ b/tests/test_0086-nep13-ufunc.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0089-numpy-functions.py
+++ b/tests/test_0089-numpy-functions.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0093-simplify-uniontypes-and-optiontypes.py
+++ b/tests/test_0093-simplify-uniontypes-and-optiontypes.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0094-getattr-for-record-field.py
+++ b/tests/test_0094-getattr-for-record-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0107-assign-fields-to-records.py
+++ b/tests/test_0107-assign-fields-to-records.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0110-various-cleanups.py
+++ b/tests/test_0110-various-cleanups.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0111-jagged-and-masked-getitem.py
+++ b/tests/test_0111-jagged-and-masked-getitem.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0114-rpad-operation.py
+++ b/tests/test_0114-rpad-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0115-generic-reducer-operation.py
+++ b/tests/test_0115-generic-reducer-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0117-finish-the-sizes-operation.py
+++ b/tests/test_0117-finish-the-sizes-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0118-numba-cpointers.py
+++ b/tests/test_0118-numba-cpointers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import sys
 import operator
 

--- a/tests/test_0119-numexpr-and-broadcast-arrays.py
+++ b/tests/test_0119-numexpr-and-broadcast-arrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0120-autograd-support.py
+++ b/tests/test_0120-autograd-support.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0124-strings-in-numba.py
+++ b/tests/test_0124-strings-in-numba.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0127-tomask-operation.py
+++ b/tests/test_0127-tomask-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0127b-tomask-operation-numba.py
+++ b/tests/test_0127b-tomask-operation-numba.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0135-awkward0-awkward1-converter.py
+++ b/tests/test_0135-awkward0-awkward1-converter.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0138-emptyarray-type.py
+++ b/tests/test_0138-emptyarray-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0150-attributeerrors.py
+++ b/tests/test_0150-attributeerrors.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0156-array-and-record-constructors.py
+++ b/tests/test_0156-array-and-record-constructors.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0163-negative-axis-wrap.py
+++ b/tests/test_0163-negative-axis-wrap.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0173-astype-operation.py
+++ b/tests/test_0173-astype-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0184-concatenate-operation.py
+++ b/tests/test_0184-concatenate-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0193-is_none-axis-parameter.py
+++ b/tests/test_0193-is_none-axis-parameter.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0198-tutorial-documentation-1.py
+++ b/tests/test_0198-tutorial-documentation-1.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0222-count-with-axis0.py
+++ b/tests/test_0222-count-with-axis0.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0224-arrow-to-awkward.py
+++ b/tests/test_0224-arrow-to-awkward.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0230-virtualarray-segfault.py
+++ b/tests/test_0230-virtualarray-segfault.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0231-indexform.py
+++ b/tests/test_0231-indexform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0264-reduce-last-empty.py
+++ b/tests/test_0264-reduce-last-empty.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0273-path-for-with-field.py
+++ b/tests/test_0273-path-for-with-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0274-access-ArrayGenerator-in-Python.py
+++ b/tests/test_0274-access-ArrayGenerator-in-Python.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pytest  # noqa: F401

--- a/tests/test_0286-broadcast-single-value-with-field.py
+++ b/tests/test_0286-broadcast-single-value-with-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0290-bug-fixes-for-hats.py
+++ b/tests/test_0290-bug-fixes-for-hats.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0315-integerindex.py
+++ b/tests/test_0315-integerindex.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0324-fix-partitionedarray-getitem-string-int.py
+++ b/tests/test_0324-fix-partitionedarray-getitem-string-int.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0331-pandas-indexedarray.py
+++ b/tests/test_0331-pandas-indexedarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0334-fully-broadcastable-where.py
+++ b/tests/test_0334-fully-broadcastable-where.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0337-numpy-format-integer-size-issues.py
+++ b/tests/test_0337-numpy-format-integer-size-issues.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0339-highlevel-sorting-function.py
+++ b/tests/test_0339-highlevel-sorting-function.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0341-parquet-reader-writer.py
+++ b/tests/test_0341-parquet-reader-writer.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/test_0344-repr-quote-keys.py
+++ b/tests/test_0344-repr-quote-keys.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0348-form-keys.py
+++ b/tests/test_0348-form-keys.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pickle
 
 import pytest  # noqa: F401

--- a/tests/test_0355-mixins.py
+++ b/tests/test_0355-mixins.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0381-fill-documentation-stubs-3.py
+++ b/tests/test_0381-fill-documentation-stubs-3.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0384-lazy-arrayset.py
+++ b/tests/test_0384-lazy-arrayset.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0390-virtual-forms.py
+++ b/tests/test_0390-virtual-forms.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import collections
 import json
 

--- a/tests/test_0393-fix-bitmaskedarray-mask.py
+++ b/tests/test_0393-fix-bitmaskedarray-mask.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0395-complex-type-arrays.py
+++ b/tests/test_0395-complex-type-arrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0395-fix-numba-indexedarray.py
+++ b/tests/test_0395-fix-numba-indexedarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0397-arrays-as-constants-in-numba.py
+++ b/tests/test_0397-arrays-as-constants-in-numba.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import sys
 
 import pytest  # noqa: F401

--- a/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0402-fix-form-getitem-field.py
+++ b/tests/test_0402-fix-form-getitem-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pytest  # noqa: F401

--- a/tests/test_0404-array-validity-check.py
+++ b/tests/test_0404-array-validity-check.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
-
 import numpy as np
 import awkward as ak
 

--- a/tests/test_0410-fix-argminmax-positions-for-missing-values.py
+++ b/tests/test_0410-fix-argminmax-positions-for-missing-values.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0420-fix-numpyarray-carry-for-noncontiguous.py
+++ b/tests/test_0420-fix-numpyarray-carry-for-noncontiguous.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0437-stream-of-many-json-files.py
+++ b/tests/test_0437-stream-of-many-json-files.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0446-fix-flatten-of-sliced-array.py
+++ b/tests/test_0446-fix-flatten-of-sliced-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0447-preserve-regularness-in-reduce.py
+++ b/tests/test_0447-preserve-regularness-in-reduce.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0449-merge-many-arrays-in-one-pass.py
+++ b/tests/test_0449-merge-many-arrays-in-one-pass.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0457-remove-broadcasting-over-fields.py
+++ b/tests/test_0457-remove-broadcasting-over-fields.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0473-empty-listarray.py
+++ b/tests/test_0473-empty-listarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0479-lazy-arrays-lose-weak-reference.py
+++ b/tests/test_0479-lazy-arrays-lose-weak-reference.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 from collections.abc import MutableMapping
 
 import pytest  # noqa: F401

--- a/tests/test_0484-masked-take-empty-array.py
+++ b/tests/test_0484-masked-take-empty-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0493-zeros-ones-full-like.py
+++ b/tests/test_0493-zeros-ones-full-like.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0494-numba-array-contains.py
+++ b/tests/test_0494-numba-array-contains.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0496-provide-local-index.py
+++ b/tests/test_0496-provide-local-index.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0499-getitem-indexedarray-bug.py
+++ b/tests/test_0499-getitem-indexedarray-bug.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0501-string-comparison-bug.py
+++ b/tests/test_0501-string-comparison-bug.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0504-block-ufuncs-for-strings.py
+++ b/tests/test_0504-block-ufuncs-for-strings.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0511-copy-and-deepcopy.py
+++ b/tests/test_0511-copy-and-deepcopy.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import copy
 
 import pytest  # noqa: F401

--- a/tests/test_0521-matrix-multiplication.py
+++ b/tests/test_0521-matrix-multiplication.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0527-fix-unionarray-ufuncs-and-parameters-in-merging.py
+++ b/tests/test_0527-fix-unionarray-ufuncs-and-parameters-in-merging.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0546-fill_none-replacement-value-type.py
+++ b/tests/test_0546-fill_none-replacement-value-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0549-numba-array-asarray.py
+++ b/tests/test_0549-numba-array-asarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0552-with_field-should-not-right-broadcast.py
+++ b/tests/test_0552-with_field-should-not-right-broadcast.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0557-min-max-initial-argument.py
+++ b/tests/test_0557-min-max-initial-argument.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0559-fix-booleans-in-numba.py
+++ b/tests/test_0559-fix-booleans-in-numba.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0560-setting-virtual-field.py
+++ b/tests/test_0560-setting-virtual-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0572-numba-array-ndim.py
+++ b/tests/test_0572-numba-array-ndim.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0582-propagate-context-in-broadcast_and_apply.py
+++ b/tests/test_0582-propagate-context-in-broadcast_and_apply.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0583-implement-unflatten-function.py
+++ b/tests/test_0583-implement-unflatten-function.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0585-fix-corner-case.py
+++ b/tests/test_0585-fix-corner-case.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0590-allow-regulararray-size-zero.py
+++ b/tests/test_0590-allow-regulararray-size-zero.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0593-preserve-nullability-in-arrow-and-parquet.py
+++ b/tests/test_0593-preserve-nullability-in-arrow-and-parquet.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/test_0595-0630-default-for-nep18.py
+++ b/tests/test_0595-0630-default-for-nep18.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0597-virtual-virtual-forms.py
+++ b/tests/test_0597-virtual-virtual-forms.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0603-concatenate-should-minimally-touch-laziness.py
+++ b/tests/test_0603-concatenate-should-minimally-touch-laziness.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0612-partition-axis_wrap_if_negative.py
+++ b/tests/test_0612-partition-axis_wrap_if_negative.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0618-deprecation-for-selecting-within-multiple-records.py
+++ b/tests/test_0618-deprecation-for-selecting-within-multiple-records.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0627-behavior-from-dict-of-arrays.py
+++ b/tests/test_0627-behavior-from-dict-of-arrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0628-accept-numpy-integers-in-slices.py
+++ b/tests/test_0628-accept-numpy-integers-in-slices.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0634-fill_none-with-record.py
+++ b/tests/test_0634-fill_none-with-record.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0645-from-jax.py
+++ b/tests/test_0645-from-jax.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0645-jax-refcount.py
+++ b/tests/test_0645-jax-refcount.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import sys
 
 import pytest  # noqa: F401

--- a/tests/test_0645-to-jax.py
+++ b/tests/test_0645-to-jax.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0648-add-forth-machine-to-codebase.py
+++ b/tests/test_0648-add-forth-machine-to-codebase.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0652-tests-of-complex-numbers.py
+++ b/tests/test_0652-tests-of-complex-numbers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pytest  # noqa: F401

--- a/tests/test_0674-categorical-validation.py
+++ b/tests/test_0674-categorical-validation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0688-lazy-parquet-with-Forms.py
+++ b/tests/test_0688-lazy-parquet-with-Forms.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/test_0689-fix-dimension-of-empty-slices.py
+++ b/tests/test_0689-fix-dimension-of-empty-slices.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0690-array-builder-perf-study.py
+++ b/tests/test_0690-array-builder-perf-study.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0693-fixes-for-scipy-prep.py
+++ b/tests/test_0693-fixes-for-scipy-prep.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0699-fixes-for-scipy-prep-2.py
+++ b/tests/test_0699-fixes-for-scipy-prep-2.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0702-partitioned-to-arrow.py
+++ b/tests/test_0702-partitioned-to-arrow.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0706-implement-parquet-dataset.py
+++ b/tests/test_0706-implement-parquet-dataset.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/test_0713-getitem_field-should-simplify_optiontype.py
+++ b/tests/test_0713-getitem_field-should-simplify_optiontype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0719-prevent-nullptr-in-caches.py
+++ b/tests/test_0719-prevent-nullptr-in-caches.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0721-unflatten-partitionedarray.py
+++ b/tests/test_0721-unflatten-partitionedarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0723-ensure-that-jagged-slice-fits-array-length.py
+++ b/tests/test_0723-ensure-that-jagged-slice-fits-array-length.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0724-fix-flatten-segfault.py
+++ b/tests/test_0724-fix-flatten-segfault.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0730-unflatten-axis-parameter.py
+++ b/tests/test_0730-unflatten-axis-parameter.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0733-run_lengths.py
+++ b/tests/test_0733-run_lengths.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0734-strings_astype.py
+++ b/tests/test_0734-strings_astype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0736-implement-argsort-for-strings.py
+++ b/tests/test_0736-implement-argsort-for-strings.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0740-numpy-scalars-as-numbers.py
+++ b/tests/test_0740-numpy-scalars-as-numbers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0747-from_parquet-row_groups.py
+++ b/tests/test_0747-from_parquet-row_groups.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/test_0756-num-of-partitioned-recordarrays.py
+++ b/tests/test_0756-num-of-partitioned-recordarrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0758-ak-zip-scalars.py
+++ b/tests/test_0758-ak-zip-scalars.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0766-prevent-combinations-of-characters.py
+++ b/tests/test_0766-prevent-combinations-of-characters.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0771-akArray-dict-constructor-require-equal-lengths.py
+++ b/tests/test_0771-akArray-dict-constructor-require-equal-lengths.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0773-typeparser.py
+++ b/tests/test_0773-typeparser.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import awkward as ak  # noqa: F401
 

--- a/tests/test_0776-numba-booleans-in-virtual-array.py
+++ b/tests/test_0776-numba-booleans-in-virtual-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0781-forth-machine-error-handling.py
+++ b/tests/test_0781-forth-machine-error-handling.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0783-disambiguate-parquet-list-cache-keys.py
+++ b/tests/test_0783-disambiguate-parquet-list-cache-keys.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0788-indexedarray-carrying-recordarray-parameters.py
+++ b/tests/test_0788-indexedarray-carrying-recordarray-parameters.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0793-jax-element-wise-ops.py
+++ b/tests/test_0793-jax-element-wise-ops.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import awkward as ak
 import numpy as np
 import pytest

--- a/tests/test_0794-ak-cartesian-on-empty-array.py
+++ b/tests/test_0794-ak-cartesian-on-empty-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0798-forbid-Tensor-in-Parquet.py
+++ b/tests/test_0798-forbid-Tensor-in-Parquet.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/test_0803-argsort-fix-type.py
+++ b/tests/test_0803-argsort-fix-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0806-empty-lists-cartesian-fix.py
+++ b/tests/test_0806-empty-lists-cartesian-fix.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0812-argsort-empty-union-type-fix.py
+++ b/tests/test_0812-argsort-empty-union-type-fix.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0813-full-like-dtype-arg.py
+++ b/tests/test_0813-full-like-dtype-arg.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0815-broadcast-union-types-to-all-possibilities.py
+++ b/tests/test_0815-broadcast-union-types-to-all-possibilities.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0819-issue.py
+++ b/tests/test_0819-issue.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0824-fix-akRecord-promote-to-behavior.py
+++ b/tests/test_0824-fix-akRecord-promote-to-behavior.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0828-arrow-datatype-null.py
+++ b/tests/test_0828-arrow-datatype-null.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0835-datetime-type.py
+++ b/tests/test_0835-datetime-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0836-nonflat-bools-in-parquet.py
+++ b/tests/test_0836-nonflat-bools-in-parquet.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/test_0846-matrix-multiplication-numpy.py
+++ b/tests/test_0846-matrix-multiplication-numpy.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0850-argsort-mask-array.py
+++ b/tests/test_0850-argsort-mask-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0858-complex-array-concatenate.py
+++ b/tests/test_0858-complex-array-concatenate.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0863-is-none-numpy-array.py
+++ b/tests/test_0863-is-none-numpy-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0866-getitem_field-and-flatten-unions.py
+++ b/tests/test_0866-getitem_field-and-flatten-unions.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0868-matrix-multiplication-of-vector.py
+++ b/tests/test_0868-matrix-multiplication-of-vector.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0871-nested-virtual-in-numba.py
+++ b/tests/test_0871-nested-virtual-in-numba.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os.path
 
 import pytest  # noqa: F401

--- a/tests/test_0875-arrow-null-type.py
+++ b/tests/test_0875-arrow-null-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/test_0876-fix-lost-slice-array-offset.py
+++ b/tests/test_0876-fix-lost-slice-array-offset.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0879-non-primitive-with-field.py
+++ b/tests/test_0879-non-primitive-with-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0889-ptp.py
+++ b/tests/test_0889-ptp.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0898-unzip-heterogeneous-records.py
+++ b/tests/test_0898-unzip-heterogeneous-records.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0899-distinguish-cache-keys-for-non-leaf-nodes.py
+++ b/tests/test_0899-distinguish-cache-keys-for-non-leaf-nodes.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0903-ArrayView-expects-contiguous-NumpyArrays.py
+++ b/tests/test_0903-ArrayView-expects-contiguous-NumpyArrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0905-leading-zeros-in-unflatten.py
+++ b/tests/test_0905-leading-zeros-in-unflatten.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0906-arrow-fixed-size-list-type.py
+++ b/tests/test_0906-arrow-fixed-size-list-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0910-unflatten-counts-relation.py
+++ b/tests/test_0910-unflatten-counts-relation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0916-datetime-values-astype.py
+++ b/tests/test_0916-datetime-values-astype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0917-fill-none-axis.py
+++ b/tests/test_0917-fill-none-axis.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0921-parquet-from-file-like.py
+++ b/tests/test_0921-parquet-from-file-like.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import io
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401

--- a/tests/test_0924-layout-builder.py
+++ b/tests/test_0924-layout-builder.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0927-numpy-array-nbytes.py
+++ b/tests/test_0927-numpy-array-nbytes.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0930-bug-in-unionarray-purelist_parameter.py
+++ b/tests/test_0930-bug-in-unionarray-purelist_parameter.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0940-with-cache-already-exists.py
+++ b/tests/test_0940-with-cache-already-exists.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0945-argsort-sort-nan-array.py
+++ b/tests/test_0945-argsort-sort-nan-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0973-flatten-multidimensional-numpy-array.py
+++ b/tests/test_0973-flatten-multidimensional-numpy-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0975-mask-multidimensional-numpy-array.py
+++ b/tests/test_0975-mask-multidimensional-numpy-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0977-array-builder.py
+++ b/tests/test_0977-array-builder.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0979-where-multidimensional-numpy-array.py
+++ b/tests/test_0979-where-multidimensional-numpy-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0982-missing-case-in-nonlocal-reducers.py
+++ b/tests/test_0982-missing-case-in-nonlocal-reducers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0984-ravel.py
+++ b/tests/test_0984-ravel.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_0992-correct-ptp-unmasking.py
+++ b/tests/test_0992-correct-ptp-unmasking.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1000-fixes-argmax-for-ListOffsetArray-with-nonzero-start.py
+++ b/tests/test_1000-fixes-argmax-for-ListOffsetArray-with-nonzero-start.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1006-packed-regular-array-zero-size.py
+++ b/tests/test_1006-packed-regular-array-zero-size.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1007-from_buffers-empty-ndarray.py
+++ b/tests/test_1007-from_buffers-empty-ndarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1012-zip-regular-arrays.py
+++ b/tests/test_1012-zip-regular-arrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1017-numpyarray-broadcast.py
+++ b/tests/test_1017-numpyarray-broadcast.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1026-jagged-slicing-of-multidim-NumpyArray.py
+++ b/tests/test_1026-jagged-slicing-of-multidim-NumpyArray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1030-mixin-class-name.py
+++ b/tests/test_1030-mixin-class-name.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1048-to_numpy-with-RegularArray-of-size-zero.py
+++ b/tests/test_1048-to_numpy-with-RegularArray-of-size-zero.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1055-fill_none-numpy-dimension.py
+++ b/tests/test_1055-fill_none-numpy-dimension.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1066-to_numpy-masked-structured-array.py
+++ b/tests/test_1066-to_numpy-masked-structured-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1071-mask-identity-false-should-not-return-option-type.py
+++ b/tests/test_1071-mask-identity-false-should-not-return-option-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1106-argminmax-axis-None-missing-values.py
+++ b/tests/test_1106-argminmax-axis-None-missing-values.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1114-fix-copyjson-casting-bug.py
+++ b/tests/test_1114-fix-copyjson-casting-bug.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pytest  # noqa: F401

--- a/tests/test_1136-regulararray-zeros-in-shape.py
+++ b/tests/test_1136-regulararray-zeros-in-shape.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1159-add-json-commands-to-awkwardforth.py
+++ b/tests/test_1159-add-json-commands-to-awkwardforth.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pytest  # noqa: F401

--- a/tests/test_1170-parquet-files-with-zero-record-batches.py
+++ b/tests/test_1170-parquet-files-with-zero-record-batches.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1173-numbers_to_type-length.py
+++ b/tests/test_1173-numbers_to_type-length.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1189-fix-singletons-for-non-optional-data.py
+++ b/tests/test_1189-fix-singletons-for-non-optional-data.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1192-iterables-in-__array_function__.py
+++ b/tests/test_1192-iterables-in-__array_function__.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1214-flattened-record-array-drop-parameters.py
+++ b/tests/test_1214-flattened-record-array-drop-parameters.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/test_1344-broadcast-arrays-depth-limit.py
+++ b/tests/test_1344-broadcast-arrays-depth-limit.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0002-minimal-listarray.py
+++ b/tests/v2/test_0002-minimal-listarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0006-deep-iteration.py
+++ b/tests/v2/test_0006-deep-iteration.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0008-slices-and-getitem.py
+++ b/tests/v2/test_0008-slices-and-getitem.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0011-listarray.py
+++ b/tests/v2/test_0011-listarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0013-error-handling-struct.py
+++ b/tests/v2/test_0013-error-handling-struct.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0014-finish-up-getitem.py
+++ b/tests/v2/test_0014-finish-up-getitem.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import itertools
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0018-fromiter-fillable.py
+++ b/tests/v2/test_0018-fromiter-fillable.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest
 import awkward as ak
 

--- a/tests/v2/test_0019-use-json-library.py
+++ b/tests/v2/test_0019-use-json-library.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 import json
 

--- a/tests/v2/test_0020-support-unsigned-indexes.py
+++ b/tests/v2/test_0020-support-unsigned-indexes.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0021-emptyarray.py
+++ b/tests/v2/test_0021-emptyarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0023-regular-array.py
+++ b/tests/v2/test_0023-regular-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import itertools
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0024-use-regular-array.py
+++ b/tests/v2/test_0024-use-regular-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0025-record-array.py
+++ b/tests/v2/test_0025-record-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0028-add-dressed-types.py
+++ b/tests/v2/test_0028-add-dressed-types.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0032-replace-dressedtype.py
+++ b/tests/v2/test_0032-replace-dressedtype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0046-start-indexedarray.py
+++ b/tests/v2/test_0046-start-indexedarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0049-distinguish-record-and-recordarray-behaviors.py
+++ b/tests/v2/test_0049-distinguish-record-and-recordarray-behaviors.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0057-introducing-forms.py
+++ b/tests/v2/test_0057-introducing-forms.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pickle

--- a/tests/v2/test_0070-argmin-and-argmax.py
+++ b/tests/v2/test_0070-argmin-and-argmax.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0072-fillna-operation.py
+++ b/tests/v2/test_0072-fillna-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0074-argsort-and-sort.py
+++ b/tests/v2/test_0074-argsort-and-sort.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0077-zip-operation.py
+++ b/tests/v2/test_0077-zip-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0078-argcross-and-cross.py
+++ b/tests/v2/test_0078-argcross-and-cross.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0079-argchoose-and-choose.py
+++ b/tests/v2/test_0079-argchoose-and-choose.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0080-flatpandas-multiindex-rows-and-columns.py
+++ b/tests/v2/test_0080-flatpandas-multiindex-rows-and-columns.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 import setuptools
 

--- a/tests/v2/test_0084-start-unionarray.py
+++ b/tests/v2/test_0084-start-unionarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0086-nep13-ufunc.py
+++ b/tests/v2/test_0086-nep13-ufunc.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0089-numpy-functions.py
+++ b/tests/v2/test_0089-numpy-functions.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0093-simplify-uniontypes-and-optiontypes.py
+++ b/tests/v2/test_0093-simplify-uniontypes-and-optiontypes.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0107-assign-fields-to-records.py
+++ b/tests/v2/test_0107-assign-fields-to-records.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0111-jagged-and-masked-getitem.py
+++ b/tests/v2/test_0111-jagged-and-masked-getitem.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0115-generic-reducer-operation.py
+++ b/tests/v2/test_0115-generic-reducer-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0119-numexpr-and-broadcast-arrays.py
+++ b/tests/v2/test_0119-numexpr-and-broadcast-arrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0127-tomask-operation.py
+++ b/tests/v2/test_0127-tomask-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0138-emptyarray-type.py
+++ b/tests/v2/test_0138-emptyarray-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0150-flatten.py
+++ b/tests/v2/test_0150-flatten.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0163-negative-axis-wrap.py
+++ b/tests/v2/test_0163-negative-axis-wrap.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0166-0167-0170-random-issues.py
+++ b/tests/v2/test_0166-0167-0170-random-issues.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0173-astype-operation.py
+++ b/tests/v2/test_0173-astype-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0184-concatenate-operation.py
+++ b/tests/v2/test_0184-concatenate-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0222-count-with-axis0.py
+++ b/tests/v2/test_0222-count-with-axis0.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0224-arrow-to-awkward.py
+++ b/tests/v2/test_0224-arrow-to-awkward.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0264-reduce-last-empty.py
+++ b/tests/v2/test_0264-reduce-last-empty.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0273-path-for-with-field.py
+++ b/tests/v2/test_0273-path-for-with-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0286-broadcast-single-value-with-field.py
+++ b/tests/v2/test_0286-broadcast-single-value-with-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0315-integerindex.py
+++ b/tests/v2/test_0315-integerindex.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0331-pandas-indexedarray.py
+++ b/tests/v2/test_0331-pandas-indexedarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0334-fully-broadcastable-where.py
+++ b/tests/v2/test_0334-fully-broadcastable-where.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0339-highlevel-sorting-function.py
+++ b/tests/v2/test_0339-highlevel-sorting-function.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0348-form-keys.py
+++ b/tests/v2/test_0348-form-keys.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pickle
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0395-complex-type-arrays.py
+++ b/tests/v2/test_0395-complex-type-arrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import numbers  # noqa: F401

--- a/tests/v2/test_0397-arrays-as-constants-in-numba.py
+++ b/tests/v2/test_0397-arrays-as-constants-in-numba.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import sys
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0404-array-validity-check.py
+++ b/tests/v2/test_0404-array-validity-check.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0410-fix-argminmax-positions-for-missing-values.py
+++ b/tests/v2/test_0410-fix-argminmax-positions-for-missing-values.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0437-stream-of-many-json-files.py
+++ b/tests/v2/test_0437-stream-of-many-json-files.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0447-preserve-regularness-in-reduce.py
+++ b/tests/v2/test_0447-preserve-regularness-in-reduce.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0449-merge-many-arrays-in-one-pass.py
+++ b/tests/v2/test_0449-merge-many-arrays-in-one-pass.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0496-provide-local-index.py
+++ b/tests/v2/test_0496-provide-local-index.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0499-getitem-indexedarray-bug.py
+++ b/tests/v2/test_0499-getitem-indexedarray-bug.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0504-block-ufuncs-for-strings.py
+++ b/tests/v2/test_0504-block-ufuncs-for-strings.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0511-copy-and-deepcopy.py
+++ b/tests/v2/test_0511-copy-and-deepcopy.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import copy
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0527-fix-unionarray-ufuncs-and-parameters-in-merging.py
+++ b/tests/v2/test_0527-fix-unionarray-ufuncs-and-parameters-in-merging.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0546-fill_none-replacement-value-type.py
+++ b/tests/v2/test_0546-fill_none-replacement-value-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0557-min-max-initial-argument.py
+++ b/tests/v2/test_0557-min-max-initial-argument.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0582-propagate-context-in-broadcast_and_apply.py
+++ b/tests/v2/test_0582-propagate-context-in-broadcast_and_apply.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0583-implement-unflatten-function.py
+++ b/tests/v2/test_0583-implement-unflatten-function.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0590-allow-regulararray-size-zero.py
+++ b/tests/v2/test_0590-allow-regulararray-size-zero.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0593-preserve-nullability-in-arrow-and-parquet.py
+++ b/tests/v2/test_0593-preserve-nullability-in-arrow-and-parquet.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 # import os
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0627-behavior-from-dict-of-arrays.py
+++ b/tests/v2/test_0627-behavior-from-dict-of-arrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0652-tests-of-complex-numbers.py
+++ b/tests/v2/test_0652-tests-of-complex-numbers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0713-getitem_field-should-simplify_optiontype.py
+++ b/tests/v2/test_0713-getitem_field-should-simplify_optiontype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0723-ensure-that-jagged-slice-fits-array-length.py
+++ b/tests/v2/test_0723-ensure-that-jagged-slice-fits-array-length.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0730-unflatten-axis-parameter.py
+++ b/tests/v2/test_0730-unflatten-axis-parameter.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0733-run_lengths.py
+++ b/tests/v2/test_0733-run_lengths.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0736-implement-argsort-for-strings.py
+++ b/tests/v2/test_0736-implement-argsort-for-strings.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0758-ak-zip-scallars.py
+++ b/tests/v2/test_0758-ak-zip-scallars.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0766-prevent-combinations-of-characters.py
+++ b/tests/v2/test_0766-prevent-combinations-of-characters.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0788-indexedarray-carrying-recordarray-parameters.py
+++ b/tests/v2/test_0788-indexedarray-carrying-recordarray-parameters.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0794-ak-cartesian-on-empty-array.py
+++ b/tests/v2/test_0794-ak-cartesian-on-empty-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0803-argsort-fix-type.py
+++ b/tests/v2/test_0803-argsort-fix-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0806-empty-lists-cartesian-fix.py
+++ b/tests/v2/test_0806-empty-lists-cartesian-fix.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0813-full-like-dtype-arg.py
+++ b/tests/v2/test_0813-full-like-dtype-arg.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0819-issue.py
+++ b/tests/v2/test_0819-issue.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0828-arrow-datatype-null.py
+++ b/tests/v2/test_0828-arrow-datatype-null.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0835-datetime-type-pandas.py
+++ b/tests/v2/test_0835-datetime-type-pandas.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0835-datetime-type-pyarrow.py
+++ b/tests/v2/test_0835-datetime-type-pyarrow.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import datetime
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0835-datetime-type.py
+++ b/tests/v2/test_0835-datetime-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0850-argsort-mask-array.py
+++ b/tests/v2/test_0850-argsort-mask-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0866-getitem_field-and-flatten-unions.py
+++ b/tests/v2/test_0866-getitem_field-and-flatten-unions.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0875-arrow-null-type.py
+++ b/tests/v2/test_0875-arrow-null-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import os
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0879-non-primitive-with-field.py
+++ b/tests/v2/test_0879-non-primitive-with-field.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0884-index-and-identifier-refactoring.py
+++ b/tests/v2/test_0884-index-and-identifier-refactoring.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0889-ptp.py
+++ b/tests/v2/test_0889-ptp.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0896-content-classes-refactoring.py
+++ b/tests/v2/test_0896-content-classes-refactoring.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0898-unzip-heterogeneous-records.py
+++ b/tests/v2/test_0898-unzip-heterogeneous-records.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0905-leading-zeros-in-unflatten.py
+++ b/tests/v2/test_0905-leading-zeros-in-unflatten.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0906-arrow-fixed-size-list-type.py
+++ b/tests/v2/test_0906-arrow-fixed-size-list-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0910-unflatten-counts-relation.py
+++ b/tests/v2/test_0910-unflatten-counts-relation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0912-packed.py
+++ b/tests/v2/test_0912-packed.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0914-types-and-forms.py
+++ b/tests/v2/test_0914-types-and-forms.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0916-datetime-values-astype.py
+++ b/tests/v2/test_0916-datetime-values-astype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0927-numpy-array-nbytes.py
+++ b/tests/v2/test_0927-numpy-array-nbytes.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0945-argsort-sort-nan-array.py
+++ b/tests/v2/test_0945-argsort-sort-nan-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0958-new-forms-must-accept-old-form-json.py
+++ b/tests/v2/test_0958-new-forms-must-accept-old-form-json.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import json
 
 import pytest  # noqa: F401

--- a/tests/v2/test_0959-_getitem_array-implementation.py
+++ b/tests/v2/test_0959-_getitem_array-implementation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0975-mask-multidimensional-numpy-array.py
+++ b/tests/v2/test_0975-mask-multidimensional-numpy-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0979-where-multidimentional-numpy-array.py
+++ b/tests/v2/test_0979-where-multidimentional-numpy-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0982-missing-case-in-nonlocal-reducers.py
+++ b/tests/v2/test_0982-missing-case-in-nonlocal-reducers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0984-ravel.py
+++ b/tests/v2/test_0984-ravel.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_0992-correct-ptp-unmasking.py
+++ b/tests/v2/test_0992-correct-ptp-unmasking.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1000-fixes-argmax-for-ListOffsetArray-with-nonzero-start.py
+++ b/tests/v2/test_1000-fixes-argmax-for-ListOffsetArray-with-nonzero-start.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1006-packed-regular-array-zero-size.py
+++ b/tests/v2/test_1006-packed-regular-array-zero-size.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1007-from_buffers-empty-ndarray.py
+++ b/tests/v2/test_1007-from_buffers-empty-ndarray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1017-numpyarray-broadcast.py
+++ b/tests/v2/test_1017-numpyarray-broadcast.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1031-start-getitem_next.py
+++ b/tests/v2/test_1031-start-getitem_next.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1031b-start-getitem_next-specialized.py
+++ b/tests/v2/test_1031b-start-getitem_next-specialized.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1055-fill_none-numpy-dimension.py
+++ b/tests/v2/test_1055-fill_none-numpy-dimension.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1059-localindex.py
+++ b/tests/v2/test_1059-localindex.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1066-to_numpy-masked-structured-array.py
+++ b/tests/v2/test_1066-to_numpy-masked-structured-array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1071-mask-identity-false-should-not-return-option-type.py
+++ b/tests/v2/test_1071-mask-identity-false-should-not-return-option-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1072-sort.py
+++ b/tests/v2/test_1072-sort.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1074-combinations.py
+++ b/tests/v2/test_1074-combinations.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1075-validityerror.py
+++ b/tests/v2/test_1075-validityerror.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1106-argminmax-axis-None-missing-values.py
+++ b/tests/v2/test_1106-argminmax-axis-None-missing-values.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1116-project-maskedarrays.py
+++ b/tests/v2/test_1116-project-maskedarrays.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1125-to-arrow-from-arrow.py
+++ b/tests/v2/test_1125-to-arrow-from-arrow.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import os
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1132-utility-methods-for-highlevel-functions.py
+++ b/tests/v2/test_1132-utility-methods-for-highlevel-functions.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1134-from-buffers-to-buffers.py
+++ b/tests/v2/test_1134-from-buffers-to-buffers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1135-rpad-operation.py
+++ b/tests/v2/test_1135-rpad-operation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1136-regulararray-zeros-in-shape.py
+++ b/tests/v2/test_1136-regulararray-zeros-in-shape.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1137-num.py
+++ b/tests/v2/test_1137-num.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1142-numbers-to-type.py
+++ b/tests/v2/test_1142-numbers-to-type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1149-datetime-sort.py
+++ b/tests/v2/test_1149-datetime-sort.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1154-arrow-tables-should-preserve-parameters.py
+++ b/tests/v2/test_1154-arrow-tables-should-preserve-parameters.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1162-ak-from_json_schema.py
+++ b/tests/v2/test_1162-ak-from_json_schema.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1183-bugs-found-by-dask-project-2.py
+++ b/tests/v2/test_1183-bugs-found-by-dask-project-2.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1192-iterables-in-__array_function__.py
+++ b/tests/v2/test_1192-iterables-in-__array_function__.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1233-ak-with_name.py
+++ b/tests/v2/test_1233-ak-with_name.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1240-v2-implementation-of-numba-1.py
+++ b/tests/v2/test_1240-v2-implementation-of-numba-1.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import sys
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1259-simplify_optiontype.py
+++ b/tests/v2/test_1259-simplify_optiontype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1260-simplify-masked-option-types.py
+++ b/tests/v2/test_1260-simplify-masked-option-types.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1294-to-and-from_parquet.py
+++ b/tests/v2/test_1294-to-and-from_parquet.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import os.path
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401

--- a/tests/v2/test_1344-broadcast-arrays-depth-limit.py
+++ b/tests/v2/test_1344-broadcast-arrays-depth-limit.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401


### PR DESCRIPTION
Just FYI @henryiii: changing

```python
for i in range(len(out)):
    if i > 0:
        out[i] = " " + out[i]
    else:
        out[i] = "[" + out[i]
    if i < len(out) - 1:
        out[i] = out[i] + ","
    else:
        out[i] = out[i] + "]"
```

into a for loop with

```python
for i, val in enumerate(out):
```

and all `out[i]` on the right-hand side of assignments converted into `val` broke this functionality. The original for loop relied on a side-effect in which `out[i]` was changed twice. Using an assigned-once name, `val`, prevented the first change from being seen in the final result.

I repeatedly run into cases in which side-effect turn out to be a bad idea (there's really something to this pure functional paradigm), and this could be counted as one of them. But side-effect based programming is a part of ordinary Python use and I wanted to bring to your attention that there are corner-cases like this in which `for i in range(len(XYZ))` → `for i, val in enumerate(XYZ)` can be dangerous. Not to avoid these refactorings, but to keep an eye out for them!

(Also, I haven't yet checked the history to be sure that that's how this bug crept in, I'm just guessing that because it looks like it.)