### PR TITLE
Rename low-level methods to match high-level function names.

### DIFF
--- a/src/awkward/_v2/_slicing.py
+++ b/src/awkward/_v2/_slicing.py
@@ -295,7 +295,7 @@ def prepare_tuple_bool_to_int(item):
         and issubclass(item.content.dtype.type, (bool, np.bool_))
     ):
         if item.nplike.known_data or item.nplike.known_shape:
-            localindex = item.localindex(axis=1)
+            localindex = item.local_index(axis=1)
             nextcontent = localindex.content.data[item.content.data]
 
             cumsum = item.nplike.empty(item.content.data.shape[0] + 1, np.int64)
@@ -337,7 +337,7 @@ def prepare_tuple_bool_to_int(item):
                     safeindex.shape[0], np.bool_
                 )
 
-            localindex = item.localindex(axis=1)
+            localindex = item.local_index(axis=1)
 
             # nextcontent does not include missing values
             expanded[isnegative] = False

--- a/src/awkward/_v2/contents/bitmaskedarray.py
+++ b/src/awkward/_v2/contents/bitmaskedarray.py
@@ -414,8 +414,8 @@ class BitMaskedArray(Content):
     def fillna(self, value):
         return self.toIndexedOptionArray64().fillna(value)
 
-    def _localindex(self, axis, depth):
-        return self.toByteMaskedArray()._localindex(axis, depth)
+    def _local_index(self, axis, depth):
+        return self.toByteMaskedArray()._local_index(axis, depth)
 
     def numbers_to_type(self, name):
         return self.toByteMaskedArray().numbers_to_type(name)

--- a/src/awkward/_v2/contents/bitmaskedarray.py
+++ b/src/awkward/_v2/contents/bitmaskedarray.py
@@ -526,8 +526,8 @@ class BitMaskedArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
-        return self.toByteMaskedArray()._rpad(target, axis, depth, clip)
+    def _pad_none(self, target, axis, depth, clip):
+        return self.toByteMaskedArray()._pad_none(target, axis, depth, clip)
 
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         return self.toByteMaskedArray()._to_arrow(

--- a/src/awkward/_v2/contents/bitmaskedarray.py
+++ b/src/awkward/_v2/contents/bitmaskedarray.py
@@ -501,7 +501,7 @@ class BitMaskedArray(Content):
             keepdims,
         )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         if self.mask.length * 8 < self.length:
             return f'at {path} ("{type(self)}"): len(mask) * 8 < length'
         elif self._content.length < self.length:
@@ -518,7 +518,7 @@ class BitMaskedArray(Content):
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
         else:
-            return self._content.validityerror(path + ".content")
+            return self._content.validity_error(path + ".content")
 
     def _nbytes_part(self):
         result = self.mask._nbytes_part() + self.content._nbytes_part()

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -878,10 +878,10 @@ class ByteMaskedArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self.rpad_axis0(target, clip)
+            return self.pad_none_axis0(target, clip)
         elif posaxis == depth + 1:
             mask = ak._v2.index.Index8(self.mask_as_bool(valid_when=False))
             index = ak._v2.index.Index64.empty(mask.length, self._nplike)
@@ -897,7 +897,7 @@ class ByteMaskedArray(Content):
                     self._mask.length,
                 )
             )
-            next = self.project()._rpad(target, posaxis, depth, clip)
+            next = self.project()._pad_none(target, posaxis, depth, clip)
             return ak._v2.contents.indexedoptionarray.IndexedOptionArray(
                 index,
                 next,
@@ -908,7 +908,7 @@ class ByteMaskedArray(Content):
         else:
             return ak._v2.contents.bytemaskedarray.ByteMaskedArray(
                 self._mask,
-                self._content._rpad(target, posaxis, depth, clip),
+                self._content._pad_none(target, posaxis, depth, clip),
                 self._valid_when,
                 None,
                 self._parameters,

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -855,7 +855,7 @@ class ByteMaskedArray(Content):
                     )
                 )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         if self._nplike.known_shape and self._content.length < self.mask.length:
             return f'at {path} ("{type(self)}"): len(content) < len(mask)'
         elif isinstance(
@@ -870,7 +870,7 @@ class ByteMaskedArray(Content):
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
         else:
-            return self._content.validityerror(path + ".content")
+            return self._content.validity_error(path + ".content")
 
     def _nbytes_part(self):
         result = self.mask._nbytes_part() + self.content._nbytes_part()

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -590,16 +590,16 @@ class ByteMaskedArray(Content):
     def fillna(self, value):
         return self.toIndexedOptionArray64().fillna(value)
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         else:
             numnull = ak._v2.index.Index64.empty(1, self._nplike)
             nextcarry, outindex = self._nextcarry_outindex(numnull)
 
             next = self._content._carry(nextcarry, False)
-            out = next._localindex(posaxis, depth)
+            out = next._local_index(posaxis, depth)
             out2 = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
                 outindex,
                 out,

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1462,7 +1462,7 @@ class Content:
         else:
             return self._to_nplike(ak._v2._util.regularize_backend(backend))
 
-    def withparameter(self, key, value):
+    def with_parameter(self, key, value):
         out = copy.copy(self)
 
         if self._parameters is None:

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1235,7 +1235,7 @@ class Content:
     def dimension_optiontype(self):
         return self.Form.dimension_optiontype.__get__(self)
 
-    def rpad_axis0(self, target, clip):
+    def pad_none_axis0(self, target, clip):
         if not clip and target < self.length:
             index = ak._v2.index.Index64(
                 self._nplike.arange(self.length, dtype=np.int64)
@@ -1261,8 +1261,8 @@ class Content:
         )
         return next.simplify_optiontype()
 
-    def rpad(self, length, axis, clip=False):
-        return self._rpad(length, axis, 0, clip)
+    def pad_none(self, length, axis, clip=False):
+        return self._pad_none(length, axis, 0, clip)
 
     def to_arrow(
         self,

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1040,7 +1040,7 @@ class Content:
                 )
         return self._combinations(n, replacement, recordlookup, parameters, axis, 0)
 
-    def validityerror_parameters(self, path):
+    def validity_error_parameters(self, path):
         if self.parameter("__array__") == "string":
             content = None
             if isinstance(
@@ -1140,11 +1140,11 @@ class Content:
 
         return ""
 
-    def validityerror(self, path="layout"):
-        paramcheck = self.validityerror_parameters(path)
+    def validity_error(self, path="layout"):
+        paramcheck = self.validity_error_parameters(path)
         if paramcheck != "":
             return paramcheck
-        return self._validityerror(path)
+        return self._validity_error(path)
 
     @property
     def nbytes(self):

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -691,7 +691,7 @@ class Content:
 
         return axis
 
-    def _localindex_axis0(self):
+    def _local_index_axis0(self):
         localindex = ak._v2.index.Index64.empty(self.length, self._nplike)
         self._handle_error(
             self._nplike["awkward_localindex", np.int64](
@@ -790,8 +790,8 @@ class Content:
 
         return (head, tail)
 
-    def localindex(self, axis):
-        return self._localindex(axis, 0)
+    def local_index(self, axis):
+        return self._local_index(axis, 0)
 
     def _reduce(self, reducer, axis=-1, mask=True, keepdims=False):
         if axis is None:

--- a/src/awkward/_v2/contents/emptyarray.py
+++ b/src/awkward/_v2/contents/emptyarray.py
@@ -261,14 +261,14 @@ class EmptyArray(Content):
             return self.identifier._nbytes_part()
         return 0
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis != depth:
             raise ak._v2._util.error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array({depth})")
             )
         else:
-            return self.rpad_axis0(target, True)
+            return self.pad_none_axis0(target, True)
 
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         if options["emptyarray_to"] is None:

--- a/src/awkward/_v2/contents/emptyarray.py
+++ b/src/awkward/_v2/contents/emptyarray.py
@@ -253,7 +253,7 @@ class EmptyArray(Content):
             keepdims,
         )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         return ""
 
     def _nbytes_part(self):

--- a/src/awkward/_v2/contents/emptyarray.py
+++ b/src/awkward/_v2/contents/emptyarray.py
@@ -179,7 +179,7 @@ class EmptyArray(Content):
     def fillna(self, value):
         return EmptyArray(None, self._parameters, self._nplike)
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         return ak._v2.contents.numpyarray.NumpyArray(
             self._nplike.empty(0, np.int64), None, None, self._nplike
         )

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -1061,7 +1061,7 @@ class IndexedArray(Content):
                     )
                 )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         error = self._nplike["awkward_IndexedArray_validity", self.index.dtype.type](
             self.index.data, self.index.length, self._content.length, False
         )
@@ -1089,7 +1089,7 @@ class IndexedArray(Content):
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
         else:
-            return self._content.validityerror(path + ".content")
+            return self._content.validity_error(path + ".content")
 
     def _nbytes_part(self):
         result = self.index._nbytes_part() + self.content._nbytes_part()

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -653,12 +653,12 @@ class IndexedArray(Content):
             self._nplike,
         )
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         else:
-            return self.project()._localindex(posaxis, depth)
+            return self.project()._local_index(posaxis, depth)
 
     def _unique_index(self, index, sorted=True):
         next = ak._v2.index.Index64.zeros(self.length, self._nplike)

--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -1097,16 +1097,16 @@ class IndexedArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self.rpad_axis0(target, clip)
+            return self.pad_none_axis0(target, clip)
         elif posaxis == depth + 1:
-            return self.project()._rpad(target, posaxis, depth, clip)
+            return self.project()._pad_none(target, posaxis, depth, clip)
         else:
             return ak._v2.contents.indexedarray.IndexedArray(
                 self._index,
-                self._content._rpad(target, posaxis, depth, clip),
+                self._content._pad_none(target, posaxis, depth, clip),
                 None,
                 self._parameters,
                 self._nplike,

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1426,7 +1426,7 @@ class IndexedOptionArray(Content):
             )
             return out2.simplify_optiontype()
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         assert self.index.nplike is self._nplike
         error = self._nplike["awkward_IndexedArray_validity", self.index.dtype.type](
             self.index.data, self.index.length, self._content.length, True
@@ -1455,7 +1455,7 @@ class IndexedOptionArray(Content):
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
         else:
-            return self._content.validityerror(path + ".content")
+            return self._content.validity_error(path + ".content")
 
     def _nbytes_part(self):
         result = self.index._nbytes_part() + self.content._nbytes_part()

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -764,15 +764,15 @@ class IndexedOptionArray(Content):
         )
         return out.simplify_uniontype(True, True)
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._nplike)
 
             next = self._content._carry(nextcarry, False)
-            out = next._localindex(posaxis, depth)
+            out = next._local_index(posaxis, depth)
             out2 = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
                 outindex,
                 out,

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -1463,10 +1463,10 @@ class IndexedOptionArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self.rpad_axis0(target, clip)
+            return self.pad_none_axis0(target, clip)
         elif posaxis == depth + 1:
             mask = ak._v2.index.Index8(self.mask_as_bool(valid_when=False))
             index = ak._v2.index.Index64.empty(mask.length, self._nplike)
@@ -1478,7 +1478,7 @@ class IndexedOptionArray(Content):
                     mask.dtype.type,
                 ](index.data, mask.data, mask.length)
             )
