### PR TITLE
Feat: add missing `_like` methods to `TypeTracer`

### DIFF
--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -206,7 +206,15 @@ class TypeTracerArray:
 
         # not array-like
         if not hasattr(array, "shape"):
-            array = np.array(array)
+            sequence = list(array)
+            array = np.array(sequence)
+            if array.dtype is object:
+                raise ak._v2._util.error(
+                    ValueError(
+                        f"bug in Awkward Array: attempt to construct `TypeTracerArray` "
+                        f"from a sequence of non-primitive types: {sequence}"
+                    )
+                )
 
         if dtype is None:
             dtype = array.dtype

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -432,9 +432,6 @@ class TypeTracerArray:
         return self
 
 
-unset = object()
-
-
 class TypeTracer(ak.nplike.NumpyLike):
     known_data = False
     known_shape = False
@@ -483,21 +480,21 @@ class TypeTracer(ak.nplike.NumpyLike):
 
     ############################ array creation
 
-    def array(self, data, dtype=unset, **kwargs):
+    def array(self, data, dtype=None, **kwargs):
         # data[, dtype=[, copy=]]
-        if dtype is unset:
+        if dtype is None:
             dtype = data.dtype
         return TypeTracerArray.from_array(data, dtype=dtype)
 
-    def asarray(self, array, dtype=unset, **kwargs):
+    def asarray(self, array, dtype=None, **kwargs):
         # array[, dtype=][, order=]
-        if dtype is unset:
+        if dtype is None:
             dtype = array.dtype
         return TypeTracerArray.from_array(array, dtype=dtype)
 
-    def ascontiguousarray(self, array, dtype=unset, **kwargs):
+    def ascontiguousarray(self, array, dtype=None, **kwargs):
         # array[, dtype=]
-        if dtype is unset:
+        if dtype is None:
             dtype = array.dtype
         return TypeTracerArray.from_array(array, dtype=dtype)
 
@@ -520,9 +517,9 @@ class TypeTracer(ak.nplike.NumpyLike):
         # shape/len[, dtype=]
         return TypeTracerArray(dtype, shape)
 
-    def full(self, shape, value, dtype=unset, **kwargs):
+    def full(self, shape, value, dtype=None, **kwargs):
         # shape/len, value[, dtype=]
-        if dtype is unset:
+        if dtype is None:
             dtype = numpy.array(value).dtype
         return TypeTracerArray(dtype, shape)
 
@@ -854,7 +851,7 @@ class TypeTracer(ak.nplike.NumpyLike):
         raise ak._v2._util.error(NotImplementedError)
 
     def array_str(
-        self, array, max_line_width=unset, precision=unset, suppress_small=unset
+        self, array, max_line_width=None, precision=None, suppress_small=None
     ):
         # array, max_line_width, precision=None, suppress_small=None
         return "[?? ... ??]"

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -207,8 +207,8 @@ class TypeTracerArray:
         # not array-like
         if not hasattr(array, "shape"):
             sequence = list(array)
