### PR TITLE
Package: fix MANIFEST to include cpp-headers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include dev/generate-kernel-signatures.py
 include kernel-specification.yml
 recursive-include include *.h
 recursive-include src *.cpp *.py *.cu
+recursive-include src/awkward/_v2/cpp-headers *.h
 recursive-include tests *.cpp *.py samples/*
 recursive-include tests-cpu-kernels *.py
 recursive-include tests-cuda-kernels *.py


### PR DESCRIPTION
We can write any number of patterns here. I chose `recursive-include src/awkward/_v2/cpp-headers *.h` because it's explicit and simple.

We could just include any headers found in the source like we do for `cpp` files. Right now, I'm tempted to keep it very narrow, as I imagine we'll modify this build tooling in the near future once `scikit-build` gets Hatch(?) support?