-            next = self.project()._rpad(target, posaxis, depth, clip)
+            next = self.project()._pad_none(target, posaxis, depth, clip)
             return ak._v2.contents.indexedoptionarray.IndexedOptionArray(
                 index,
                 next,
@@ -1489,7 +1489,7 @@ class IndexedOptionArray(Content):
         else:
             return ak._v2.contents.indexedoptionarray.IndexedOptionArray(
                 self._index,
-                self._content._rpad(target, posaxis, depth, clip),
+                self._content._pad_none(target, posaxis, depth, clip),
                 None,
                 self._parameters,
                 self._nplike,

--- a/src/awkward/_v2/contents/listarray.py
+++ b/src/awkward/_v2/contents/listarray.py
@@ -1243,11 +1243,11 @@ class ListArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         if not clip:
             posaxis = self.axis_wrap_if_negative(axis)
             if posaxis == depth:
-                return self.rpad_axis0(target, clip)
+                return self.pad_none_axis0(target, clip)
             elif posaxis == depth + 1:
                 min_ = ak._v2.index.Index64.empty(1, self._nplike)
                 assert (
@@ -1346,13 +1346,15 @@ class ListArray(Content):
                 return ak._v2.contents.listarray.ListArray(
                     self._starts,
                     self._stops,
-                    self._content._rpad(target, posaxis, depth + 1, clip),
+                    self._content._pad_none(target, posaxis, depth + 1, clip),
                     None,
                     self._parameters,
                     self._nplike,
                 )
         else:
-            return self.toListOffsetArray64(True)._rpad(target, axis, depth, clip=True)
+            return self.toListOffsetArray64(True)._pad_none(
+                target, axis, depth, clip=True
+            )
 
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         return self.toListOffsetArray64(False)._to_arrow(

--- a/src/awkward/_v2/contents/listarray.py
+++ b/src/awkward/_v2/contents/listarray.py
@@ -1201,7 +1201,7 @@ class ListArray(Content):
             keepdims,
         )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         if self._nplike.known_shape and self.stops.length < self.starts.length:
             return f'at {path} ("{type(self)}"): len(stops) < len(starts)'
         assert self.starts.nplike is self._nplike and self.stops.nplike is self._nplike
@@ -1231,7 +1231,7 @@ class ListArray(Content):
             ):
                 return ""
             else:
-                return self._content.validityerror(path + ".content")
+                return self._content.validity_error(path + ".content")
 
     def _nbytes_part(self):
         result = (

--- a/src/awkward/_v2/contents/listarray.py
+++ b/src/awkward/_v2/contents/listarray.py
@@ -1069,10 +1069,10 @@ class ListArray(Content):
             self._nplike,
         )
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         elif posaxis == depth + 1:
             offsets = self._compact_offsets64(True)
             if self._nplike.known_data:
@@ -1103,7 +1103,7 @@ class ListArray(Content):
             return ak._v2.contents.listarray.ListArray(
                 self._starts,
                 self._stops,
-                self._content._localindex(posaxis, depth + 1),
+                self._content._local_index(posaxis, depth + 1),
                 self._identifier,
                 self._parameters,
                 self._nplike,

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -753,10 +753,10 @@ class ListOffsetArray(Content):
             self._nplike,
         )
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         elif posaxis == depth + 1:
             offsets = self._compact_offsets64(True)
             if self._nplike.known_data:
@@ -786,7 +786,7 @@ class ListOffsetArray(Content):
         else:
             return ak._v2.contents.listoffsetarray.ListOffsetArray(
                 self._offsets,
-                self._content._localindex(posaxis, depth + 1),
+                self._content._local_index(posaxis, depth + 1),
                 self._identifier,
                 self._parameters,
                 self._nplike,

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -1763,10 +1763,10 @@ class ListOffsetArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self.rpad_axis0(target, clip)
+            return self.pad_none_axis0(target, clip)
         if posaxis == depth + 1:
             if not clip:
                 tolength = ak._v2.index.Index64.empty(1, self._nplike)
@@ -1882,7 +1882,7 @@ class ListOffsetArray(Content):
         else:
             return ak._v2.contents.listoffsetarray.ListOffsetArray(
                 self._offsets,
-                self._content._rpad(target, posaxis, depth + 1, clip),
+                self._content._pad_none(target, posaxis, depth + 1, clip),
                 None,
                 self._parameters,
                 self._nplike,

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -1725,7 +1725,7 @@ class ListOffsetArray(Content):
             nextstarts,
         )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         if self.offsets.length < 1:
             return f'at {path} ("{type(self)}"): len(offsets) < 1'
         assert self.starts.nplike is self._nplike and self.stops.nplike is self._nplike
@@ -1755,7 +1755,7 @@ class ListOffsetArray(Content):
             ):
                 return ""
             else:
-                return self._content.validityerror(path + ".content")
+                return self._content.validity_error(path + ".content")
 
     def _nbytes_part(self):
         result = self.offsets._nbytes_part() + self.content._nbytes_part()

--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -1197,11 +1197,11 @@ class NumpyArray(Content):
                 return f'at {path} ("{type(self)}"): shape[{i}] % itemsize != 0'
         return ""
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         if len(self.shape) == 0:
-            raise ak._v2._util.error(ValueError("cannot rpad a scalar"))
+            raise ak._v2._util.error(ValueError("cannot apply ak.pad_none to a scalar"))
         elif len(self.shape) > 1 or not self.is_contiguous:
-            return self.toRegularArray()._rpad(target, axis, depth, clip)
+            return self.toRegularArray()._pad_none(target, axis, depth, clip)
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis != depth:
             raise ak._v2._util.error(
@@ -1211,9 +1211,9 @@ class NumpyArray(Content):
             if target < self.length:
                 return self
             else:
-                return self._rpad(target, posaxis, depth, clip=True)
+                return self._pad_none(target, posaxis, depth, clip=True)
         else:
-            return self.rpad_axis0(target, clip=True)
+            return self.pad_none_axis0(target, clip=True)
 
     def _nbytes_part(self):
         result = self.data.nbytes

--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -1186,7 +1186,7 @@ class NumpyArray(Content):
 
         return out
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         if len(self.shape) == 0:
             return f'at {path} ("{type(self)}"): shape is zero-dimensional'
         for i, dim in enumerate(self.shape):

--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -501,14 +501,16 @@ class NumpyArray(Content):
     def fillna(self, value):
         return self
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         elif len(self.shape) <= 1:
-            raise ak._v2._util.error(np.AxisError("'axis' out of range for localindex"))
+            raise ak._v2._util.error(
+                np.AxisError("'axis' out of range for local_index")
+            )
         else:
-            return self.toRegularArray()._localindex(posaxis, depth)
+            return self.toRegularArray()._local_index(posaxis, depth)
 
     def contiguous(self):
         if self.is_contiguous:

--- a/src/awkward/_v2/contents/recordarray.py
+++ b/src/awkward/_v2/contents/recordarray.py
@@ -690,14 +690,14 @@ class RecordArray(Content):
             self._nplike,
         )
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._localindex(posaxis, depth))
+                contents.append(content._local_index(posaxis, depth))
             return RecordArray(
                 contents,
                 self._fields,

--- a/src/awkward/_v2/contents/recordarray.py
+++ b/src/awkward/_v2/contents/recordarray.py
@@ -843,14 +843,14 @@ class RecordArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self.rpad_axis0(target, clip)
+            return self.pad_none_axis0(target, clip)
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._rpad(target, posaxis, depth, clip))
+                contents.append(content._pad_none(target, posaxis, depth, clip))
             if len(contents) == 0:
                 return ak._v2.contents.recordarray.RecordArray(
                     contents,

--- a/src/awkward/_v2/contents/recordarray.py
+++ b/src/awkward/_v2/contents/recordarray.py
@@ -825,12 +825,12 @@ class RecordArray(Content):
             self._nplike,
         )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         for i, cont in enumerate(self.contents):
             if cont.length < self.length:
                 return f'at {path} ("{type(self)}"): len(field({i})) < len(recordarray)'
         for i, cont in enumerate(self.contents):
-            sub = cont.validityerror(f"{path}.field({i})")
+            sub = cont.validity_error(f"{path}.field({i})")
             if sub != "":
                 return sub
         return ""

--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -1024,17 +1024,17 @@ class RegularArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self.rpad_axis0(target, clip)
+            return self.pad_none_axis0(target, clip)
 
         elif posaxis == depth + 1:
             if not clip:
                 if target < self._size:
                     return self
                 else:
-                    return self._rpad(target, posaxis, depth, True)
+                    return self._pad_none(target, posaxis, depth, True)
 
             else:
                 index = ak._v2.index.Index64.empty(self.length * target, self._nplike)
@@ -1062,7 +1062,7 @@ class RegularArray(Content):
 
         else:
             return ak._v2.contents.regulararray.RegularArray(
-                self._content._rpad(target, posaxis, depth + 1, clip),
+                self._content._pad_none(target, posaxis, depth + 1, clip),
                 self._size,
                 self.length,
                 None,

--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -1007,7 +1007,7 @@ class RegularArray(Content):
 
         return out
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         if self.size < 0:
             return f'at {path} ("{type(self)}"): size < 0'
         if (
@@ -1016,7 +1016,7 @@ class RegularArray(Content):
         ):
             return ""
         else:
-            return self._content.validityerror(path + ".content")
+            return self._content.validity_error(path + ".content")
 
     def _nbytes_part(self):
         result = self.content._nbytes_part()

--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -693,10 +693,10 @@ class RegularArray(Content):
             self._nplike,
         )
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         elif posaxis == depth + 1:
             localindex = ak._v2.index.Index64.empty(
                 self._length * self._size, self._nplike
@@ -718,7 +718,7 @@ class RegularArray(Content):
             )
         else:
             return ak._v2.contents.RegularArray(
-                self._content._localindex(posaxis, depth + 1),
+                self._content._local_index(posaxis, depth + 1),
                 self._size,
                 self._length,
                 self._identifier,

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -1183,14 +1183,14 @@ class UnionArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self.rpad_axis0(target, clip)
+            return self.pad_none_axis0(target, clip)
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._rpad(target, posaxis, depth, clip))
+                contents.append(content._pad_none(target, posaxis, depth, clip))
             out = ak._v2.contents.unionarray.UnionArray(
                 self.tags,
                 self.index,

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -1129,7 +1129,7 @@ class UnionArray(Content):
             keepdims,
         )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         for i in range(len(self.contents)):
             if isinstance(self.contents[i], ak._v2.contents.unionarray.UnionArray):
                 return "{} contains {}, the operation that made it might have forgotten to call 'simplify_uniontype'".format(
@@ -1169,7 +1169,7 @@ class UnionArray(Content):
                 )
 
             for i in range(len(self.contents)):
-                sub = self.contents[i].validityerror(path + f".content({i})")
+                sub = self.contents[i].validity_error(path + f".content({i})")
                 if sub != "":
                     return sub
 

--- a/src/awkward/_v2/contents/unionarray.py
+++ b/src/awkward/_v2/contents/unionarray.py
@@ -984,14 +984,14 @@ class UnionArray(Content):
         )
         return out.simplify_uniontype(True, False)
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._localindex(posaxis, depth))
+                contents.append(content._local_index(posaxis, depth))
             return UnionArray(
                 self._tags,
                 self._index,

--- a/src/awkward/_v2/contents/unmaskedarray.py
+++ b/src/awkward/_v2/contents/unmaskedarray.py
@@ -294,13 +294,13 @@ class UnmaskedArray(Content):
     def fillna(self, value):
         return self._content.fillna(value)
 
-    def _localindex(self, axis, depth):
+    def _local_index(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._localindex_axis0()
+            return self._local_index_axis0()
         else:
             return UnmaskedArray(
-                self._content._localindex(posaxis, depth),
+                self._content._local_index(posaxis, depth),
                 self._identifier,
                 self._parameters,
                 self._nplike,

--- a/src/awkward/_v2/contents/unmaskedarray.py
+++ b/src/awkward/_v2/contents/unmaskedarray.py
@@ -442,7 +442,7 @@ class UnmaskedArray(Content):
             keepdims,
         )
 
-    def _validityerror(self, path):
+    def _validity_error(self, path):
         if isinstance(
             self._content,
             (
@@ -455,7 +455,7 @@ class UnmaskedArray(Content):
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
         else:
-            return self._content.validityerror(path + ".content")
+            return self._content.validity_error(path + ".content")
 
     def _nbytes_part(self):
         result = self.content._nbytes_part()

--- a/src/awkward/_v2/contents/unmaskedarray.py
+++ b/src/awkward/_v2/contents/unmaskedarray.py
@@ -463,15 +463,15 @@ class UnmaskedArray(Content):
             result = result + self.identifier._nbytes_part()
         return result
 
-    def _rpad(self, target, axis, depth, clip):
+    def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self.rpad_axis0(target, clip)
+            return self.pad_none_axis0(target, clip)
         elif posaxis == depth + 1:
-            return self._content._rpad(target, posaxis, depth, clip)
+            return self._content._pad_none(target, posaxis, depth, clip)
         else:
             return ak._v2.contents.unmaskedarray.UnmaskedArray(
-                self._content._rpad(target, posaxis, depth, clip),
+                self._content._pad_none(target, posaxis, depth, clip),
                 None,
                 self._parameters,
                 self._nplike,

--- a/src/awkward/_v2/operations/ak_argcartesian.py
+++ b/src/awkward/_v2/operations/ak_argcartesian.py
@@ -91,7 +91,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
         layouts = {
             n: ak._v2.operations.to_layout(
                 x, allow_record=False, allow_other=False
-            ).localindex(axis)
+            ).local_index(axis)
             for n, x in arrays.items()
         }
     else:
@@ -100,7 +100,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
         layouts = [
             ak._v2.operations.to_layout(
                 x, allow_record=False, allow_other=False
-            ).localindex(axis)
+            ).local_index(axis)
             for x in arrays
         ]
 

--- a/src/awkward/_v2/operations/ak_argcombinations.py
+++ b/src/awkward/_v2/operations/ak_argcombinations.py
@@ -92,7 +92,7 @@ def _impl(
     else:
         layout = ak._v2.operations.to_layout(
             array, allow_record=False, allow_other=False
-        ).localindex(axis)
+        ).local_index(axis)
         out = layout.combinations(
             n, replacement=replacement, axis=axis, fields=fields, parameters=parameters
         )

--- a/src/awkward/_v2/operations/ak_local_index.py
+++ b/src/awkward/_v2/operations/ak_local_index.py
@@ -80,5 +80,5 @@ def local_index(array, axis=-1, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     layout = ak._v2.operations.to_layout(array, allow_record=True, allow_other=False)
-    out = layout.localindex(axis)
+    out = layout.local_index(axis)
     return ak._v2._util.wrap(out, behavior, highlevel)

--- a/src/awkward/_v2/operations/ak_pad_none.py
+++ b/src/awkward/_v2/operations/ak_pad_none.py
@@ -137,6 +137,6 @@ def pad_none(array, target, axis=1, clip=False, highlevel=True, behavior=None):
 
 def _impl(array, target, axis, clip, highlevel, behavior):
     layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = layout.rpad(target, axis, clip=clip)
+    out = layout.pad_none(target, axis, clip=clip)
 
     return ak._v2._util.wrap(out, behavior, highlevel)

--- a/src/awkward/_v2/operations/ak_strings_astype.py
+++ b/src/awkward/_v2/operations/ak_strings_astype.py
@@ -59,7 +59,7 @@ def _impl(array, to, highlevel, behavior):
             max_length = ak._v2.operations.max(
                 ak._v2.operations.num(layout, behavior=behavior)
             )
-            regulararray = layout.rpad(max_length, 1)
+            regulararray = layout.pad_none(max_length, 1)
             maskedarray = ak._v2.operations.to_numpy(regulararray, allow_missing=True)
             npstrings = maskedarray.data
             if maskedarray.mask is not False:

--- a/src/awkward/_v2/operations/ak_validity_error.py
+++ b/src/awkward/_v2/operations/ak_validity_error.py
@@ -28,7 +28,7 @@ def validity_error(array, exception=False):
 
 def _impl(array, exception):
     layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = layout.validityerror(path="highlevel")
+    out = layout.validity_error(path="highlevel")
 
     if out not in (None, "") and exception:
         raise ak._v2._util.error(ValueError(out))

--- a/src/awkward/_v2/operations/ak_with_parameter.py
+++ b/src/awkward/_v2/operations/ak_with_parameter.py
@@ -42,7 +42,7 @@ def _impl(array, parameter, value, highlevel, behavior):
     behavior = ak._v2._util.behavior_of(array, behavior=behavior)
     layout = ak._v2.operations.to_layout(array, allow_record=True, allow_other=False)
 
-    out = layout.withparameter(parameter, value)
+    out = layout.with_parameter(parameter, value)
 
     return ak._v2._util.wrap(
         out, ak._v2._util.behavior_of(array, behavior=behavior), highlevel

--- a/src/awkward/_v2/record.py
+++ b/src/awkward/_v2/record.py
@@ -72,8 +72,8 @@ class Record:
         out.append(post)
         return "".join(out)
 
-    def validityerror(self, path="layout.array"):
-        return self._array.validityerror(path)
+    def validity_error(self, path="layout.array"):
+        return self._array.validity_error(path)
 
     @property
     def parameters(self):

--- a/tests/v2/test_0072-fillna-operation.py
+++ b/tests/v2/test_0072-fillna-operation.py
@@ -12,7 +12,7 @@ def test_fillna_empty_array():
     value = ak._v2.contents.NumpyArray(np.array([10]))
 
     assert to_list(empty) == []
-    array = empty.rpad(5, 0)
+    array = empty.pad_none(5, 0)
     assert to_list(array) == [None, None, None, None, None]
     assert to_list(array.fillna(value)) == [10, 10, 10, 10, 10]
 
@@ -21,11 +21,11 @@ def test_fillna_numpy_array():
     content = ak._v2.contents.NumpyArray(np.array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]]))
     value = ak._v2.contents.NumpyArray(np.array([0]))
 
-    array = content.rpad(3, 0)
+    array = content.pad_none(3, 0)
     assert to_list(array) == [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], None]
     assert to_list(array.fillna(value)) == [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], 0]
 