-            array = np.array(sequence)
-            if array.dtype is object:
+            array = numpy.array(sequence)
+            if array.dtype == np.dtype("O"):
                 raise ak._v2._util.error(
                     ValueError(
                         f"bug in Awkward Array: attempt to construct `TypeTracerArray` "

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -204,17 +204,14 @@ class TypeTracerArray:
         if isinstance(array, ak._v2.index.Index):
             array = array.data
 
-        # array-like
-        if hasattr(array, "shape"):
-            if dtype is None:
-                dtype = array.dtype
-            return cls(dtype, shape=array.shape)
-        # list of known scalar
-        else:
-            sequence = list(array)
-            if dtype is None:
-                dtype = np.array(sequence).dtype
-            return cls(dtype, shape=(len(sequence,)))
+        # not array-like
+        if not hasattr(array, "shape"):
+            array = np.array(array)
+
+        if dtype is None:
+            dtype = array.dtype
+
+        return cls(dtype, shape=array.shape)
 
     def __init__(self, dtype, shape=None):
         self._dtype = np.dtype(dtype)

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -523,17 +523,20 @@ class TypeTracer(ak.nplike.NumpyLike):
             dtype = numpy.array(value).dtype
         return TypeTracerArray(dtype, shape)
 
-    def zeros_like(self, *args, **kwargs):
-        # array
-        raise ak._v2._util.error(NotImplementedError)
+    def zeros_like(self, a, dtype=None, **kwargs):
+        if dtype is None:
+            dtype = a.dtype
 
-    def ones_like(self, *args, **kwargs):
-        # array
-        raise ak._v2._util.error(NotImplementedError)
+        if isinstance(a, UnknownScalar):
+            return UnknownScalar(dtype)
 
-    def full_like(self, *args, **kwargs):
-        # array, fill_value
-        raise ak._v2._util.error(NotImplementedError)
+        return TypeTracerArray(dtype, a.shape)
+
+    def ones_like(self, a, dtype=None, **kwargs):
+        return self.zeros_like(a, dtype)
+
+    def full_like(self, a, fill_value, dtype=None, **kwargs):
+        return self.zeros_like(a, dtype)
 
     def arange(self, *args, **kwargs):
         # stop[, dtype=]

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -203,9 +203,18 @@ class TypeTracerArray:
     def from_array(cls, array, dtype=None):
         if isinstance(array, ak._v2.index.Index):
             array = array.data
-        if dtype is None:
-            dtype = array.dtype
-        return cls(dtype, shape=array.shape)
+
+        # array-like
+        if hasattr(array, "shape"):
+            if dtype is None:
+                dtype = array.dtype
+            return cls(dtype, shape=array.shape)
+        # list of known scalar
+        else:
+            sequence = list(array)
+            if dtype is None:
+                dtype = np.array(sequence).dtype
+            return cls(dtype, shape=(len(sequence,)))
 
     def __init__(self, dtype, shape=None):
         self._dtype = np.dtype(dtype)

--- a/src/awkward/_v2/_typetracer.py
+++ b/src/awkward/_v2/_typetracer.py
@@ -214,7 +214,14 @@ class TypeTracerArray:
             sequence = list(array)
             if dtype is None:
                 dtype = np.array(sequence).dtype
-            return cls(dtype, shape=(len(sequence,)))
+            return cls(
+                dtype,
+                shape=(
+                    len(
+                        sequence,
+                    )
+                ),
+            )
 
     def __init__(self, dtype, shape=None):
         self._dtype = np.dtype(dtype)

--- a/tests/v2/test_1504-typetracer-like.py
+++ b/tests/v2/test_1504-typetracer-like.py
@@ -8,34 +8,34 @@ typetracer = ak._v2._typetracer.TypeTracer.instance()
 
 @pytest.mark.parametrize("dtype", [np.float64, np.int64, np.uint8, None])
 @pytest.mark.parametrize("like_dtype", [np.float64, np.int64, np.uint8, None])
-def test(dtype, like_dtype):
-    a = ak._v2.contents.numpyarray.NumpyArray(
+def test_ones_like(dtype, like_dtype):
+    array = ak._v2.contents.numpyarray.NumpyArray(
         np.array([99, 88, 77, 66, 66], dtype=dtype)
     )
-    ones = ak._v2.ones_like(a.typetracer, dtype=like_dtype, highlevel=False)
-    assert ones.typetracer.shape == a.shape
-    assert ones.typetracer.dtype == like_dtype or a.dtype
+    ones = ak._v2.ones_like(array.typetracer, dtype=like_dtype, highlevel=False)
+    assert ones.typetracer.shape == array.shape
+    assert ones.typetracer.dtype == like_dtype or array.dtype
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.int64, np.uint8, None])
 @pytest.mark.parametrize("like_dtype", [np.float64, np.int64, np.uint8, None])
-def test(dtype, like_dtype):
-    a = ak._v2.contents.numpyarray.NumpyArray(
+def test_zeros_like(dtype, like_dtype):
+    array = ak._v2.contents.numpyarray.NumpyArray(
         np.array([99, 88, 77, 66, 66], dtype=dtype)
     )
 
-    full = ak._v2.zeros_like(a.typetracer, dtype=like_dtype, highlevel=False)
-    assert full.typetracer.shape == a.shape
-    assert full.typetracer.dtype == like_dtype or a.dtype
+    full = ak._v2.zeros_like(array.typetracer, dtype=like_dtype, highlevel=False)
+    assert full.typetracer.shape == array.shape
+    assert full.typetracer.dtype == like_dtype or array.dtype
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.int64, np.uint8, None])
 @pytest.mark.parametrize("like_dtype", [np.float64, np.int64, np.uint8, None])
 @pytest.mark.parametrize("value", [1.0, -20, np.iinfo(np.uint64).max])
