### PR TITLE
DeprecationWarning fix; sre_{constants,parse} API made private in 3.11

### DIFF
--- a/src/awkward/_typeparser/generated_parser.py
+++ b/src/awkward/_typeparser/generated_parser.py
@@ -315,9 +315,15 @@ try:
 except ModuleNotFoundError:
     regex = None
 
-import sre_parse
-import sre_constants
-categ_pattern = re.compile(r'\\p{[A-Za-z_]+}')
+if sys.version_info >= (3, 11):
+    import re._constants as sre_constants
+    import re._parser as sre_parse
+else:
+    import sre_constants
+    import sre_parse
+
+categ_pattern = re.compile(r"\\p{[A-Za-z_]+}")
+
 
 def get_regexp_width(expr):
     if regex:

--- a/src/awkward/_v2/types/_awkward_datashape_parser.py
+++ b/src/awkward/_v2/types/_awkward_datashape_parser.py
@@ -398,8 +398,13 @@ try:
 except ImportError:
     regex = None
 
-import sre_parse
-import sre_constants
+if sys.version_info >= (3, 11):
+    import re._constants as sre_constants
+    import re._parser as sre_parse
+else:
+    import sre_constants
+    import sre_parse
+
 categ_pattern = re.compile(r'\\p{[A-Za-z_]+}')
 
 def get_regexp_width(expr):


### PR DESCRIPTION
Long thread here: https://github.com/python/cpython/issues/91308