### PR TITLE
Pretty-printing types

### DIFF
--- a/src/awkward/_v2/types/arraytype.py
+++ b/src/awkward/_v2/types/arraytype.py
@@ -35,7 +35,10 @@ class ArrayType:
         return self._length
 
     def __str__(self):
-        return str(self._length) + " * " + str(self._content)
+        return "".join(self._str("", True))
+
+    def _str(self, indent, compact):
+        return [str(self._length) + " * "] + self._content._str(indent, compact)
 
     def __repr__(self):
         args = [repr(self._content), repr(self._length)]

--- a/src/awkward/_v2/types/arraytype.py
+++ b/src/awkward/_v2/types/arraytype.py
@@ -1,5 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import sys
+
 import awkward as ak
 import awkward._v2.types.type
 from awkward._v2.forms.form import _parameters_equal
@@ -36,6 +38,9 @@ class ArrayType:
 
     def __str__(self):
         return "".join(self._str("", True))
+
+    def show(self, stream=sys.stdout):
+        stream.write("".join(self._str("", False) + ["\n"]))
 
     def _str(self, indent, compact):
         return [str(self._length) + " * "] + self._content._str(indent, compact)

--- a/src/awkward/_v2/types/listtype.py
+++ b/src/awkward/_v2/types/listtype.py
@@ -39,24 +39,26 @@ class ListType(Type):
     def content(self):
         return self._content
 
-    def __str__(self):
+    def _str(self, indent, compact):
         if self._typestr is not None:
-            out = self._typestr
+            out = [self._typestr]
 
         elif self.parameter("__array__") == "string":
-            return "string"
+            return ["string"]
 
         elif self.parameter("__array__") == "bytestring":
-            return "bytes"
+            return ["bytes"]
 
         else:
             params = self._str_parameters()
             if params is None:
-                out = f"var * {str(self._content)}"
+                out = ["var * "] + self._content._str(indent, compact)
             else:
-                out = f"[var * {str(self._content)}, {params}]"
+                out = (
+                    ["[var * "] + self._content._str(indent, compact) + [f", {params}]"]
+                )
 
-        return self._str_categorical_begin() + out + self._str_categorical_end()
+        return [self._str_categorical_begin()] + out + [self._str_categorical_end()]
 
     def __repr__(self):
         args = [repr(self._content)] + self._repr_args()

--- a/src/awkward/_v2/types/numpytype.py
+++ b/src/awkward/_v2/types/numpytype.py
@@ -122,15 +122,15 @@ class NumpyType(Type):
 
     _str_parameters_exclude = ("__categorical__", "__unit__")
 
-    def __str__(self):
+    def _str(self, indent, compact):
         if self._typestr is not None:
-            out = self._typestr
+            out = [self._typestr]
 
         elif self.parameter("__array__") == "char":
-            out = "char"
+            out = ["char"]
 
         elif self.parameter("__array__") == "byte":
-            out = "byte"
+            out = ["byte"]
 
         else:
             if self.parameter("__unit__") is not None:
@@ -143,7 +143,7 @@ class NumpyType(Type):
             params = self._str_parameters()
 
             if units is None and params is None:
-                out = self._primitive
+                out = [self._primitive]
             else:
                 if units is not None and params is not None:
                     units = units + ", "
@@ -151,9 +151,9 @@ class NumpyType(Type):
                     units = ""
                 elif params is None:
                     params = ""
-                out = self._primitive + "[" + units + params + "]"
+                out = [self._primitive, "[", units, params, "]"]
 
-        return self._str_categorical_begin() + out + self._str_categorical_end()
+        return [self._str_categorical_begin()] + out + [self._str_categorical_end()]
 
     def __repr__(self):
         args = [repr(self._primitive)] + self._repr_args()

--- a/src/awkward/_v2/types/optiontype.py
+++ b/src/awkward/_v2/types/optiontype.py
@@ -42,21 +42,23 @@ class OptionType(Type):
     def content(self):
         return self._content
 
-    def __str__(self):
+    def _str(self, indent, compact):
         if self._typestr is not None:
-            out = self._typestr
+            out = [self._typestr]
 
         else:
             params = self._str_parameters()
             if params is None:
                 if not isinstance(self._content, (RegularType, ListType)):
-                    out = f"?{str(self._content)}"
+                    out = ["?"] + self._content._str(indent, compact)
                 else:
-                    out = f"option[{str(self._content)}]"
+                    out = ["option["] + self._content._str(indent, compact) + ["]"]
             else:
-                out = f"option[{str(self._content)}, {params}]"
+                out = (
+                    ["option["] + self._content._str(indent, compact) + [f", {params}]"]
+                )
 
-        return self._str_categorical_begin() + out + self._str_categorical_end()
+        return [self._str_categorical_begin()] + out + [self._str_categorical_end()]
 
     def __repr__(self):
         args = [repr(self._content)] + self._repr_args()

--- a/src/awkward/_v2/types/regulartype.py
+++ b/src/awkward/_v2/types/regulartype.py
@@ -52,24 +52,28 @@ class RegularType(Type):
     def size(self):
         return self._size
 
-    def __str__(self):
+    def _str(self, indent, compact):
         if self._typestr is not None:
-            out = self._typestr
+            out = [self._typestr]
 
         elif self.parameter("__array__") == "string":
-            return f"string[{self._size}]"
+            return [f"string[{self._size}]"]
 
         elif self.parameter("__array__") == "bytestring":
-            return f"bytes[{self._size}]"
+            return [f"bytes[{self._size}]"]
 
         else:
             params = self._str_parameters()
             if params is None:
-                out = f"{self._size} * {str(self._content)}"
+                out = [str(self._size), " * "] + self._content._str(indent, compact)
             else:
-                out = f"[{self._size} * {str(self._content)}, {params}]"
+                out = (
+                    ["[", str(self._size), " * "]
+                    + self._content._str(indent, compact)
+                    + [", ", params, "]"]
+                )
 
-        return self._str_categorical_begin() + out + self._str_categorical_end()
+        return [self._str_categorical_begin()] + out + [self._str_categorical_end()]
 
     def __repr__(self):
         args = [repr(self._content), repr(self._size)] + self._repr_args()

--- a/src/awkward/_v2/types/type.py
+++ b/src/awkward/_v2/types/type.py
@@ -22,6 +22,9 @@ class Type:
     def typestr(self):
         return self._typestr
 
+    def __str__(self):
+        return "".join(self._str("", True))
+
     _str_parameters_exclude = ("__categorical__",)
 
     def _str_categorical_begin(self):

--- a/src/awkward/_v2/types/type.py
+++ b/src/awkward/_v2/types/type.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import json
+import sys
 
 import awkward as ak
 
@@ -24,6 +25,9 @@ class Type:
 
     def __str__(self):
         return "".join(self._str("", True))
+
+    def show(self, stream=sys.stdout):
+        stream.write("".join(self._str("", False) + ["\n"]))
 
     _str_parameters_exclude = ("__categorical__",)
 

--- a/src/awkward/_v2/types/uniontype.py
+++ b/src/awkward/_v2/types/uniontype.py
@@ -52,20 +52,21 @@ class UnionType(Type):
     def contents(self):
         return self._contents
 
-    def __str__(self):
+    def _str(self, indent, compact):
         if self._typestr is not None:
-            out = self._typestr
+            out = [self._typestr]
 
         else:
-            children = [str(x) for x in self._contents]
+            children = [x._str(indent, compact) for x in self._contents]
+            with_commas = [y for x in children for y in x + [", "]][:-1]
             params = self._str_parameters()
 
             if params is None:
-                out = "union[{}]".format(", ".join(children))
+                out = ["union["] + with_commas + ["]"]
             else:
-                out = "union[{}, {}]".format(", ".join(children), params)
+                out = ["union["] + with_commas + [", ", params, "]"]
 
-        return self._str_categorical_begin() + out + self._str_categorical_end()
+        return [self._str_categorical_begin()] + out + [self._str_categorical_end()]
 
     def __repr__(self):
         args = [repr(self._contents)] + self._repr_args()

--- a/src/awkward/_v2/types/uniontype.py
+++ b/src/awkward/_v2/types/uniontype.py
@@ -57,14 +57,32 @@ class UnionType(Type):
             out = [self._typestr]
 
         else:
-            children = [x._str(indent, compact) for x in self._contents]
-            with_commas = [y for x in children for y in x + [", "]][:-1]
+            if compact:
+                pre, post = "", ""
+            else:
+                pre, post = "\n" + indent + "    ", "\n" + indent
+
+            children = []
+            for i, x in enumerate(self._contents):
+                if i + 1 < len(self._contents):
+                    if compact:
+                        y = x._str(indent, compact) + [", "]
+                    else:
+                        y = x._str(indent + "    ", compact) + [",\n", indent, "    "]
+                else:
+                    if compact:
+                        y = x._str(indent, compact)
+                    else:
+                        y = x._str(indent + "    ", compact)
+                children.append(y)
+
+            flat_children = [y for x in children for y in x]
             params = self._str_parameters()
 
             if params is None:
-                out = ["union["] + with_commas + ["]"]
+                out = ["union[", pre] + flat_children + [post, "]"]
             else:
-                out = ["union["] + with_commas + [", ", params, "]"]
+                out = ["union[", pre] + flat_children + [", ", post, params, "]"]
 
         return [self._str_categorical_begin()] + out + [self._str_categorical_end()]
 

--- a/src/awkward/_v2/types/unknowntype.py
+++ b/src/awkward/_v2/types/unknowntype.py
@@ -26,18 +26,18 @@ class UnknownType(Type):
         self._parameters = parameters
         self._typestr = typestr
 
-    def __str__(self):
+    def _str(self, indent, compact):
         if self._typestr is not None:
-            out = self._typestr
+            out = [self._typestr]
 
         else:
             params = self._str_parameters()
             if params is None:
-                out = "unknown"
+                out = ["unknown"]
             else:
-                out = "unknown[" + params + "]"
+                out = ["unknown[", params, "]"]
 
-        return self._str_categorical_begin() + out + self._str_categorical_end()
+        return [self._str_categorical_begin()] + out + [self._str_categorical_end()]
 
     def __repr__(self):
         args = self._repr_args()

--- a/tests/v2/test_0914-types-and-forms.py
+++ b/tests/v2/test_0914-types-and-forms.py
@@ -660,7 +660,7 @@ def test_RecordType():
                 {"x": 123},
             )
         )
-        == 'struct[["x", "y"], [unknown, bool], parameters={"x": 123}]'
+        == 'struct[{x: unknown, y: bool}, parameters={"x": 123}]'
     )
     assert (
         str(
@@ -876,7 +876,7 @@ def test_RecordType():
                 {"x": 123, "__categorical__": True},
             )
         )
-        == 'categorical[type=struct[["x", "y"], [unknown, bool], parameters={"x": 123}]]'
+        == 'categorical[type=struct[{x: unknown, y: bool}, parameters={"x": 123}]]'
     )
     assert (
         str(


### PR DESCRIPTION
For example,

```python
>>> import awkward._v2 as ak
>>> expert_fields = ak.from_parquet("s3://pivarski-princeton/argo-floats-expert.parquet", row_groups=[0])

>>> print(expert_fields.type)
10000 * {latitude: float64, longitude: float64, time: datetime64[us], levels: var * {pres: float32,
pres_adjusted: float32, pres_adjusted_error: float32, pres_adjusted_qc: string, pres_qc: string,
psal: float32, psal_adjusted: float32, psal_adjusted_error: float32, psal_adjusted_qc: string,
psal_qc: string, temp: float32, temp_adjusted: float32, temp_adjusted_error: float32,
temp_adjusted_qc: string, temp_qc: string}, config_mission_number: int32, cycle_number: int32,
data_centre: string, data_mode: string, data_state_indicator: string, dc_reference: string,
direction: string, firmware_version: string, float_serial_no: string, pi_name: string,
platform_number: int32, platform_type: string, positioning_system: string, position_qc: string,
profile_pres_qc: string, profile_psal_qc: string, profile_temp_qc: string, project_name: string,
time_location: datetime64[us], time_qc: string, vertical_sampling_scheme: string, wmo_inst_type: int16}

>>> expert_fields.type.show()
10000 * {
    latitude: float64,
    longitude: float64,
    time: datetime64[us],
    levels: var * {
        pres: float32,
        pres_adjusted: float32,
        pres_adjusted_error: float32,
        pres_adjusted_qc: string,
        pres_qc: string,
        psal: float32,
        psal_adjusted: float32,
        psal_adjusted_error: float32,
        psal_adjusted_qc: string,
        psal_qc: string,
        temp: float32,
        temp_adjusted: float32,
        temp_adjusted_error: float32,
        temp_adjusted_qc: string,
        temp_qc: string
    },
    config_mission_number: int32,
    cycle_number: int32,
    data_centre: string,
    data_mode: string,
    data_state_indicator: string,
    dc_reference: string,
    direction: string,
    firmware_version: string,
    float_serial_no: string,
    pi_name: string,
    platform_number: int32,
    platform_type: string,
    positioning_system: string,
    position_qc: string,
    profile_pres_qc: string,
    profile_psal_qc: string,
    profile_temp_qc: string,
    project_name: string,
    time_location: datetime64[us],
    time_qc: string,
    vertical_sampling_scheme: string,
    wmo_inst_type: int16
}
```