-def test(dtype, like_dtype, value):
-    a = ak._v2.contents.numpyarray.NumpyArray(
+def test_full_like(dtype, like_dtype, value):
+    array = ak._v2.contents.numpyarray.NumpyArray(
         np.array([99, 88, 77, 66, 66], dtype=dtype)
     )
-    full = ak._v2.full_like(a.typetracer, value, dtype=like_dtype, highlevel=False)
-    assert full.typetracer.shape == a.shape
-    assert full.typetracer.dtype == like_dtype or a.dtype
+    full = ak._v2.full_like(array.typetracer, value, dtype=like_dtype, highlevel=False)
+    assert full.typetracer.shape == array.shape
+    assert full.typetracer.dtype == like_dtype or array.dtype

--- a/tests/v2/test_1504-typetracer-like.py
+++ b/tests/v2/test_1504-typetracer-like.py
@@ -1,0 +1,41 @@
+import awkward as ak
+import numpy as np
+import pytest
+
+
+typetracer = ak._v2._typetracer.TypeTracer.instance()
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.int64, np.uint8, None])
+@pytest.mark.parametrize("like_dtype", [np.float64, np.int64, np.uint8, None])
+def test(dtype, like_dtype):
+    a = ak._v2.contents.numpyarray.NumpyArray(
+        np.array([99, 88, 77, 66, 66], dtype=dtype)
+    )
+    ones = ak._v2.ones_like(a.typetracer, dtype=like_dtype, highlevel=False)
+    assert ones.typetracer.shape == a.shape
+    assert ones.typetracer.dtype == like_dtype or a.dtype
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.int64, np.uint8, None])
+@pytest.mark.parametrize("like_dtype", [np.float64, np.int64, np.uint8, None])
+def test(dtype, like_dtype):
+    a = ak._v2.contents.numpyarray.NumpyArray(
+        np.array([99, 88, 77, 66, 66], dtype=dtype)
+    )
+
+    full = ak._v2.zeros_like(a.typetracer, dtype=like_dtype, highlevel=False)
+    assert full.typetracer.shape == a.shape
+    assert full.typetracer.dtype == like_dtype or a.dtype
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.int64, np.uint8, None])
+@pytest.mark.parametrize("like_dtype", [np.float64, np.int64, np.uint8, None])
+@pytest.mark.parametrize("value", [1.0, -20, np.iinfo(np.uint64).max])
+def test(dtype, like_dtype, value):
+    a = ak._v2.contents.numpyarray.NumpyArray(
+        np.array([99, 88, 77, 66, 66], dtype=dtype)
+    )
+    full = ak._v2.full_like(a.typetracer, value, dtype=like_dtype, highlevel=False)
+    assert full.typetracer.shape == a.shape
+    assert full.typetracer.dtype == like_dtype or a.dtype

--- a/tests/v2/test_1504-typetracer-like.py
+++ b/tests/v2/test_1504-typetracer-like.py
@@ -39,3 +39,10 @@ def test_full_like(dtype, like_dtype, value):
     full = ak._v2.full_like(array.typetracer, value, dtype=like_dtype, highlevel=False)
     assert full.typetracer.shape == array.shape
     assert full.typetracer.dtype == like_dtype or array.dtype
+
+
+def test_full_like_cast():
+    with pytest.raises(ValueError):
+        ak._v2._typetracer.TypeTracerArray.from_array(
+            [1, ak._v2._typetracer.UnknownScalar(np.uint8)]
+        )


### PR DESCRIPTION
This PR just implements some of the missing `TypeTracer` methods to fix #1504

Changes:
- [x] Remove `unset` from `TypeTracer` signatures - we should support explicit `None`
- [x] Extend `from_array` to handle literal sequence of primitives
- [x] Add `_like` methods