### PR TITLE
chore: remove unneeded lines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "actions/*"


### PR DESCRIPTION
These aren't needed anymore, `v2` will no longer update to `v3.0.0`, but only to `v3`, etc. 