### PR TITLE
ErrorContexts should only contain strings.

### DIFF
--- a/src/awkward/_v2/_prettyprint.py
+++ b/src/awkward/_v2/_prettyprint.py
@@ -6,6 +6,8 @@ import numbers
 
 import awkward as ak
 
+numpy = ak.nplike.Numpy.instance()
+
 
 def half(integer):
     return int(math.ceil(integer / 2))
@@ -32,6 +34,38 @@ def alternate(length):
 is_identifier = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*$")
 
 
+# avoid recursion in which ak._v2.Array.__getitem__ calls prettyprint
+# to form an error string: private reimplementation of ak._v2.Array.__getitem__
+
+
+def get_at(data, index):
+    out = data._layout._getitem_at(index)
+    if isinstance(out, ak._v2.contents.NumpyArray):
+        array_param = out.parameter("__array__")
+        if array_param == "byte":
+            return ak._v2._util.tobytes(out.raw(numpy))
+        elif array_param == "char":
+            return ak._v2._util.tobytes(out.raw(numpy)).decode(errors="surrogateescape")
+    if isinstance(out, (ak._v2.contents.Content, ak._v2.record.Record)):
+        return ak._v2._util.wrap(out, data._behavior)
+    else:
+        return out
+
+
+def get_field(data, field):
+    out = data._layout._getitem_field(field)
+    if isinstance(out, ak._v2.contents.NumpyArray):
+        array_param = out.parameter("__array__")
+        if array_param == "byte":
+            return ak._v2._util.tobytes(out.raw(numpy))
+        elif array_param == "char":
+            return ak._v2._util.tobytes(out.raw(numpy)).decode(errors="surrogateescape")
+    if isinstance(out, (ak._v2.contents.Content, ak._v2.record.Record)):
+        return ak._v2._util.wrap(out, data._behavior)
+    else:
+        return out
+
+
 def valuestr_horiz(data, limit_cols):
     original_limit_cols = limit_cols
 
@@ -43,7 +77,7 @@ def valuestr_horiz(data, limit_cols):
             return 2, front + back
 
         elif len(data) == 1:
-            cols_taken, strs = valuestr_horiz(data[0], limit_cols)
+            cols_taken, strs = valuestr_horiz(get_at(data, 0), limit_cols)
             return 2 + cols_taken, front + strs + back
 
         else:
@@ -53,7 +87,7 @@ def valuestr_horiz(data, limit_cols):
                 if forward:
                     for_comma = 0 if which == 0 else 2
                     cols_taken, strs = valuestr_horiz(
-                        data[index], limit_cols - for_comma
+                        get_at(data, index), limit_cols - for_comma
                     )
                     if limit_cols - (for_comma + cols_taken) >= 0:
                         if which != 0:
@@ -64,7 +98,9 @@ def valuestr_horiz(data, limit_cols):
                     else:
                         break
                 else:
-                    cols_taken, strs = valuestr_horiz(data[index], limit_cols - 2)
+                    cols_taken, strs = valuestr_horiz(
+                        get_at(data, index), limit_cols - 2
+                    )
                     if limit_cols - (2 + cols_taken) >= 0:
                         back[:0] = strs
                         back.insert(0, ", ")
@@ -114,7 +150,7 @@ def valuestr_horiz(data, limit_cols):
                 which += 1
 
                 target = limit_cols if len(fields) == 1 else half(limit_cols)
-                cols_taken, strs = valuestr_horiz(data[key], target)
+                cols_taken, strs = valuestr_horiz(get_field(data, key), target)
                 if limit_cols - cols_taken >= 0:
                     front.extend(strs)
                     limit_cols -= cols_taken
@@ -164,7 +200,7 @@ def valuestr(data, limit_rows, limit_cols):
         front, back = [], []
         which = 0
         for forward, index in alternate(len(data)):
-            _, strs = valuestr_horiz(data[index], limit_cols - 2)
+            _, strs = valuestr_horiz(get_at(data, index), limit_cols - 2)
             if forward:
                 front.append("".join(strs))
             else:
@@ -208,7 +244,9 @@ def valuestr(data, limit_rows, limit_cols):
                 else:
                     key_str = key + ": "
 
-            _, strs = valuestr_horiz(data[key], limit_cols - 2 - len(key_str))
+            _, strs = valuestr_horiz(
+                get_field(data, key), limit_cols - 2 - len(key_str)
+            )
             front.append(key_str + "".join(strs))
 
             which += 1

--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -266,7 +266,7 @@ class SlicingErrorContext(ErrorContext):
         else:
             message = f"Error details: {str(exception)}"
 
-        return f"""cannot slice{location}
+        return f"""while attempting to slice{location}
 
     {self.array}
 

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -478,8 +478,7 @@ class Content:
             )
 
     def __getitem__(self, where):
-        with ak._v2._util.SlicingErrorContext(self, where):
-            return self._getitem(where)
+        return self._getitem(where)
 
     def _getitem(self, where):
         if ak._util.isint(where):

--- a/src/awkward/_v2/contents/listarray.py
+++ b/src/awkward/_v2/contents/listarray.py
@@ -312,7 +312,7 @@ class ListArray(Content):
                     slicestarts.length,
                     self._starts.data,
                     self._stops.data,
-                )
+                ),
             )
 
             asListOffsetArray64 = self.toListOffsetArray64(True)
@@ -553,7 +553,8 @@ class ListArray(Content):
                     self._stops.data,
                     lenstarts,
                     head,
-                )
+                ),
+                head,
             )
             nextcontent = self._content._carry(nextcarry, True)
             return nextcontent._getitem_next(nexthead, nexttail, advanced)

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -347,7 +347,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             self._array = array
 
         def __getitem__(self, where):
-            return ak._v2.operations.structure.mask(self._array, where, True)
+            with ak._v2._util.OperationErrorContext(
+                "ak._v2.Array.mask", {0: self._array, 1: where}
+            ):
+                return ak._v2.operations.structure.mask(self._array, where, True)
 
     @property
     def mask(self):
@@ -948,19 +951,20 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         acting at the last level, while the higher levels of the indexer all
         have the same dimension as the array being indexed.
         """
-        out = self._layout[where]
-        if isinstance(out, ak._v2.contents.NumpyArray):
-            array_param = out.parameter("__array__")
-            if array_param == "byte":
-                return ak._v2._util.tobytes(out.raw(numpy))
-            elif array_param == "char":
-                return ak._v2._util.tobytes(out.raw(numpy)).decode(
-                    errors="surrogateescape"
-                )
-        if isinstance(out, (ak._v2.contents.Content, ak._v2.record.Record)):
-            return ak._v2._util.wrap(out, self._behavior)
-        else:
-            return out
+        with ak._v2._util.SlicingErrorContext(self, where):
+            out = self._layout[where]
+            if isinstance(out, ak._v2.contents.NumpyArray):
+                array_param = out.parameter("__array__")
+                if array_param == "byte":
+                    return ak._v2._util.tobytes(out.raw(numpy))
+                elif array_param == "char":
+                    return ak._v2._util.tobytes(out.raw(numpy)).decode(
+                        errors="surrogateescape"
+                    )
+            if isinstance(out, (ak._v2.contents.Content, ak._v2.record.Record)):
+                return ak._v2._util.wrap(out, self._behavior)
+            else:
+                return out
 
     def __setitem__(self, where, what):
         """
