### PR TITLE
Implement `recursively_apply` for `Record`

### DIFF
--- a/src/awkward/_v2/record.py
+++ b/src/awkward/_v2/record.py
@@ -212,42 +212,23 @@ class Record:
         }
 
         if return_array:
-
-            def continuation():
-                return Record(
-                    self._array._recursively_apply(
-                        action,
-                        1,
-                        copy.copy(depth_context),
-                        lateral_context,
-                        options,
-                    ),
-                    self._at,
-                )
-
-        else:
-
-            def continuation():
+            return Record(
                 self._array._recursively_apply(
                     action,
                     1,
-                    copy.copy(depth_context),
+                    depth_context,
                     lateral_context,
                     options,
-                )
+                ),
+                self._at,
+            )
 
-        result = action(
-            self,
-            depth=1,
-            depth_context=depth_context,
-            lateral_context=lateral_context,
-            continuation=continuation,
-            options=options,
+        self._array._recursively_apply(
+            action,
+            1,
+            depth_context,
+            lateral_context,
+            options,
         )
 
-        if isinstance(result, Record):
-            return result
-        elif result is None:
-            return continuation()
-        else:
-            raise ak._v2._util.error(AssertionError(result))
+        return None

--- a/src/awkward/_v2/record.py
+++ b/src/awkward/_v2/record.py
@@ -204,31 +204,29 @@ class Record:
         return_array=True,
         function_name=None,
     ):
-        options = {
-            "keep_parameters": keep_parameters,
-            "numpy_to_regular": numpy_to_regular,
-            "return_array": return_array,
-            "function_name": function_name,
-        }
 
         if return_array:
             return Record(
-                self._array._recursively_apply(
+                self._array.recursively_apply(
                     action,
-                    1,
                     depth_context,
                     lateral_context,
-                    options,
+                    keep_parameters,
+                    numpy_to_regular,
+                    True,
+                    function_name,
                 ),
                 self._at,
             )
 
-        self._array._recursively_apply(
+        self._array.recursively_apply(
             action,
-            1,
             depth_context,
             lateral_context,
-            options,
+            keep_parameters,
+            numpy_to_regular,
+            False,
+            function_name,
         )
 
         return None

--- a/src/awkward/_v2/record.py
+++ b/src/awkward/_v2/record.py
@@ -205,28 +205,17 @@ class Record:
         function_name=None,
     ):
 
-        if return_array:
-            return Record(
-                self._array.recursively_apply(
-                    action,
-                    depth_context,
-                    lateral_context,
-                    keep_parameters,
-                    numpy_to_regular,
-                    True,
-                    function_name,
-                ),
-                self._at,
-            )
-
-        self._array.recursively_apply(
+        out = self._array.recursively_apply(
             action,
             depth_context,
             lateral_context,
             keep_parameters,
             numpy_to_regular,
-            False,
+            return_array,
             function_name,
         )
 
-        return None
+        if return_array:
+            return Record(out, self._at)
+        else:
+            return None

--- a/tests/v2/test_1400-with_name-record.py
+++ b/tests/v2/test_1400-with_name-record.py
@@ -1,0 +1,10 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    record = ak._v2.with_name(ak._v2.Record({"x": 10.0}), "X")
+    assert ak._v2.parameters(record) == {"__record__": "X"}


### PR DESCRIPTION
Fixes #1400

As per the discussion below, `Record.recursively_apply` is a top-level function that just forwards the `_recursively_apply` call to the content.