-    array = content.rpad(5, 1)
+    array = content.pad_none(5, 1)
     assert to_list(array) == [
         [1.1, 2.2, 3.3, None, None],
         [4.4, 5.5, 6.6, None, None],
@@ -115,7 +115,7 @@ def test_fillna_unionarray():
 
     assert to_list(array) == [[], [2, 2], [1.1], [1], [2.2, 2.2], []]
 
-    padded_array = array.rpad(2, 1)
+    padded_array = array.pad_none(2, 1)
     assert to_list(padded_array) == [
         [None, None],
         [2, 2],

--- a/tests/v2/test_0078-argcross-and-cross.py
+++ b/tests/v2/test_0078-argcross-and-cross.py
@@ -316,16 +316,16 @@ def test_localindex():
     array = ak._v2.operations.from_iter(
         [[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]], highlevel=False
     )
-    assert to_list(array.localindex(0)) == [0, 1, 2, 3, 4]
-    assert to_list(array.localindex(1)) == [[0, 1, 2], [], [0, 1], [0], [0, 1, 2, 3]]
+    assert to_list(array.local_index(0)) == [0, 1, 2, 3, 4]
+    assert to_list(array.local_index(1)) == [[0, 1, 2], [], [0, 1], [0], [0, 1, 2, 3]]
 
     array = ak._v2.operations.from_iter(
         [[[0.0, 1.1, 2.2], [], [3.3, 4.4]], [], [[5.5]], [[6.6, 7.7, 8.8, 9.9]]],
         highlevel=False,
     )
-    assert to_list(array.localindex(0)) == [0, 1, 2, 3]
-    assert to_list(array.localindex(1)) == [[0, 1, 2], [], [0], [0]]
-    assert to_list(array.localindex(2)) == [
+    assert to_list(array.local_index(0)) == [0, 1, 2, 3]
+    assert to_list(array.local_index(1)) == [[0, 1, 2], [], [0], [0]]
+    assert to_list(array.local_index(2)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         [[0]],
@@ -335,9 +335,9 @@ def test_localindex():
     array = ak._v2.operations.from_numpy(
         np.arange(2 * 3 * 5).reshape(2, 3, 5), regulararray=True, highlevel=False
     )
-    assert to_list(array.localindex(0)) == [0, 1]
-    assert to_list(array.localindex(1)) == [[0, 1, 2], [0, 1, 2]]
-    assert to_list(array.localindex(2)) == [
+    assert to_list(array.local_index(0)) == [0, 1]
+    assert to_list(array.local_index(1)) == [[0, 1, 2], [0, 1, 2]]
+    assert to_list(array.local_index(2)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]

--- a/tests/v2/test_0127-tomask-operation.py
+++ b/tests/v2/test_0127-tomask-operation.py
@@ -744,18 +744,18 @@ def test_ByteMaskedArray_localindex():
         None,
         [[], [10.0, 11.1, 12.2]],
     ]
-    assert to_list(array.localindex(axis=0)) == [0, 1, 2, 3, 4]
-    assert to_list(array.localindex(axis=-3)) == [0, 1, 2, 3, 4]
-    assert to_list(array.localindex(axis=1)) == [[0, 1, 2], [], None, None, [0, 1]]
-    assert to_list(array.localindex(axis=-2)) == [[0, 1, 2], [], None, None, [0, 1]]
-    assert to_list(array.localindex(axis=2)) == [
+    assert to_list(array.local_index(axis=0)) == [0, 1, 2, 3, 4]
+    assert to_list(array.local_index(axis=-3)) == [0, 1, 2, 3, 4]
+    assert to_list(array.local_index(axis=1)) == [[0, 1, 2], [], None, None, [0, 1]]
+    assert to_list(array.local_index(axis=-2)) == [[0, 1, 2], [], None, None, [0, 1]]
+    assert to_list(array.local_index(axis=2)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         None,
         None,
         [[], [0, 1, 2]],
     ]
-    assert to_list(array.localindex(axis=-1)) == [
+    assert to_list(array.local_index(axis=-1)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         None,

--- a/tests/v2/test_0184-concatenate-operation.py
+++ b/tests/v2/test_0184-concatenate-operation.py
@@ -65,7 +65,7 @@ def test_list_offset_array_concatenate():
     three = ak._v2.contents.ListOffsetArray(offsets_three, one)
     four = ak._v2.contents.ListOffsetArray(offsets_four, two)
 
-    padded_one = one.rpad(7, 0)
+    padded_one = one.pad_none(7, 0)
     assert to_list(padded_one) == [
         [0.0, 1.1, 2.2],
         [],
@@ -116,7 +116,7 @@ def test_list_offset_array_concatenate():
         [],
     ]
 
-    padded = three.rpad(6, 0)
+    padded = three.pad_none(6, 0)
 
     assert to_list(ak._v2.operations.concatenate([padded, four], 1)) == [
         [[0.0, 1.1, 2.2], [], [3.3, 4.4], [0.33], []],

--- a/tests/v2/test_1059-localindex.py
+++ b/tests/v2/test_1059-localindex.py
@@ -11,108 +11,108 @@ def test_listoffsetarray_localindex():
     v2_array = ak._v2.operations.from_iter(
         [[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]], highlevel=False
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3, 4]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == [
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3, 4]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == [
         [0, 1, 2],
         [],
         [0, 1],
         [0],
         [0, 1, 2, 3],
     ]
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(-1)) == [
         [0, 1, 2],
         [],
         [0, 1],
         [0],
         [0, 1, 2, 3],
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == [0, 1, 2, 3, 4]
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == [0, 1, 2, 3, 4]
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-3)
+        v2_array.local_index(-3)
     with pytest.raises(IndexError):
-        v2_array.localindex(2)
+        v2_array.local_index(2)
 
     v2_array = ak._v2.operations.from_iter(
         [[[0.0, 1.1, 2.2], [], [3.3, 4.4]], [], [[5.5]], [[6.6, 7.7, 8.8, 9.9]]],
         highlevel=False,
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == [[0, 1, 2], [], [0], [0]]
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(2)) == [
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == [[0, 1, 2], [], [0], [0]]
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(2)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         [[0]],
         [[0, 1, 2, 3]],
     ]
-    assert v2_array.typetracer.localindex(2).form == v2_array.localindex(2).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(2).form == v2_array.local_index(2).form
+    assert to_list(v2_array.local_index(-1)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         [[0]],
         [[0, 1, 2, 3]],
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == [[0, 1, 2], [], [0], [0]]
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
-    assert to_list(v2_array.localindex(-3)) == [0, 1, 2, 3]
-    assert v2_array.typetracer.localindex(-3).form == v2_array.localindex(-3).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == [[0, 1, 2], [], [0], [0]]
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
+    assert to_list(v2_array.local_index(-3)) == [0, 1, 2, 3]
+    assert v2_array.typetracer.local_index(-3).form == v2_array.local_index(-3).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-4)
+        v2_array.local_index(-4)
     with pytest.raises(IndexError):
-        v2_array.localindex(3)
+        v2_array.local_index(3)
 
 
 def test_regulararray_localindex():
     v2_array = ak._v2.operations.from_numpy(
         np.arange(2 * 3 * 5).reshape(2, 3, 5), regulararray=True, highlevel=False
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == [[0, 1, 2], [0, 1, 2]]
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(2)) == [
+    assert to_list(v2_array.local_index(0)) == [0, 1]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == [[0, 1, 2], [0, 1, 2]]
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(2)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]
-    assert v2_array.typetracer.localindex(2).form == v2_array.localindex(2).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(2).form == v2_array.local_index(2).form
+    assert to_list(v2_array.local_index(-1)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == [[0, 1, 2], [0, 1, 2]]
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
-    assert to_list(v2_array.localindex(-3)) == [0, 1]
-    assert v2_array.typetracer.localindex(-3).form == v2_array.localindex(-3).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == [[0, 1, 2], [0, 1, 2]]
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
+    assert to_list(v2_array.local_index(-3)) == [0, 1]
+    assert v2_array.typetracer.local_index(-3).form == v2_array.local_index(-3).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-4)
+        v2_array.local_index(-4)
     with pytest.raises(IndexError):
-        v2_array.localindex(3)
+        v2_array.local_index(3)
 
     v2_array = ak._v2.operations.from_numpy(
         np.arange(2 * 3 * 5 * 10).reshape(2, 3, 5, 10),
         regulararray=True,
         highlevel=False,
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == [[0, 1, 2], [0, 1, 2]]
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(2)) == [
+    assert to_list(v2_array.local_index(0)) == [0, 1]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == [[0, 1, 2], [0, 1, 2]]
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(2)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]
-    assert v2_array.typetracer.localindex(2).form == v2_array.localindex(2).form
-    assert to_list(v2_array.localindex(3)) == [
+    assert v2_array.typetracer.local_index(2).form == v2_array.local_index(2).form
+    assert to_list(v2_array.local_index(3)) == [
         [
             [
                 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
@@ -160,8 +160,8 @@ def test_regulararray_localindex():
             ],
         ],
     ]
-    assert v2_array.typetracer.localindex(3).form == v2_array.localindex(3).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(3).form == v2_array.local_index(3).form
+    assert to_list(v2_array.local_index(-1)) == [
         [
             [
                 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
@@ -209,21 +209,21 @@ def test_regulararray_localindex():
             ],
         ],
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == [
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
-    assert to_list(v2_array.localindex(-3)) == [[0, 1, 2], [0, 1, 2]]
-    assert v2_array.typetracer.localindex(-3).form == v2_array.localindex(-3).form
-    assert to_list(v2_array.localindex(-4)) == [0, 1]
-    assert v2_array.typetracer.localindex(-4).form == v2_array.localindex(-4).form
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
+    assert to_list(v2_array.local_index(-3)) == [[0, 1, 2], [0, 1, 2]]
+    assert v2_array.typetracer.local_index(-3).form == v2_array.local_index(-3).form
+    assert to_list(v2_array.local_index(-4)) == [0, 1]
+    assert v2_array.typetracer.local_index(-4).form == v2_array.local_index(-4).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-5)
+        v2_array.local_index(-5)
     with pytest.raises(IndexError):
-        v2_array.localindex(4)
+        v2_array.local_index(4)
 
     v2_array = ak._v2.highlevel.Array(
         ak._v2.contents.RegularArray(
@@ -231,23 +231,23 @@ def test_regulararray_localindex():
         )
     ).layout
 
-    assert to_list(v2_array.localindex(0)) == []
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == []
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(2)) == []
-    assert v2_array.typetracer.localindex(2).form == v2_array.localindex(2).form
-    assert to_list(v2_array.localindex(-1)) == []
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == []
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
-    assert to_list(v2_array.localindex(-3)) == []
-    assert v2_array.typetracer.localindex(-3).form == v2_array.localindex(-3).form
+    assert to_list(v2_array.local_index(0)) == []
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == []
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(2)) == []
+    assert v2_array.typetracer.local_index(2).form == v2_array.local_index(2).form
+    assert to_list(v2_array.local_index(-1)) == []
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == []
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
+    assert to_list(v2_array.local_index(-3)) == []
+    assert v2_array.typetracer.local_index(-3).form == v2_array.local_index(-3).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-4)
+        v2_array.local_index(-4)
     with pytest.raises(IndexError):
-        v2_array.localindex(3)
+        v2_array.local_index(3)
 
 
 def test_bytemaskedarray_localindex():
@@ -271,16 +271,17 @@ def test_bytemaskedarray_localindex():
         None,
         [[], [10.0, 11.1, 12.2]],
     ]
-    assert to_list(v2_array.localindex(axis=0)) == [0, 1, 2, 3, 4]
+    assert to_list(v2_array.local_index(axis=0)) == [0, 1, 2, 3, 4]
     assert (
-        v2_array.typetracer.localindex(axis=0).form == v2_array.localindex(axis=0).form
+        v2_array.typetracer.local_index(axis=0).form
+        == v2_array.local_index(axis=0).form
     )
-    assert to_list(v2_array.localindex(axis=-3)) == [0, 1, 2, 3, 4]
+    assert to_list(v2_array.local_index(axis=-3)) == [0, 1, 2, 3, 4]
     assert (
-        v2_array.typetracer.localindex(axis=-3).form
-        == v2_array.localindex(axis=-3).form
+        v2_array.typetracer.local_index(axis=-3).form
+        == v2_array.local_index(axis=-3).form
     )
-    assert to_list(v2_array.localindex(axis=1)) == [
+    assert to_list(v2_array.local_index(axis=1)) == [
         [0, 1, 2],
         [],
         None,
@@ -288,9 +289,10 @@ def test_bytemaskedarray_localindex():
         [0, 1],
     ]
     assert (
-        v2_array.typetracer.localindex(axis=1).form == v2_array.localindex(axis=1).form
+        v2_array.typetracer.local_index(axis=1).form
+        == v2_array.local_index(axis=1).form
     )
-    assert to_list(v2_array.localindex(axis=-2)) == [
+    assert to_list(v2_array.local_index(axis=-2)) == [
         [0, 1, 2],
         [],
         None,
@@ -298,10 +300,10 @@ def test_bytemaskedarray_localindex():
         [0, 1],
     ]
     assert (
-        v2_array.typetracer.localindex(axis=-2).form
-        == v2_array.localindex(axis=-2).form
+        v2_array.typetracer.local_index(axis=-2).form
+        == v2_array.local_index(axis=-2).form
     )
-    assert to_list(v2_array.localindex(axis=2)) == [
+    assert to_list(v2_array.local_index(axis=2)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         None,
@@ -309,9 +311,10 @@ def test_bytemaskedarray_localindex():
         [[], [0, 1, 2]],
     ]
     assert (
-        v2_array.typetracer.localindex(axis=2).form == v2_array.localindex(axis=2).form
+        v2_array.typetracer.local_index(axis=2).form
+        == v2_array.local_index(axis=2).form
     )
-    assert to_list(v2_array.localindex(axis=-1)) == [
+    assert to_list(v2_array.local_index(axis=-1)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         None,
@@ -319,36 +322,37 @@ def test_bytemaskedarray_localindex():
         [[], [0, 1, 2]],
     ]
     assert (
-        v2_array.typetracer.localindex(axis=-1).form
-        == v2_array.localindex(axis=-1).form
+        v2_array.typetracer.local_index(axis=-1).form
+        == v2_array.local_index(axis=-1).form
     )
 
     with pytest.raises(IndexError):
-        v2_array.localindex(axis=4)
+        v2_array.local_index(axis=4)
     with pytest.raises(IndexError):
-        v2_array.localindex(axis=-4)
+        v2_array.local_index(axis=-4)
 
 
 def test_numpyarray_localindex():
     v2_array = ak._v2.contents.numpyarray.NumpyArray(
         np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
     )
-    assert to_list(v2_array.localindex(axis=0)) == [0, 1, 2, 3]
+    assert to_list(v2_array.local_index(axis=0)) == [0, 1, 2, 3]
     assert (
-        v2_array.typetracer.localindex(axis=0).form == v2_array.localindex(axis=0).form
+        v2_array.typetracer.local_index(axis=0).form
+        == v2_array.local_index(axis=0).form
     )
-    assert to_list(v2_array.localindex(axis=-1)) == [0, 1, 2, 3]
+    assert to_list(v2_array.local_index(axis=-1)) == [0, 1, 2, 3]
     assert (
-        v2_array.typetracer.localindex(axis=-1).form
-        == v2_array.localindex(axis=-1).form
+        v2_array.typetracer.local_index(axis=-1).form
+        == v2_array.local_index(axis=-1).form
     )
 
     with pytest.raises(IndexError):
-        v2_array.localindex(axis=1)
+        v2_array.local_index(axis=1)
     with pytest.raises(IndexError):
-        v2_array.localindex(axis=2)
+        v2_array.local_index(axis=2)
     with pytest.raises(IndexError):
-        v2_array.localindex(axis=-2)
+        v2_array.local_index(axis=-2)
 
 
 def test_bitmaskedarray_localindex():
@@ -385,7 +389,7 @@ def test_bitmaskedarray_localindex():
         lsb_order=False,
     )
 
-    assert to_list(v2_array.localindex(0)) == [
+    assert to_list(v2_array.local_index(0)) == [
         0,
         1,
         2,
@@ -400,7 +404,7 @@ def test_bitmaskedarray_localindex():
         11,
         12,
     ]
-    assert to_list(v2_array.localindex(-1)) == [
+    assert to_list(v2_array.local_index(-1)) == [
         0,
         1,
         2,
@@ -415,12 +419,12 @@ def test_bitmaskedarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.bitmaskedarray.BitMaskedArray(
         ak._v2.index.Index(
@@ -455,7 +459,7 @@ def test_bitmaskedarray_localindex():
         lsb_order=False,
     )
 
-    assert to_list(v2_array.localindex(0)) == [
+    assert to_list(v2_array.local_index(0)) == [
         0,
         1,
         2,
@@ -470,8 +474,8 @@ def test_bitmaskedarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [
         0,
         1,
         2,
@@ -486,12 +490,12 @@ def test_bitmaskedarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.bitmaskedarray.BitMaskedArray(
         ak._v2.index.Index(
@@ -528,7 +532,7 @@ def test_bitmaskedarray_localindex():
         length=13,
         lsb_order=True,
     )
-    assert to_list(v2_array.localindex(0)) == [
+    assert to_list(v2_array.local_index(0)) == [
         0,
         1,
         2,
@@ -543,8 +547,8 @@ def test_bitmaskedarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [
         0,
         1,
         2,
@@ -559,12 +563,12 @@ def test_bitmaskedarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
 
 def test_unmaskedarray_localindex():
@@ -573,15 +577,15 @@ def test_unmaskedarray_localindex():
             np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
         )
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [0, 1, 2, 3]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [0, 1, 2, 3]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
 
 def test_unionarray_localindex():
@@ -593,15 +597,15 @@ def test_unionarray_localindex():
             ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
         ],
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3, 4, 5, 6]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [0, 1, 2, 3, 4, 5, 6]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3, 4, 5, 6]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [0, 1, 2, 3, 4, 5, 6]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
 
 def test_recordarray_localindex():
@@ -616,19 +620,19 @@ def test_recordarray_localindex():
         ),
         3,
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == [[0, 1, 2], [0, 1, 2]]
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(-1)) == [[0, 1, 2], [0, 1, 2]]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == [0, 1]
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
+    assert to_list(v2_array.local_index(0)) == [0, 1]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == [[0, 1, 2], [0, 1, 2]]
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(-1)) == [[0, 1, 2], [0, 1, 2]]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == [0, 1]
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-3)
+        v2_array.local_index(-3)
     with pytest.raises(IndexError):
-        v2_array.localindex(2)
+        v2_array.local_index(2)
 
     v2_array = ak._v2.contents.regulararray.RegularArray(  # noqa: F841
         ak._v2.contents.recordarray.RecordArray(
@@ -638,7 +642,7 @@ def test_recordarray_localindex():
         zeros_length=10,
     )
 
-    assert to_list(v2_array.localindex(0)) == [
+    assert to_list(v2_array.local_index(0)) == [
         0,
         1,
         2,
@@ -650,8 +654,8 @@ def test_recordarray_localindex():
         8,
         9,
     ]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == [
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == [
         [],
         [],
         [],
@@ -663,8 +667,8 @@ def test_recordarray_localindex():
         [],
         [],
     ]
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(-1)) == [
         [],
         [],
         [],
@@ -676,8 +680,8 @@ def test_recordarray_localindex():
         [],
         [],
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == [
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == [
         0,
         1,
         2,
@@ -689,10 +693,10 @@ def test_recordarray_localindex():
         8,
         9,
     ]
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-3)
+        v2_array.local_index(-3)
 
     v2_array = ak._v2.contents.listarray.ListArray(  # noqa: F841
         ak._v2.index.Index(np.array([4, 100, 1])),
@@ -707,19 +711,19 @@ def test_recordarray_localindex():
         ),
     )
 
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == [[0, 1, 2], [], [0, 1]]
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(-1)) == [[0, 1, 2], [], [0, 1]]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == [0, 1, 2]
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == [[0, 1, 2], [], [0, 1]]
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(-1)) == [[0, 1, 2], [], [0, 1]]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == [0, 1, 2]
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-3)
+        v2_array.local_index(-3)
     with pytest.raises(IndexError):
-        v2_array.localindex(2)
+        v2_array.local_index(2)
 
     v2_array = ak._v2.contents.listoffsetarray.ListOffsetArray(  # noqa: F841
         ak._v2.index.Index(np.array([1, 4, 4, 6])),
@@ -732,19 +736,19 @@ def test_recordarray_localindex():
             ["nest"],
         ),
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(1)) == [[0, 1, 2], [], [0, 1]]
-    assert v2_array.typetracer.localindex(1).form == v2_array.localindex(1).form
-    assert to_list(v2_array.localindex(-1)) == [[0, 1, 2], [], [0, 1]]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
-    assert to_list(v2_array.localindex(-2)) == [0, 1, 2]
-    assert v2_array.typetracer.localindex(-2).form == v2_array.localindex(-2).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(1)) == [[0, 1, 2], [], [0, 1]]
+    assert v2_array.typetracer.local_index(1).form == v2_array.local_index(1).form
+    assert to_list(v2_array.local_index(-1)) == [[0, 1, 2], [], [0, 1]]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
+    assert to_list(v2_array.local_index(-2)) == [0, 1, 2]
+    assert v2_array.typetracer.local_index(-2).form == v2_array.local_index(-2).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-3)
+        v2_array.local_index(-3)
     with pytest.raises(IndexError):
-        v2_array.localindex(2)
+        v2_array.local_index(2)
 
     v2_array = ak._v2.contents.indexedarray.IndexedArray(  # noqa: F841
         ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
@@ -757,15 +761,15 @@ def test_recordarray_localindex():
             ["nest"],
         ),
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3, 4, 5, 6]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [0, 1, 2, 3, 4, 5, 6]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3, 4, 5, 6]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [0, 1, 2, 3, 4, 5, 6]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.indexedoptionarray.IndexedOptionArray(  # noqa: F841
         ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
@@ -778,15 +782,15 @@ def test_recordarray_localindex():
             ["nest"],
         ),
     )
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3, 4, 5, 6]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [0, 1, 2, 3, 4, 5, 6]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3, 4, 5, 6]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [0, 1, 2, 3, 4, 5, 6]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.bytemaskedarray.ByteMaskedArray(  # noqa: F841
         ak._v2.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
@@ -801,15 +805,15 @@ def test_recordarray_localindex():
         valid_when=True,
     )
 
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3, 4]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [0, 1, 2, 3, 4]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3, 4]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [0, 1, 2, 3, 4]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.bytemaskedarray.ByteMaskedArray(  # noqa: F841
         ak._v2.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
@@ -824,15 +828,15 @@ def test_recordarray_localindex():
         valid_when=False,
     )
 
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3, 4]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [0, 1, 2, 3, 4]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3, 4]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [0, 1, 2, 3, 4]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.bitmaskedarray.BitMaskedArray(
         ak._v2.index.Index(
@@ -886,7 +890,7 @@ def test_recordarray_localindex():
         lsb_order=False,
     )
 
-    assert to_list(v2_array.localindex(0)) == [
+    assert to_list(v2_array.local_index(0)) == [
         0,
         1,
         2,
@@ -901,8 +905,8 @@ def test_recordarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [
         0,
         1,
         2,
@@ -917,11 +921,11 @@ def test_recordarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.bitmaskedarray.BitMaskedArray(  # noqa: F841
         ak._v2.index.Index(
@@ -976,7 +980,7 @@ def test_recordarray_localindex():
         lsb_order=False,
     )
 
-    assert to_list(v2_array.localindex(0)) == [
+    assert to_list(v2_array.local_index(0)) == [
         0,
         1,
         2,
@@ -991,8 +995,8 @@ def test_recordarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [
         0,
         1,
         2,
@@ -1007,12 +1011,12 @@ def test_recordarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.bitmaskedarray.BitMaskedArray(  # noqa: F841
         ak._v2.index.Index(
@@ -1070,7 +1074,7 @@ def test_recordarray_localindex():
         lsb_order=True,
     )
 
-    assert to_list(v2_array.localindex(0)) == [
+    assert to_list(v2_array.local_index(0)) == [
         0,
         1,
         2,
@@ -1085,8 +1089,8 @@ def test_recordarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [
         0,
         1,
         2,
@@ -1101,12 +1105,12 @@ def test_recordarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.bitmaskedarray.BitMaskedArray(  # noqa: F841
         ak._v2.index.Index(
@@ -1164,7 +1168,7 @@ def test_recordarray_localindex():
         lsb_order=True,
     )
 
-    assert to_list(v2_array.localindex(0)) == [
+    assert to_list(v2_array.local_index(0)) == [
         0,
         1,
         2,
@@ -1179,8 +1183,8 @@ def test_recordarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [
         0,
         1,
         2,
@@ -1195,12 +1199,12 @@ def test_recordarray_localindex():
         11,
         12,
     ]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.unmaskedarray.UnmaskedArray(  # noqa: F841
         ak._v2.contents.recordarray.RecordArray(
@@ -1213,15 +1217,15 @@ def test_recordarray_localindex():
         )
     )
 
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [0, 1, 2, 3]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [0, 1, 2, 3]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)
 
     v2_array = ak._v2.contents.unionarray.UnionArray(  # noqa: F841
         ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
@@ -1241,12 +1245,12 @@ def test_recordarray_localindex():
         ],
     )
 
-    assert to_list(v2_array.localindex(0)) == [0, 1, 2, 3, 4, 5, 6]
-    assert v2_array.typetracer.localindex(0).form == v2_array.localindex(0).form
-    assert to_list(v2_array.localindex(-1)) == [0, 1, 2, 3, 4, 5, 6]
-    assert v2_array.typetracer.localindex(-1).form == v2_array.localindex(-1).form
+    assert to_list(v2_array.local_index(0)) == [0, 1, 2, 3, 4, 5, 6]
+    assert v2_array.typetracer.local_index(0).form == v2_array.local_index(0).form
+    assert to_list(v2_array.local_index(-1)) == [0, 1, 2, 3, 4, 5, 6]
+    assert v2_array.typetracer.local_index(-1).form == v2_array.local_index(-1).form
 
     with pytest.raises(IndexError):
-        v2_array.localindex(-2)
+        v2_array.local_index(-2)
     with pytest.raises(IndexError):
-        v2_array.localindex(1)
+        v2_array.local_index(1)

--- a/tests/v2/test_1075-validityerror.py
+++ b/tests/v2/test_1075-validityerror.py
@@ -10,8 +10,8 @@ def test_ListOffsetArray():
         [[0.0, 1.1, 2.2, 3.3], [], [4.4, 5.5, 6.6], [7.7], [8.8, 9.9, 10.0, 11.1, 12.2]]
     ).layout
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
     v2_array = ak._v2.highlevel.Array(
         [
@@ -21,8 +21,8 @@ def test_ListOffsetArray():
         ]
     ).layout
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_RegularArray():
@@ -30,15 +30,15 @@ def test_RegularArray():
         np.array([[0.0, 1.1, 2.2, 3.3], [4.4, 5.5, 6.6, 7.7]])
     ).layout
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_NumpyArray():
     v2_array = ak._v2.highlevel.Array([0.0, 1.1, 2.2, 3.3]).layout
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_IndexedArray():
@@ -54,8 +54,8 @@ def test_IndexedArray():
         ]
     ).layout
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_ByteMaskedArray():
@@ -66,8 +66,8 @@ def test_ByteMaskedArray():
     mask = ak._v2.index.Index8(np.array([0, 0, 1, 1, 0], dtype=np.int8))
     v2_array = ak._v2.contents.ByteMaskedArray(mask, content, valid_when=False)
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_IndexedOptionArray():
@@ -78,8 +78,8 @@ def test_IndexedOptionArray():
     index = ak._v2.index.Index64(np.array([0, 1, -1, -1, 4], dtype=np.int64))
     v2_array = ak._v2.contents.IndexedOptionArray(index, content)
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_BitMaskedArray():
@@ -116,15 +116,15 @@ def test_BitMaskedArray():
         lsb_order=False,
     )
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_EmptyArray():
     v2_array = ak._v2.contents.emptyarray.EmptyArray()
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_RecordArray():
@@ -141,8 +141,8 @@ def test_RecordArray():
         ),
     )
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_UnionArray():
@@ -164,8 +164,8 @@ def test_UnionArray():
         ],
     )
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""
 
 
 def test_UnmaskedArray():
@@ -175,5 +175,5 @@ def test_UnmaskedArray():
         )
     )
 
-    assert v2_array.validityerror() == ""
-    assert v2_array.typetracer.validityerror() == ""
+    assert v2_array.validity_error() == ""
+    assert v2_array.typetracer.validity_error() == ""

--- a/tests/v2/test_1135-rpad-operation.py
+++ b/tests/v2/test_1135-rpad-operation.py
@@ -10,11 +10,12 @@ to_list = ak._v2.operations.to_list
 def test_rpad_and_clip_empty_array():
     empty = ak._v2.contents.emptyarray.EmptyArray()
     assert to_list(empty) == []
-    assert to_list(empty.rpad(5, 0)) == [None, None, None, None, None]
-    assert empty.typetracer.rpad(5, 0).form == empty.rpad(5, 0).form
-    assert to_list(empty.rpad(5, 0, clip=True)) == [None, None, None, None, None]
+    assert to_list(empty.pad_none(5, 0)) == [None, None, None, None, None]
+    assert empty.typetracer.pad_none(5, 0).form == empty.pad_none(5, 0).form
+    assert to_list(empty.pad_none(5, 0, clip=True)) == [None, None, None, None, None]
     assert (
-        empty.typetracer.rpad(5, 0, clip=True).form == empty.rpad(5, 0, clip=True).form
+        empty.typetracer.pad_none(5, 0, clip=True).form
+        == empty.pad_none(5, 0, clip=True).form
     )
 
 
@@ -27,7 +28,7 @@ def test_rpad_and_clip_numpy_array():
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
 
-    assert to_list(array.rpad(5, 0, clip=True)) == [
+    assert to_list(array.pad_none(5, 0, clip=True)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
         None,
@@ -35,18 +36,20 @@ def test_rpad_and_clip_numpy_array():
         None,
     ]
     assert (
-        array.typetracer.rpad(5, 0, clip=True).form == array.rpad(5, 0, clip=True).form
+        array.typetracer.pad_none(5, 0, clip=True).form
+        == array.pad_none(5, 0, clip=True).form
     )
 
-    assert to_list(array.rpad(5, 1, clip=True)) == [
+    assert to_list(array.pad_none(5, 1, clip=True)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14], None, None],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29], None, None],
     ]
     assert (
-        array.typetracer.rpad(5, 1, clip=True).form == array.rpad(5, 1, clip=True).form
+        array.typetracer.pad_none(5, 1, clip=True).form
+        == array.pad_none(5, 1, clip=True).form
     )
 