@@ -1013,18 +1017,24 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         in-place. (Internally, this method uses #ak.with_field, so performance
         is not a factor in choosing one over the other.)
         """
-        if not (
-            ak._v2._util.isstr(where)
-            or (isinstance(where, tuple) and all(ak._v2._util.isstr(x) for x in where))
+        with ak._v2._util.OperationErrorContext(
+            "ak._v2.Array.__setitem__", {"field_name": where, "field_value": what}
         ):
-            raise ak._v2._util.error(
-                TypeError("only fields may be assigned in-place (by field name)")
-            )
+            if not (
+                ak._v2._util.isstr(where)
+                or (
+                    isinstance(where, tuple)
+                    and all(ak._v2._util.isstr(x) for x in where)
+                )
+            ):
+                raise ak._v2._util.error(
+                    TypeError("only fields may be assigned in-place (by field name)")
+                )
 
-        self._layout = ak._v2.operations.structure.with_field(
-            self._layout, what, where, highlevel=False
-        )
-        self._numbaview = None
+            self._layout = ak._v2.operations.structure.with_field(
+                self._layout, what, where, highlevel=False
+            )
+            self._numbaview = None
 
     def __getattr__(self, where):
         """
@@ -1098,114 +1108,42 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             )
         )
 
-    @property
-    def slot0(self):
-        """
-        Equivalent to #__getitem__ with `"0"`, which selects slot `0` from
-        all tuples.
-
-        Record fields can be accessed from #__getitem__ with strings (see
-        <<projection>>), but tuples only have slot positions, which are
-        0-indexed integers. However, they must also be quoted as strings
-        to avoid confusion with integers as array indexes. Sometimes, though,
-        interleaving integers in strings and integers outside of strings
-        can be confusing in analysis code.
-
-        Record fields can also be accessed as attributes (with limitations),
-        and the distinction between attributes (#__getattr__) and subscripts
-        (#__getitem__) shows up more clearly in dense code. But integers would
-        not be valid attribute names, so they're named #slot0 through #slot9.
-
-        (Tuples with more than 10 slots are rare and can defer to
-        #__getitem__.)
-        """
-        return self["0"]
-
-    @property
-    def slot1(self):
-        """
-        Equivalent to #__getitem__ with `"1"`. See #slot0.
-        """
-        return self["1"]
-
-    @property
-    def slot2(self):
-        """
-        Equivalent to #__getitem__ with `"2"`. See #slot0.
-        """
-        return self["2"]
-
-    @property
-    def slot3(self):
-        """
-        Equivalent to #__getitem__ with `"3"`. See #slot0.
-        """
-        return self["3"]
-
-    @property
-    def slot4(self):
-        """
-        Equivalent to #__getitem__ with `"4"`. See #slot0.
-        """
-        return self["4"]
-
-    @property
-    def slot5(self):
-        """
-        Equivalent to #__getitem__ with `"5"`. See #slot0.
-        """
-        return self["5"]
-
-    @property
-    def slot6(self):
-        """
-        Equivalent to #__getitem__ with `"6"`. See #slot0.
-        """
-        return self["6"]
-
-    @property
-    def slot7(self):
-        """
-        Equivalent to #__getitem__ with `"7"`. See #slot0.
-        """
-        return self["7"]
-
-    @property
-    def slot8(self):
-        """
-        Equivalent to #__getitem__ with `"8"`. See #slot0.
-        """
-        return self["8"]
-
-    @property
-    def slot9(self):
-        """
-        Equivalent to #__getitem__ with `"9"`. See #slot0.
-        """
-        return self["9"]
-
     def __str__(self):
         import awkward._v2._prettyprint
 
         return awkward._v2._prettyprint.valuestr(self, 1, 80)
 
     def __repr__(self):
+        return self._repr(80)
+
+    def _repr(self, limit_cols):
         import awkward._v2._prettyprint
 
         pytype = type(self).__name__
+
         if self._layout.nplike.known_shape and self._layout.nplike.known_data:
-            valuestr = " " + awkward._v2._prettyprint.valuestr(self, 1, 50)
             typestr = repr(str(self.type))[1:-1]
+            strwidth = max(
+                0, min(40, limit_cols - len(pytype) - len(" type='...'") - 3)
+            )
+            if len(pytype) - len(" type=''") - len(typestr) - 3 < limit_cols:
+                strwidth = max(
+                    0, limit_cols - len(pytype) - len(" type=''") - len(typestr) - 3
+                )
+            valuestr = " " + awkward._v2._prettyprint.valuestr(self, 1, strwidth)
+
         else:
-            valuestr = "-typetracer"
             typestr = repr(
                 "?? * " + str(self._layout.form.type_from_behavior(self._behavior))
             )[1:-1]
-        length = max(10, 80 - len(pytype) - 10 - len(valuestr))
+            valuestr = "-typetracer"
+
+        length = max(3, limit_cols - len(pytype) - len("type='...'") - len(valuestr))
         if len(typestr) > length:
             typestr = "'" + typestr[: length - 3] + "...'"
         else:
             typestr = "'" + typestr + "'"
+
         return f"<{pytype}{valuestr} type={typestr}>"
 
     def show(self, limit_rows=20, limit_cols=80, type=False, stream=sys.stdout):
@@ -1693,19 +1631,20 @@ class Record(NDArrayOperatorsMixin):
             >>> record["y", 1]
             2
         """
-        out = self._layout[where]
-        if isinstance(out, ak._v2.contents.NumpyArray):
-            array_param = out.parameter("__array__")
-            if array_param == "byte":
-                return ak._v2._util.tobytes(out.raw(numpy))
-            elif array_param == "char":
-                return ak._v2._util.tobytes(out.raw(numpy)).decode(
-                    errors="surrogateescape"
-                )
-        if isinstance(out, (ak._v2.contents.Content, ak._v2.record.Record)):
-            return ak._v2._util.wrap(out, self._behavior)
-        else:
-            return out
+        with ak._v2._util.SlicingErrorContext(self, where):
+            out = self._layout[where]
+            if isinstance(out, ak._v2.contents.NumpyArray):
+                array_param = out.parameter("__array__")
+                if array_param == "byte":
+                    return ak._v2._util.tobytes(out.raw(numpy))
+                elif array_param == "char":
+                    return ak._v2._util.tobytes(out.raw(numpy)).decode(
+                        errors="surrogateescape"
+                    )
+            if isinstance(out, (ak._v2.contents.Content, ak._v2.record.Record)):
+                return ak._v2._util.wrap(out, self._behavior)
+            else:
+                return out
 
     def __setitem__(self, where, what):
         """
@@ -1725,18 +1664,24 @@ class Record(NDArrayOperatorsMixin):
         in-place. (Internally, this method uses #ak.with_field, so performance
         is not a factor in choosing one over the other.)
         """
-        if not (
-            ak._v2._util.isstr(where)
-            or (isinstance(where, tuple) and all(ak._v2._util.isstr(x) for x in where))
+        with ak._v2._util.OperationErrorContext(
+            "ak._v2.Record.__setitem__", {"field_name": where, "field_value": what}
         ):
-            raise ak._v2._util.error(
-                TypeError("only fields may be assigned in-place (by field name)")
-            )
+            if not (
+                ak._v2._util.isstr(where)
+                or (
+                    isinstance(where, tuple)
+                    and all(ak._v2._util.isstr(x) for x in where)
+                )
+            ):
+                raise ak._v2._util.error(
+                    TypeError("only fields may be assigned in-place (by field name)")
+                )
 
-        self._layout = ak._v2.operations.structure.with_field(
-            self._layout, what, where, highlevel=False
-        )
-        self._numbaview = None
+            self._layout = ak._v2.operations.structure.with_field(
+                self._layout, what, where, highlevel=False
+            )
+            self._numbaview = None
 
     def __getattr__(self, where):
         """
@@ -1799,131 +1744,45 @@ class Record(NDArrayOperatorsMixin):
             )
         )
 
