### PR TITLE
fix ak2 convert class name msg

### DIFF
--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -999,7 +999,7 @@ def to_list(array):
             ak._v2.highlevel.ArrayBuilder,
         ),
     ):
-        raise TypeError("use ak._v2.operations.convert.to_list for v2 arrays (for now)")
+        raise TypeError("use ak._v2.operations.to_list for v2 arrays (for now)")
 
     elif isinstance(array, dict):
         return {n: to_list(x) for n, x in array.items()}


### PR DESCRIPTION
```python
>>> ak.to_list(arr)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/akako/Documents/github/dotFiles/homedir/.julia/conda/3/lib/python3.9/site-packages/awkward/operations/convert.py", line 1002, in to_list
    raise TypeError("use ak._v2.operations.convert.to_list for v2 arrays (for now)")
TypeError: use ak._v2.operations.convert.to_list for v2 arrays (for now)
>>> ak._v2.operations.convert.to_list(arr)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'awkward._v2.operations' has no attribute 'convert'
>>> ak._v2.operations.to_list(arr)
[{'one_integers': 3, 'two_v_floats': [1.2000000476837158], 
```