-    assert to_list(array.rpad(7, 2, clip=True)) == [
+    assert to_list(array.pad_none(7, 2, clip=True)) == [
         [
             [0, 1, 2, 3, 4, None, None],
             [5, 6, 7, 8, 9, None, None],
@@ -59,21 +62,23 @@ def test_rpad_and_clip_numpy_array():
         ],
     ]
     assert (
-        array.typetracer.rpad(7, 2, clip=True).form == array.rpad(7, 2, clip=True).form
+        array.typetracer.pad_none(7, 2, clip=True).form
+        == array.pad_none(7, 2, clip=True).form
     )
 
-    assert to_list(array.rpad(2, 2, clip=True)) == [
+    assert to_list(array.pad_none(2, 2, clip=True)) == [
         [[0, 1], [5, 6], [10, 11]],
         [[15, 16], [20, 21], [25, 26]],
     ]
     assert (
-        array.typetracer.rpad(2, 2, clip=True).form == array.rpad(2, 2, clip=True).form
+        array.typetracer.pad_none(2, 2, clip=True).form
+        == array.pad_none(2, 2, clip=True).form
     )
 
 
 def test_rpad_numpy_array():
     array = ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
-    assert to_list(array.rpad(10, 0)) == [
+    assert to_list(array.pad_none(10, 0)) == [
         1.1,
         2.2,
         3.3,
@@ -85,24 +90,24 @@ def test_rpad_numpy_array():
         None,
         None,
     ]
-    assert array.typetracer.rpad(10, 0).form == array.rpad(10, 0).form
+    assert array.typetracer.pad_none(10, 0).form == array.pad_none(10, 0).form
 
     array = ak._v2.contents.numpyarray.NumpyArray(
         np.array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]])
     )