-    @property
-    def slot0(self):
-        """
-        Equivalent to #__getitem__ with `"0"`, which selects slot `0` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["0"]
-
-    @property
-    def slot1(self):
-        """
-        Equivalent to #__getitem__ with `"1"`, which selects slot `1` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["1"]
-
-    @property
-    def slot2(self):
-        """
-        Equivalent to #__getitem__ with `"2"`, which selects slot `2` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["2"]
-
-    @property
-    def slot3(self):
-        """
-        Equivalent to #__getitem__ with `"3"`, which selects slot `3` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["3"]
-
-    @property
-    def slot4(self):
-        """
-        Equivalent to #__getitem__ with `"4"`, which selects slot `4` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["4"]
-
-    @property
-    def slot5(self):
-        """
-        Equivalent to #__getitem__ with `"5"`, which selects slot `5` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["5"]
-
-    @property
-    def slot6(self):
-        """
-        Equivalent to #__getitem__ with `"6"`, which selects slot `6` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["6"]
-
-    @property
-    def slot7(self):
-        """
-        Equivalent to #__getitem__ with `"7"`, which selects slot `7` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["7"]
-
-    @property
-    def slot8(self):
-        """
-        Equivalent to #__getitem__ with `"8"`, which selects slot `8` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["8"]
-
-    @property
-    def slot9(self):
-        """
-        Equivalent to #__getitem__ with `"9"`, which selects slot `9` from
-        the Record as a tuple.
-
-        See #ak.Array.slot0 for a more complete description.
-        """
-        return self["9"]
-
     def __str__(self):
         import awkward._v2._prettyprint
 
         return awkward._v2._prettyprint.valuestr(self, 1, 80)
 
     def __repr__(self):
+        return self._repr(80)
+
+    def _repr(self, limit_cols):
         import awkward._v2._prettyprint
 
         pytype = type(self).__name__
+
         if (
             self._layout.array.nplike.known_shape
             and self._layout.array.nplike.known_data
         ):
-            valuestr = " " + awkward._v2._prettyprint.valuestr(self, 1, 50)
             typestr = repr(str(self.type))[1:-1]
+            strwidth = max(
+                0, min(40, limit_cols - len(pytype) - len(" type='...'") - 3)
+            )
+            if len(pytype) - len(" type=''") - len(typestr) - 3 < limit_cols:
+                strwidth = max(
+                    0, limit_cols - len(pytype) - len(" type=''") - len(typestr) - 3
+                )
+            valuestr = " " + awkward._v2._prettyprint.valuestr(self, 1, strwidth)
+
         else:
+            typestr = repr(str(self._layout.form.type_from_behavior(self._behavior)))[
+                1:-1
+            ]
             valuestr = "-typetracer"
-            typestr = repr(
-                str(self._layout.array.form.type_from_behavior(self._behavior))
-            )[1:-1]
-        length = max(10, 80 - len(pytype) - 10 - len(valuestr))
+
+        length = max(3, limit_cols - len(pytype) - len("type='...'") - len(valuestr))
         if len(typestr) > length:
             typestr = "'" + typestr[: length - 3] + "...'"
         else:
             typestr = "'" + typestr + "'"
+
         return f"<{pytype}{valuestr} type={typestr}>"
 
     def show(self, limit_rows=20, limit_cols=80, type=False, stream=sys.stdout):
@@ -2293,9 +2152,12 @@ class ArrayBuilder(Sized):
         return self.__repr__()
 
     def __repr__(self):
+        return self._repr(80)
+
+    def _repr(self, limit_cols):
         typestr = repr(self.typestr)
 
-        limit_type = 80 - len("<ArrayBuilder type=>")
+        limit_type = limit_cols - len("<ArrayBuilder type=>")
         if len(typestr) > limit_type:
             typestr = typestr[: (limit_type - 4)] + "..." + typestr[-1]
 

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -1018,7 +1018,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         is not a factor in choosing one over the other.)
         """
         with ak._v2._util.OperationErrorContext(
-            "ak._v2.Array.__setitem__", {"field_name": where, "field_value": what}
+            "ak._v2.Array.__setitem__",
+            dict(self=self, field_name=where, field_value=what),
         ):
             if not (
                 ak._v2._util.isstr(where)
@@ -1665,7 +1666,8 @@ class Record(NDArrayOperatorsMixin):
         is not a factor in choosing one over the other.)
         """
         with ak._v2._util.OperationErrorContext(
-            "ak._v2.Record.__setitem__", {"field_name": where, "field_value": what}
+            "ak._v2.Record.__setitem__",
+            dict(self=self, field_name=where, field_value=what),
         ):
             if not (
                 ak._v2._util.isstr(where)

--- a/src/awkward/_v2/operations/convert/ak_to_layout.py
+++ b/src/awkward/_v2/operations/convert/ak_to_layout.py
@@ -48,8 +48,13 @@ def _impl(array, allow_record, allow_other, numpytype):
     if isinstance(array, ak._v2.contents.Content):
         return array
 
-    elif allow_record and isinstance(array, ak._v2.record.Record):
-        return array
+    elif isinstance(array, ak._v2.record.Record):
+        if not allow_record:
+            raise ak._v2._util.error(
+                TypeError("ak._v2.Record objects are not allowed here")
+            )
+        else:
+            return array
 
     elif isinstance(array, ak._v2.highlevel.Array):
         return array.layout

--- a/src/awkward/_v2/operations/structure/ak_mask.py
+++ b/src/awkward/_v2/operations/structure/ak_mask.py
@@ -119,10 +119,10 @@ def _impl(array, mask, valid_when, highlevel, behavior):
             return None
 
     layoutarray = ak._v2.operations.convert.to_layout(
-        array, allow_record=True, allow_other=False
+        array, allow_record=False, allow_other=False
     )
     layoutmask = ak._v2.operations.convert.to_layout(
-        mask, allow_record=True, allow_other=False
+        mask, allow_record=False, allow_other=False
     )
 
     behavior = ak._v2._util.behavior_of(array, mask, behavior=behavior)

--- a/src/awkward/_v2/types/recordtype.py
+++ b/src/awkward/_v2/types/recordtype.py
@@ -89,7 +89,15 @@ class RecordType(Type):
                     else:
                         out = name + "[" + ", ".join(children) + "]"
                 else:
-                    pairs = [k + ": " + v for k, v in zip(self._fields, children)]
+                    pairs = []
+                    for k, v in zip(self._fields, children):
+                        if ak._v2._prettyprint.is_identifier.match(k) is None:
+                            key_str = repr(k)
+                            if key_str.startswith("u"):
+                                key_str = key_str[1:]
+                        else:
+                            key_str = k
+                        pairs.append(key_str + ": " + v)
                     if name is None:
                         out = "{" + ", ".join(pairs) + "}"
                     else:

--- a/tests/v2/test_0013-error-handling-struct.py
+++ b/tests/v2/test_0013-error-handling-struct.py
@@ -120,16 +120,16 @@ def test_listarray_numpyarray():
     content = ak._v2.contents.NumpyArray(np.arange(10) * 1.1)
     array = ak._v2.contents.ListArray(starts, stops, content)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array[2, 20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array[2, -20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array[1:][2, 20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array[1:][2, -20]
 
     with pytest.raises(ValueError):
@@ -165,7 +165,7 @@ def test_listarray_listarray_numpyarray():
             20,
         ]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[2, 20]
 
     with pytest.raises(IndexError):
@@ -176,10 +176,10 @@ def test_listarray_listarray_numpyarray():
             -20,
         ]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[2, -20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[1, 0, 20]
 
     with pytest.raises(IndexError):
@@ -190,10 +190,10 @@ def test_listarray_listarray_numpyarray():
             20,
         ]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[2, 20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[1:][2, 20]
 
     with pytest.raises(IndexError):
@@ -204,17 +204,17 @@ def test_listarray_listarray_numpyarray():
             -20,
         ]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[2, -20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[1:][2, -20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[1, 0, 20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[1:][2, 0, 20]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         array2[:, 1:][3, 0, 20]

--- a/tests/v2/test_0021-emptyarray.py
+++ b/tests/v2/test_0021-emptyarray.py
@@ -67,7 +67,7 @@ def test_getitem():
 
     assert to_list(a[2, 1]) == []
     assert a.typetracer[2, 1].form == a[2, 1].form
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         a[2, 1, 0]
     assert to_list(a[2, 1][()]) == []
     assert a.typetracer[2, 1][()].form == a[2, 1][()].form
@@ -102,7 +102,7 @@ def test_getitem():
 
     assert to_list(a[1:, 1:]) == [[[]], [[], []]]
     assert a.typetracer[1:, 1:].form == a[1:, 1:].form
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         a[1:, 1:, 0]
 
 
@@ -151,14 +151,14 @@ def test_from_json_getitem():
     assert a[2].tolist() == [[], [], []]
 
     assert a[2, 1].tolist() == []
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(IndexError) as excinfo:
         a[2, 1, 0]
     assert "index out of range while attempting to get index 0" in str(excinfo.value)
     assert a[2, 1][()].tolist() == []
     with pytest.raises(IndexError) as excinfo:
         a[2, 1][0]
     assert (
-        "cannot slice\n\n    <Array [] type='0 * unknown'>\n\nwith\n\n    0\n\nat inner EmptyArray of length 0, using sub-slice 0.\n\nError details: array is empty."
+        "<Array [] type='0 * unknown'>\n\nwith\n\n    0\n\nat inner EmptyArray of length 0, using sub-slice 0.\n\nError details: array is empty."
         in str(excinfo.value)
     )
     assert a[2, 1][100:200].tolist() == []
@@ -171,13 +171,13 @@ def test_from_json_getitem():
     with pytest.raises(IndexError) as excinfo:
         a[2, 1][100:200, 0]
     assert (
-        "cannot slice\n\n    <Array [] type='0 * unknown'>\n\nwith\n\n    (100:200, 0)\n\nat inner EmptyArray of length 0, using sub-slice 0.\n\nError details: array is empty."
+        "<Array [] type='0 * unknown'>\n\nwith\n\n    (100:200, 0)\n\nat inner EmptyArray of length 0, using sub-slice 0.\n\nError details: array is empty."
         in str(excinfo.value)
     )
     with pytest.raises(IndexError) as excinfo:
         a[2, 1][100:200, 200:300]
     assert (
-        "cannot slice\n\n    <Array [] type='0 * unknown'>\n\nwith\n\n    (100:200, 200:300)\n\nat inner EmptyArray of length 0, using sub-slice 200:300.\n\nError details: array is empty."
+        "<Array [] type='0 * unknown'>\n\nwith\n\n    (100:200, 200:300)\n\nat inner EmptyArray of length 0, using sub-slice 200:300.\n\nError details: array is empty."
         in str(excinfo.value)
     )
 
@@ -187,6 +187,6 @@ def test_from_json_getitem():
     # assert ", too many dimensions in slice" in str(excinfo.value)
 
     assert a[1:, 1:].tolist() == [[[]], [[], []]]
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(IndexError) as excinfo:
         a[1:, 1:, 0]
     assert "index out of range while attempting to get index 0" in str(excinfo.value)


### PR DESCRIPTION
Since operations on the GPU accumulate a list of ErrorContexts, it's important that these don't carry any references to the arrays themselves. Otherwise, it would be called a memory leak.

("Would be called" is appropriate phrasing, since it's a matter of opinion! But we can expect users to find it very surprising that temporary arrays, no longer needed for computation, are still in memory because we thought we would need to print them out in an error message.)

For the future: it will also be important for those GPU arrays to not print their contents, like the typetracer handling in `__repr__`.

This touches a lot of things because a few "print-out bugs" were discovered via testing ("print-out bugs" only affect the way a `__repr__` looks, not the underlying data), use of ErrorContexts were made a bit more consistent (every high-level operation should have one, and no mid-level operation should), and I refactored the ErrorContexts to contain their own `format_exception` handlers (a point raised by @agoose77).