-    assert to_list(array.rpad(5, 0)) == [
+    assert to_list(array.pad_none(5, 0)) == [
         [1.1, 2.2, 3.3],
         [4.4, 5.5, 6.6],
         None,
         None,
         None,
     ]
-    assert array.typetracer.rpad(5, 0).form == array.rpad(5, 0).form
-    assert to_list(array.rpad(5, 1)) == [
+    assert array.typetracer.pad_none(5, 0).form == array.pad_none(5, 0).form
+    assert to_list(array.pad_none(5, 1)) == [
         [1.1, 2.2, 3.3, None, None],
         [4.4, 5.5, 6.6, None, None],
     ]
-    assert array.typetracer.rpad(5, 1).form == array.rpad(5, 1).form
+    assert array.typetracer.pad_none(5, 1).form == array.pad_none(5, 1).form
 
     array = ak._v2.contents.numpyarray.NumpyArray(
         np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
@@ -112,66 +117,66 @@ def test_rpad_numpy_array():
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
 
-    assert to_list(array.rpad(1, 0)) == [
+    assert to_list(array.pad_none(1, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
 
-    assert array.typetracer.rpad(1, 0).form == array.rpad(1, 0).form
-    assert to_list(array.rpad(2, 0)) == [
+    assert array.typetracer.pad_none(1, 0).form == array.pad_none(1, 0).form
+    assert to_list(array.pad_none(2, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert array.typetracer.rpad(2, 0).form == array.rpad(2, 0).form
-    assert to_list(array.rpad(3, 0)) == [
+    assert array.typetracer.pad_none(2, 0).form == array.pad_none(2, 0).form
+    assert to_list(array.pad_none(3, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
         None,
     ]
-    assert array.typetracer.rpad(3, 0).form == array.rpad(3, 0).form
-    assert to_list(array.rpad(4, 0)) == [
-        [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
-        [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
-        None,
-        None,
-    ]
-    assert array.typetracer.rpad(4, 0).form == array.rpad(4, 0).form
-    assert to_list(array.rpad(5, 0)) == [
+    assert array.typetracer.pad_none(3, 0).form == array.pad_none(3, 0).form
+    assert to_list(array.pad_none(4, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
         None,
         None,
+    ]
+    assert array.typetracer.pad_none(4, 0).form == array.pad_none(4, 0).form
+    assert to_list(array.pad_none(5, 0)) == [
+        [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
+        [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
+        None,
+        None,
         None,
     ]
-    assert array.typetracer.rpad(5, 0).form == array.rpad(5, 0).form
+    assert array.typetracer.pad_none(5, 0).form == array.pad_none(5, 0).form
 
-    assert to_list(array.rpad(2, 1)) == [
+    assert to_list(array.pad_none(2, 1)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert to_list(array.rpad(3, 1)) == [
+    assert to_list(array.pad_none(3, 1)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert array.typetracer.rpad(3, 1).form == array.rpad(3, 1).form
-    assert to_list(array.rpad(4, 1)) == [
+    assert array.typetracer.pad_none(3, 1).form == array.pad_none(3, 1).form
+    assert to_list(array.pad_none(4, 1)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14], None],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29], None],
     ]
-    assert array.typetracer.rpad(4, 1).form == array.rpad(4, 1).form
-    assert to_list(array.rpad(5, 1)) == [
+    assert array.typetracer.pad_none(4, 1).form == array.pad_none(4, 1).form
+    assert to_list(array.pad_none(5, 1)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14], None, None],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29], None, None],
     ]
-    assert array.typetracer.rpad(5, 1).form == array.rpad(5, 1).form
+    assert array.typetracer.pad_none(5, 1).form == array.pad_none(5, 1).form
 
-    assert to_list(array.rpad(3, 2)) == [
+    assert to_list(array.pad_none(3, 2)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert array.typetracer.rpad(3, 2).form == array.rpad(3, 2).form
+    assert array.typetracer.pad_none(3, 2).form == array.pad_none(3, 2).form
 
-    assert to_list(array.rpad(7, 2)) == [
+    assert to_list(array.pad_none(7, 2)) == [
         [
             [0, 1, 2, 3, 4, None, None],
             [5, 6, 7, 8, 9, None, None],
@@ -183,13 +188,13 @@ def test_rpad_numpy_array():
             [25, 26, 27, 28, 29, None, None],
         ],
     ]
-    assert array.typetracer.rpad(7, 2).form == array.rpad(7, 2).form
+    assert array.typetracer.pad_none(7, 2).form == array.pad_none(7, 2).form
 
-    assert to_list(array.rpad(2, 2)) == [
+    assert to_list(array.pad_none(2, 2)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert array.typetracer.rpad(2, 2).form == array.rpad(2, 2).form
+    assert array.typetracer.pad_none(2, 2).form == array.pad_none(2, 2).form
 
 
 def test_rpad_and_clip_regular_array():
@@ -224,7 +229,7 @@ def test_rpad_and_clip_regular_array():
     indexedarray = ak._v2.contents.indexedoptionarray.IndexedOptionArray(index, content)
     array = ak._v2.contents.regulararray.RegularArray(indexedarray, 3, zeros_length=0)
 
-    assert to_list(array.rpad(5, 0, clip=True)) == [
+    assert to_list(array.pad_none(5, 0, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
@@ -232,68 +237,81 @@ def test_rpad_and_clip_regular_array():
         None,
     ]
     assert (
-        array.typetracer.rpad(5, 0, clip=True).form == array.rpad(5, 0, clip=True).form
+        array.typetracer.pad_none(5, 0, clip=True).form
+        == array.pad_none(5, 0, clip=True).form
     )
-    assert to_list(array.rpad(4, 0, clip=True)) == [
+    assert to_list(array.pad_none(4, 0, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
         None,
     ]
     assert (
-        array.typetracer.rpad(4, 0, clip=True).form == array.rpad(4, 0, clip=True).form
+        array.typetracer.pad_none(4, 0, clip=True).form
+        == array.pad_none(4, 0, clip=True).form
     )
-    assert to_list(array.rpad(3, 0, clip=True)) == [
+    assert to_list(array.pad_none(3, 0, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
     assert (
-        array.typetracer.rpad(3, 0, clip=True).form == array.rpad(3, 0, clip=True).form
+        array.typetracer.pad_none(3, 0, clip=True).form
+        == array.pad_none(3, 0, clip=True).form
     )
-    assert to_list(array.rpad(2, 0, clip=True)) == [[6.9, 3.9, 6.9], [2.2, 1.5, 1.6]]
+    assert to_list(array.pad_none(2, 0, clip=True)) == [
+        [6.9, 3.9, 6.9],
+        [2.2, 1.5, 1.6],
+    ]
     assert (
-        array.typetracer.rpad(2, 0, clip=True).form == array.rpad(2, 0, clip=True).form
+        array.typetracer.pad_none(2, 0, clip=True).form
+        == array.pad_none(2, 0, clip=True).form
     )
-    assert to_list(array.rpad(1, 0, clip=True)) == [[6.9, 3.9, 6.9]]
+    assert to_list(array.pad_none(1, 0, clip=True)) == [[6.9, 3.9, 6.9]]
     assert (
-        array.typetracer.rpad(1, 0, clip=True).form == array.rpad(1, 0, clip=True).form
+        array.typetracer.pad_none(1, 0, clip=True).form
+        == array.pad_none(1, 0, clip=True).form
     )
-    assert to_list(array.rpad(5, 1, clip=True)) == [
+    assert to_list(array.pad_none(5, 1, clip=True)) == [
         [6.9, 3.9, 6.9, None, None],
         [2.2, 1.5, 1.6, None, None],
         [3.6, None, 6.7, None, None],
     ]
     assert (
-        array.typetracer.rpad(5, 1, clip=True).form == array.rpad(5, 1, clip=True).form
+        array.typetracer.pad_none(5, 1, clip=True).form
+        == array.pad_none(5, 1, clip=True).form
     )
-    assert to_list(array.rpad(4, 1, clip=True)) == [
+    assert to_list(array.pad_none(4, 1, clip=True)) == [
         [6.9, 3.9, 6.9, None],
         [2.2, 1.5, 1.6, None],
         [3.6, None, 6.7, None],
     ]
     assert (
-        array.typetracer.rpad(4, 1, clip=True).form == array.rpad(4, 1, clip=True).form
+        array.typetracer.pad_none(4, 1, clip=True).form
+        == array.pad_none(4, 1, clip=True).form
     )
-    assert to_list(array.rpad(3, 1, clip=True)) == [
+    assert to_list(array.pad_none(3, 1, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
     assert (
-        array.typetracer.rpad(3, 1, clip=True).form == array.rpad(3, 1, clip=True).form
+        array.typetracer.pad_none(3, 1, clip=True).form
+        == array.pad_none(3, 1, clip=True).form
     )
-    assert to_list(array.rpad(2, 1, clip=True)) == [
+    assert to_list(array.pad_none(2, 1, clip=True)) == [
         [6.9, 3.9],
         [2.2, 1.5],
         [3.6, None],
     ]
     assert (
-        array.typetracer.rpad(2, 1, clip=True).form == array.rpad(2, 1, clip=True).form
+        array.typetracer.pad_none(2, 1, clip=True).form
+        == array.pad_none(2, 1, clip=True).form
     )
-    assert to_list(array.rpad(1, 1, clip=True)) == [[6.9], [2.2], [3.6]]
+    assert to_list(array.pad_none(1, 1, clip=True)) == [[6.9], [2.2], [3.6]]
     assert (
-        array.typetracer.rpad(1, 1, clip=True).form == array.rpad(1, 1, clip=True).form
+        array.typetracer.pad_none(1, 1, clip=True).form
+        == array.pad_none(1, 1, clip=True).form
     )
 
     array = ak._v2.contents.numpyarray.NumpyArray(np.arange(2 * 3 * 5).reshape(2, 3, 5))
@@ -302,7 +320,7 @@ def test_rpad_and_clip_regular_array():
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
 
-    assert to_list(array.rpad(7, 2, clip=True)) == [
+    assert to_list(array.pad_none(7, 2, clip=True)) == [
         [
             [0, 1, 2, 3, 4, None, None],
             [5, 6, 7, 8, 9, None, None],
@@ -315,7 +333,8 @@ def test_rpad_and_clip_regular_array():
         ],
     ]
     assert (
-        array.typetracer.rpad(7, 2, clip=True).form == array.rpad(7, 2, clip=True).form
+        array.typetracer.pad_none(7, 2, clip=True).form
+        == array.pad_none(7, 2, clip=True).form
     )
 
     content = ak._v2.contents.numpyarray.NumpyArray(
@@ -327,131 +346,131 @@ def test_rpad_and_clip_regular_array():
         listoffsetarray, 2, zeros_length=0
     )
 
-    assert to_list(regulararray.rpad(1, 0, clip=True)) == [[[0.0, 1.1, 2.2], []]]
+    assert to_list(regulararray.pad_none(1, 0, clip=True)) == [[[0.0, 1.1, 2.2], []]]
     assert (
-        regulararray.typetracer.rpad(1, 0, clip=True).form
-        == regulararray.rpad(1, 0, clip=True).form
+        regulararray.typetracer.pad_none(1, 0, clip=True).form
+        == regulararray.pad_none(1, 0, clip=True).form
     )
-    assert to_list(regulararray.rpad(2, 0, clip=True)) == [
+    assert to_list(regulararray.pad_none(2, 0, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
     ]
     assert (
-        regulararray.typetracer.rpad(2, 0, clip=True).form
-        == regulararray.rpad(2, 0, clip=True).form
+        regulararray.typetracer.pad_none(2, 0, clip=True).form
+        == regulararray.pad_none(2, 0, clip=True).form
     )
-    assert to_list(regulararray.rpad(3, 0, clip=True)) == [
-        [[0.0, 1.1, 2.2], []],
-        [[3.3, 4.4], [5.5]],
-        [[6.6, 7.7, 8.8, 9.9], []],
-    ]
-    assert (
-        regulararray.typetracer.rpad(3, 0, clip=True).form
-        == regulararray.rpad(3, 0, clip=True).form
-    )
-    assert to_list(regulararray.rpad(4, 0, clip=True)) == [
+    assert to_list(regulararray.pad_none(3, 0, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
-        None,
     ]
     assert (
-        regulararray.typetracer.rpad(4, 0, clip=True).form
-        == regulararray.rpad(4, 0, clip=True).form
+        regulararray.typetracer.pad_none(3, 0, clip=True).form
+        == regulararray.pad_none(3, 0, clip=True).form
     )
-    assert to_list(regulararray.rpad(5, 0, clip=True)) == [
+    assert to_list(regulararray.pad_none(4, 0, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
         None,
+    ]
+    assert (
+        regulararray.typetracer.pad_none(4, 0, clip=True).form
+        == regulararray.pad_none(4, 0, clip=True).form
+    )
+    assert to_list(regulararray.pad_none(5, 0, clip=True)) == [
+        [[0.0, 1.1, 2.2], []],
+        [[3.3, 4.4], [5.5]],
+        [[6.6, 7.7, 8.8, 9.9], []],
+        None,
         None,
     ]
     assert (
-        regulararray.typetracer.rpad(5, 0, clip=True).form
-        == regulararray.rpad(5, 0, clip=True).form
+        regulararray.typetracer.pad_none(5, 0, clip=True).form
+        == regulararray.pad_none(5, 0, clip=True).form
     )
 
-    assert to_list(regulararray.rpad(1, 1, clip=True)) == [
+    assert to_list(regulararray.pad_none(1, 1, clip=True)) == [
         [[0.0, 1.1, 2.2]],
         [[3.3, 4.4]],
         [[6.6, 7.7, 8.8, 9.9]],
     ]
     assert (
-        regulararray.typetracer.rpad(1, 1, clip=True).form
-        == regulararray.rpad(1, 1, clip=True).form
+        regulararray.typetracer.pad_none(1, 1, clip=True).form
+        == regulararray.pad_none(1, 1, clip=True).form
     )
-    assert to_list(regulararray.rpad(2, 1, clip=True)) == [
+    assert to_list(regulararray.pad_none(2, 1, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
     assert (
-        regulararray.typetracer.rpad(2, 1, clip=True).form
-        == regulararray.rpad(2, 1, clip=True).form
+        regulararray.typetracer.pad_none(2, 1, clip=True).form
+        == regulararray.pad_none(2, 1, clip=True).form
     )
-    assert to_list(regulararray.rpad(3, 1, clip=True)) == [
+    assert to_list(regulararray.pad_none(3, 1, clip=True)) == [
         [[0.0, 1.1, 2.2], [], None],
         [[3.3, 4.4], [5.5], None],
         [[6.6, 7.7, 8.8, 9.9], [], None],
     ]
     assert (
-        regulararray.typetracer.rpad(3, 1, clip=True).form
-        == regulararray.rpad(3, 1, clip=True).form
+        regulararray.typetracer.pad_none(3, 1, clip=True).form
+        == regulararray.pad_none(3, 1, clip=True).form
     )
-    assert to_list(regulararray.rpad(7, 1, clip=True)) == [
+    assert to_list(regulararray.pad_none(7, 1, clip=True)) == [
         [[0.0, 1.1, 2.2], [], None, None, None, None, None],
         [[3.3, 4.4], [5.5], None, None, None, None, None],
         [[6.6, 7.7, 8.8, 9.9], [], None, None, None, None, None],
     ]
     assert (
-        regulararray.typetracer.rpad(7, 1, clip=True).form
-        == regulararray.rpad(7, 1, clip=True).form
+        regulararray.typetracer.pad_none(7, 1, clip=True).form
+        == regulararray.pad_none(7, 1, clip=True).form
     )
 
-    assert to_list(regulararray.rpad(1, 2, clip=True)) == [
+    assert to_list(regulararray.pad_none(1, 2, clip=True)) == [
         [[0.0], [None]],
         [[3.3], [5.5]],
         [[6.6], [None]],
     ]
     assert (
-        regulararray.typetracer.rpad(1, 2, clip=True).form
-        == regulararray.rpad(1, 2, clip=True).form
+        regulararray.typetracer.pad_none(1, 2, clip=True).form
+        == regulararray.pad_none(1, 2, clip=True).form
     )
-    assert to_list(regulararray.rpad(2, 2, clip=True)) == [
+    assert to_list(regulararray.pad_none(2, 2, clip=True)) == [
         [[0.0, 1.1], [None, None]],
         [[3.3, 4.4], [5.5, None]],
         [[6.6, 7.7], [None, None]],
     ]
     assert (
-        regulararray.typetracer.rpad(2, 2, clip=True).form
-        == regulararray.rpad(2, 2, clip=True).form
+        regulararray.typetracer.pad_none(2, 2, clip=True).form
+        == regulararray.pad_none(2, 2, clip=True).form
     )
-    assert to_list(regulararray.rpad(3, 2, clip=True)) == [
+    assert to_list(regulararray.pad_none(3, 2, clip=True)) == [
         [[0.0, 1.1, 2.2], [None, None, None]],
         [[3.3, 4.4, None], [5.5, None, None]],
         [[6.6, 7.7, 8.8], [None, None, None]],
     ]
     assert (
-        regulararray.typetracer.rpad(3, 2, clip=True).form
-        == regulararray.rpad(3, 2, clip=True).form
+        regulararray.typetracer.pad_none(3, 2, clip=True).form
+        == regulararray.pad_none(3, 2, clip=True).form
     )
-    assert to_list(regulararray.rpad(4, 2, clip=True)) == [
+    assert to_list(regulararray.pad_none(4, 2, clip=True)) == [
         [[0.0, 1.1, 2.2, None], [None, None, None, None]],
         [[3.3, 4.4, None, None], [5.5, None, None, None]],
         [[6.6, 7.7, 8.8, 9.9], [None, None, None, None]],
     ]
     assert (
-        regulararray.typetracer.rpad(4, 2, clip=True).form
-        == regulararray.rpad(4, 2, clip=True).form
+        regulararray.typetracer.pad_none(4, 2, clip=True).form
+        == regulararray.pad_none(4, 2, clip=True).form
     )
-    assert to_list(regulararray.rpad(5, 2, clip=True)) == [
+    assert to_list(regulararray.pad_none(5, 2, clip=True)) == [
         [[0.0, 1.1, 2.2, None, None], [None, None, None, None, None]],
         [[3.3, 4.4, None, None, None], [5.5, None, None, None, None]],
         [[6.6, 7.7, 8.8, 9.9, None], [None, None, None, None, None]],
     ]
     assert (
-        regulararray.typetracer.rpad(5, 2, clip=True).form
-        == regulararray.rpad(5, 2, clip=True).form
+        regulararray.typetracer.pad_none(5, 2, clip=True).form
+        == regulararray.pad_none(5, 2, clip=True).form
     )
 
 
@@ -487,57 +506,57 @@ def test_rpad_regular_array():
     indexedarray = ak._v2.contents.indexedoptionarray.IndexedOptionArray(index, content)
     array = ak._v2.contents.regulararray.RegularArray(indexedarray, 3, zeros_length=0)
 
-    assert to_list(array.rpad(5, 0)) == [
+    assert to_list(array.pad_none(5, 0)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
         None,
         None,
     ]
-    assert array.typetracer.rpad(5, 0).form == array.rpad(5, 0).form
-    assert to_list(array.rpad(4, 0)) == [
+    assert array.typetracer.pad_none(5, 0).form == array.pad_none(5, 0).form
+    assert to_list(array.pad_none(4, 0)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
         None,
     ]
-    assert array.typetracer.rpad(4, 0).form == array.rpad(4, 0).form
-    assert to_list(array.rpad(3, 0)) == [
+    assert array.typetracer.pad_none(4, 0).form == array.pad_none(4, 0).form
+    assert to_list(array.pad_none(3, 0)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert array.typetracer.rpad(3, 0).form == array.rpad(3, 0).form
-    assert to_list(array.rpad(1, 0)) == [
+    assert array.typetracer.pad_none(3, 0).form == array.pad_none(3, 0).form
+    assert to_list(array.pad_none(1, 0)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert array.typetracer.rpad(1, 0).form == array.rpad(1, 0).form
-    assert to_list(array.rpad(5, 1)) == [
+    assert array.typetracer.pad_none(1, 0).form == array.pad_none(1, 0).form
+    assert to_list(array.pad_none(5, 1)) == [
         [6.9, 3.9, 6.9, None, None],
         [2.2, 1.5, 1.6, None, None],
         [3.6, None, 6.7, None, None],
     ]
-    assert array.typetracer.rpad(5, 1).form == array.rpad(5, 1).form
-    assert to_list(array.rpad(4, 1)) == [
+    assert array.typetracer.pad_none(5, 1).form == array.pad_none(5, 1).form
+    assert to_list(array.pad_none(4, 1)) == [
         [6.9, 3.9, 6.9, None],
         [2.2, 1.5, 1.6, None],
         [3.6, None, 6.7, None],
     ]
-    assert array.typetracer.rpad(4, 1).form == array.rpad(4, 1).form
-    assert to_list(array.rpad(3, 1)) == [
+    assert array.typetracer.pad_none(4, 1).form == array.pad_none(4, 1).form
+    assert to_list(array.pad_none(3, 1)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert array.typetracer.rpad(3, 1).form == array.rpad(3, 1).form
-    assert to_list(array.rpad(1, 1)) == [
+    assert array.typetracer.pad_none(3, 1).form == array.pad_none(3, 1).form
+    assert to_list(array.pad_none(1, 1)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert array.typetracer.rpad(1, 1).form == array.rpad(1, 1).form
+    assert array.typetracer.pad_none(1, 1).form == array.pad_none(1, 1).form
 
     content = ak._v2.contents.numpyarray.NumpyArray(
         np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
@@ -548,26 +567,32 @@ def test_rpad_regular_array():
         listoffsetarray, 2, zeros_length=0
     )
 
-    assert to_list(regulararray.rpad(1, 0)) == [
+    assert to_list(regulararray.pad_none(1, 0)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
-    assert regulararray.typetracer.rpad(1, 0).form == regulararray.rpad(1, 0).form
-    assert to_list(regulararray.rpad(3, 0)) == [
+    assert (
+        regulararray.typetracer.pad_none(1, 0).form == regulararray.pad_none(1, 0).form
+    )
+    assert to_list(regulararray.pad_none(3, 0)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
-    assert regulararray.typetracer.rpad(3, 0).form == regulararray.rpad(3, 0).form
-    assert to_list(regulararray.rpad(4, 0)) == [
+    assert (
+        regulararray.typetracer.pad_none(3, 0).form == regulararray.pad_none(3, 0).form
+    )
+    assert to_list(regulararray.pad_none(4, 0)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
         None,
     ]
-    assert regulararray.typetracer.rpad(4, 0).form == regulararray.rpad(4, 0).form
-    assert to_list(regulararray.rpad(7, 0)) == [
+    assert (
+        regulararray.typetracer.pad_none(4, 0).form == regulararray.pad_none(4, 0).form
+    )
+    assert to_list(regulararray.pad_none(7, 0)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
@@ -576,63 +601,83 @@ def test_rpad_regular_array():
         None,
         None,
     ]
-    assert regulararray.typetracer.rpad(7, 0).form == regulararray.rpad(7, 0).form
+    assert (
+        regulararray.typetracer.pad_none(7, 0).form == regulararray.pad_none(7, 0).form
+    )
 
-    assert to_list(regulararray.rpad(1, 1)) == [
+    assert to_list(regulararray.pad_none(1, 1)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
-    assert regulararray.typetracer.rpad(1, 1).form == regulararray.rpad(1, 1).form
-    assert to_list(regulararray.rpad(2, 1)) == [
+    assert (
+        regulararray.typetracer.pad_none(1, 1).form == regulararray.pad_none(1, 1).form
+    )
+    assert to_list(regulararray.pad_none(2, 1)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
-    assert regulararray.typetracer.rpad(2, 1).form == regulararray.rpad(2, 1).form
-    assert to_list(regulararray.rpad(3, 1)) == [
+    assert (
+        regulararray.typetracer.pad_none(2, 1).form == regulararray.pad_none(2, 1).form
+    )
+    assert to_list(regulararray.pad_none(3, 1)) == [
         [[0.0, 1.1, 2.2], [], None],
         [[3.3, 4.4], [5.5], None],
         [[6.6, 7.7, 8.8, 9.9], [], None],
     ]
-    assert regulararray.typetracer.rpad(3, 1).form == regulararray.rpad(3, 1).form
-    assert to_list(regulararray.rpad(5, 1)) == [
+    assert (
+        regulararray.typetracer.pad_none(3, 1).form == regulararray.pad_none(3, 1).form
+    )
+    assert to_list(regulararray.pad_none(5, 1)) == [
         [[0.0, 1.1, 2.2], [], None, None, None],
         [[3.3, 4.4], [5.5], None, None, None],
         [[6.6, 7.7, 8.8, 9.9], [], None, None, None],
     ]
-    assert regulararray.typetracer.rpad(5, 1).form == regulararray.rpad(5, 1).form
-    assert to_list(regulararray.rpad(7, 1)) == [
+    assert (
+        regulararray.typetracer.pad_none(5, 1).form == regulararray.pad_none(5, 1).form
+    )
+    assert to_list(regulararray.pad_none(7, 1)) == [
         [[0.0, 1.1, 2.2], [], None, None, None, None, None],
         [[3.3, 4.4], [5.5], None, None, None, None, None],
         [[6.6, 7.7, 8.8, 9.9], [], None, None, None, None, None],
     ]
-    assert regulararray.typetracer.rpad(7, 1).form == regulararray.rpad(7, 1).form
+    assert (
+        regulararray.typetracer.pad_none(7, 1).form == regulararray.pad_none(7, 1).form
+    )
 
-    assert to_list(regulararray.rpad(1, 2)) == [
+    assert to_list(regulararray.pad_none(1, 2)) == [
         [[0.0, 1.1, 2.2], [None]],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], [None]],
     ]
-    assert regulararray.typetracer.rpad(1, 2).form == regulararray.rpad(1, 2).form
-    assert to_list(regulararray.rpad(2, 2)) == [
+    assert (
+        regulararray.typetracer.pad_none(1, 2).form == regulararray.pad_none(1, 2).form
+    )
+    assert to_list(regulararray.pad_none(2, 2)) == [
         [[0.0, 1.1, 2.2], [None, None]],
         [[3.3, 4.4], [5.5, None]],
         [[6.6, 7.7, 8.8, 9.9], [None, None]],
     ]
-    assert regulararray.typetracer.rpad(2, 2).form == regulararray.rpad(2, 2).form
-    assert to_list(regulararray.rpad(3, 2)) == [
+    assert (
+        regulararray.typetracer.pad_none(2, 2).form == regulararray.pad_none(2, 2).form
+    )
+    assert to_list(regulararray.pad_none(3, 2)) == [
         [[0.0, 1.1, 2.2], [None, None, None]],
         [[3.3, 4.4, None], [5.5, None, None]],
         [[6.6, 7.7, 8.8, 9.9], [None, None, None]],
     ]
-    assert regulararray.typetracer.rpad(3, 2).form == regulararray.rpad(3, 2).form
-    assert to_list(regulararray.rpad(4, 2)) == [
+    assert (
+        regulararray.typetracer.pad_none(3, 2).form == regulararray.pad_none(3, 2).form
+    )
+    assert to_list(regulararray.pad_none(4, 2)) == [
         [[0.0, 1.1, 2.2, None], [None, None, None, None]],
         [[3.3, 4.4, None, None], [5.5, None, None, None]],
         [[6.6, 7.7, 8.8, 9.9], [None, None, None, None]],
     ]
-    assert regulararray.typetracer.rpad(4, 2).form == regulararray.rpad(4, 2).form
+    assert (
+        regulararray.typetracer.pad_none(4, 2).form == regulararray.pad_none(4, 2).form
+    )
 
 
 def test_rpad_and_clip_listoffset_array():
@@ -650,20 +695,20 @@ def test_rpad_and_clip_listoffset_array():
         [],
     ]
 
-    assert to_list(listoffsetarray.rpad(3, 0, clip=True)) == [
+    assert to_list(listoffsetarray.pad_none(3, 0, clip=True)) == [
         [0.0, 1.1, 2.2],
         [],
         [3.3, 4.4],
     ]
     assert (
-        listoffsetarray.typetracer.rpad(3, 0, clip=True).form
-        == listoffsetarray.rpad(3, 0, clip=True).form
+        listoffsetarray.typetracer.pad_none(3, 0, clip=True).form
+        == listoffsetarray.pad_none(3, 0, clip=True).form
     )
     assert "option[" + str(listoffsetarray.form.type) + "]" == str(
-        listoffsetarray.rpad(3, 0, clip=True).form.type
+        listoffsetarray.pad_none(3, 0, clip=True).form.type
     )
 
-    assert to_list(listoffsetarray.rpad(7, 0, clip=True)) == [
+    assert to_list(listoffsetarray.pad_none(7, 0, clip=True)) == [
         [0.0, 1.1, 2.2],
         [],
         [3.3, 4.4],
@@ -673,14 +718,14 @@ def test_rpad_and_clip_listoffset_array():
         None,
     ]
     assert (
-        listoffsetarray.typetracer.rpad(7, 0, clip=True).form
-        == listoffsetarray.rpad(7, 0, clip=True).form
+        listoffsetarray.typetracer.pad_none(7, 0, clip=True).form
+        == listoffsetarray.pad_none(7, 0, clip=True).form
     )
     assert "option[" + str(listoffsetarray.form.type) + "]" == str(
-        listoffsetarray.rpad(7, 0, clip=True).form.type
+        listoffsetarray.pad_none(7, 0, clip=True).form.type
     )
 
-    assert to_list(listoffsetarray.rpad(5, 1, clip=True)) == [
+    assert to_list(listoffsetarray.pad_none(5, 1, clip=True)) == [
         [0.0, 1.1, 2.2, None, None],
         [None, None, None, None, None],
         [3.3, 4.4, None, None, None],
@@ -689,14 +734,14 @@ def test_rpad_and_clip_listoffset_array():
         [None, None, None, None, None],
     ]
     assert (
-        listoffsetarray.typetracer.rpad(5, 1, clip=True).form
-        == listoffsetarray.rpad(5, 1, clip=True).form
+        listoffsetarray.typetracer.pad_none(5, 1, clip=True).form
+        == listoffsetarray.pad_none(5, 1, clip=True).form
     )
 
-    assert str(listoffsetarray.rpad(5, 1).form.type) == "var * ?float64"
-    assert str(listoffsetarray.rpad(5, 1, clip=True).form.type) == "5 * ?float64"
+    assert str(listoffsetarray.pad_none(5, 1).form.type) == "var * ?float64"
+    assert str(listoffsetarray.pad_none(5, 1, clip=True).form.type) == "5 * ?float64"
 
-    assert to_list(listoffsetarray.rpad(1, 1, clip=True)) == [
+    assert to_list(listoffsetarray.pad_none(1, 1, clip=True)) == [
         [0.0],
         [None],
         [3.3],
@@ -705,8 +750,8 @@ def test_rpad_and_clip_listoffset_array():
         [None],
     ]
     assert (
-        listoffsetarray.typetracer.rpad(1, 1, clip=True).form
-        == listoffsetarray.rpad(1, 1, clip=True).form
+        listoffsetarray.typetracer.pad_none(1, 1, clip=True).form
+        == listoffsetarray.pad_none(1, 1, clip=True).form
     )
 
     content = ak._v2.contents.numpyarray.NumpyArray(np.array([1.5, 3.3]))
@@ -757,12 +802,12 @@ def test_rpad_and_clip_listoffset_array():
         [],
         [],
     ]
-    assert to_list(listoffsetarray.rpad(1, 0, clip=True)) == [[3.3]]
+    assert to_list(listoffsetarray.pad_none(1, 0, clip=True)) == [[3.3]]
     assert (
-        listoffsetarray.typetracer.rpad(1, 0, clip=True).form
-        == listoffsetarray.rpad(1, 0, clip=True).form
+        listoffsetarray.typetracer.pad_none(1, 0, clip=True).form
+        == listoffsetarray.pad_none(1, 0, clip=True).form
     )
-    assert to_list(listoffsetarray.rpad(1, 1, clip=True)) == [
+    assert to_list(listoffsetarray.pad_none(1, 1, clip=True)) == [
         [3.3],
         [None],
         [None],
@@ -771,8 +816,8 @@ def test_rpad_and_clip_listoffset_array():
         [None],
     ]
     assert (
-        listoffsetarray.typetracer.rpad(1, 1, clip=True).form
-        == listoffsetarray.rpad(1, 1, clip=True).form
+        listoffsetarray.typetracer.pad_none(1, 1, clip=True).form
+        == listoffsetarray.pad_none(1, 1, clip=True).form
     )
 
 
@@ -792,7 +837,7 @@ def test_rpad_listoffset_array():
         [],
     ]
 
-    assert to_list(listoffsetarray.rpad(3, 0)) == [
+    assert to_list(listoffsetarray.pad_none(3, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [3.3, 4.4],
@@ -800,13 +845,16 @@ def test_rpad_listoffset_array():
         [6.6, 7.7, 8.8, 9.9],
         [],
     ]
-    assert listoffsetarray.typetracer.rpad(3, 0).form == listoffsetarray.rpad(3, 0).form
-
-    assert "option[" + str(ak._v2.operations.type(listoffsetarray)) + "]" == str(
-        ak._v2.operations.type(listoffsetarray.rpad(3, 0))
+    assert (
+        listoffsetarray.typetracer.pad_none(3, 0).form
+        == listoffsetarray.pad_none(3, 0).form
     )
 
-    assert to_list(listoffsetarray.rpad(7, 0)) == [
+    assert "option[" + str(ak._v2.operations.type(listoffsetarray)) + "]" == str(
+        ak._v2.operations.type(listoffsetarray.pad_none(3, 0))
+    )
+
+    assert to_list(listoffsetarray.pad_none(7, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [3.3, 4.4],
@@ -815,13 +863,16 @@ def test_rpad_listoffset_array():
         [],
         None,
     ]
-    assert listoffsetarray.typetracer.rpad(7, 0).form == listoffsetarray.rpad(7, 0).form
-
-    assert "option[" + str(ak._v2.operations.type(listoffsetarray)) + "]" == str(
-        ak._v2.operations.type(listoffsetarray.rpad(7, 0))
+    assert (
+        listoffsetarray.typetracer.pad_none(7, 0).form
+        == listoffsetarray.pad_none(7, 0).form
     )
 
-    assert to_list(listoffsetarray.rpad(5, 1)) == [
+    assert "option[" + str(ak._v2.operations.type(listoffsetarray)) + "]" == str(
+        ak._v2.operations.type(listoffsetarray.pad_none(7, 0))
+    )
+
+    assert to_list(listoffsetarray.pad_none(5, 1)) == [
         [0.0, 1.1, 2.2, None, None],
         [None, None, None, None, None],
         [3.3, 4.4, None, None, None],
@@ -829,10 +880,15 @@ def test_rpad_listoffset_array():
         [6.6, 7.7, 8.8, 9.9, None],
         [None, None, None, None, None],
     ]
-    assert listoffsetarray.typetracer.rpad(5, 1).form == listoffsetarray.rpad(5, 1).form
-    assert str(ak._v2.operations.type(listoffsetarray.rpad(5, 1))) == "var * ?float64"
+    assert (
+        listoffsetarray.typetracer.pad_none(5, 1).form
+        == listoffsetarray.pad_none(5, 1).form
+    )
+    assert (
+        str(ak._v2.operations.type(listoffsetarray.pad_none(5, 1))) == "var * ?float64"
+    )
 
-    assert to_list(listoffsetarray.rpad(1, 1)) == [
+    assert to_list(listoffsetarray.pad_none(1, 1)) == [
         [0.0, 1.1, 2.2],
         [None],
         [3.3, 4.4],
@@ -840,7 +896,10 @@ def test_rpad_listoffset_array():
         [6.6, 7.7, 8.8, 9.9],
         [None],
     ]
-    assert listoffsetarray.typetracer.rpad(1, 1).form == listoffsetarray.rpad(1, 1).form
+    assert (
+        listoffsetarray.typetracer.pad_none(1, 1).form
+        == listoffsetarray.pad_none(1, 1).form
+    )
 
     content = ak._v2.contents.numpyarray.NumpyArray(np.array([1.5, 3.3]))
     index = ak._v2.index.Index64(
@@ -891,7 +950,7 @@ def test_rpad_listoffset_array():
         [],
     ]
 
-    assert to_list(listoffsetarray.rpad(1, 0)) == [
+    assert to_list(listoffsetarray.pad_none(1, 0)) == [
         [3.3],
         [],
         [],
@@ -899,12 +958,15 @@ def test_rpad_listoffset_array():
         [],
         [],
     ]
-    assert listoffsetarray.typetracer.rpad(1, 0).form == listoffsetarray.rpad(1, 0).form
+    assert (
+        listoffsetarray.typetracer.pad_none(1, 0).form
+        == listoffsetarray.pad_none(1, 0).form
+    )
     assert f"option[{str(ak._v2.operations.type(listoffsetarray))}]" == str(
-        ak._v2.operations.type(listoffsetarray.rpad(1, 0))
+        ak._v2.operations.type(listoffsetarray.pad_none(1, 0))
     )
 
-    assert to_list(listoffsetarray.rpad(6, 0)) == [
+    assert to_list(listoffsetarray.pad_none(6, 0)) == [
         [3.3],
         [],
         [],
@@ -912,12 +974,15 @@ def test_rpad_listoffset_array():
         [],
         [],
     ]
-    assert listoffsetarray.typetracer.rpad(6, 0).form == listoffsetarray.rpad(6, 0).form
+    assert (
+        listoffsetarray.typetracer.pad_none(6, 0).form
+        == listoffsetarray.pad_none(6, 0).form
+    )
     assert "option[" + str(ak._v2.operations.type(listoffsetarray)) + "]" == str(
-        ak._v2.operations.type(listoffsetarray.rpad(6, 0))
+        ak._v2.operations.type(listoffsetarray.pad_none(6, 0))
     )
 
-    assert to_list(listoffsetarray.rpad(7, 0)) == [
+    assert to_list(listoffsetarray.pad_none(7, 0)) == [
         [3.3],
         [],
         [],
@@ -926,12 +991,15 @@ def test_rpad_listoffset_array():
         [],
         None,
     ]
-    assert listoffsetarray.typetracer.rpad(7, 0).form == listoffsetarray.rpad(7, 0).form
+    assert (
+        listoffsetarray.typetracer.pad_none(7, 0).form
+        == listoffsetarray.pad_none(7, 0).form
+    )
     assert "option[" + str(ak._v2.operations.type(listoffsetarray)) + "]" == str(
-        ak._v2.operations.type(listoffsetarray.rpad(7, 0))
+        ak._v2.operations.type(listoffsetarray.pad_none(7, 0))
     )
 
-    assert to_list(listoffsetarray.rpad(9, 0)) == [
+    assert to_list(listoffsetarray.pad_none(9, 0)) == [
         [3.3],
         [],
         [],
@@ -942,12 +1010,15 @@ def test_rpad_listoffset_array():
         None,
         None,
     ]
-    assert listoffsetarray.typetracer.rpad(9, 0).form == listoffsetarray.rpad(9, 0).form
+    assert (
+        listoffsetarray.typetracer.pad_none(9, 0).form
+        == listoffsetarray.pad_none(9, 0).form
+    )
     assert "option[" + str(ak._v2.operations.type(listoffsetarray)) + "]" == str(
-        ak._v2.operations.type(listoffsetarray.rpad(9, 0))
+        ak._v2.operations.type(listoffsetarray.pad_none(9, 0))
     )
 
-    assert to_list(listoffsetarray.rpad(1, 1)) == [
+    assert to_list(listoffsetarray.pad_none(1, 1)) == [
         [3.3],
         [None],
         [None],
@@ -955,12 +1026,15 @@ def test_rpad_listoffset_array():
         [None],
         [None],
     ]
-    assert listoffsetarray.typetracer.rpad(1, 1).form == listoffsetarray.rpad(1, 1).form
+    assert (
+        listoffsetarray.typetracer.pad_none(1, 1).form
+        == listoffsetarray.pad_none(1, 1).form
+    )
     assert str(ak._v2.operations.type(listoffsetarray)) == str(
-        ak._v2.operations.type(listoffsetarray.rpad(1, 1))
+        ak._v2.operations.type(listoffsetarray.pad_none(1, 1))
     )
 
-    assert to_list(listoffsetarray.rpad(4, 1)) == [
+    assert to_list(listoffsetarray.pad_none(4, 1)) == [
         [3.3, None, None, None],
         [None, None, None, None],
         [None, None, None, None],
@@ -969,7 +1043,7 @@ def test_rpad_listoffset_array():
         [None, None, None, None],
     ]
     assert str(ak._v2.operations.type(listoffsetarray)) == str(
-        ak._v2.operations.type(listoffsetarray.rpad(4, 1))
+        ak._v2.operations.type(listoffsetarray.pad_none(4, 1))
     )
 
 
@@ -988,7 +1062,7 @@ def test_rpad_list_array():
         [5.5, 6.6, 7.7],
         [8.8],
     ]
-    assert to_list(array.rpad(1, 0)) == [
+    assert to_list(array.pad_none(1, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -996,10 +1070,10 @@ def test_rpad_list_array():
         [8.8],
     ]
     assert f"option[{str(ak._v2.operations.type(array))}]" == str(
-        ak._v2.operations.type(array.rpad(1, 0))
+        ak._v2.operations.type(array.pad_none(1, 0))
     )
 
-    assert to_list(array.rpad(2, 0)) == [
+    assert to_list(array.pad_none(2, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -1007,10 +1081,10 @@ def test_rpad_list_array():
         [8.8],
     ]
     assert f"option[{str(ak._v2.operations.type(array))}]" == str(
-        ak._v2.operations.type(array.rpad(2, 0))
+        ak._v2.operations.type(array.pad_none(2, 0))
     )
 
-    assert to_list(array.rpad(7, 0)) == [
+    assert to_list(array.pad_none(7, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -1020,10 +1094,10 @@ def test_rpad_list_array():
         None,
     ]
     assert "option[" + str(ak._v2.operations.type(array)) + "]" == str(
-        ak._v2.operations.type(array.rpad(7, 0))
+        ak._v2.operations.type(array.pad_none(7, 0))
     )
 
-    assert to_list(array.rpad(1, 1)) == [
+    assert to_list(array.pad_none(1, 1)) == [
         [0.0, 1.1, 2.2],
         [None],
         [4.4, 5.5],
@@ -1031,7 +1105,7 @@ def test_rpad_list_array():
         [8.8],
     ]
 
-    assert to_list(array.rpad(2, 1)) == [
+    assert to_list(array.pad_none(2, 1)) == [
         [0.0, 1.1, 2.2],
         [None, None],
         [4.4, 5.5],
@@ -1039,7 +1113,7 @@ def test_rpad_list_array():
         [8.8, None],
     ]
 
-    assert to_list(array.rpad(3, 1)) == [
+    assert to_list(array.pad_none(3, 1)) == [
         [0.0, 1.1, 2.2],
         [None, None, None],
         [4.4, 5.5, None],
@@ -1047,7 +1121,7 @@ def test_rpad_list_array():
         [8.8, None, None],
     ]
 
-    assert to_list(array.rpad(4, 1)) == [
+    assert to_list(array.pad_none(4, 1)) == [
         [0.0, 1.1, 2.2, None],
         [None, None, None, None],
         [4.4, 5.5, None, None],
@@ -1071,23 +1145,25 @@ def test_rpad_and_clip_list_array():
         [5.5, 6.6, 7.7],
         [8.8],
     ]
-    assert to_list(array.rpad(1, 0, clip=True)) == [[0.0, 1.1, 2.2]]
+    assert to_list(array.pad_none(1, 0, clip=True)) == [[0.0, 1.1, 2.2]]
     assert (
-        array.typetracer.rpad(1, 0, clip=True).form == array.rpad(1, 0, clip=True).form
+        array.typetracer.pad_none(1, 0, clip=True).form
+        == array.pad_none(1, 0, clip=True).form
     )
     assert "option[" + str(array.form.type) + "]" == str(
-        array.rpad(1, 0, clip=True).form.type
+        array.pad_none(1, 0, clip=True).form.type
     )
 
-    assert to_list(array.rpad(2, 0, clip=True)) == [[0.0, 1.1, 2.2], []]
+    assert to_list(array.pad_none(2, 0, clip=True)) == [[0.0, 1.1, 2.2], []]
     assert (
-        array.typetracer.rpad(2, 0, clip=True).form == array.rpad(2, 0, clip=True).form
+        array.typetracer.pad_none(2, 0, clip=True).form
+        == array.pad_none(2, 0, clip=True).form
     )
     assert "option[" + str(array.form.type) + "]" == str(
-        array.rpad(2, 0, clip=True).form.type
+        array.pad_none(2, 0, clip=True).form.type
     )
 
-    assert to_list(array.rpad(7, 0, clip=True)) == [
+    assert to_list(array.pad_none(7, 0, clip=True)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -1097,13 +1173,14 @@ def test_rpad_and_clip_list_array():
         None,
     ]
     assert (
-        array.typetracer.rpad(7, 0, clip=True).form == array.rpad(7, 0, clip=True).form
+        array.typetracer.pad_none(7, 0, clip=True).form
+        == array.pad_none(7, 0, clip=True).form
     )
     assert "option[" + str(array.form.type) + "]" == str(
-        array.rpad(7, 0, clip=True).form.type
+        array.pad_none(7, 0, clip=True).form.type
     )
 
-    assert to_list(array.rpad(1, 1, clip=True)) == [
+    assert to_list(array.pad_none(1, 1, clip=True)) == [
         [0.0],
         [None],
         [4.4],
@@ -1111,10 +1188,11 @@ def test_rpad_and_clip_list_array():
         [8.8],
     ]
     assert (
-        array.typetracer.rpad(1, 1, clip=True).form == array.rpad(1, 1, clip=True).form
+        array.typetracer.pad_none(1, 1, clip=True).form
+        == array.pad_none(1, 1, clip=True).form
     )
 
-    assert to_list(array.rpad(2, 1, clip=True)) == [
+    assert to_list(array.pad_none(2, 1, clip=True)) == [
         [0.0, 1.1],
         [None, None],
         [4.4, 5.5],
@@ -1122,7 +1200,8 @@ def test_rpad_and_clip_list_array():
         [8.8, None],
     ]
     assert (
-        array.typetracer.rpad(2, 1, clip=True).form == array.rpad(2, 1, clip=True).form
+        array.typetracer.pad_none(2, 1, clip=True).form
+        == array.pad_none(2, 1, clip=True).form
     )
 
 
@@ -1149,47 +1228,55 @@ def test_rpad_indexed_array():
         [0.0, 1.1, 2.2],
     ]
 
-    assert to_list(backward.rpad(4, 1)) == to_list(indexedarray.rpad(4, 1))
-    assert to_list(indexedarray.rpad(1, 0)) == [
+    assert to_list(backward.pad_none(4, 1)) == to_list(indexedarray.pad_none(4, 1))
+    assert to_list(indexedarray.pad_none(1, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
         [0.0, 1.1, 2.2],
     ]
-    assert to_list(indexedarray.rpad(2, 1)) == [
+    assert to_list(indexedarray.pad_none(2, 1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5, None],
         [3.3, 4.4],
         [None, None],
         [0.0, 1.1, 2.2],
     ]
-    assert indexedarray.typetracer.rpad(2, 1).form == indexedarray.rpad(2, 1).form
-    assert to_list(indexedarray.rpad(3, 1)) == [
+    assert (
+        indexedarray.typetracer.pad_none(2, 1).form == indexedarray.pad_none(2, 1).form
+    )
+    assert to_list(indexedarray.pad_none(3, 1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5, None, None],
         [3.3, 4.4, None],
         [None, None, None],
         [0.0, 1.1, 2.2],
     ]
-    assert indexedarray.typetracer.rpad(3, 1).form == indexedarray.rpad(3, 1).form
-    assert to_list(indexedarray.rpad(4, 0)) == [
+    assert (
+        indexedarray.typetracer.pad_none(3, 1).form == indexedarray.pad_none(3, 1).form
+    )
+    assert to_list(indexedarray.pad_none(4, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
         [0.0, 1.1, 2.2],
     ]
-    assert indexedarray.typetracer.rpad(4, 0).form == indexedarray.rpad(4, 0).form
-    assert to_list(indexedarray.rpad(5, 0)) == [
+    assert (
+        indexedarray.typetracer.pad_none(4, 0).form == indexedarray.pad_none(4, 0).form
+    )
+    assert to_list(indexedarray.pad_none(5, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
         [0.0, 1.1, 2.2],
     ]
-    assert indexedarray.typetracer.rpad(5, 0).form == indexedarray.rpad(5, 0).form
-    assert to_list(indexedarray.rpad(6, 0)) == [
+    assert (
+        indexedarray.typetracer.pad_none(5, 0).form == indexedarray.pad_none(5, 0).form
+    )
+    assert to_list(indexedarray.pad_none(6, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1197,8 +1284,10 @@ def test_rpad_indexed_array():
         [0.0, 1.1, 2.2],
         None,
     ]
-    assert indexedarray.typetracer.rpad(6, 0).form == indexedarray.rpad(6, 0).form
-    assert to_list(indexedarray.rpad(7, 0)) == [
+    assert (
+        indexedarray.typetracer.pad_none(6, 0).form == indexedarray.pad_none(6, 0).form
+    )
+    assert to_list(indexedarray.pad_none(7, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1207,7 +1296,9 @@ def test_rpad_indexed_array():
         None,
         None,
     ]
-    assert indexedarray.typetracer.rpad(7, 0).form == indexedarray.rpad(7, 0).form
+    assert (
+        indexedarray.typetracer.pad_none(7, 0).form == indexedarray.pad_none(7, 0).form
+    )
 
 
 def test_rpad_and_clip_indexed_array():
@@ -1232,78 +1323,65 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2],
     ]
 
-    assert to_list(backward.rpad(4, 1, clip=True)) == to_list(
-        indexedarray.rpad(4, 1, clip=True)
+    assert to_list(backward.pad_none(4, 1, clip=True)) == to_list(
+        indexedarray.pad_none(4, 1, clip=True)
     )
-    assert to_list(indexedarray.rpad(1, 0, clip=True)) == [[6.6, 7.7, 8.8, 9.9]]
+    assert to_list(indexedarray.pad_none(1, 0, clip=True)) == [[6.6, 7.7, 8.8, 9.9]]
     assert (
-        indexedarray.typetracer.rpad(1, 0, clip=True).form
-        == indexedarray.rpad(1, 0, clip=True).form
+        indexedarray.typetracer.pad_none(1, 0, clip=True).form
+        == indexedarray.pad_none(1, 0, clip=True).form
     )
-    assert to_list(indexedarray.rpad(2, 0, clip=True)) == [
+    assert to_list(indexedarray.pad_none(2, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
     ]
     assert (
-        indexedarray.typetracer.rpad(2, 0, clip=True).form
-        == indexedarray.rpad(2, 0, clip=True).form
+        indexedarray.typetracer.pad_none(2, 0, clip=True).form
+        == indexedarray.pad_none(2, 0, clip=True).form
     )
-    assert to_list(indexedarray.rpad(3, 0, clip=True)) == [
-        [6.6, 7.7, 8.8, 9.9],
-        [5.5],
-        [3.3, 4.4],
-    ]
-    assert (
-        indexedarray.typetracer.rpad(3, 0, clip=True).form
-        == indexedarray.rpad(3, 0, clip=True).form
-    )
-    assert to_list(indexedarray.rpad(4, 0, clip=True)) == [
+    assert to_list(indexedarray.pad_none(3, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
-        [],
     ]
     assert (
-        indexedarray.typetracer.rpad(4, 0, clip=True).form
-        == indexedarray.rpad(4, 0, clip=True).form
+        indexedarray.typetracer.pad_none(3, 0, clip=True).form
+        == indexedarray.pad_none(3, 0, clip=True).form
     )
-    assert to_list(indexedarray.rpad(5, 0, clip=True)) == [
+    assert to_list(indexedarray.pad_none(4, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
-        [0.0, 1.1, 2.2],
     ]
     assert (
-        indexedarray.typetracer.rpad(5, 0, clip=True).form
-        == indexedarray.rpad(5, 0, clip=True).form
+        indexedarray.typetracer.pad_none(4, 0, clip=True).form
+        == indexedarray.pad_none(4, 0, clip=True).form
     )
-    assert to_list(indexedarray.rpad(6, 0, clip=True)) == [
+    assert to_list(indexedarray.pad_none(5, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
         [0.0, 1.1, 2.2],
-        None,
     ]
     assert (
-        indexedarray.typetracer.rpad(6, 0, clip=True).form
-        == indexedarray.rpad(6, 0, clip=True).form
+        indexedarray.typetracer.pad_none(5, 0, clip=True).form
+        == indexedarray.pad_none(5, 0, clip=True).form
     )
-    assert to_list(indexedarray.rpad(7, 0, clip=True)) == [
+    assert to_list(indexedarray.pad_none(6, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
         [0.0, 1.1, 2.2],
         None,
-        None,
     ]
     assert (
-        indexedarray.typetracer.rpad(7, 0, clip=True).form
-        == indexedarray.rpad(7, 0, clip=True).form
+        indexedarray.typetracer.pad_none(6, 0, clip=True).form
+        == indexedarray.pad_none(6, 0, clip=True).form
     )
-    assert to_list(indexedarray.rpad(8, 0, clip=True)) == [
+    assert to_list(indexedarray.pad_none(7, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1311,14 +1389,27 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2],
         None,
         None,
+    ]
+    assert (
+        indexedarray.typetracer.pad_none(7, 0, clip=True).form
+        == indexedarray.pad_none(7, 0, clip=True).form
+    )
+    assert to_list(indexedarray.pad_none(8, 0, clip=True)) == [
+        [6.6, 7.7, 8.8, 9.9],
+        [5.5],
+        [3.3, 4.4],
+        [],
+        [0.0, 1.1, 2.2],
+        None,
+        None,
         None,
     ]
     assert (
-        indexedarray.typetracer.rpad(8, 0, clip=True).form
-        == indexedarray.rpad(8, 0, clip=True).form
+        indexedarray.typetracer.pad_none(8, 0, clip=True).form
+        == indexedarray.pad_none(8, 0, clip=True).form
     )
 
-    assert to_list(indexedarray.rpad(1, 1, clip=True)) == [
+    assert to_list(indexedarray.pad_none(1, 1, clip=True)) == [
         [6.6],
         [5.5],
         [3.3],
@@ -1326,10 +1417,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0],
     ]
     assert (
-        indexedarray.typetracer.rpad(1, 1, clip=True).form
-        == indexedarray.rpad(1, 1, clip=True).form
+        indexedarray.typetracer.pad_none(1, 1, clip=True).form
+        == indexedarray.pad_none(1, 1, clip=True).form
     )
-    assert to_list(indexedarray.rpad(2, 1, clip=True)) == [
+    assert to_list(indexedarray.pad_none(2, 1, clip=True)) == [
         [6.6, 7.7],
         [5.5, None],
         [3.3, 4.4],
@@ -1337,10 +1428,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1],
     ]
     assert (
-        indexedarray.typetracer.rpad(2, 1, clip=True).form
-        == indexedarray.rpad(2, 1, clip=True).form
+        indexedarray.typetracer.pad_none(2, 1, clip=True).form
+        == indexedarray.pad_none(2, 1, clip=True).form
     )
-    assert to_list(indexedarray.rpad(3, 1, clip=True)) == [
+    assert to_list(indexedarray.pad_none(3, 1, clip=True)) == [
         [6.6, 7.7, 8.8],
         [5.5, None, None],
         [3.3, 4.4, None],
@@ -1348,10 +1439,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2],
     ]
     assert (
-        indexedarray.typetracer.rpad(3, 1, clip=True).form
-        == indexedarray.rpad(3, 1, clip=True).form
+        indexedarray.typetracer.pad_none(3, 1, clip=True).form
+        == indexedarray.pad_none(3, 1, clip=True).form
     )
-    assert to_list(indexedarray.rpad(4, 1, clip=True)) == [
+    assert to_list(indexedarray.pad_none(4, 1, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5, None, None, None],
         [3.3, 4.4, None, None],
@@ -1359,10 +1450,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2, None],
     ]
     assert (
-        indexedarray.typetracer.rpad(4, 1, clip=True).form
-        == indexedarray.rpad(4, 1, clip=True).form
+        indexedarray.typetracer.pad_none(4, 1, clip=True).form
+        == indexedarray.pad_none(4, 1, clip=True).form
     )
-    assert to_list(indexedarray.rpad(5, 1, clip=True)) == [
+    assert to_list(indexedarray.pad_none(5, 1, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9, None],
         [5.5, None, None, None, None],
         [3.3, 4.4, None, None, None],
@@ -1370,8 +1461,8 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2, None, None],
     ]
     assert (
-        indexedarray.typetracer.rpad(5, 1, clip=True).form
-        == indexedarray.rpad(5, 1, clip=True).form
+        indexedarray.typetracer.pad_none(5, 1, clip=True).form
+        == indexedarray.pad_none(5, 1, clip=True).form
     )
 
 
@@ -1435,84 +1526,100 @@ def test_rpad_indexed_option_array():
         [0.0, None, None],
     ]
 
-    assert to_list(backward.rpad(4, 1)) == to_list(indexedarray.rpad(4, 1))
-    assert to_list(indexedarray.rpad(1, 0)) == [
+    assert to_list(backward.pad_none(4, 1)) == to_list(indexedarray.pad_none(4, 1))
+    assert to_list(indexedarray.pad_none(1, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         None,
         [0.0, None, None],
     ]
-    assert indexedarray.typetracer.rpad(1, 0).form == indexedarray.rpad(1, 0).form
-    assert to_list(indexedarray.rpad(1, 1)) == [
+    assert (
+        indexedarray.typetracer.pad_none(1, 0).form == indexedarray.pad_none(1, 0).form
+    )
+    assert to_list(indexedarray.pad_none(1, 1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         None,
         [0.0, None, None],
     ]
-    assert indexedarray.typetracer.rpad(1, 1).form == indexedarray.rpad(1, 1).form
-    assert to_list(indexedarray.rpad(3, 1)) == [
+    assert (
+        indexedarray.typetracer.pad_none(1, 1).form == indexedarray.pad_none(1, 1).form
+    )
+    assert to_list(indexedarray.pad_none(3, 1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5, None, None],
         [3.3, 4.4, None],
         None,
         [0.0, None, None],
     ]
-    assert indexedarray.typetracer.rpad(3, 1).form == indexedarray.rpad(3, 1).form
-    assert to_list(indexedarray.rpad(4, 0)) == [
-        [6.6, 7.7, 8.8, 9.9],
-        [5.5],
-        [3.3, 4.4],
-        None,
-        [0.0, None, None],
-    ]
-    assert indexedarray.typetracer.rpad(4, 0).form == indexedarray.rpad(4, 0).form
-    assert to_list(indexedarray.rpad(5, 0)) == [
-        [6.6, 7.7, 8.8, 9.9],
-        [5.5],
-        [3.3, 4.4],
-        None,
-        [0.0, None, None],
-    ]
-    assert indexedarray.typetracer.rpad(5, 0).form == indexedarray.rpad(5, 0).form
-    assert to_list(indexedarray.rpad(6, 0)) == [
-        [6.6, 7.7, 8.8, 9.9],
-        [5.5],
-        [3.3, 4.4],
-        None,
-        [0.0, None, None],
-        None,
-    ]
-    assert indexedarray.typetracer.rpad(6, 0).form == indexedarray.rpad(6, 0).form
-    assert to_list(indexedarray.rpad(7, 0)) == [
-        [6.6, 7.7, 8.8, 9.9],
-        [5.5],
-        [3.3, 4.4],
-        None,
-        [0.0, None, None],
-        None,
-        None,
-    ]
-    assert indexedarray.typetracer.rpad(7, 0).form == indexedarray.rpad(7, 0).form
-    assert to_list(indexedarray.rpad(8, 0)) == [
-        [6.6, 7.7, 8.8, 9.9],
-        [5.5],
-        [3.3, 4.4],
-        None,
-        [0.0, None, None],
-        None,
-        None,
-        None,
-    ]
-    assert indexedarray.typetracer.rpad(8, 0).form == indexedarray.rpad(8, 0).form
-
-    assert to_list(indexedarray.rpad(1, 0, clip=True)) == [[6.6, 7.7, 8.8, 9.9]]
     assert (
-        indexedarray.typetracer.rpad(1, 0, clip=True).form
-        == indexedarray.rpad(1, 0, clip=True).form
+        indexedarray.typetracer.pad_none(3, 1).form == indexedarray.pad_none(3, 1).form
     )
-    assert to_list(indexedarray.rpad(1, 1, clip=True)) == [
+    assert to_list(indexedarray.pad_none(4, 0)) == [
+        [6.6, 7.7, 8.8, 9.9],
+        [5.5],
+        [3.3, 4.4],
+        None,
+        [0.0, None, None],
+    ]
+    assert (
+        indexedarray.typetracer.pad_none(4, 0).form == indexedarray.pad_none(4, 0).form
+    )
+    assert to_list(indexedarray.pad_none(5, 0)) == [
+        [6.6, 7.7, 8.8, 9.9],
+        [5.5],
+        [3.3, 4.4],
+        None,
+        [0.0, None, None],
+    ]
+    assert (
+        indexedarray.typetracer.pad_none(5, 0).form == indexedarray.pad_none(5, 0).form
+    )
+    assert to_list(indexedarray.pad_none(6, 0)) == [
+        [6.6, 7.7, 8.8, 9.9],
+        [5.5],
+        [3.3, 4.4],
+        None,
+        [0.0, None, None],
+        None,
+    ]
+    assert (
+        indexedarray.typetracer.pad_none(6, 0).form == indexedarray.pad_none(6, 0).form
+    )
+    assert to_list(indexedarray.pad_none(7, 0)) == [
+        [6.6, 7.7, 8.8, 9.9],
+        [5.5],
+        [3.3, 4.4],
+        None,
+        [0.0, None, None],
+        None,
+        None,
+    ]
+    assert (
+        indexedarray.typetracer.pad_none(7, 0).form == indexedarray.pad_none(7, 0).form
+    )
+    assert to_list(indexedarray.pad_none(8, 0)) == [
+        [6.6, 7.7, 8.8, 9.9],
+        [5.5],
+        [3.3, 4.4],
+        None,
+        [0.0, None, None],
+        None,
+        None,
+        None,
+    ]
+    assert (
+        indexedarray.typetracer.pad_none(8, 0).form == indexedarray.pad_none(8, 0).form
+    )
+
+    assert to_list(indexedarray.pad_none(1, 0, clip=True)) == [[6.6, 7.7, 8.8, 9.9]]
+    assert (
+        indexedarray.typetracer.pad_none(1, 0, clip=True).form
+        == indexedarray.pad_none(1, 0, clip=True).form
+    )
+    assert to_list(indexedarray.pad_none(1, 1, clip=True)) == [
         [6.6],
         [5.5],
         [3.3],
@@ -1520,8 +1627,8 @@ def test_rpad_indexed_option_array():
         [0.0],
     ]
     assert (
-        indexedarray.typetracer.rpad(1, 1, clip=True).form
-        == indexedarray.rpad(1, 1, clip=True).form
+        indexedarray.typetracer.pad_none(1, 1, clip=True).form
+        == indexedarray.pad_none(1, 1, clip=True).form
     )
 
 
@@ -1536,21 +1643,21 @@ def test_rpad_recordarray():
     contents = [content1, content2]
     array = ak._v2.contents.recordarray.RecordArray(contents, keys)
 
-    assert to_list(array.rpad(5, 0)) == [
+    assert to_list(array.pad_none(5, 0)) == [
         {"x": [], "y": [2, 2]},
         {"x": [1.1], "y": [1]},
         {"x": [2.2, 2.2], "y": []},
         None,
         None,
     ]
-    assert array.typetracer.rpad(5, 0).form == array.rpad(5, 0).form
+    assert array.typetracer.pad_none(5, 0).form == array.pad_none(5, 0).form
 
-    assert to_list(array.rpad(2, 1)) == [
+    assert to_list(array.pad_none(2, 1)) == [
         {"x": [None, None], "y": [2, 2]},
         {"x": [1.1, None], "y": [1, None]},
         {"x": [2.2, 2.2], "y": [None, None]},
     ]
-    assert array.typetracer.rpad(2, 1).form == array.rpad(2, 1).form
+    assert array.typetracer.pad_none(2, 1).form == array.pad_none(2, 1).form
 
 
 def test_rpad_unionarray():
@@ -1565,7 +1672,7 @@ def test_rpad_unionarray():
     array = ak._v2.contents.unionarray.UnionArray(tags, index, [content1, content2])
     assert to_list(array) == [[], [2, 2], [1.1], [1], [2.2, 2.2], []]
 
-    assert to_list(array.rpad(7, 0)) == [
+    assert to_list(array.pad_none(7, 0)) == [
         [],
         [2, 2],
         [1.1],
@@ -1574,9 +1681,9 @@ def test_rpad_unionarray():
         [],
         None,
     ]
-    assert array.typetracer.rpad(7, 0).form == array.rpad(7, 0).form
+    assert array.typetracer.pad_none(7, 0).form == array.pad_none(7, 0).form
 
-    assert to_list(array.rpad(2, 1)) == [
+    assert to_list(array.pad_none(2, 1)) == [
         [None, None],
         [2, 2],
         [1.1, None],
@@ -1584,4 +1691,4 @@ def test_rpad_unionarray():
         [2.2, 2.2],
         [None, None],
     ]
-    assert array.typetracer.rpad(2, 1).form == array.rpad(2, 1).form
+    assert array.typetracer.pad_none(2, 1).form == array.pad_none(2, 1).form


### PR DESCRIPTION
There were fewer of these than I thought there was going to be.

  * localindex → local_index
  * validityerror → validity_error
  * rpad → pad_none
  * withparameter → with_parameter

I changed mid-level names (i.e. on the layouts) because that's a public interface for downstream developers. I didn't change any kernel function names because those are totally internal and can be changed at any time. Also, those wouldn't be across-the-board changes that affect mergeability. Also, also, the kernel names aren't very good as they are, but they're defined in terms of their function (the Python snippets in kernel-signatures.yml), rather than a meaningful name.