### PR TITLE
builder options and layout builder updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ if(BUILD_TESTING)
   addtest_nolibs(test_1494-layout-builder tests-cpp/test_1494-layout-builder.cpp)
   addtest_nolibs(test_1542-growable-buffer tests-cpp/test_1542-growable-buffer.cpp)
   addtest(test_1542-array-builder tests-cpp/test_1542-array-builder.cpp)
+  addtest_nolibs(test_1560-builder-options tests-cpp/test_1560-builder-options.cpp)
 
 endif()
 

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -9,11 +9,11 @@
 
 #include "awkward/common.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/BuilderOptions.h"
 
 namespace awkward {
   class Builder;
   using BuilderPtr = std::shared_ptr<Builder>;
-  class ArrayBuilderOptions;
 
   /// @class ArrayBuilder
   ///
@@ -26,7 +26,7 @@ namespace awkward {
     ///
     /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
-    ArrayBuilder(const ArrayBuilderOptions& options);
+    ArrayBuilder(const BuilderOptions& options);
 
     /// @brief Copy the current snapshot into the BuffersContainer and
     /// return a Form as a std::string (JSON).

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -13,6 +13,7 @@
 namespace awkward {
   class Builder;
   using BuilderPtr = std::shared_ptr<Builder>;
+  class ArrayBuilderOptions;
 
   /// @class ArrayBuilder
   ///
@@ -23,9 +24,9 @@ namespace awkward {
   public:
     /// @brief Creates an ArrayBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
-    ArrayBuilder(const int64_t initial);
+    ArrayBuilder(const ArrayBuilderOptions& options);
 
     /// @brief Copy the current snapshot into the BuffersContainer and
     /// return a Form as a std::string (JSON).

--- a/include/awkward/builder/BoolBuilder.h
+++ b/include/awkward/builder/BoolBuilder.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -18,17 +19,17 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL BoolBuilder: public Builder {
   public:
     /// @brief Create an empty BoolBuilder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial);
+      fromempty(const BuilderOptions& options);
 
     /// @brief Create a BoolBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param buffer Contains the accumulated boolean values.
-    BoolBuilder(const int64_t initial,
+    BoolBuilder(const BuilderOptions& options,
                 GrowableBuffer<uint8_t> buffer);
 
     /// @brief User-friendly name of this class: `"BoolBuilder"`.
@@ -98,13 +99,13 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const GrowableBuffer<uint8_t>& buffer() const { return buffer_; }
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     GrowableBuffer<uint8_t> buffer_;
   };
 

--- a/include/awkward/builder/Complex128Builder.h
+++ b/include/awkward/builder/Complex128Builder.h
@@ -4,6 +4,7 @@
 #define AWKWARD_COMPLEX128BUILDER_H_
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -16,33 +17,33 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL Complex128Builder: public Builder {
   public:
     /// @brief Create an empty Complex128Builder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial);
+      fromempty(const BuilderOptions& options);
 
     /// @brief Create a Complex128Builder from an existing Int64Builder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param old The Int64Builder's buffer.
     static const BuilderPtr
-      fromint64(const int64_t initial,
+      fromint64(const BuilderOptions& options,
                 const GrowableBuffer<int64_t>& old);
 
     /// @brief Create a Complex128Builder from an existing Float64Builder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param old The Float64Builder's buffer.
     static const BuilderPtr
-      fromfloat64(const int64_t initial,
+      fromfloat64(const BuilderOptions& options,
                   const GrowableBuffer<double>& old);
 
     /// @brief Create a Complex128Builder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param buffer Contains the accumulated real numbers.
-    Complex128Builder(const int64_t initial,
+    Complex128Builder(const BuilderOptions& options,
                       GrowableBuffer<std::complex<double>> buffer);
 
     /// @brief User-friendly name of this class: `"Complex128Builder"`.
@@ -112,13 +113,13 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const GrowableBuffer<std::complex<double>>& buffer() const { return buffer_; }
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     GrowableBuffer<std::complex<double>> buffer_;
   };
 

--- a/include/awkward/builder/DatetimeBuilder.h
+++ b/include/awkward/builder/DatetimeBuilder.h
@@ -4,6 +4,7 @@
 #define AWKWARD_DATETIMEBUILDER_H_
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -15,17 +16,17 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL DatetimeBuilder: public Builder {
   public:
     /// @brief Create an empty DatetimeBuilder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial, const std::string& units);
+      fromempty(const BuilderOptions& options, const std::string& units);
 
     /// @brief Create an DatetimeBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param buffer Contains the accumulated integers.
-    DatetimeBuilder(const int64_t initial,
+    DatetimeBuilder(const BuilderOptions& options,
                     GrowableBuffer<int64_t> content,
                     const std::string& units);
 
@@ -96,8 +97,8 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const std::string&
       units() const;
@@ -107,7 +108,7 @@ namespace awkward {
     const std::string& unit() const { return units_; }
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     GrowableBuffer<int64_t> content_;
     const std::string units_;
   };

--- a/include/awkward/builder/Float64Builder.h
+++ b/include/awkward/builder/Float64Builder.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -17,25 +18,25 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL Float64Builder: public Builder {
   public:
     /// @brief Create an empty Float64Builder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial);
+      fromempty(const BuilderOptions& options);
 
     /// @brief Create a Float64Builder from an existing Int64Builder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param old The Int64Builder's buffer.
     static const BuilderPtr
-      fromint64(const int64_t initial,
+      fromint64(const BuilderOptions& options,
                 const GrowableBuffer<int64_t>& old);
 
     /// @brief Create a Float64Builder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param buffer Contains the accumulated real numbers.
-    Float64Builder(const int64_t initial,
+    Float64Builder(const BuilderOptions& options,
                    GrowableBuffer<double> buffer);
 
     /// @brief Contains the accumulated real numbers (`double`).
@@ -109,11 +110,11 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     GrowableBuffer<double> buffer_;
   };
 

--- a/include/awkward/builder/Int64Builder.h
+++ b/include/awkward/builder/Int64Builder.h
@@ -4,6 +4,7 @@
 #define AWKWARD_INT64BUILDER_H_
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -15,17 +16,17 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL Int64Builder: public Builder {
   public:
     /// @brief Create an empty Int64Builder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial);
+      fromempty(const BuilderOptions& options);
 
     /// @brief Create an Int64Builder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param buffer Contains the accumulated integers.
-    Int64Builder(const int64_t initial,
+    Int64Builder(const BuilderOptions& options,
                  GrowableBuffer<int64_t> buffer);
 
     /// @brief Contains the accumulated integers.
@@ -99,11 +100,11 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     GrowableBuffer<int64_t> buffer_;
   };
 }

--- a/include/awkward/builder/ListBuilder.h
+++ b/include/awkward/builder/ListBuilder.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -17,14 +18,14 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL ListBuilder: public Builder {
   public:
     /// @brief Create an empty ListBuilder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial);
+      fromempty(const BuilderOptions& options);
 
     /// @brief Create a ListBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param offsets Contains the accumulated offsets (like
     /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
@@ -32,7 +33,7 @@ namespace awkward {
     /// @param begun If `true`, the ListBuilder is in a state after
     /// #beginlist and before #endlist and is #active; if `false`,
     /// it is not.
-    ListBuilder(const int64_t initial,
+    ListBuilder(const BuilderOptions& options,
                 GrowableBuffer<int64_t> offsets,
                 const BuilderPtr& content,
                 bool begun);
@@ -105,8 +106,8 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const GrowableBuffer<int64_t>& buffer() const { return offsets_; }
 
@@ -118,7 +119,7 @@ namespace awkward {
       maybeupdate(const BuilderPtr builder);
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     GrowableBuffer<int64_t> offsets_;
     BuilderPtr content_;
     bool begun_;

--- a/include/awkward/builder/OptionBuilder.h
+++ b/include/awkward/builder/OptionBuilder.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -17,32 +18,32 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL OptionBuilder: public Builder {
   public:
     /// @brief Create an OptionBuilder from a number of nulls (all missing).
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param nullcount Length of the purely missing data to create.
     /// @param content Builder for the non-missing data.
     static const BuilderPtr
-      fromnulls(const int64_t initial,
+      fromnulls(const BuilderOptions& options,
                 int64_t nullcount,
                 const BuilderPtr& content);
 
     /// @brief Create an OptionBuilder from an existing builder (all
     /// non-missing).
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param content Builder for the non-missing data.
     static const BuilderPtr
-      fromvalids(const int64_t initial,
+      fromvalids(const BuilderOptions& options,
                  const BuilderPtr& content);
 
     /// @brief Create a OptionBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param index Contains the accumulated index (like
     /// {@link IndexedArrayOf#index IndexedOptionArray::index}).
     /// @param content Builder for the non-missing data.
-    OptionBuilder(const int64_t initial,
+    OptionBuilder(const BuilderOptions& options,
                   GrowableBuffer<int64_t> index,
                   const BuilderPtr content);
 

--- a/include/awkward/builder/RecordBuilder.h
+++ b/include/awkward/builder/RecordBuilder.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -17,14 +18,14 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL RecordBuilder: public Builder {
   public:
     /// @brief Create an empty RecordBuilder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial);
+      fromempty(const BuilderOptions& options);
 
     /// @brief Create a RecordBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param contents A Builder for each record field.
     /// @param keys Names for each record field.
@@ -36,7 +37,7 @@ namespace awkward {
     /// `false` otherwise.
     /// @param nextindex The next field index to fill with data.
     /// @param nexttotry The next field index to check against a key string.
-    RecordBuilder(const int64_t initial,
+    RecordBuilder(const BuilderOptions& options,
                   const std::vector<BuilderPtr>& contents,
                   const std::vector<std::string>& keys,
                   const std::vector<const char*>& pointers,
@@ -123,8 +124,8 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const std::vector<std::string>& keys() const { return keys_; }
 
@@ -144,7 +145,7 @@ namespace awkward {
     void
       field_check(const char* key);
 
-    const int64_t initial_;
+    const BuilderOptions options_;
     std::vector<BuilderPtr> contents_;
     std::vector<std::string> keys_;
     std::vector<const char*> pointers_;

--- a/include/awkward/builder/StringBuilder.h
+++ b/include/awkward/builder/StringBuilder.h
@@ -4,6 +4,7 @@
 #define AWKWARD_STRINGBUILDER_H_
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -15,17 +16,17 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL StringBuilder: public Builder {
   public:
     /// @brief Create an empty StringBuilder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param encoding If `nullptr`, the string is an unencoded bytestring;
     /// if `"utf-8"`, it is encoded with variable-width UTF-8.
     /// Currently, no other encodings have been defined.
     static const BuilderPtr
-      fromempty(const int64_t initial, const char* encoding);
+      fromempty(const BuilderOptions& options, const char* encoding);
 
     /// @brief Create a StringBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param offsets Contains the accumulated offsets (like
     /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
@@ -34,7 +35,7 @@ namespace awkward {
     /// @param encoding If `nullptr`, the string is an unencoded bytestring;
     /// if `"utf-8"`, it is encoded with variable-width UTF-8.
     /// Currently, no other encodings have been defined.
-    StringBuilder(const int64_t initial,
+    StringBuilder(const BuilderOptions& options,
                   GrowableBuffer<int64_t> offsets,
                   GrowableBuffer<uint8_t> content,
                   const char* encoding);
@@ -112,15 +113,15 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const GrowableBuffer<int64_t>& buffer() const { return offsets_; }
 
     const GrowableBuffer<uint8_t>& content() const { return content_; }
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     GrowableBuffer<int64_t> offsets_;
     GrowableBuffer<uint8_t> content_;
     const char* encoding_;

--- a/include/awkward/builder/TupleBuilder.h
+++ b/include/awkward/builder/TupleBuilder.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -17,21 +18,21 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL TupleBuilder: public Builder {
   public:
     /// @brief Create an empty TupleBuilder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial);
+      fromempty(const BuilderOptions& options);
 
     /// @brief Create a TupleBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param contents A Builder for each tuple field.
     /// @param length Length of accumulated array (same as #length).
     /// @param begun If `true`, the TupleBuilder is in an active state;
     /// `false` otherwise.
     /// @param nextindex The next field index to fill with data.
-    TupleBuilder(const int64_t initial,
+    TupleBuilder(const BuilderOptions& options,
                  const std::vector<BuilderPtr>& contents,
                  int64_t length,
                  bool begun,
@@ -109,8 +110,8 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const std::vector<BuilderPtr>& contents() const { return contents_; }
 
@@ -122,7 +123,7 @@ namespace awkward {
       maybeupdate(int64_t i, const BuilderPtr builder);
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     std::vector<BuilderPtr> contents_;
     int64_t length_;
     bool begun_;

--- a/include/awkward/builder/UnionBuilder.h
+++ b/include/awkward/builder/UnionBuilder.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
 
@@ -19,19 +20,19 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL UnionBuilder: public Builder {
   public:
     static const BuilderPtr
-      fromsingle(const int64_t initial,
+      fromsingle(const BuilderOptions& options,
                  const BuilderPtr& firstcontent);
 
     /// @brief Create a UnionBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param tags Contains the accumulated tags (like
     /// {@link UnionArrayOf#tags UnionArray::tags}).
     /// @param index Contains the accumulated index (like
     /// {@link UnionArrayOf#index UnionArray::index}).
     /// @param contents A Builder for each of the union's possibilities.
-    UnionBuilder(const int64_t initial,
+    UnionBuilder(const BuilderOptions& options,
                  GrowableBuffer<int8_t> tags,
                  GrowableBuffer<int64_t> index,
                  std::vector<BuilderPtr>& contents);
@@ -104,8 +105,8 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const GrowableBuffer<int8_t>& tags() const {  return tags_; }
     GrowableBuffer<int8_t>& tags_buffer() {  return tags_; }
@@ -119,7 +120,7 @@ namespace awkward {
     int8_t current() { return current_;}
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     GrowableBuffer<int8_t> tags_;
     GrowableBuffer<int64_t> index_;
     std::vector<BuilderPtr> contents_;

--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/builder/Builder.h"
 
 namespace awkward {
@@ -16,17 +17,17 @@ namespace awkward {
   class LIBAWKWARD_EXPORT_SYMBOL UnknownBuilder: public Builder {
   public:
     /// @brief Create an empty UnknownBuilder.
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     static const BuilderPtr
-      fromempty(const int64_t initial);
+      fromempty(const BuilderOptions& options);
 
     /// @brief Create a ListBuilder from a full set of parameters.
     ///
-    /// @param initial Configuration initial for building an array;
+    /// @param options Configuration options for building an array;
     /// these are passed to every Builder's constructor.
     /// @param nullcount The number of null values encountered so far.
-    UnknownBuilder(const int64_t initial, int64_t nullcount);
+    UnknownBuilder(const BuilderOptions& options, int64_t nullcount);
 
     /// @brief User-friendly name of this class: `"UnknownBuilder"`.
     const std::string
@@ -95,13 +96,13 @@ namespace awkward {
     const BuilderPtr
       endrecord() override;
 
-    const int64_t
-      initial() const { return initial_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
     const int64_t nullcount() const { return nullcount_; }
 
   private:
-    const int64_t initial_;
+    const BuilderOptions options_;
     int64_t nullcount_;
   };
 }

--- a/src/awkward/_v2/cpp-headers/awkward/ArrayBuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/ArrayBuilderOptions.h
@@ -1,0 +1,34 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#ifndef AWKWARD_ARRAYBUILDEROPTIONS_H_
+#define AWKWARD_ARRAYBUILDEROPTIONS_H_
+
+namespace awkward {
+  /// @class ArrayBuilderOptions
+  ///
+  /// @brief Container for all configuration options needed by ArrayBuilder,
+  /// GrowableBuffer, and the Builder subclasses.
+  struct ArrayBuilderOptions {
+    /// @brief Creates an ArrayBuilderOptions from a full set of parameters.
+    ///
+    /// @param initial The initial number of
+    /// {@link GrowableBuffer#reserved reserved} entries for a GrowableBuffer.
+    /// @param resize The factor with which a GrowableBuffer is resized
+    /// when its {@link GrowableBuffer#length length} reaches its
+    /// {@link GrowableBuffer#reserved reserved}.
+    ArrayBuilderOptions(int64_t from_initial, double from_resize)
+      : initial(from_initial) ,
+        resize(from_resize) {}
+
+    /// @brief The initial number of
+    /// {@link GrowableBuffer#reserved reserved} entries for a GrowableBuffer.
+    int64_t initial;
+
+    /// @brief The factor with which a GrowableBuffer is resized
+    /// when its {@link GrowableBuffer#length length} reaches its
+    /// {@link GrowableBuffer#reserved reserved}.
+    double resize;
+  };
+}
+
+#endif // AWKWARD_ARRAYBUILDEROPTIONS_H_

--- a/src/awkward/_v2/cpp-headers/awkward/ArrayBuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/ArrayBuilderOptions.h
@@ -3,6 +3,8 @@
 #ifndef AWKWARD_ARRAYBUILDEROPTIONS_H_
 #define AWKWARD_ARRAYBUILDEROPTIONS_H_
 
+#include <cstring>
+
 namespace awkward {
   /// @class ArrayBuilderOptions
   ///

--- a/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
@@ -31,10 +31,6 @@ namespace awkward {
     using OptionType =
         typename std::tuple_element<INDEX, decltype(OptionsPack())>::type;
 
-    /// @brief Creates an Options tuple with a default set of parameters:
-    /// an initial number and a resize factor.
-    Options() : pars({1024, 1}) {}
-
     /// @brief Creates an Options tuple from a full set of parameters.
     Options(OPTIONS... options) : pars({options...}) {}
 

--- a/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
@@ -15,7 +15,7 @@ namespace awkward {
   ///
   /// @brief Container for all configuration options needed by ArrayBuilder,
   /// GrowableBuffer, LayoutBuilder and the Builder subclasses.
-  template<typename... OPTIONS>
+  template <typename... OPTIONS>
   struct Options {
     static constexpr std::size_t value = sizeof...(OPTIONS);
 
@@ -27,19 +27,16 @@ namespace awkward {
     // template<std::size_t INDEX>
     // using OptionType = std::tuple_element_t<INDEX, OptionsPack>;
 
-    template<std::size_t INDEX>
-    using OptionType = typename std::tuple_element<INDEX, decltype(OptionsPack())>::type;
+    template <std::size_t INDEX>
+    using OptionType =
+        typename std::tuple_element<INDEX, decltype(OptionsPack())>::type;
 
     /// @brief Creates an Options tuple with a default set of parameters:
     /// an initial number and a resize factor.
-    Options()
-      : pars({1024, 1}) {
-    }
+    Options() : pars({1024, 1}) {}
 
     /// @brief Creates an Options tuple from a full set of parameters.
-    Options(OPTIONS... options)
-      : pars({options...}) {
-    }
+    Options(OPTIONS... options) : pars({options...}) {}
 
     /// @brief The initial number of
     /// {@link GrowableBuffer#reserved reserved} entries for a GrowableBuffer.
@@ -57,7 +54,7 @@ namespace awkward {
     }
 
     /// @brief Access to all other options.
-    template<std::size_t INDEX>
+    template <std::size_t INDEX>
     const OptionType<INDEX>&
     option() const noexcept {
       return std::get<INDEX>(pars);
@@ -67,6 +64,6 @@ namespace awkward {
   };
 
   using BuilderOptions = Options<int64_t, double>;
-}
+}  // namespace awkward
 
-#endif // AWKWARD_BUILDEROPTIONS_H_
+#endif  // AWKWARD_BUILDEROPTIONS_H_

--- a/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
@@ -21,11 +21,13 @@ namespace awkward {
 
     using OptionsPack = typename std::tuple<OPTIONS...>;
 
+    // FIXME:
     // std::tuple_element_t is missing on some of the CI node compilers
     //
     // template<std::size_t INDEX>
     // using OptionType = std::tuple_element_t<INDEX, OptionsPack>;
 
+    template<std::size_t INDEX>
     using OptionType = typename std::tuple_element<INDEX, decltype(OptionsPack())>::type;
 
     /// @brief Creates an Options tuple with a default set of parameters:

--- a/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
@@ -1,24 +1,24 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#ifndef AWKWARD_ARRAYBUILDEROPTIONS_H_
-#define AWKWARD_ARRAYBUILDEROPTIONS_H_
+#ifndef AWKWARD_BUILDEROPTIONS_H_
+#define AWKWARD_BUILDEROPTIONS_H_
 
 #include <cstring>
 
 namespace awkward {
-  /// @class ArrayBuilderOptions
+  /// @class BuilderOptions
   ///
   /// @brief Container for all configuration options needed by ArrayBuilder,
   /// GrowableBuffer, and the Builder subclasses.
-  struct ArrayBuilderOptions {
-    /// @brief Creates an ArrayBuilderOptions from a full set of parameters.
+  struct BuilderOptions {
+    /// @brief Creates an BuilderOptions from a full set of parameters.
     ///
     /// @param initial The initial number of
     /// {@link GrowableBuffer#reserved reserved} entries for a GrowableBuffer.
     /// @param resize The factor with which a GrowableBuffer is resized
     /// when its {@link GrowableBuffer#length length} reaches its
     /// {@link GrowableBuffer#reserved reserved}.
-    ArrayBuilderOptions(int64_t from_initial, double from_resize)
+    BuilderOptions(int64_t from_initial, double from_resize)
       : initial(from_initial) ,
         resize(from_resize) {}
 
@@ -33,4 +33,4 @@ namespace awkward {
   };
 }
 
-#endif // AWKWARD_ARRAYBUILDEROPTIONS_H_
+#endif // AWKWARD_BUILDEROPTIONS_H_

--- a/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
@@ -32,7 +32,7 @@ namespace awkward {
         typename std::tuple_element<INDEX, decltype(OptionsPack())>::type;
 
     /// @brief Creates an Options tuple from a full set of parameters.
-    Options(OPTIONS... options) : pars({options...}) {}
+    Options(OPTIONS... options) : pars(options...) {}
 
     /// @brief The initial number of
     /// {@link GrowableBuffer#reserved reserved} entries for a GrowableBuffer.

--- a/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
@@ -3,34 +3,64 @@
 #ifndef AWKWARD_BUILDEROPTIONS_H_
 #define AWKWARD_BUILDEROPTIONS_H_
 
+#include <cassert>
 #include <cstring>
+#include <tuple>
+#include <type_traits>
+#include <vector>
 
 namespace awkward {
-  /// @class BuilderOptions
+
+  /// @class Options
   ///
   /// @brief Container for all configuration options needed by ArrayBuilder,
-  /// GrowableBuffer, and the Builder subclasses.
-  struct BuilderOptions {
-    /// @brief Creates an BuilderOptions from a full set of parameters.
-    ///
-    /// @param initial The initial number of
-    /// {@link GrowableBuffer#reserved reserved} entries for a GrowableBuffer.
-    /// @param resize The factor with which a GrowableBuffer is resized
-    /// when its {@link GrowableBuffer#length length} reaches its
-    /// {@link GrowableBuffer#reserved reserved}.
-    BuilderOptions(int64_t from_initial, double from_resize)
-      : initial(from_initial) ,
-        resize(from_resize) {}
+  /// GrowableBuffer, LayoutBuilder and the Builder subclasses.
+  template<typename... OPTIONS>
+  struct Options {
+    static constexpr std::size_t value = sizeof...(OPTIONS);
+
+    using OptionsPack = typename std::tuple<OPTIONS...>;
+
+    template<std::size_t INDEX>
+    using OptionType = std::tuple_element_t<INDEX, OptionsPack>;
+
+    /// @brief Creates an Options tuple with a default set of parameters:
+    /// an initial number and a resize factor.
+    Options()
+      : pars({1024, 1}) {
+    }
+
+    /// @brief Creates an Options tuple from a full set of parameters.
+    Options(OPTIONS... options)
+      : pars({options...}) {
+    }
 
     /// @brief The initial number of
     /// {@link GrowableBuffer#reserved reserved} entries for a GrowableBuffer.
-    int64_t initial;
+    int64_t
+    initial() const noexcept {
+      return option<0>();
+    }
 
     /// @brief The factor with which a GrowableBuffer is resized
     /// when its {@link GrowableBuffer#length length} reaches its
     /// {@link GrowableBuffer#reserved reserved}.
-    double resize;
+    double
+    resize() const noexcept {
+      return option<1>();
+    }
+
+    /// @brief Access to all other options.
+    template<std::size_t INDEX>
+    const OptionType<INDEX>&
+    option() const noexcept {
+      return std::get<INDEX>(pars);
+    }
+
+    OptionsPack pars;
   };
+
+  using BuilderOptions = Options<int64_t, double>;
 }
 
 #endif // AWKWARD_BUILDEROPTIONS_H_

--- a/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
+++ b/src/awkward/_v2/cpp-headers/awkward/BuilderOptions.h
@@ -21,8 +21,12 @@ namespace awkward {
 
     using OptionsPack = typename std::tuple<OPTIONS...>;
 
-    template<std::size_t INDEX>
-    using OptionType = std::tuple_element_t<INDEX, OptionsPack>;
+    // std::tuple_element_t is missing on some of the CI node compilers
+    //
+    // template<std::size_t INDEX>
+    // using OptionType = std::tuple_element_t<INDEX, OptionsPack>;
+
+    using OptionType = typename std::tuple_element<INDEX, decltype(OptionsPack())>::type;
 
     /// @brief Creates an Options tuple with a default set of parameters:
     /// an initial number and a resize factor.

--- a/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
@@ -20,26 +20,22 @@ namespace awkward {
   class Panel {
   public:
     Panel(size_t reserved)
-      : ptr_(std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[reserved])),
-        length_(0),
-        reserved_(reserved),
-        next_(nullptr) {  }
+        : ptr_(std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[reserved])),
+          length_(0),
+          reserved_(reserved),
+          next_(nullptr) {}
 
     Panel(std::unique_ptr<PRIMITIVE[]> ptr, size_t length, size_t reserved)
-      : ptr_(std::move(ptr)),
-        length_(length),
-        reserved_(reserved),
-        next_(nullptr) {
-    }
+        : ptr_(std::move(ptr)),
+          length_(length),
+          reserved_(reserved),
+          next_(nullptr) {}
 
-    PRIMITIVE &operator[](size_t i) {
-      return ptr_.get()[i];
-    }
+    PRIMITIVE& operator[](size_t i) { return ptr_.get()[i]; }
 
     Panel*
     append_panel(size_t reserved) {
-      next_ = std::move(std::unique_ptr<Panel>(
-        new Panel(reserved)));
+      next_ = std::move(std::unique_ptr<Panel>(new Panel(reserved)));
       return next_.get();
     }
 
@@ -66,13 +62,15 @@ namespace awkward {
 
     void
     concatenate_to(PRIMITIVE* to_ptr, size_t offset) const noexcept {
-      memcpy(to_ptr + offset, reinterpret_cast<void*>(ptr_.get()), length_ * sizeof(PRIMITIVE));
+      memcpy(to_ptr + offset,
+             reinterpret_cast<void*>(ptr_.get()),
+             length_ * sizeof(PRIMITIVE));
       if (next_) {
         next_->concatenate_to(to_ptr, offset + length_);
       }
     }
 
-    template<typename TO_PRIMITIVE>
+    template <typename TO_PRIMITIVE>
     void
     copy_as(TO_PRIMITIVE* to_ptr, size_t offset) {
       for (size_t i = 0; i < length_; i++) {
@@ -131,9 +129,11 @@ namespace awkward {
       if (actual < minreserve) {
         actual = minreserve;
       }
-      return GrowableBuffer(options,
-        std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]),
-        0, actual);
+      return GrowableBuffer(
+          options,
+          std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]),
+          0,
+          actual);
     }
 
     /// @brief Creates a GrowableBuffer in which all elements are initialized to `0`.
@@ -152,7 +152,7 @@ namespace awkward {
       }
       auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]);
       PRIMITIVE* rawptr = ptr.get();
-      for (int64_t i = 0;  i < length;  i++) {
+      for (int64_t i = 0; i < length; i++) {
         rawptr[i] = 0;
       }
       return GrowableBuffer(options, std::move(ptr), length, actual);
@@ -176,7 +176,7 @@ namespace awkward {
       }
       auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]);
       PRIMITIVE* rawptr = ptr.get();
-      for (int64_t i = 0;  i < length;  i++) {
+      for (int64_t i = 0; i < length; i++) {
         rawptr[i] = value;
       }
       return GrowableBuffer<PRIMITIVE>(options, std::move(ptr), length, actual);
@@ -199,7 +199,7 @@ namespace awkward {
       }
       auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]);
       PRIMITIVE* rawptr = ptr.get();
-      for (int64_t i = 0;  i < length;  i++) {
+      for (int64_t i = 0; i < length; i++) {
         rawptr[i] = (PRIMITIVE)i;
       }
       return GrowableBuffer(options, std::move(ptr), length, actual);
@@ -210,18 +210,24 @@ namespace awkward {
     ///
     /// Used to change the data type of buffer content from `PRIMITIVE`
     /// to `TO_PRIMITIVE` for building arrays.
-    template<typename TO_PRIMITIVE>
+    template <typename TO_PRIMITIVE>
     static GrowableBuffer<TO_PRIMITIVE>
     copy_as(const GrowableBuffer<PRIMITIVE>& other) {
       auto len = other.length();
-      int64_t actual = (len < other.options_.initial()) ? other.options_.initial() : len;
+      int64_t actual =
+          (len < other.options_.initial()) ? other.options_.initial() : len;
 
-      auto ptr = std::unique_ptr<TO_PRIMITIVE[]>(new TO_PRIMITIVE[(size_t)actual]);
+      auto ptr =
+          std::unique_ptr<TO_PRIMITIVE[]>(new TO_PRIMITIVE[(size_t)actual]);
       TO_PRIMITIVE* rawptr = ptr.get();
 
       other.panel_->copy_as(rawptr, 0);
 
-      return GrowableBuffer<TO_PRIMITIVE>(BuilderOptions(actual, other.options().resize()), std::move(ptr), len, actual);
+      return GrowableBuffer<TO_PRIMITIVE>(
+          BuilderOptions(actual, other.options().resize()),
+          std::move(ptr),
+          len,
+          actual);
     }
 
     /// @brief Creates a GrowableBuffer from a full set of parameters.
@@ -240,26 +246,27 @@ namespace awkward {
                    int64_t reserved)
         : options_(options),
           length_(0),
-          panel_(std::unique_ptr<Panel<PRIMITIVE>>(new Panel<PRIMITIVE>(std::move(ptr), (size_t)length, (size_t)reserved))),
-          ptr_(panel_.get()) {
-    }
+          panel_(std::unique_ptr<Panel<PRIMITIVE>>(new Panel<PRIMITIVE>(
+              std::move(ptr), (size_t)length, (size_t)reserved))),
+          ptr_(panel_.get()) {}
 
     /// @brief Creates a GrowableBuffer by allocating a new buffer, taking an
     /// options #reserved from #options.
     GrowableBuffer(const BuilderOptions& options)
         : GrowableBuffer(options,
-                         std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)options.initial()]),
+                         std::unique_ptr<PRIMITIVE[]>(
+                             new PRIMITIVE[(size_t)options.initial()]),
                          0,
-                         options.initial()) { }
+                         options.initial()) {}
 
     /// @brief Move constructor
     ///
     /// panel_ is move-only
     GrowableBuffer(GrowableBuffer&& other) noexcept
-      : options_(other.options_),
-        length_(other.length_),
-        panel_(std::move(other.panel_)),
-        ptr_(other.ptr_) { }
+        : options_(other.options_),
+          length_(other.length_),
+          panel_(std::move(other.panel_)),
+          ptr_(other.ptr_) {}
 
     /// @brief Currently used number of elements.
     ///
@@ -281,7 +288,8 @@ namespace awkward {
     /// options.initial(), and a new #ptr is allocated.
     void
     clear() {
-      panel_ = std::move(std::unique_ptr<Panel<PRIMITIVE>>(new Panel<PRIMITIVE>((size_t)options_.initial())));
+      panel_ = std::move(std::unique_ptr<Panel<PRIMITIVE>>(
+          new Panel<PRIMITIVE>((size_t)options_.initial())));
       ptr_ = panel_.get();
     }
 
@@ -290,8 +298,7 @@ namespace awkward {
     last() const {
       if (ptr_->current_length() == 0) {
         throw std::runtime_error("Buffer is empty");
-      }
-      else {
+      } else {
         return (*ptr_)[ptr_->current_length() - 1];
       }
     }
@@ -328,13 +335,12 @@ namespace awkward {
         for (size_t i = 0; i < empty_slots; i++) {
           fill_panel(ptr[i]);
         }
-        add_panel(size - empty_slots > ptr_->reserved() ?
-                  size - empty_slots : ptr_->reserved());
+        add_panel(size - empty_slots > ptr_->reserved() ? size - empty_slots
+                                                        : ptr_->reserved());
         for (size_t i = empty_slots; i < size; i++) {
           fill_panel(ptr[i]);
         }
-      }
-      else {
+      } else {
         for (size_t i = 0; i < size; i++) {
           fill_panel(ptr[i]);
         }
@@ -342,7 +348,8 @@ namespace awkward {
     }
 
     /// @brief Like append, but the type signature returns the reference to `PRIMITIVE`.
-    PRIMITIVE& append_and_get_ref(PRIMITIVE datum) {
+    PRIMITIVE&
+    append_and_get_ref(PRIMITIVE datum) {
       append(datum);
       return (*ptr_)[ptr_->current_length() - 1];
     }
@@ -383,6 +390,6 @@ namespace awkward {
     /// @brief A pointer to a current panel.
     Panel<PRIMITIVE>* ptr_;
   };
-}
+}  // namespace awkward
 
-#endif // AWKWARD_GROWABLEBUFFER_H_
+#endif  // AWKWARD_GROWABLEBUFFER_H_

--- a/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
@@ -347,14 +347,14 @@ namespace awkward {
     /// for the rest of the array elements.
     void
     extend(PRIMITIVE* ptr, size_t size) {
-      size_t empty_slots = ptr_->reserved() - ptr_->current_length();
-      if (size > empty_slots) {
-        for (size_t i = 0; i < empty_slots; i++) {
+      size_t unfilled_items = ptr_->reserved() - ptr_->current_length();
+      if (size > unfilled_items) {
+        for (size_t i = 0; i < unfilled_items; i++) {
           fill_panel(ptr[i]);
         }
-        add_panel(size - empty_slots > ptr_->reserved() ? size - empty_slots
+        add_panel(size - unfilled_items > ptr_->reserved() ? size - unfilled_items
                                                         : ptr_->reserved());
-        for (size_t i = empty_slots; i < size; i++) {
+        for (size_t i = unfilled_items; i < size; i++) {
           fill_panel(ptr[i]);
         }
       } else {

--- a/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
@@ -127,12 +127,12 @@ namespace awkward {
     /// of `minreserve` and #initial.
     static GrowableBuffer<PRIMITIVE>
     empty(const BuilderOptions& options, int64_t minreserve) {
-      int64_t actual = options.initial;
+      int64_t actual = options.initial();
       if (actual < minreserve) {
         actual = minreserve;
       }
       return GrowableBuffer(options,
-        std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[actual]),
+        std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]),
         0, actual);
     }
 
@@ -146,11 +146,11 @@ namespace awkward {
     /// [zeros](https://docs.scipy.org/doc/numpy/reference/generated/numpy.zeros.html).
     static GrowableBuffer<PRIMITIVE>
     zeros(const BuilderOptions& options, int64_t length) {
-      int64_t actual = options.initial;
+      int64_t actual = options.initial();
       if (actual < length) {
         actual = length;
       }
-      auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[actual]);
+      auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]);
       PRIMITIVE* rawptr = ptr.get();
       for (int64_t i = 0;  i < length;  i++) {
         rawptr[i] = 0;
@@ -170,11 +170,11 @@ namespace awkward {
     /// [full](https://docs.scipy.org/doc/numpy/reference/generated/numpy.full.html).
     static GrowableBuffer<PRIMITIVE>
     full(const BuilderOptions& options, PRIMITIVE value, int64_t length) {
-      int64_t actual = options.initial;
+      int64_t actual = options.initial();
       if (actual < length) {
         actual = length;
       }
-      auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[actual]);
+      auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]);
       PRIMITIVE* rawptr = ptr.get();
       for (int64_t i = 0;  i < length;  i++) {
         rawptr[i] = value;
@@ -193,11 +193,11 @@ namespace awkward {
     /// [arange](https://docs.scipy.org/doc/numpy/reference/generated/numpy.arange.html).
     static GrowableBuffer<PRIMITIVE>
     arange(const BuilderOptions& options, int64_t length) {
-      int64_t actual = options.initial;
+      int64_t actual = options.initial();
       if (actual < length) {
         actual = length;
       }
-      auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[actual]);
+      auto ptr = std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)actual]);
       PRIMITIVE* rawptr = ptr.get();
       for (int64_t i = 0;  i < length;  i++) {
         rawptr[i] = (PRIMITIVE)i;
@@ -214,14 +214,14 @@ namespace awkward {
     static GrowableBuffer<TO_PRIMITIVE>
     copy_as(const GrowableBuffer<PRIMITIVE>& other) {
       auto len = other.length();
-      int64_t actual = (len < other.options_.initial) ? other.options_.initial : len;
+      int64_t actual = (len < other.options_.initial()) ? other.options_.initial() : len;
 
-      auto ptr = std::unique_ptr<TO_PRIMITIVE[]>(new TO_PRIMITIVE[actual]);
+      auto ptr = std::unique_ptr<TO_PRIMITIVE[]>(new TO_PRIMITIVE[(size_t)actual]);
       TO_PRIMITIVE* rawptr = ptr.get();
 
       other.panel_->copy_as(rawptr, 0);
 
-      return GrowableBuffer<TO_PRIMITIVE>(BuilderOptions(actual, other.options().resize), std::move(ptr), len, actual);
+      return GrowableBuffer<TO_PRIMITIVE>(BuilderOptions(actual, other.options().resize()), std::move(ptr), len, actual);
     }
 
     /// @brief Creates a GrowableBuffer from a full set of parameters.
@@ -248,9 +248,9 @@ namespace awkward {
     /// options #reserved from #options.
     GrowableBuffer(const BuilderOptions& options)
         : GrowableBuffer(options,
-                         std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[options.initial]),
+                         std::unique_ptr<PRIMITIVE[]>(new PRIMITIVE[(size_t)options.initial()]),
                          0,
-                         options.initial) { }
+                         options.initial()) { }
 
     /// @brief Move constructor
     ///
@@ -278,10 +278,10 @@ namespace awkward {
     }
 
     /// @brief Discards accumulated data, the #reserved returns to
-    /// options.initial, and a new #ptr is allocated.
+    /// options.initial(), and a new #ptr is allocated.
     void
     clear() {
-      panel_ = std::move(std::unique_ptr<Panel<PRIMITIVE>>(new Panel<PRIMITIVE>((size_t)options_.initial)));
+      panel_ = std::move(std::unique_ptr<Panel<PRIMITIVE>>(new Panel<PRIMITIVE>((size_t)options_.initial())));
       ptr_ = panel_.get();
     }
 
@@ -310,7 +310,7 @@ namespace awkward {
     void
     append(PRIMITIVE datum) {
       if (ptr_->current_length() == ptr_->reserved()) {
-        add_panel((size_t)ceil(ptr_->reserved() * options_.resize));
+        add_panel((size_t)ceil(ptr_->reserved() * options_.resize()));
       }
       fill_panel(datum);
     }
@@ -373,9 +373,6 @@ namespace awkward {
 
     /// @brief Initial size configuration for building a panel.
     const BuilderOptions options_;
-
-    /// @brief Filled panels data length.
-    int64_t length_;
 
     /// @brief Filled panels data length.
     int64_t length_;

--- a/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
@@ -61,6 +61,23 @@ namespace awkward {
     }
 
     void
+    append(PRIMITIVE* to_ptr, size_t offset, size_t from, int64_t length) const noexcept {
+      memcpy(to_ptr + offset,
+             reinterpret_cast<void*>(ptr_.get() + from),
+             length * sizeof(PRIMITIVE) - from);
+    }
+
+    void
+    concatenate_to_from(PRIMITIVE* to_ptr, size_t offset, size_t from) const noexcept {
+      memcpy(to_ptr + offset,
+             reinterpret_cast<void*>(ptr_.get() + from),
+             length_ * sizeof(PRIMITIVE) - from);
+      if (next_) {
+        next_->concatenate_to(to_ptr, offset + length_);
+      }
+    }
+
+    void
     concatenate_to(PRIMITIVE* to_ptr, size_t offset) const noexcept {
       memcpy(to_ptr + offset,
              reinterpret_cast<void*>(ptr_.get()),
@@ -360,6 +377,24 @@ namespace awkward {
     concatenate(PRIMITIVE* external_pointer) const noexcept {
       if (external_pointer) {
         panel_->concatenate_to(external_pointer, 0);
+      }
+    }
+
+    /// @brief Copies and concatenates all accumulated data from multiple panels to one
+    /// contiguously allocated `external_pointer`.
+    void
+    concatenate_from(PRIMITIVE* external_pointer, size_t to, size_t from) const noexcept {
+      if (external_pointer) {
+        panel_->concatenate_to_from(external_pointer, to, from);
+      }
+    }
+
+    /// @brief Copies and concatenates all accumulated data from multiple panels to one
+    /// contiguously allocated `external_pointer`.
+    void
+    append(PRIMITIVE* external_pointer, size_t offset, size_t from, int64_t length) const noexcept {
+      if (external_pointer) {
+        panel_->append(external_pointer, offset, from, length);
       }
     }
 

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -16,1764 +16,1808 @@ namespace awkward {
 
   namespace LayoutBuilder {
 
-  // helper class for RecordLayoutBuilder
-  template<std::size_t ENUM, typename BUILDER>
-  class Field {
-  public:
-    using Builder = BUILDER;
+    // helper class for RecordLayoutBuilder
+    template <std::size_t ENUM, typename BUILDER>
+    class Field {
+    public:
+      using Builder = BUILDER;
 
-    std::string index_as_field() const {
-      return std::to_string(static_cast<size_t>(index));
-    }
-
-    const std::size_t index = ENUM;
-    Builder builder;
-  };
-
-  // NumpyLayoutBuilder
-  template <typename PRIMITIVE>
-  class Numpy {
-  public:
-
-    Numpy()
-        : data_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    Numpy(const awkward::BuilderOptions& options)
-        : data_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    void
-    append(PRIMITIVE x) noexcept {
-      data_.append(x);
-    }
-
-    void
-    extend(PRIMITIVE* ptr, size_t size) noexcept {
-      data_.extend(ptr, size);
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-    }
-
-    void
-    clear() noexcept {
-      data_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return data_.length();
-    }
-
-    bool
-    is_valid(std::string& error) const noexcept {
-      return true;
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      names_nbytes["node" + std::to_string(id_) + "-data"] = data_.nbytes();
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      data_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-data"]));
-    }
-
-    std::string
-    form() const {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
+      std::string
+      index_as_field() const {
+        return std::to_string(static_cast<size_t>(index));
       }
 
-      if (std::is_arithmetic<PRIMITIVE>::value) {
-        return "{ \"class\": \"NumpyArray\", \"primitive\": \""
-                  + type_to_name<PRIMITIVE>() +"\"" + params
-                  + ", \"form_key\": \"" + form_key.str() + "\" }";
-      }
-      else if (is_specialization<PRIMITIVE, std::complex>::value) {
-        return "{ \"class\": \"NumpyArray\", \"primitive\": \""
-                  + type_to_name<PRIMITIVE>() + "\"" + params
-                  + ", \"form_key\": \"" + form_key.str() + "\" }";
-      }
-      else {
-        throw std::runtime_error
-          ("type " + std::string(typeid(PRIMITIVE).name()) + "is not supported");
-      }
-    }
+      const std::size_t index = ENUM;
+      Builder builder;
+    };
 
-  private:
-    awkward::GrowableBuffer<PRIMITIVE> data_;
-    std::string parameters_;
-    size_t id_;
-  };
-
-  // ListOffsetLayoutBuilder
-  template <typename PRIMITIVE, typename BUILDER>
-  class ListOffset {
-  public:
-
-    ListOffset()
-        : offsets_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
-      offsets_.append(0);
-      size_t id = 0;
-      set_id(id);
-    }
-
-    ListOffset(const awkward::BuilderOptions& options)
-        : offsets_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
-      offsets_.append(0);
-      size_t id = 0;
-      set_id(id);
-    }
-
-    BUILDER&
-    content() noexcept {
-      return content_;
-    }
-
-    BUILDER&
-    begin_list() noexcept {
-      return content_;
-    }
-
-    void
-    end_list() noexcept {
-      offsets_.append(content_.length());
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      content_.set_id(id);
-    }
-
-    void
-    clear() noexcept {
-      offsets_.clear();
-      offsets_.append(0);
-      content_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return offsets_.length() - 1;
-    }
-
-    bool
-    is_valid(std::string& error) const noexcept {
-      if (content_.length() != offsets_.last()) {
-        std::stringstream out;
-        out << "ListOffset node" << id_ << "has content length " << content_.length()
-            << "but last offset " << offsets_.last() << "\n";
-        error.append(out.str());
-
-        return false;
-      }
-      else {
-        return content_.is_valid(error);
-      }
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      names_nbytes["node" + std::to_string(id_) + "-offsets"] = offsets_.nbytes();
-      content_.buffer_nbytes(names_nbytes);
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      offsets_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-offsets"]));
-      content_.to_buffers(buffers);
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
-      }
-      return "{ \"class\": \"ListOffsetArray\", \"offsets\": \""
-                + type_to_numpy_like<PRIMITIVE>()
-                + "\", \"content\": "+ content_.form() + params
-                + ", \"form_key\": \"" + form_key.str() + "\" }";
-    }
-
-  private:
-    GrowableBuffer<PRIMITIVE> offsets_;
-    BUILDER content_;
-    std::string parameters_;
-    size_t id_;
-  };
-
-  // ListLayoutBuilder
-  template <typename PRIMITIVE, typename BUILDER>
-  class List {
-  public:
-
-    List()
-        : starts_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions()))
-        , stops_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    List(const awkward::BuilderOptions& options)
-        : starts_(awkward::GrowableBuffer<PRIMITIVE>(options))
-        , stops_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    BUILDER&
-    content() noexcept {
-      return content_;
-    }
-
-    BUILDER&
-    begin_list() noexcept {
-      starts_.append(content_.length());
-      return content_;
-    }
-
-    void
-    end_list() noexcept {
-      stops_.append(content_.length());
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      content_.set_id(id);
-    }
-
-    void
-    clear() noexcept {
-      starts_.clear();
-      stops_.clear();
-      content_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return starts_.length();
-    }
-
-    bool
-    is_valid(std::string& error) const noexcept {
-      if (starts_.length() != stops_.length()) {
-        std::stringstream out;
-        out << "List node" << id_ << " has starts length " << starts_.length()
-            << " but stops length " << stops_.length() << "\n";
-        error.append(out.str());
-
-        return false;
-      }
-      else if (stops_.length() > 0 && content_.length() != stops_.last()) {
-        std::stringstream out;
-        out << "List node" << id_ << " has content length " << content_.length()
-            << " but last stops " << stops_.last() << "\n";
-        error.append(out.str());
-
-        return false;
-      }
-      else {
-        return content_.is_valid(error);
-      }
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      names_nbytes["node" + std::to_string(id_) + "-starts"] = starts_.nbytes();
-      names_nbytes["node" + std::to_string(id_) + "-stops"] = stops_.nbytes();
-      content_.buffer_nbytes(names_nbytes);
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      starts_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-starts"]));
-      stops_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-stops"]));
-      content_.to_buffers(buffers);
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
-      }
-      return "{ \"class\": \"ListArray\", \"starts\": \"" + type_to_numpy_like<PRIMITIVE>()
-                + "\", \"stops\": \"" + type_to_numpy_like<PRIMITIVE>() + "\", \"content\": "
-                + content_.form() + params + ", \"form_key\": \"" + form_key.str() + "\" }";
-    }
-
-  private:
-    GrowableBuffer<PRIMITIVE> starts_;
-    GrowableBuffer<PRIMITIVE> stops_;
-    BUILDER content_;
-    std::string parameters_;
-    size_t id_;
-  };
-
-  // EmptyLayoutBuilder
-  class Empty {
-  public:
-    Empty() {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-    }
-
-    void
-    clear() noexcept { }
-
-    size_t
-    length() const noexcept {
-      return 0;
-    }
-
-    bool
-    is_valid(std::string& /* error */) const noexcept {
-      return true;
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept { }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept { }
-
-    std::string
-    form() const noexcept {
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
-      }
-      return "{ \"class\": \"EmptyArray\"" + params + " }";
-    }
-
-  private:
-    std::string parameters_;
-    size_t id_;
-  };
-
-  // EmptyRecordLayoutBuilder
-  template<bool IS_TUPLE>
-  class EmptyRecord {
-  public:
-    EmptyRecord()
-    : length_(0) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    void
-    append() noexcept {
-      length_++;
-    }
-
-    void
-    extend(size_t size) noexcept {
-      length_ += size;
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-    }
-
-    void
-    clear() noexcept {
-      length_ = 0;
-    }
-
-    size_t
-    length() const noexcept {
-      return length_;
-    }
-
-    bool
-    is_valid(std::string& /* error */) const noexcept {
-      return true;
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept { }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept { }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
+    // NumpyLayoutBuilder
+    template <typename PRIMITIVE>
+    class Numpy {
+    public:
+      Numpy()
+          : data_(
+                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+        size_t id = 0;
+        set_id(id);
       }
 
-      if (is_tuple_) {
-        return "{ \"class\": \"RecordArray\", \"contents\": []" + params
-                  + ", \"form_key\": \"" + form_key.str() + "\" }";
+      Numpy(const awkward::BuilderOptions& options)
+          : data_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
+        size_t id = 0;
+        set_id(id);
       }
-      else {
-        return "{ \"class\": \"RecordArray\", \"contents\": {}" + params
-                  + ", \"form_key\": \"" + form_key.str() + "\" }";
+
+      void
+      append(PRIMITIVE x) noexcept {
+        data_.append(x);
       }
-    }
 
-  private:
-    std::string parameters_;
-    size_t id_;
-    size_t length_;
-    bool is_tuple_ = IS_TUPLE;
-  };
+      void
+      extend(PRIMITIVE* ptr, size_t size) noexcept {
+        data_.extend(ptr, size);
+      }
 
-  // RecordLayoutBuilder
-  template <class MAP = std::map<std::size_t, std::string>, typename... BUILDERS>
-  class Record {
-  public:
-    using RecordContents = typename std::tuple<BUILDERS...>;
-    using UserDefinedMap = MAP;
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
 
-    template<std::size_t INDEX>
-    using RecordFieldType = std::tuple_element_t<INDEX, RecordContents>;
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
 
-    Record() {
-      size_t id = 0;
-      set_id(id);
-      map_fields(std::index_sequence_for<BUILDERS...>());
-    }
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+      }
 
-    Record(UserDefinedMap user_defined_field_id_to_name_map)
-      : content_names_(user_defined_field_id_to_name_map) {
-      assert(content_names_.size() == fields_count_);
-      size_t id = 0;
-      set_id(id);
-    }
+      void
+      clear() noexcept {
+        data_.clear();
+      }
 
-    const std::vector<std::string>
-    field_names() const noexcept {
-      if (content_names_.empty()) {
-        return field_names_;
-      } else {
-        std::vector<std::string> result;
-        for(auto it : content_names_) {
-          result.emplace_back(it.second);
+      size_t
+      length() const noexcept {
+        return data_.length();
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        return true;
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        names_nbytes["node" + std::to_string(id_) + "-data"] = data_.nbytes();
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        data_.concatenate(static_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-data"]));
+      }
+
+      std::string
+      form() const {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
-        return result;
-      }
-    }
 
-    void
-    set_field_names(MAP user_defined_field_id_to_name_map) noexcept {
+        if (std::is_arithmetic<PRIMITIVE>::value) {
+          return "{ \"class\": \"NumpyArray\", \"primitive\": \"" +
+                 type_to_name<PRIMITIVE>() + "\"" + params +
+                 ", \"form_key\": \"" + form_key.str() + "\" }";
+        } else if (is_specialization<PRIMITIVE, std::complex>::value) {
+          return "{ \"class\": \"NumpyArray\", \"primitive\": \"" +
+                 type_to_name<PRIMITIVE>() + "\"" + params +
+                 ", \"form_key\": \"" + form_key.str() + "\" }";
+        } else {
+          throw std::runtime_error("type " +
+                                   std::string(typeid(PRIMITIVE).name()) +
+                                   "is not supported");
+        }
+      }
+
+    private:
+      awkward::GrowableBuffer<PRIMITIVE> data_;
+      std::string parameters_;
+      size_t id_;
+    };
+
+    // ListOffsetLayoutBuilder
+    template <typename PRIMITIVE, typename BUILDER>
+    class ListOffset {
+    public:
+      ListOffset()
+          : offsets_(
+                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+        offsets_.append(0);
+        size_t id = 0;
+        set_id(id);
+      }
+
+      ListOffset(const awkward::BuilderOptions& options)
+          : offsets_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
+        offsets_.append(0);
+        size_t id = 0;
+        set_id(id);
+      }
+
+      BUILDER&
+      content() noexcept {
+        return content_;
+      }
+
+      BUILDER&
+      begin_list() noexcept {
+        return content_;
+      }
+
+      void
+      end_list() noexcept {
+        offsets_.append(content_.length());
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
+      }
+
+      void
+      clear() noexcept {
+        offsets_.clear();
+        offsets_.append(0);
+        content_.clear();
+      }
+
+      size_t
+      length() const noexcept {
+        return offsets_.length() - 1;
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (content_.length() != offsets_.last()) {
+          std::stringstream out;
+          out << "ListOffset node" << id_ << "has content length "
+              << content_.length() << "but last offset " << offsets_.last()
+              << "\n";
+          error.append(out.str());
+
+          return false;
+        } else {
+          return content_.is_valid(error);
+        }
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        names_nbytes["node" + std::to_string(id_) + "-offsets"] =
+            offsets_.nbytes();
+        content_.buffer_nbytes(names_nbytes);
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        offsets_.concatenate(static_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-offsets"]));
+        content_.to_buffers(buffers);
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+        return "{ \"class\": \"ListOffsetArray\", \"offsets\": \"" +
+               type_to_numpy_like<PRIMITIVE>() +
+               "\", \"content\": " + content_.form() + params +
+               ", \"form_key\": \"" + form_key.str() + "\" }";
+      }
+
+    private:
+      GrowableBuffer<PRIMITIVE> offsets_;
+      BUILDER content_;
+      std::string parameters_;
+      size_t id_;
+    };
+
+    // ListLayoutBuilder
+    template <typename PRIMITIVE, typename BUILDER>
+    class List {
+    public:
+      List()
+          : starts_(
+                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())),
+            stops_(
+                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      List(const awkward::BuilderOptions& options)
+          : starts_(awkward::GrowableBuffer<PRIMITIVE>(options)),
+            stops_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      BUILDER&
+      content() noexcept {
+        return content_;
+      }
+
+      BUILDER&
+      begin_list() noexcept {
+        starts_.append(content_.length());
+        return content_;
+      }
+
+      void
+      end_list() noexcept {
+        stops_.append(content_.length());
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
+      }
+
+      void
+      clear() noexcept {
+        starts_.clear();
+        stops_.clear();
+        content_.clear();
+      }
+
+      size_t
+      length() const noexcept {
+        return starts_.length();
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (starts_.length() != stops_.length()) {
+          std::stringstream out;
+          out << "List node" << id_ << " has starts length " << starts_.length()
+              << " but stops length " << stops_.length() << "\n";
+          error.append(out.str());
+
+          return false;
+        } else if (stops_.length() > 0 && content_.length() != stops_.last()) {
+          std::stringstream out;
+          out << "List node" << id_ << " has content length "
+              << content_.length() << " but last stops " << stops_.last()
+              << "\n";
+          error.append(out.str());
+
+          return false;
+        } else {
+          return content_.is_valid(error);
+        }
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        names_nbytes["node" + std::to_string(id_) + "-starts"] =
+            starts_.nbytes();
+        names_nbytes["node" + std::to_string(id_) + "-stops"] = stops_.nbytes();
+        content_.buffer_nbytes(names_nbytes);
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        starts_.concatenate(static_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-starts"]));
+        stops_.concatenate(static_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-stops"]));
+        content_.to_buffers(buffers);
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+        return "{ \"class\": \"ListArray\", \"starts\": \"" +
+               type_to_numpy_like<PRIMITIVE>() + "\", \"stops\": \"" +
+               type_to_numpy_like<PRIMITIVE>() +
+               "\", \"content\": " + content_.form() + params +
+               ", \"form_key\": \"" + form_key.str() + "\" }";
+      }
+
+    private:
+      GrowableBuffer<PRIMITIVE> starts_;
+      GrowableBuffer<PRIMITIVE> stops_;
+      BUILDER content_;
+      std::string parameters_;
+      size_t id_;
+    };
+
+    // EmptyLayoutBuilder
+    class Empty {
+    public:
+      Empty() {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {}
+
+      void
+      clear() noexcept {}
+
+      size_t
+      length() const noexcept {
+        return 0;
+      }
+
+      bool
+      is_valid(std::string& /* error */) const noexcept {
+        return true;
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {}
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {}
+
+      std::string
+      form() const noexcept {
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+        return "{ \"class\": \"EmptyArray\"" + params + " }";
+      }
+
+    private:
+      std::string parameters_;
+      size_t id_;
+    };
+
+    // EmptyRecordLayoutBuilder
+    template <bool IS_TUPLE>
+    class EmptyRecord {
+    public:
+      EmptyRecord() : length_(0) {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      void
+      append() noexcept {
+        length_++;
+      }
+
+      void
+      extend(size_t size) noexcept {
+        length_ += size;
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+      }
+
+      void
+      clear() noexcept {
+        length_ = 0;
+      }
+
+      size_t
+      length() const noexcept {
+        return length_;
+      }
+
+      bool
+      is_valid(std::string& /* error */) const noexcept {
+        return true;
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {}
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {}
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+
+        if (is_tuple_) {
+          return "{ \"class\": \"RecordArray\", \"contents\": []" + params +
+                 ", \"form_key\": \"" + form_key.str() + "\" }";
+        } else {
+          return "{ \"class\": \"RecordArray\", \"contents\": {}" + params +
+                 ", \"form_key\": \"" + form_key.str() + "\" }";
+        }
+      }
+
+    private:
+      std::string parameters_;
+      size_t id_;
+      size_t length_;
+      bool is_tuple_ = IS_TUPLE;
+    };
+
+    // RecordLayoutBuilder
+    template <class MAP = std::map<std::size_t, std::string>,
+              typename... BUILDERS>
+    class Record {
+    public:
+      using RecordContents = typename std::tuple<BUILDERS...>;
+      using UserDefinedMap = MAP;
+
+      template <std::size_t INDEX>
+      using RecordFieldType = std::tuple_element_t<INDEX, RecordContents>;
+
+      Record() {
+        size_t id = 0;
+        set_id(id);
+        map_fields(std::index_sequence_for<BUILDERS...>());
+      }
+
+      Record(UserDefinedMap user_defined_field_id_to_name_map)
+          : content_names_(user_defined_field_id_to_name_map) {
+        assert(content_names_.size() == fields_count_);
+        size_t id = 0;
+        set_id(id);
+      }
+
+      const std::vector<std::string>
+      field_names() const noexcept {
+        if (content_names_.empty()) {
+          return field_names_;
+        } else {
+          std::vector<std::string> result;
+          for (auto it : content_names_) {
+            result.emplace_back(it.second);
+          }
+          return result;
+        }
+      }
+
+      void
+      set_field_names(MAP user_defined_field_id_to_name_map) noexcept {
         content_names_ = user_defined_field_id_to_name_map;
-    }
-
-    template<std::size_t INDEX>
-    typename RecordFieldType<INDEX>::Builder&
-    field() noexcept {
-      return std::get<INDEX>(contents).builder;
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      for (size_t i = 0; i < fields_count_; i++) {
-        visit_at(contents, i, [&id] (auto& content) { content.builder.set_id(id); });
       }
-    }
 
-    void
-    clear() noexcept {
-      for (size_t i = 0; i < fields_count_; i++)
-        visit_at(contents, i, [](auto& content) { content.builder.clear(); });
-    }
+      template <std::size_t INDEX>
+      typename RecordFieldType<INDEX>::Builder&
+      field() noexcept {
+        return std::get<INDEX>(contents).builder;
+      }
 
-    const size_t
-    length() const noexcept {
-      return (std::get<0>(contents).builder.length());
-    }
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
 
-    bool
-    is_valid(std::string& error) const noexcept {
-      auto index_sequence((std::index_sequence_for<BUILDERS...>()));
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
 
-      size_t length = -1;
-      bool result = false;
-      std::vector<size_t> lengths = field_lengths(index_sequence);
-      for (size_t i = 0; i < lengths.size(); i++) {
-        if (length == -1) {
-          length = lengths[i];
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        for (size_t i = 0; i < fields_count_; i++) {
+          visit_at(contents, i, [&id](auto& content) {
+            content.builder.set_id(id);
+          });
         }
-        else if (length != lengths[i]) {
+      }
+
+      void
+      clear() noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [](auto& content) {
+            content.builder.clear();
+          });
+      }
+
+      const size_t
+      length() const noexcept {
+        return (std::get<0>(contents).builder.length());
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        auto index_sequence((std::index_sequence_for<BUILDERS...>()));
+
+        size_t length = -1;
+        bool result = false;
+        std::vector<size_t> lengths = field_lengths(index_sequence);
+        for (size_t i = 0; i < lengths.size(); i++) {
+          if (length == -1) {
+            length = lengths[i];
+          } else if (length != lengths[i]) {
+            std::stringstream out;
+            out << "Record node" << id_ << " has field \""
+                << field_names().at(i) << "\" length " << lengths[i]
+                << " that differs from the first length " << length << "\n";
+            error.append(out.str());
+
+            return false;
+          }
+        }
+
+        std::vector<bool> valid_fields = field_is_valid(index_sequence, error);
+        return std::none_of(std::cbegin(valid_fields),
+                            std::cend(valid_fields),
+                            std::logical_not<bool>());
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [&names_nbytes](auto& content) {
+            content.builder.buffer_nbytes(names_nbytes);
+          });
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [&buffers](auto& content) {
+            content.builder.to_buffers(buffers);
+          });
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string("\"parameters\": { " + parameters_ + " }, ");
+        }
+        std::stringstream out;
+        out << "{ \"class\": \"RecordArray\", \"contents\": { ";
+        for (size_t i = 0; i < fields_count_; i++) {
+          if (i != 0) {
+            out << ", ";
+          }
+          auto contents_form = [&](auto& content) {
+            out << "\""
+                << (!content_names_.empty() ? content_names_.at(content.index)
+                                            : content.index_as_field())
+                << +"\": ";
+            out << content.builder.form();
+          };
+          visit_at(contents, i, contents_form);
+        }
+        out << " }, ";
+        out << params << "\"form_key\": \"" << form_key.str() << "\" }";
+        return out.str();
+      }
+
+      RecordContents contents;
+
+    private:
+      std::vector<std::string> field_names_;
+      UserDefinedMap content_names_;
+      std::string parameters_;
+      size_t id_;
+
+      static constexpr size_t fields_count_ = sizeof...(BUILDERS);
+
+      template <std::size_t... S>
+      void
+      map_fields(std::index_sequence<S...>) noexcept {
+        field_names_ = std::vector<std::string>(
+            {std::string(std::get<S>(contents).index_as_field())...});
+      }
+
+      template <std::size_t... S>
+      std::vector<size_t>
+      field_lengths(std::index_sequence<S...>) const noexcept {
+        return std::vector<size_t>({std::get<S>(contents).builder.length()...});
+      }
+
+      template <std::size_t... S>
+      std::vector<bool>
+      field_is_valid(std::index_sequence<S...>, std::string& error) const
+          noexcept {
+        return std::vector<bool>(
+            {std::get<S>(contents).builder.is_valid(error)...});
+      }
+    };
+
+    // TupleLayoutBuilder
+    template <typename... BUILDERS>
+    class Tuple {
+      using TupleContents = typename std::tuple<BUILDERS...>;
+
+      template <std::size_t INDEX>
+      using TupleContentType = std::tuple_element_t<INDEX, TupleContents>;
+
+    public:
+      Tuple() {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      template <std::size_t INDEX>
+      TupleContentType<INDEX>&
+      index() noexcept {
+        return std::get<INDEX>(contents);
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        for (size_t i = 0; i < fields_count_; i++) {
+          visit_at(contents, i, [&id](auto& content) {
+            content.set_id(id);
+          });
+        }
+      }
+
+      void
+      clear() noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [](auto& content) {
+            content.builder.clear();
+          });
+      }
+
+      const size_t
+      length() const noexcept {
+        return (std::get<0>(contents).builder.length());
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        auto index_sequence((std::index_sequence_for<BUILDERS...>()));
+
+        size_t length = -1;
+        bool result = false;
+        std::vector<size_t> lengths = content_lengths(index_sequence);
+        for (size_t i = 0; i < lengths.size(); i++) {
+          if (length == -1) {
+            length = lengths[i];
+          } else if (length != lengths[i]) {
+            std::stringstream out;
+            out << "Record node" << id_ << " has index \"" << i << "\" length "
+                << lengths[i] << " that differs from the first length "
+                << length << "\n";
+            error.append(out.str());
+
+            return false;
+          }
+        }
+
+        std::vector<bool> valid_fields =
+            content_is_valid(index_sequence, error);
+        return std::none_of(std::cbegin(valid_fields),
+                            std::cend(valid_fields),
+                            std::logical_not<bool>());
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [&names_nbytes](auto& content) {
+            content.buffer_nbytes(names_nbytes);
+          });
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [&buffers](auto& content) {
+            content.to_buffers(buffers);
+          });
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string("\"parameters\": { " + parameters_ + " }, ");
+        }
+        std::stringstream out;
+        out << "{ \"class\": \"RecordArray\", \"contents\": [";
+        for (size_t i = 0; i < fields_count_; i++) {
+          if (i != 0) {
+            out << ", ";
+          }
+          auto contents_form = [&out](auto& content) {
+            out << content.form();
+          };
+          visit_at(contents, i, contents_form);
+        }
+        out << "], ";
+        out << params << "\"form_key\": \"" << form_key.str() << "\" }";
+        return out.str();
+      }
+
+      TupleContents contents;
+
+    private:
+      std::vector<int64_t> field_index_;
+      std::string parameters_;
+      size_t id_;
+
+      static constexpr size_t fields_count_ = sizeof...(BUILDERS);
+
+      template <std::size_t... S>
+      std::vector<size_t>
+      content_lengths(std::index_sequence<S...>) const noexcept {
+        return std::vector<size_t>({std::get<S>(contents).length()...});
+      }
+
+      template <std::size_t... S>
+      std::vector<bool>
+      content_is_valid(std::index_sequence<S...>, std::string& error) const
+          noexcept {
+        return std::vector<bool>({std::get<S>(contents).is_valid(error)...});
+      }
+    };
+
+    // RegularLayoutBuilder
+    template <unsigned SIZE, typename BUILDER>
+    class Regular {
+    public:
+      Regular() : length_(0) {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      BUILDER&
+      content() noexcept {
+        return content_;
+      }
+
+      BUILDER&
+      begin_list() noexcept {
+        return content_;
+      }
+
+      void
+      end_list() noexcept {
+        length_++;
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
+      }
+
+      void
+      clear() noexcept {
+        content_.clear();
+      }
+
+      size_t
+      length() const noexcept {
+        return length_;
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (content_.length() != length_ * size_) {
           std::stringstream out;
-          out << "Record node" << id_ << " has field \"" << field_names().at(i) << "\" length "
-              << lengths[i] << " that differs from the first length "
-              << length << "\n";
+          out << "Regular node" << id_ << "has content length "
+              << content_.length() << ", but length " << length_ << " and size "
+              << size_ << "\n";
           error.append(out.str());
 
           return false;
+        } else {
+          return content_.is_valid(error);
         }
       }
 
-      std::vector<bool> valid_fields = field_is_valid(index_sequence, error);
-      return std::none_of(std::cbegin(valid_fields), std::cend(valid_fields), std::logical_not<bool>());
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      for (size_t i = 0; i < fields_count_; i++)
-        visit_at(contents, i, [&names_nbytes](auto& content) {
-          content.builder.buffer_nbytes(names_nbytes);
-        });
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      for (size_t i = 0; i < fields_count_; i++)
-        visit_at(contents, i, [&buffers](auto& content) {
-          content.builder.to_buffers(buffers);
-        });
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string("\"parameters\": { " + parameters_ + " }, ");
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        content_.buffer_nbytes(names_nbytes);
       }
-      std::stringstream out;
-      out << "{ \"class\": \"RecordArray\", \"contents\": { ";
-      for (size_t i = 0;  i < fields_count_;  i++) {
-        if (i != 0) {
-          out << ", ";
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        content_.to_buffers(buffers);
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
-        auto contents_form = [&] (auto& content) {
-          out << "\""
-          << (!content_names_.empty() ? content_names_.at(content.index)
-          : content.index_as_field())
-          << + "\": ";
-          out << content.builder.form();
-        };
-        visit_at(contents, i, contents_form);
+        return "{ \"class\": \"RegularArray\", \"content\": " +
+               content_.form() + ", \"size\": " + std::to_string(size_) +
+               params + ", \"form_key\": \"" + form_key.str() + "\" }";
       }
-      out << " }, ";
-      out << params << "\"form_key\": \"" << form_key.str() << "\" }";
-      return out.str();
-    }
 
-    RecordContents contents;
+    private:
+      BUILDER content_;
+      std::string parameters_;
+      size_t id_;
+      size_t length_;
+      size_t size_ = SIZE;
+    };
 
-  private:
-    std::vector<std::string> field_names_;
-    UserDefinedMap content_names_;
-    std::string parameters_;
-    size_t id_;
-
-    static constexpr size_t fields_count_ = sizeof...(BUILDERS);
-
-    template <std::size_t... S>
-    void
-    map_fields(std::index_sequence<S...>) noexcept {
-      field_names_ = std::vector<std::string>({std::string(std::get<S>(contents).index_as_field())...});
-    }
-
-    template <std::size_t... S>
-    std::vector<size_t>
-    field_lengths(std::index_sequence<S...>) const noexcept {
-      return std::vector<size_t>({std::get<S>(contents).builder.length()...});
-    }
-
-    template <std::size_t... S>
-    std::vector<bool>
-    field_is_valid(std::index_sequence<S...>, std::string& error) const noexcept {
-      return std::vector<bool>({std::get<S>(contents).builder.is_valid(error)...});
-    }
-
-  };
-
-  // TupleLayoutBuilder
-  template <typename... BUILDERS>
-  class Tuple {
-    using TupleContents = typename std::tuple<BUILDERS...>;
-
-    template<std::size_t INDEX>
-    using TupleContentType = std::tuple_element_t<INDEX, TupleContents>;
-
-  public:
-    Tuple() {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    template<std::size_t INDEX>
-    TupleContentType<INDEX>&
-    index() noexcept {
-      return std::get<INDEX>(contents);
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      for (size_t i = 0; i < fields_count_; i++) {
-        visit_at(contents, i, [&id] (auto& content) { content.set_id(id); });
+    // IndexedLayoutBuilder
+    template <typename PRIMITIVE, typename BUILDER>
+    class Indexed {
+    public:
+      Indexed()
+          : index_(
+                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())),
+            last_valid_(-1) {
+        size_t id = 0;
+        set_id(id);
       }
-    }
 
-    void
-    clear() noexcept {
-      for (size_t i = 0; i < fields_count_; i++)
-        visit_at(contents, i, [](auto& content) { content.builder.clear(); });
-    }
+      Indexed(const awkward::BuilderOptions& options)
+          : index_(awkward::GrowableBuffer<PRIMITIVE>(options)),
+            last_valid_(-1) {
+        size_t id = 0;
+        set_id(id);
+      }
 
-    const size_t
-    length() const noexcept {
-      return (std::get<0>(contents).builder.length());
-    }
+      BUILDER&
+      content() noexcept {
+        return content_;
+      }
 
-    bool
-    is_valid(std::string& error) const noexcept {
-      auto index_sequence((std::index_sequence_for<BUILDERS...>()));
+      BUILDER&
+      append_index() noexcept {
+        last_valid_ = content_.length();
+        index_.append(last_valid_);
+        return content_;
+      }
 
-      size_t length = -1;
-      bool result = false;
-      std::vector<size_t> lengths = content_lengths(index_sequence);
-      for (size_t i = 0; i < lengths.size(); i++) {
-        if (length == -1) {
-          length = lengths[i];
+      BUILDER&
+      extend_index(size_t size) noexcept {
+        size_t start = content_.length();
+        size_t stop = start + size;
+        last_valid_ = stop - 1;
+        for (size_t i = start; i < stop; i++) {
+          index_.append(i);
         }
-        else if (length != lengths[i]) {
+        return content_;
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
+      }
+
+      void
+      clear() noexcept {
+        last_valid_ = -1;
+        index_.clear();
+        content_.clear();
+      }
+
+      size_t
+      length() const noexcept {
+        return index_.length();
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (content_.length() != index_.length()) {
           std::stringstream out;
-          out << "Record node" << id_ << " has index \"" << i << "\" length "
-              << lengths[i] << " that differs from the first length "
-              << length << "\n";
+          out << "Indexed node" << id_ << " has content length "
+              << content_.length() << " but index length " << index_.length()
+              << "\n";
           error.append(out.str());
 
           return false;
+        } else if (content_.length() != last_valid_ + 1) {
+          std::stringstream out;
+          out << "Indexed node" << id_ << " has content length "
+              << content_.length() << " but last valid index is " << last_valid_
+              << "\n";
+          error.append(out.str());
+
+          return false;
+        } else {
+          return content_.is_valid(error);
         }
       }
 
-      std::vector<bool> valid_fields = content_is_valid(index_sequence, error);
-      return std::none_of(std::cbegin(valid_fields), std::cend(valid_fields), std::logical_not<bool>());
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      for (size_t i = 0; i < fields_count_; i++)
-        visit_at(contents, i, [&names_nbytes](auto& content) {
-          content.buffer_nbytes(names_nbytes);
-        });
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      for (size_t i = 0; i < fields_count_; i++)
-        visit_at(contents, i, [&buffers](auto& content) {
-          content.to_buffers(buffers);
-        });
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string("\"parameters\": { " + parameters_ + " }, ");
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
+        content_.buffer_nbytes(names_nbytes);
       }
-      std::stringstream out;
-      out << "{ \"class\": \"RecordArray\", \"contents\": [";
-      for (size_t i = 0;  i < fields_count_;  i++) {
-        if (i != 0) {
-          out << ", ";
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        index_.concatenate(static_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-index"]));
+        content_.to_buffers(buffers);
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
-        auto contents_form = [&out] (auto& content) {
-          out << content.form();
-        };
-        visit_at(contents, i, contents_form);
+        return "{ \"class\": \"IndexedArray\", \"index\": \"" +
+               type_to_numpy_like<PRIMITIVE>() +
+               "\", \"content\": " + content_.form() + params +
+               ", \"form_key\": \"" + form_key.str() + "\" }";
       }
-      out << "], ";
-      out << params << "\"form_key\": \"" << form_key.str() << "\" }";
-      return out.str();
-    }
 
-    TupleContents contents;
+    private:
+      GrowableBuffer<PRIMITIVE> index_;
+      BUILDER content_;
+      std::string parameters_;
+      size_t id_;
+      size_t last_valid_;
+    };
 
-  private:
-    std::vector<int64_t> field_index_;
-    std::string parameters_;
-    size_t id_;
-
-    static constexpr size_t fields_count_ = sizeof...(BUILDERS);
-
-    template <std::size_t... S>
-    std::vector<size_t>
-    content_lengths(std::index_sequence<S...>) const noexcept {
-      return std::vector<size_t>({std::get<S>(contents).length()...});
-    }
-
-    template <std::size_t... S>
-    std::vector<bool>
-    content_is_valid(std::index_sequence<S...>, std::string& error) const noexcept {
-      return std::vector<bool>({std::get<S>(contents).is_valid(error)...});
-    }
-  };
-
-  // RegularLayoutBuilder
-  template <unsigned SIZE, typename BUILDER>
-  class Regular {
-  public:
-    Regular()
-        : length_(0) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    BUILDER&
-    content() noexcept {
-      return content_;
-    }
-
-    BUILDER&
-    begin_list() noexcept {
-      return content_;
-    }
-
-    void
-    end_list() noexcept {
-      length_++;
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      content_.set_id(id);
-    }
-
-    void
-    clear() noexcept {
-      content_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return length_;
-    }
-
-    bool
-    is_valid(std::string& error) const noexcept {
-      if (content_.length() != length_ * size_) {
-        std::stringstream out;
-        out << "Regular node" << id_ << "has content length " << content_.length()
-            << ", but length " << length_ << " and size " << size_ << "\n";
-        error.append(out.str());
-
-        return false;
+    // IndexedOptionLayoutBuilder
+    template <typename PRIMITIVE, typename BUILDER>
+    class IndexedOption {
+    public:
+      IndexedOption()
+          : index_(
+                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())),
+            last_valid_(-1) {
+        size_t id = 0;
+        set_id(id);
       }
-      else {
-        return content_.is_valid(error);
+
+      IndexedOption(const awkward::BuilderOptions& options)
+          : index_(awkward::GrowableBuffer<PRIMITIVE>(options)),
+            last_valid_(-1) {
+        size_t id = 0;
+        set_id(id);
       }
-    }
 
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      content_.buffer_nbytes(names_nbytes);
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      content_.to_buffers(buffers);
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
+      BUILDER&
+      content() noexcept {
+        return content_;
       }
-      return "{ \"class\": \"RegularArray\", \"content\": " + content_.form()
-                + ", \"size\": " + std::to_string(size_)  + params
-                + ", \"form_key\": \"" + form_key.str() + "\" }";
-    }
 
-  private:
-    BUILDER content_;
-    std::string parameters_;
-    size_t id_;
-    size_t length_;
-    size_t size_ = SIZE;
-  };
-
-  // IndexedLayoutBuilder
-  template <typename PRIMITIVE, typename BUILDER>
-  class Indexed {
-  public:
-
-    Indexed()
-        : index_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions()))
-        , last_valid_(-1) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    Indexed(const awkward::BuilderOptions& options)
-        : index_(awkward::GrowableBuffer<PRIMITIVE>(options))
-        , last_valid_(-1) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    BUILDER&
-    content() noexcept {
-      return content_;
-    }
-
-    BUILDER&
-    append_index() noexcept {
-      last_valid_ = content_.length();
-      index_.append(last_valid_);
-      return content_;
-    }
-
-    BUILDER&
-    extend_index(size_t size) noexcept {
-      size_t start = content_.length();
-      size_t stop = start + size;
-      last_valid_ = stop - 1;
-      for (size_t i = start; i < stop; i++) {
-        index_.append(i);
+      BUILDER&
+      append_index() noexcept {
+        last_valid_ = content_.length();
+        index_.append(last_valid_);
+        return content_;
       }
-      return content_;
-    }
 
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      content_.set_id(id);
-    }
-
-    void
-    clear() noexcept {
-      last_valid_ = -1;
-      index_.clear();
-      content_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return index_.length();
-    }
-
-    bool is_valid(std::string& error) const noexcept {
-      if (content_.length() != index_.length()) {
-        std::stringstream out;
-        out << "Indexed node" << id_ << " has content length " << content_.length()
-            << " but index length " << index_.length() << "\n";
-        error.append(out.str());
-
-        return false;
+      BUILDER&
+      extend_index(size_t size) noexcept {
+        size_t start = content_.length();
+        size_t stop = start + size;
+        last_valid_ = stop - 1;
+        for (size_t i = start; i < stop; i++) {
+          index_.append(i);
+        }
+        return content_;
       }
-      else if (content_.length() != last_valid_ + 1) {
-        std::stringstream out;
-        out << "Indexed node" << id_ << " has content length " << content_.length()
-            << " but last valid index is " << last_valid_ << "\n";
-        error.append(out.str());
 
-        return false;
-      }
-      else {
-        return content_.is_valid(error);
-      }
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
-      content_.buffer_nbytes(names_nbytes);
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      index_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-index"]));
-      content_.to_buffers(buffers);
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
-      }
-      return "{ \"class\": \"IndexedArray\", \"index\": \""
-                + type_to_numpy_like<PRIMITIVE>()
-                + "\", \"content\": " + content_.form() + params
-                + ", \"form_key\": \"" + form_key.str() + "\" }";
-    }
-
-  private:
-    GrowableBuffer<PRIMITIVE> index_;
-    BUILDER content_;
-    std::string parameters_;
-    size_t id_;
-    size_t last_valid_;
-  };
-
-  // IndexedOptionLayoutBuilder
-  template <typename PRIMITIVE, typename BUILDER>
-  class IndexedOption {
-  public:
-
-    IndexedOption()
-        : index_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions()))
-        , last_valid_(-1) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    IndexedOption(const awkward::BuilderOptions& options)
-        : index_(awkward::GrowableBuffer<PRIMITIVE>(options))
-        , last_valid_(-1) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    BUILDER&
-    content() noexcept {
-      return content_;
-    }
-
-    BUILDER&
-    append_index() noexcept {
-      last_valid_ = content_.length();
-      index_.append(last_valid_);
-      return content_;
-    }
-
-    BUILDER&
-    extend_index(size_t size) noexcept {
-      size_t start = content_.length();
-      size_t stop = start + size;
-      last_valid_ = stop - 1;
-      for (size_t i = start; i < stop; i++) {
-        index_.append(i);
-      }
-      return content_;
-    }
-
-    void
-    append_null() noexcept {
-      index_.append(-1);
-    }
-
-    void
-    extend_null(size_t size) noexcept {
-      for (size_t i = 0; i < size; i++) {
+      void
+      append_null() noexcept {
         index_.append(-1);
       }
-    }
 
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      content_.set_id(id);
-    }
-
-    void
-    clear() noexcept {
-      last_valid_ = -1;
-      index_.clear();
-      content_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return index_.length();
-    }
-
-    bool
-    is_valid(std::string& error) const noexcept {
-      if (content_.length() != last_valid_ + 1) {
-        std::stringstream out;
-        out << "IndexedOption node" << id_ << " has content length "<< content_.length()
-            << " but last valid index is " << last_valid_ << "\n";
-        error.append(out.str());
-
-        return false;
-      }
-      else {
-        return content_.is_valid(error);
-      }
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
-      content_.buffer_nbytes(names_nbytes);
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      index_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-index"]));
-      content_.to_buffers(buffers);
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
-      }
-      return "{ \"class\": \"IndexedOptionArray\", \"index\": \""
-                + type_to_numpy_like<PRIMITIVE>()
-                + "\", \"content\": " + content_.form() + params
-                + ", \"form_key\": \"" + form_key.str() + "\" }";
-    }
-
-  private:
-    GrowableBuffer<PRIMITIVE> index_;
-    BUILDER content_;
-    std::string parameters_;
-    size_t id_;
-    size_t last_valid_;
-  };
-
-  // UnmaskedLayoutBuilder
-  template <typename BUILDER>
-  class Unmasked {
-  public:
-    Unmasked() {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    BUILDER&
-    content() noexcept {
-      return content_;
-    }
-
-    BUILDER&
-    append_valid() noexcept {
-      return content_;
-    }
-
-    BUILDER&
-    extend_valid(size_t size) noexcept {
-      return content_;
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      content_.set_id(id);
-    }
-
-    void
-    clear() noexcept {
-      content_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return content_.length();
-    }
-
-    bool is_valid(std::string& error) const noexcept {
-      return content_.is_valid(error);
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      content_.buffer_nbytes(names_nbytes);
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      content_.to_buffers(buffers);
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
-      }
-      return "{ \"class\": \"UnmaskedArray\", \"content\": " + content_.form()
-                + params + ", \"form_key\": \"" + form_key.str() + "\" }";
-    }
-
-  private:
-    BUILDER content_;
-    std::string parameters_;
-    size_t id_;
-  };
-
-  // ByteMaskedLayoutBuilder
-  template <bool VALID_WHEN, typename BUILDER>
-  class ByteMasked {
-  public:
-
-    ByteMasked()
-        : mask_(awkward::GrowableBuffer<int8_t>(awkward::BuilderOptions())) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    ByteMasked(const awkward::BuilderOptions& options)
-        : mask_(awkward::GrowableBuffer<int8_t>(options)) {
-      size_t id = 0;
-      set_id(id);
-    }
-
-    BUILDER&
-    content() noexcept {
-      return content_;
-    }
-
-    bool
-    valid_when() const noexcept {
-      return valid_when_;
-    }
-
-    BUILDER&
-    append_valid() noexcept {
-      mask_.append(valid_when_);
-      return content_;
-    }
-
-    BUILDER&
-    extend_valid(size_t size) noexcept {
-      for (size_t i = 0; i < size; i++) {
-        mask_.append(valid_when_);
-      }
-      return content_;
-    }
-
-    BUILDER&
-    append_null() noexcept {
-      mask_.append(!valid_when_);
-      return content_;
-    }
-
-    BUILDER&
-    extend_null(size_t size) noexcept {
-      for (size_t i = 0; i < size; i++) {
-        mask_.append(!valid_when_);
-      }
-      return content_;
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      content_.set_id(id);
-    }
-
-    void
-    clear() noexcept {
-      mask_.clear();
-      content_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return mask_.length();
-    }
-
-    bool
-    is_valid(std::string& error) const noexcept {
-      if (content_.length() != mask_.length()) {
-        std::stringstream out;
-        out << "ByteMasked node" << id_ << "has content length " << content_.length()
-            << "but mask length " << mask_.length() << "\n";
-        error.append(out.str());
-
-        return false;
-      }
-      else {
-        return content_.is_valid(error);
-      }
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      names_nbytes["node" + std::to_string(id_) + "-mask"] = mask_.nbytes();
-      content_.buffer_nbytes(names_nbytes);
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      mask_.concatenate(static_cast<int8_t*>(buffers["node" + std::to_string(id_) + "-mask"]));
-      content_.to_buffers(buffers);
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key, form_valid_when;
-      form_key << "node" << id_;
-      form_valid_when << std::boolalpha << valid_when_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
-      }
-      return "{ \"class\": \"ByteMaskedArray\", \"mask\": \"i8\", \"content\": " + content_.form()
-                + ", \"valid_when\": " + form_valid_when.str()
-                + params + ", \"form_key\": \"" + form_key.str() + "\" }";
-    }
-
-  private:
-    GrowableBuffer<int8_t> mask_;
-    BUILDER content_;
-    std::string parameters_;
-    size_t id_;
-    bool valid_when_ = VALID_WHEN;
-  };
-
-  // FIXME: mask value incorrect
-  // BitMaskedLayoutBuilder
-  template <bool VALID_WHEN, bool LSB_ORDER, typename BUILDER>
-  class BitMasked {
-  public:
-
-    BitMasked()
-        : mask_(awkward::GrowableBuffer<uint8_t>(awkward::BuilderOptions()))
-        , current_byte_(uint8_t(0))
-        , current_byte_ref_(mask_.append_and_get_ref(current_byte_))
-        , current_index_(0)
-      {
-      size_t id = 0;
-      set_id(id);
-      if (lsb_order_) {
-        for(size_t i = 0; i < 8; i++) {
-          cast_[i] = 1 << i;
+      void
+      extend_null(size_t size) noexcept {
+        for (size_t i = 0; i < size; i++) {
+          index_.append(-1);
         }
       }
-      else {
-        for(size_t i = 0; i < 8; i++) {
-          cast_[i] = 128 >> i;
-        }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
       }
-    }
 
-    BitMasked(const awkward::BuilderOptions& options)
-        : mask_(awkward::GrowableBuffer<uint8_t>(options))
-        , current_byte_(uint8_t(0))
-        , current_byte_ref_(mask_.append_and_get_ref(current_byte_))
-        , current_index_(0)
-      {
-      size_t id = 0;
-      set_id(id);
-      if (lsb_order_) {
-        for(size_t i = 0; i < 8; i++) {
-          cast_[i] = 1 << i;
-        }
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
       }
-      else {
-        for(size_t i = 0; i < 8; i++) {
-          cast_[i] = 128 >> i;
-        }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
       }
-    }
 
-    BUILDER&
-    content() noexcept {
-      return content_;
-    }
-
-    bool
-    valid_when() const noexcept {
-      return valid_when_;
-    }
-
-    bool
-    lsb_order() const noexcept {
-      return lsb_order_;
-    }
-
-    BUILDER&
-    append_valid() noexcept {
-      append_begin();
-      current_byte_ |= cast_[current_index_];
-      append_end();
-      return content_;
-    }
-
-    BUILDER&
-    extend_valid(size_t size) noexcept {
-      for (size_t i = 0; i < size; i++) {
-        append_valid();
+      void
+      clear() noexcept {
+        last_valid_ = -1;
+        index_.clear();
+        content_.clear();
       }
-      return content_;
-    }
 
-    BUILDER&
-    append_null() noexcept {
-      append_begin();
-      append_end();
-      return content_;
-    }
-
-    BUILDER&
-    extend_null(size_t size) noexcept {
-      for (size_t i = 0; i < size; i++) {
-        append_null();
+      size_t
+      length() const noexcept {
+        return index_.length();
       }
-      return content_;
-    }
 
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      content_.set_id(id);
-    }
-
-    void
-    clear() noexcept {
-      mask_.clear();
-      content_.clear();
-    }
-
-    size_t
-    length() const noexcept {
-      return (mask_.length() - 1) * 8 + current_index_;
-    }
-
-    bool
-    is_valid(std::string& error) const noexcept {
-      if (content_.length() != length()) {
-        std::stringstream out;
-        out << "BitMasked node" << id_ << "has content length " << content_.length()
-            << "but bit mask length " << mask_.length() << "\n";
-        error.append(out.str());
-
-        return false;
-      }
-      else {
-        return content_.is_valid(error);
-      }
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      names_nbytes["node" + std::to_string(id_) + "-mask"] = mask_.nbytes();
-      content_.buffer_nbytes(names_nbytes);
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      mask_.concatenate(static_cast<uint8_t*>(buffers["node" + std::to_string(id_) + "-mask"]));
-      content_.to_buffers(buffers);
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key, form_valid_when, form_lsb_order;
-      form_key << "node" << id_;
-      form_valid_when << std::boolalpha << valid_when_;
-      form_lsb_order << std::boolalpha << lsb_order_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
-      }
-      return "{ \"class\": \"BitMaskedArray\", \"mask\": \"u8\", \"content\": " + content_.form()
-                + ", \"valid_when\": " + form_valid_when.str() + ", \"lsb_order\": "
-                + form_lsb_order.str() + params + ", \"form_key\": \"" + form_key.str() + "\" }";
-    }
-
-  private:
-    void
-    append_begin() {
-      if (current_index_ == 8) {
-        current_byte_ref_ = mask_.append_and_get_ref(current_byte_);
-        current_byte_ = uint8_t(0);
-        current_index_ = 0;
-      }
-    }
-
-    void
-    append_end() {
-      current_index_ += 1;
-      if (valid_when_) {
-        current_byte_ref_ = current_byte_;
-      }
-      else {
-        current_byte_ref_ = ~current_byte_;
-      }
-    }
-
-    GrowableBuffer<uint8_t> mask_;
-    BUILDER content_;
-    std::string parameters_;
-    size_t id_;
-    uint8_t current_byte_;
-    uint8_t& current_byte_ref_;
-    size_t current_index_;
-    uint8_t cast_[8];
-    bool valid_when_ = VALID_WHEN;
-    bool lsb_order_ = LSB_ORDER;
-  };
-
-  // UnionLayoutBuilder
-  template <typename TAGS, typename INDEX,  typename... BUILDERS>
-  class Union {
-  public:
-    using Contents = typename std::tuple<BUILDERS...>;
-
-    template<std::size_t I>
-    using ContentType = std::tuple_element_t<I, Contents>;
-
-    Union()
-        : tags_(awkward::GrowableBuffer<TAGS>(awkward::BuilderOptions()))
-        , index_(awkward::GrowableBuffer<INDEX>(awkward::BuilderOptions())) {
-      size_t id = 0;
-      set_id(id);
-      for (size_t i = 0; i < contents_count_; i++)
-        last_valid_index_[i] = -1;
-    }
-
-    Union(const awkward::BuilderOptions& options)
-        : tags_(awkward::GrowableBuffer<TAGS>(options))
-        , index_(awkward::GrowableBuffer<INDEX>(options)) {
-      size_t id = 0;
-      set_id(id);
-      for (size_t i = 0; i < contents_count_; i++)
-        last_valid_index_[i] = -1;
-    }
-
-    template<std::size_t I>
-    ContentType<I>&
-    content() noexcept {
-      return std::get<I>(contents_);
-    }
-
-    template<std::size_t TAG>
-    ContentType<TAG>&
-    append_index() noexcept {
-      auto& which_content = std::get<TAG>(contents_);
-      INDEX next_index = which_content.length();
-
-      TAGS tag = (TAGS)TAG;
-      last_valid_index_[tag] = next_index;
-      tags_.append(tag);
-      index_.append(next_index);
-
-      return which_content;
-    }
-
-    const std::string&
-    parameters() const noexcept {
-      return parameters_;
-    }
-
-    void
-    set_parameters(std::string parameter) noexcept {
-      parameters_ = parameter;
-    }
-
-    void
-    set_id(size_t &id) noexcept {
-      id_ = id;
-      id++;
-      auto contents_id = [&id](auto& content) { content.set_id(id); };
-      for (size_t i = 0; i < contents_count_; i++)
-        visit_at(contents_, i, contents_id);
-    }
-
-    void
-    clear() noexcept {
-      for (size_t i = 0; i < contents_count_; i++)
-        last_valid_index_[i] = -1;
-      tags_.clear();
-      index_.clear();
-      auto clear_contents = [](auto& content) { content.builder.clear(); };
-      for (size_t i = 0; i < contents_count_; i++)
-        visit_at(contents_, i, clear_contents);
-    }
-
-    size_t
-    length() const noexcept {
-      return tags_.length();
-    }
-
-    bool
-    is_valid(std::string& error) const noexcept {
-      auto index_sequence((std::index_sequence_for<BUILDERS...>()));
-
-      std::vector<size_t> lengths = content_lengths(index_sequence);
-      for (size_t tag = 0; tag < contents_count_; tag++) {
-        if (lengths[tag] != last_valid_index_[tag] + 1) {
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (content_.length() != last_valid_ + 1) {
           std::stringstream out;
-          out << "Union node" << id_ << " has content length " << lengths[tag]
-              << " but index length " << last_valid_index_[tag] << "\n";
+          out << "IndexedOption node" << id_ << " has content length "
+              << content_.length() << " but last valid index is " << last_valid_
+              << "\n";
           error.append(out.str());
 
           return false;
+        } else {
+          return content_.is_valid(error);
         }
       }
 
-      std::vector<bool> valid_contents = content_is_valid(index_sequence, error);
-      return std::none_of(std::cbegin(valid_contents), std::cend(valid_contents), std::logical_not<bool>());
-    }
-
-    void
-    buffer_nbytes(std::map<std::string, size_t> &names_nbytes) const noexcept {
-      auto index_sequence((std::index_sequence_for<BUILDERS...>()));
-
-      names_nbytes["node" + std::to_string(id_) + "-tags"] = tags_.nbytes();
-      names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
-
-      for (size_t i = 0; i < contents_count_; i++)
-        visit_at(contents_, i, [&names_nbytes](auto& content) {
-          content.buffer_nbytes(names_nbytes);
-        });
-    }
-
-    void
-    to_buffers(std::map<std::string, void*> &buffers) const noexcept {
-      auto index_sequence((std::index_sequence_for<BUILDERS...>()));
-
-      tags_.concatenate(static_cast<TAGS*>(buffers["node" + std::to_string(id_) + "-tags"]));
-      index_.concatenate(static_cast<INDEX*>(buffers["node" + std::to_string(id_) + "-index"]));
-
-      for (size_t i = 0; i < contents_count_; i++)
-        visit_at(contents_, i, [&buffers](auto& content) {
-          content.to_buffers(buffers);
-        });
-    }
-
-    std::string
-    form() const noexcept {
-      std::stringstream form_key;
-      form_key << "node" << id_;
-      std::string params("");
-      if (parameters_ == "") { }
-      else {
-        params = std::string(", \"parameters\": { " + parameters_ + " }");
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
+        content_.buffer_nbytes(names_nbytes);
       }
-      std::stringstream out;
-      out << "{ \"class\": \"UnionArray\", \"tags\": \""
-                + type_to_numpy_like<TAGS>() + "\", \"index\": \""
-                + type_to_numpy_like<INDEX>() + "\", \"contents\": [";
-      for (size_t i = 0;  i < contents_count_;  i++) {
-        if (i != 0) {
-          out << ", ";
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        index_.concatenate(static_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-index"]));
+        content_.to_buffers(buffers);
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
-        auto contents_form = [&] (auto& content) {
-          out << content.form();
+        return "{ \"class\": \"IndexedOptionArray\", \"index\": \"" +
+               type_to_numpy_like<PRIMITIVE>() +
+               "\", \"content\": " + content_.form() + params +
+               ", \"form_key\": \"" + form_key.str() + "\" }";
+      }
+
+    private:
+      GrowableBuffer<PRIMITIVE> index_;
+      BUILDER content_;
+      std::string parameters_;
+      size_t id_;
+      size_t last_valid_;
+    };
+
+    // UnmaskedLayoutBuilder
+    template <typename BUILDER>
+    class Unmasked {
+    public:
+      Unmasked() {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      BUILDER&
+      content() noexcept {
+        return content_;
+      }
+
+      BUILDER&
+      append_valid() noexcept {
+        return content_;
+      }
+
+      BUILDER&
+      extend_valid(size_t size) noexcept {
+        return content_;
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
+      }
+
+      void
+      clear() noexcept {
+        content_.clear();
+      }
+
+      size_t
+      length() const noexcept {
+        return content_.length();
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        return content_.is_valid(error);
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        content_.buffer_nbytes(names_nbytes);
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        content_.to_buffers(buffers);
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+        return "{ \"class\": \"UnmaskedArray\", \"content\": " +
+               content_.form() + params + ", \"form_key\": \"" +
+               form_key.str() + "\" }";
+      }
+
+    private:
+      BUILDER content_;
+      std::string parameters_;
+      size_t id_;
+    };
+
+    // ByteMaskedLayoutBuilder
+    template <bool VALID_WHEN, typename BUILDER>
+    class ByteMasked {
+    public:
+      ByteMasked()
+          : mask_(awkward::GrowableBuffer<int8_t>(awkward::BuilderOptions())) {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      ByteMasked(const awkward::BuilderOptions& options)
+          : mask_(awkward::GrowableBuffer<int8_t>(options)) {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      BUILDER&
+      content() noexcept {
+        return content_;
+      }
+
+      bool
+      valid_when() const noexcept {
+        return valid_when_;
+      }
+
+      BUILDER&
+      append_valid() noexcept {
+        mask_.append(valid_when_);
+        return content_;
+      }
+
+      BUILDER&
+      extend_valid(size_t size) noexcept {
+        for (size_t i = 0; i < size; i++) {
+          mask_.append(valid_when_);
+        }
+        return content_;
+      }
+
+      BUILDER&
+      append_null() noexcept {
+        mask_.append(!valid_when_);
+        return content_;
+      }
+
+      BUILDER&
+      extend_null(size_t size) noexcept {
+        for (size_t i = 0; i < size; i++) {
+          mask_.append(!valid_when_);
+        }
+        return content_;
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
+      }
+
+      void
+      clear() noexcept {
+        mask_.clear();
+        content_.clear();
+      }
+
+      size_t
+      length() const noexcept {
+        return mask_.length();
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (content_.length() != mask_.length()) {
+          std::stringstream out;
+          out << "ByteMasked node" << id_ << "has content length "
+              << content_.length() << "but mask length " << mask_.length()
+              << "\n";
+          error.append(out.str());
+
+          return false;
+        } else {
+          return content_.is_valid(error);
+        }
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        names_nbytes["node" + std::to_string(id_) + "-mask"] = mask_.nbytes();
+        content_.buffer_nbytes(names_nbytes);
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        mask_.concatenate(static_cast<int8_t*>(
+            buffers["node" + std::to_string(id_) + "-mask"]));
+        content_.to_buffers(buffers);
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key, form_valid_when;
+        form_key << "node" << id_;
+        form_valid_when << std::boolalpha << valid_when_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+        return "{ \"class\": \"ByteMaskedArray\", \"mask\": \"i8\", "
+               "\"content\": " +
+               content_.form() + ", \"valid_when\": " + form_valid_when.str() +
+               params + ", \"form_key\": \"" + form_key.str() + "\" }";
+      }
+
+    private:
+      GrowableBuffer<int8_t> mask_;
+      BUILDER content_;
+      std::string parameters_;
+      size_t id_;
+      bool valid_when_ = VALID_WHEN;
+    };
+
+    // FIXME: mask value incorrect
+    // BitMaskedLayoutBuilder
+    template <bool VALID_WHEN, bool LSB_ORDER, typename BUILDER>
+    class BitMasked {
+    public:
+      BitMasked()
+          : mask_(awkward::GrowableBuffer<uint8_t>(awkward::BuilderOptions())),
+            current_byte_(uint8_t(0)),
+            current_byte_ref_(mask_.append_and_get_ref(current_byte_)),
+            current_index_(0) {
+        size_t id = 0;
+        set_id(id);
+        if (lsb_order_) {
+          for (size_t i = 0; i < 8; i++) {
+            cast_[i] = 1 << i;
+          }
+        } else {
+          for (size_t i = 0; i < 8; i++) {
+            cast_[i] = 128 >> i;
+          }
+        }
+      }
+
+      BitMasked(const awkward::BuilderOptions& options)
+          : mask_(awkward::GrowableBuffer<uint8_t>(options)),
+            current_byte_(uint8_t(0)),
+            current_byte_ref_(mask_.append_and_get_ref(current_byte_)),
+            current_index_(0) {
+        size_t id = 0;
+        set_id(id);
+        if (lsb_order_) {
+          for (size_t i = 0; i < 8; i++) {
+            cast_[i] = 1 << i;
+          }
+        } else {
+          for (size_t i = 0; i < 8; i++) {
+            cast_[i] = 128 >> i;
+          }
+        }
+      }
+
+      BUILDER&
+      content() noexcept {
+        return content_;
+      }
+
+      bool
+      valid_when() const noexcept {
+        return valid_when_;
+      }
+
+      bool
+      lsb_order() const noexcept {
+        return lsb_order_;
+      }
+
+      BUILDER&
+      append_valid() noexcept {
+        append_begin();
+        current_byte_ |= cast_[current_index_];
+        append_end();
+        return content_;
+      }
+
+      BUILDER&
+      extend_valid(size_t size) noexcept {
+        for (size_t i = 0; i < size; i++) {
+          append_valid();
+        }
+        return content_;
+      }
+
+      BUILDER&
+      append_null() noexcept {
+        append_begin();
+        append_end();
+        return content_;
+      }
+
+      BUILDER&
+      extend_null(size_t size) noexcept {
+        for (size_t i = 0; i < size; i++) {
+          append_null();
+        }
+        return content_;
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
+      }
+
+      void
+      clear() noexcept {
+        mask_.clear();
+        content_.clear();
+      }
+
+      size_t
+      length() const noexcept {
+        return (mask_.length() - 1) * 8 + current_index_;
+      }
+
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (content_.length() != length()) {
+          std::stringstream out;
+          out << "BitMasked node" << id_ << "has content length "
+              << content_.length() << "but bit mask length " << mask_.length()
+              << "\n";
+          error.append(out.str());
+
+          return false;
+        } else {
+          return content_.is_valid(error);
+        }
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        names_nbytes["node" + std::to_string(id_) + "-mask"] = mask_.nbytes();
+        content_.buffer_nbytes(names_nbytes);
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        mask_.concatenate(static_cast<uint8_t*>(
+            buffers["node" + std::to_string(id_) + "-mask"]));
+        content_.to_buffers(buffers);
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key, form_valid_when, form_lsb_order;
+        form_key << "node" << id_;
+        form_valid_when << std::boolalpha << valid_when_;
+        form_lsb_order << std::boolalpha << lsb_order_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+        return "{ \"class\": \"BitMaskedArray\", \"mask\": \"u8\", "
+               "\"content\": " +
+               content_.form() + ", \"valid_when\": " + form_valid_when.str() +
+               ", \"lsb_order\": " + form_lsb_order.str() + params +
+               ", \"form_key\": \"" + form_key.str() + "\" }";
+      }
+
+    private:
+      void
+      append_begin() {
+        if (current_index_ == 8) {
+          current_byte_ref_ = mask_.append_and_get_ref(current_byte_);
+          current_byte_ = uint8_t(0);
+          current_index_ = 0;
+        }
+      }
+
+      void
+      append_end() {
+        current_index_ += 1;
+        if (valid_when_) {
+          current_byte_ref_ = current_byte_;
+        } else {
+          current_byte_ref_ = ~current_byte_;
+        }
+      }
+
+      GrowableBuffer<uint8_t> mask_;
+      BUILDER content_;
+      std::string parameters_;
+      size_t id_;
+      uint8_t current_byte_;
+      uint8_t& current_byte_ref_;
+      size_t current_index_;
+      uint8_t cast_[8];
+      bool valid_when_ = VALID_WHEN;
+      bool lsb_order_ = LSB_ORDER;
+    };
+
+    // UnionLayoutBuilder
+    template <typename TAGS, typename INDEX, typename... BUILDERS>
+    class Union {
+    public:
+      using Contents = typename std::tuple<BUILDERS...>;
+
+      template <std::size_t I>
+      using ContentType = std::tuple_element_t<I, Contents>;
+
+      Union()
+          : tags_(awkward::GrowableBuffer<TAGS>(awkward::BuilderOptions())),
+            index_(awkward::GrowableBuffer<INDEX>(awkward::BuilderOptions())) {
+        size_t id = 0;
+        set_id(id);
+        for (size_t i = 0; i < contents_count_; i++)
+          last_valid_index_[i] = -1;
+      }
+
+      Union(const awkward::BuilderOptions& options)
+          : tags_(awkward::GrowableBuffer<TAGS>(options)),
+            index_(awkward::GrowableBuffer<INDEX>(options)) {
+        size_t id = 0;
+        set_id(id);
+        for (size_t i = 0; i < contents_count_; i++)
+          last_valid_index_[i] = -1;
+      }
+
+      template <std::size_t I>
+      ContentType<I>&
+      content() noexcept {
+        return std::get<I>(contents_);
+      }
+
+      template <std::size_t TAG>
+      ContentType<TAG>&
+      append_index() noexcept {
+        auto& which_content = std::get<TAG>(contents_);
+        INDEX next_index = which_content.length();
+
+        TAGS tag = (TAGS)TAG;
+        last_valid_index_[tag] = next_index;
+        tags_.append(tag);
+        index_.append(next_index);
+
+        return which_content;
+      }
+
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        auto contents_id = [&id](auto& content) {
+          content.set_id(id);
         };
-        visit_at(contents_, i, contents_form);
+        for (size_t i = 0; i < contents_count_; i++)
+          visit_at(contents_, i, contents_id);
       }
-      out << "], ";
-      out << params << "\"form_key\": \"" << form_key.str() << "\" }";
-      return out.str();
-    }
 
-  private:
-    static constexpr size_t contents_count_ = sizeof...(BUILDERS);
+      void
+      clear() noexcept {
+        for (size_t i = 0; i < contents_count_; i++)
+          last_valid_index_[i] = -1;
+        tags_.clear();
+        index_.clear();
+        auto clear_contents = [](auto& content) {
+          content.builder.clear();
+        };
+        for (size_t i = 0; i < contents_count_; i++)
+          visit_at(contents_, i, clear_contents);
+      }
 
-    GrowableBuffer<TAGS> tags_;
-    GrowableBuffer<INDEX> index_;
-    Contents contents_;
-    size_t id_;
-    std::string parameters_;
-    size_t last_valid_index_[sizeof...(BUILDERS)];
+      size_t
+      length() const noexcept {
+        return tags_.length();
+      }
 
-    template <std::size_t... S>
-    std::vector<size_t>
-    content_lengths(std::index_sequence<S...>) const {
-      return std::vector<size_t>({std::get<S>(contents_).length()...});
-    }
+      bool
+      is_valid(std::string& error) const noexcept {
+        auto index_sequence((std::index_sequence_for<BUILDERS...>()));
 
-    template <std::size_t... S>
-    std::vector<bool>
-    content_is_valid(std::index_sequence<S...>, std::string& error) const {
-      return std::vector<bool>({std::get<S>(contents_).is_valid(error)...});
-    }
+        std::vector<size_t> lengths = content_lengths(index_sequence);
+        for (size_t tag = 0; tag < contents_count_; tag++) {
+          if (lengths[tag] != last_valid_index_[tag] + 1) {
+            std::stringstream out;
+            out << "Union node" << id_ << " has content length " << lengths[tag]
+                << " but index length " << last_valid_index_[tag] << "\n";
+            error.append(out.str());
 
-  };
+            return false;
+          }
+        }
+
+        std::vector<bool> valid_contents =
+            content_is_valid(index_sequence, error);
+        return std::none_of(std::cbegin(valid_contents),
+                            std::cend(valid_contents),
+                            std::logical_not<bool>());
+      }
+
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        auto index_sequence((std::index_sequence_for<BUILDERS...>()));
+
+        names_nbytes["node" + std::to_string(id_) + "-tags"] = tags_.nbytes();
+        names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
+
+        for (size_t i = 0; i < contents_count_; i++)
+          visit_at(contents_, i, [&names_nbytes](auto& content) {
+            content.buffer_nbytes(names_nbytes);
+          });
+      }
+
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        auto index_sequence((std::index_sequence_for<BUILDERS...>()));
+
+        tags_.concatenate(static_cast<TAGS*>(
+            buffers["node" + std::to_string(id_) + "-tags"]));
+        index_.concatenate(static_cast<INDEX*>(
+            buffers["node" + std::to_string(id_) + "-index"]));
+
+        for (size_t i = 0; i < contents_count_; i++)
+          visit_at(contents_, i, [&buffers](auto& content) {
+            content.to_buffers(buffers);
+          });
+      }
+
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+        std::stringstream out;
+        out << "{ \"class\": \"UnionArray\", \"tags\": \"" +
+                   type_to_numpy_like<TAGS>() + "\", \"index\": \"" +
+                   type_to_numpy_like<INDEX>() + "\", \"contents\": [";
+        for (size_t i = 0; i < contents_count_; i++) {
+          if (i != 0) {
+            out << ", ";
+          }
+          auto contents_form = [&](auto& content) {
+            out << content.form();
+          };
+          visit_at(contents_, i, contents_form);
+        }
+        out << "], ";
+        out << params << "\"form_key\": \"" << form_key.str() << "\" }";
+        return out.str();
+      }
+
+    private:
+      static constexpr size_t contents_count_ = sizeof...(BUILDERS);
+
+      GrowableBuffer<TAGS> tags_;
+      GrowableBuffer<INDEX> index_;
+      Contents contents_;
+      size_t id_;
+      std::string parameters_;
+      size_t last_valid_index_[sizeof...(BUILDERS)];
+
+      template <std::size_t... S>
+      std::vector<size_t>
+      content_lengths(std::index_sequence<S...>) const {
+        return std::vector<size_t>({std::get<S>(contents_).length()...});
+      }
+
+      template <std::size_t... S>
+      std::vector<bool>
+      content_is_valid(std::index_sequence<S...>, std::string& error) const {
+        return std::vector<bool>({std::get<S>(contents_).is_valid(error)...});
+      }
+    };
 
   }  // namespace LayoutBuilder
 }  // namespace awkward

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -1439,7 +1439,6 @@ namespace awkward {
       bool valid_when_ = VALID_WHEN;
     };
 
-    // FIXME: mask value incorrect
     // BitMaskedLayoutBuilder
     template <bool VALID_WHEN, bool LSB_ORDER, typename BUILDER>
     class BitMasked {
@@ -1578,8 +1577,10 @@ namespace awkward {
 
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        mask_.concatenate(static_cast<uint8_t*>(
-            buffers["node" + std::to_string(id_) + "-mask"]));
+        mask_.concatenate_from(static_cast<uint8_t*>(
+            buffers["node" + std::to_string(id_) + "-mask"]), 0, 1);
+        mask_.append(static_cast<uint8_t*>(
+            buffers["node" + std::to_string(id_) + "-mask"]), mask_.length() - 1, 0, 1);
         content_.to_buffers(buffers);
       }
 

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -3,6 +3,7 @@
 #ifndef AWKWARD_LAYOUTBUILDER_H_
 #define AWKWARD_LAYOUTBUILDER_H_
 
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/utils.h"
 
@@ -30,11 +31,18 @@ namespace awkward {
   };
 
   // NumpyLayoutBuilder
-  template <unsigned INITIAL, typename PRIMITIVE>
+  template <typename PRIMITIVE>
   class Numpy {
   public:
+
     Numpy()
-        : data_(awkward::GrowableBuffer<PRIMITIVE>(INITIAL)) {
+        : data_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+      size_t id = 0;
+      set_id(id);
+    }
+
+    Numpy(const awkward::BuilderOptions& options)
+        : data_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
       size_t id = 0;
       set_id(id);
     }
@@ -75,7 +83,8 @@ namespace awkward {
       return data_.length();
     }
 
-    bool is_valid(std::string& error) const noexcept {
+    bool
+    is_valid(std::string& error) const noexcept {
       return true;
     }
 
@@ -129,11 +138,19 @@ namespace awkward {
   };
 
   // ListOffsetLayoutBuilder
-  template <unsigned INITIAL, typename PRIMITIVE, typename BUILDER>
+  template <typename PRIMITIVE, typename BUILDER>
   class ListOffset {
   public:
+
     ListOffset()
-        : offsets_(awkward::GrowableBuffer<PRIMITIVE>(INITIAL)) {
+        : offsets_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+      offsets_.append(0);
+      size_t id = 0;
+      set_id(id);
+    }
+
+    ListOffset(const awkward::BuilderOptions& options)
+        : offsets_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
       offsets_.append(0);
       size_t id = 0;
       set_id(id);
@@ -183,7 +200,8 @@ namespace awkward {
       return offsets_.length() - 1;
     }
 
-    bool is_valid(std::string& error) const noexcept {
+    bool
+    is_valid(std::string& error) const noexcept {
       if (content_.length() != offsets_.last()) {
         std::stringstream out;
         out << "ListOffset node" << id_ << "has content length " << content_.length()
@@ -238,12 +256,20 @@ namespace awkward {
   };
 
   // ListLayoutBuilder
-  template <unsigned INITIAL, typename PRIMITIVE, typename BUILDER>
+  template <typename PRIMITIVE, typename BUILDER>
   class List {
   public:
+
     List()
-        : starts_(awkward::GrowableBuffer<PRIMITIVE>(INITIAL))
-        , stops_(awkward::GrowableBuffer<PRIMITIVE>(INITIAL)) {
+        : starts_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions()))
+        , stops_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+      size_t id = 0;
+      set_id(id);
+    }
+
+    List(const awkward::BuilderOptions& options)
+        : starts_(awkward::GrowableBuffer<PRIMITIVE>(options))
+        , stops_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
       size_t id = 0;
       set_id(id);
     }
@@ -389,7 +415,8 @@ namespace awkward {
       return 0;
     }
 
-    bool is_valid(std::string& /* error */) const noexcept {
+    bool
+    is_valid(std::string& /* error */) const noexcept {
       return true;
     }
 
@@ -460,7 +487,8 @@ namespace awkward {
       return length_;
     }
 
-    bool is_valid(std::string& /* error */) const noexcept {
+    bool
+    is_valid(std::string& /* error */) const noexcept {
       return true;
     }
 
@@ -914,11 +942,19 @@ namespace awkward {
   };
 
   // IndexedLayoutBuilder
-  template <unsigned INITIAL, typename PRIMITIVE, typename BUILDER>
+  template <typename PRIMITIVE, typename BUILDER>
   class Indexed {
   public:
+
     Indexed()
-        : index_(awkward::GrowableBuffer<PRIMITIVE>(INITIAL))
+        : index_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions()))
+        , last_valid_(-1) {
+      size_t id = 0;
+      set_id(id);
+    }
+
+    Indexed(const awkward::BuilderOptions& options)
+        : index_(awkward::GrowableBuffer<PRIMITIVE>(options))
         , last_valid_(-1) {
       size_t id = 0;
       set_id(id);
@@ -1040,11 +1076,19 @@ namespace awkward {
   };
 
   // IndexedOptionLayoutBuilder
-  template <unsigned INITIAL, typename PRIMITIVE, typename BUILDER>
+  template <typename PRIMITIVE, typename BUILDER>
   class IndexedOption {
   public:
+
     IndexedOption()
-        : index_(awkward::GrowableBuffer<PRIMITIVE>(INITIAL))
+        : index_(awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions()))
+        , last_valid_(-1) {
+      size_t id = 0;
+      set_id(id);
+    }
+
+    IndexedOption(const awkward::BuilderOptions& options)
+        : index_(awkward::GrowableBuffer<PRIMITIVE>(options))
         , last_valid_(-1) {
       size_t id = 0;
       set_id(id);
@@ -1255,11 +1299,18 @@ namespace awkward {
   };
 
   // ByteMaskedLayoutBuilder
-  template <unsigned INITIAL, bool VALID_WHEN, typename BUILDER>
+  template <bool VALID_WHEN, typename BUILDER>
   class ByteMasked {
   public:
+
     ByteMasked()
-        : mask_(awkward::GrowableBuffer<int8_t>(INITIAL)) {
+        : mask_(awkward::GrowableBuffer<int8_t>(awkward::BuilderOptions())) {
+      size_t id = 0;
+      set_id(id);
+    }
+
+    ByteMasked(const awkward::BuilderOptions& options)
+        : mask_(awkward::GrowableBuffer<int8_t>(options)) {
       size_t id = 0;
       set_id(id);
     }
@@ -1388,11 +1439,32 @@ namespace awkward {
 
   // FIXME: mask value incorrect
   // BitMaskedLayoutBuilder
-  template <unsigned INITIAL, bool VALID_WHEN, bool LSB_ORDER, typename BUILDER>
+  template <bool VALID_WHEN, bool LSB_ORDER, typename BUILDER>
   class BitMasked {
   public:
+
     BitMasked()
-        : mask_(awkward::GrowableBuffer<uint8_t>(INITIAL))
+        : mask_(awkward::GrowableBuffer<uint8_t>(awkward::BuilderOptions()))
+        , current_byte_(uint8_t(0))
+        , current_byte_ref_(mask_.append_and_get_ref(current_byte_))
+        , current_index_(0)
+      {
+      size_t id = 0;
+      set_id(id);
+      if (lsb_order_) {
+        for(size_t i = 0; i < 8; i++) {
+          cast_[i] = 1 << i;
+        }
+      }
+      else {
+        for(size_t i = 0; i < 8; i++) {
+          cast_[i] = 128 >> i;
+        }
+      }
+    }
+
+    BitMasked(const awkward::BuilderOptions& options)
+        : mask_(awkward::GrowableBuffer<uint8_t>(options))
         , current_byte_(uint8_t(0))
         , current_byte_ref_(mask_.append_and_get_ref(current_byte_))
         , current_index_(0)
@@ -1452,7 +1524,7 @@ namespace awkward {
     BUILDER&
     extend_null(size_t size) noexcept {
       for (size_t i = 0; i < size; i++) {
-      append_null();
+        append_null();
       }
       return content_;
     }
@@ -1568,7 +1640,7 @@ namespace awkward {
   };
 
   // UnionLayoutBuilder
-  template <unsigned INITIAL, typename TAGS, typename INDEX,  typename... BUILDERS>
+  template <typename TAGS, typename INDEX,  typename... BUILDERS>
   class Union {
   public:
     using Contents = typename std::tuple<BUILDERS...>;
@@ -1577,8 +1649,17 @@ namespace awkward {
     using ContentType = std::tuple_element_t<I, Contents>;
 
     Union()
-        : tags_(awkward::GrowableBuffer<TAGS>(INITIAL))
-        , index_(awkward::GrowableBuffer<INDEX>(INITIAL)) {
+        : tags_(awkward::GrowableBuffer<TAGS>(awkward::BuilderOptions()))
+        , index_(awkward::GrowableBuffer<INDEX>(awkward::BuilderOptions())) {
+      size_t id = 0;
+      set_id(id);
+      for (size_t i = 0; i < contents_count_; i++)
+        last_valid_index_[i] = -1;
+    }
+
+    Union(const awkward::BuilderOptions& options)
+        : tags_(awkward::GrowableBuffer<TAGS>(options))
+        , index_(awkward::GrowableBuffer<INDEX>(options)) {
       size_t id = 0;
       set_id(id);
       for (size_t i = 0; i < contents_count_; i++)

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -16,6 +16,8 @@ namespace awkward {
 
   namespace LayoutBuilder {
 
+    awkward::BuilderOptions default_options(1024, 1);
+
     // helper class for RecordLayoutBuilder
     template <std::size_t ENUM, typename BUILDER>
     class Field {
@@ -37,7 +39,7 @@ namespace awkward {
     public:
       Numpy()
           : data_(
-                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+                awkward::GrowableBuffer<PRIMITIVE>(default_options)) {
         size_t id = 0;
         set_id(id);
       }
@@ -139,7 +141,7 @@ namespace awkward {
     public:
       ListOffset()
           : offsets_(
-                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+                awkward::GrowableBuffer<PRIMITIVE>(default_options)) {
         offsets_.append(0);
         size_t id = 0;
         set_id(id);
@@ -254,9 +256,9 @@ namespace awkward {
     public:
       List()
           : starts_(
-                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())),
+                awkward::GrowableBuffer<PRIMITIVE>(default_options)),
             stops_(
-                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())) {
+                awkward::GrowableBuffer<PRIMITIVE>(default_options)) {
         size_t id = 0;
         set_id(id);
       }
@@ -955,7 +957,7 @@ namespace awkward {
     public:
       Indexed()
           : index_(
-                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())),
+                awkward::GrowableBuffer<PRIMITIVE>(default_options)),
             last_valid_(-1) {
         size_t id = 0;
         set_id(id);
@@ -1086,7 +1088,7 @@ namespace awkward {
     public:
       IndexedOption()
           : index_(
-                awkward::GrowableBuffer<PRIMITIVE>(awkward::BuilderOptions())),
+                awkward::GrowableBuffer<PRIMITIVE>(default_options)),
             last_valid_(-1) {
         size_t id = 0;
         set_id(id);
@@ -1307,7 +1309,7 @@ namespace awkward {
     class ByteMasked {
     public:
       ByteMasked()
-          : mask_(awkward::GrowableBuffer<int8_t>(awkward::BuilderOptions())) {
+          : mask_(awkward::GrowableBuffer<int8_t>(default_options)) {
         size_t id = 0;
         set_id(id);
       }
@@ -1443,7 +1445,7 @@ namespace awkward {
     class BitMasked {
     public:
       BitMasked()
-          : mask_(awkward::GrowableBuffer<uint8_t>(awkward::BuilderOptions())),
+          : mask_(awkward::GrowableBuffer<uint8_t>(default_options)),
             current_byte_(uint8_t(0)),
             current_byte_ref_(mask_.append_and_get_ref(current_byte_)),
             current_index_(0) {
@@ -1641,8 +1643,8 @@ namespace awkward {
       using ContentType = std::tuple_element_t<I, Contents>;
 
       Union()
-          : tags_(awkward::GrowableBuffer<TAGS>(awkward::BuilderOptions())),
-            index_(awkward::GrowableBuffer<INDEX>(awkward::BuilderOptions())) {
+          : tags_(awkward::GrowableBuffer<TAGS>(default_options)),
+            index_(awkward::GrowableBuffer<INDEX>(default_options)) {
         size_t id = 0;
         set_id(id);
         for (size_t i = 0; i < contents_count_; i++)

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -98,12 +98,6 @@ namespace awkward {
       data_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-data"]));
     }
 
-    // temporary
-    void
-    to_buffer(PRIMITIVE* ptr) const noexcept {
-      data_.concatenate(ptr);
-    }
-
     std::string
     form() const {
       std::stringstream form_key;
@@ -227,12 +221,6 @@ namespace awkward {
       content_.to_buffers(buffers);
     }
 
-    // temporary
-    void
-    to_buffer(PRIMITIVE* ptr) const noexcept {
-      offsets_.concatenate(ptr);
-    }
-
     std::string
     form() const noexcept {
       std::stringstream form_key;
@@ -354,13 +342,6 @@ namespace awkward {
       starts_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-starts"]));
       stops_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-stops"]));
       content_.to_buffers(buffers);
-    }
-
-    // temporary
-    void
-    to_buffer(PRIMITIVE* starts, PRIMITIVE* stops) const noexcept {
-      starts_.concatenate(starts);
-      stops_.concatenate(stops);
     }
 
     std::string
@@ -1046,12 +1027,6 @@ namespace awkward {
       content_.to_buffers(buffers);
     }
 
-    // temporary
-    void
-    to_buffer(PRIMITIVE* ptr) const noexcept {
-      index_.concatenate(ptr);
-    }
-
     std::string
     form() const noexcept {
       std::stringstream form_key;
@@ -1183,12 +1158,6 @@ namespace awkward {
     to_buffers(std::map<std::string, void*> &buffers) const noexcept {
       index_.concatenate(static_cast<PRIMITIVE*>(buffers["node" + std::to_string(id_) + "-index"]));
       content_.to_buffers(buffers);
-    }
-
-    // temporary
-    void
-    to_buffer(PRIMITIVE* ptr) const noexcept {
-      index_.concatenate(ptr);
     }
 
     std::string
@@ -1408,12 +1377,6 @@ namespace awkward {
       content_.to_buffers(buffers);
     }
 
-    // temporary
-    void
-    to_buffer(int8_t* ptr) const noexcept {
-      mask_.concatenate(ptr);
-    }
-
     std::string
     form() const noexcept {
       std::stringstream form_key, form_valid_when;
@@ -1582,12 +1545,6 @@ namespace awkward {
     to_buffers(std::map<std::string, void*> &buffers) const noexcept {
       mask_.concatenate(static_cast<uint8_t*>(buffers["node" + std::to_string(id_) + "-mask"]));
       content_.to_buffers(buffers);
-    }
-
-    // temporary
-    void
-    to_buffer(uint8_t* ptr) const noexcept {
-      mask_.concatenate(ptr);
     }
 
     std::string

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -142,6 +142,7 @@ type_to_numpy_like<int64_t>() {
 template <typename, typename = void>
 constexpr bool is_iterable{};
 
+// FIXME:
 // std::void_t is part of C++17, define it ourselves until we switch to it
 template<typename...>
   struct voider { using type = void; };

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -12,228 +12,230 @@
 
 namespace awkward {
 
+  template <typename T>
+  const std::string
+  type_to_name() {
+    return typeid(T).name();
+  }
 
-template <typename T>
-const std::string
-type_to_name() {
-  return typeid(T).name();
-}
+  template <>
+  const std::string
+  type_to_name<bool>() {
+    return "bool";
+  }
 
-template <>
-const std::string
-type_to_name<bool>() {
-  return "bool";
-}
+  template <>
+  const std::string
+  type_to_name<int8_t>() {
+    return "int8";
+  }
 
-template <>
-const std::string
-type_to_name<int8_t>() {
-  return "int8";
-}
+  template <>
+  const std::string
+  type_to_name<int16_t>() {
+    return "int16";
+  }
 
-template <>
-const std::string
-type_to_name<int16_t>() {
-  return "int16";
-}
+  template <>
+  const std::string
+  type_to_name<int32_t>() {
+    return "int32";
+  }
 
-template <>
-const std::string
-type_to_name<int32_t>() {
-  return "int32";
-}
+  template <>
+  const std::string
+  type_to_name<int64_t>() {
+    return "int64";
+  }
 
-template <>
-const std::string
-type_to_name<int64_t>() {
-  return "int64";
-}
+  template <>
+  const std::string
+  type_to_name<uint8_t>() {
+    return "uint8";
+  }
 
-template <>
-const std::string
-type_to_name<uint8_t>() {
-  return "uint8";
-}
+  template <>
+  const std::string
+  type_to_name<uint16_t>() {
+    return "uint16";
+  }
 
-template <>
-const std::string
-type_to_name<uint16_t>() {
-  return "uint16";
-}
+  template <>
+  const std::string
+  type_to_name<uint32_t>() {
+    return "uint32";
+  }
 
-template <>
-const std::string
-type_to_name<uint32_t>() {
-  return "uint32";
-}
+  template <>
+  const std::string
+  type_to_name<uint64_t>() {
+    return "uint64";
+  }
 
-template <>
-const std::string
-type_to_name<uint64_t>() {
-  return "uint64";
-}
-
-template <>
-const std::string
-type_to_name<float>() {
+  template <>
+  const std::string
+  type_to_name<float>() {
     return "float32";
-}
+  }
 
-template <>
-const std::string
-type_to_name<double>() {
-  return "float64";
-}
+  template <>
+  const std::string
+  type_to_name<double>() {
+    return "float64";
+  }
 
-template <>
-const std::string
-type_to_name<char>() {
-  return "char";
-}
+  template <>
+  const std::string
+  type_to_name<char>() {
+    return "char";
+  }
 
-template <>
-const std::string
-type_to_name<std::complex<float>>() {
-  return "complex64";
-}
+  template <>
+  const std::string
+  type_to_name<std::complex<float>>() {
+    return "complex64";
+  }
 
-template <>
-const std::string
-type_to_name<std::complex<double>>() {
-  return "complex128";
-}
+  template <>
+  const std::string
+  type_to_name<std::complex<double>>() {
+    return "complex128";
+  }
 
-template <typename T>
-const std::string
-type_to_numpy_like() {
-  return type_to_name<T>();
-}
+  template <typename T>
+  const std::string
+  type_to_numpy_like() {
+    return type_to_name<T>();
+  }
 
-template <>
-const std::string
-type_to_numpy_like<uint8_t>() {
-  return "u8";
-}
+  template <>
+  const std::string
+  type_to_numpy_like<uint8_t>() {
+    return "u8";
+  }
 
-template <>
-const std::string
-type_to_numpy_like<int8_t>() {
-  return "i8";
-}
+  template <>
+  const std::string
+  type_to_numpy_like<int8_t>() {
+    return "i8";
+  }
 
-template <>
-const std::string
-type_to_numpy_like<uint32_t>() {
-  return "u32";
-}
+  template <>
+  const std::string
+  type_to_numpy_like<uint32_t>() {
+    return "u32";
+  }
 
-template <>
-const std::string
-type_to_numpy_like<int32_t>() {
-  return "i32";
-}
+  template <>
+  const std::string
+  type_to_numpy_like<int32_t>() {
+    return "i32";
+  }
 
-template <>
-const std::string
-type_to_numpy_like<int64_t>() {
-  return "i64";
-}
+  template <>
+  const std::string
+  type_to_numpy_like<int64_t>() {
+    return "i64";
+  }
 
-template <typename, typename = void>
-constexpr bool is_iterable{};
+  template <typename, typename = void>
+  constexpr bool is_iterable{};
 
-// FIXME:
-// std::void_t is part of C++17, define it ourselves until we switch to it
-template<typename...>
-  struct voider { using type = void; };
+  // FIXME:
+  // std::void_t is part of C++17, define it ourselves until we switch to it
+  template <typename...>
+  struct voider {
+    using type = void;
+  };
 
-template<typename... T>
+  template <typename... T>
   using void_t = typename voider<T...>::type;
 
-template <typename T>
-constexpr bool is_iterable<
-  T,
-  void_t< decltype(std::declval<T>().begin()),
-          decltype(std::declval<T>().end())
-  >
-> = true;
+  template <typename T>
+  constexpr bool is_iterable<T,
+                             void_t<decltype(std::declval<T>().begin()),
+                                    decltype(std::declval<T>().end())>> = true;
 
-template <typename Test, template <typename...> class Ref>
-struct is_specialization : std::false_type {
-};
+  template <typename Test, template <typename...> class Ref>
+  struct is_specialization : std::false_type {};
 
-template <template <typename...> class Ref, typename... Args>
-struct is_specialization<Ref<Args...>, Ref> : std::true_type {
-};
+  template <template <typename...> class Ref, typename... Args>
+  struct is_specialization<Ref<Args...>, Ref> : std::true_type {};
 
-template <typename T>
-std::string
-type_to_form(int64_t form_key_id) {
-  if (std::string(typeid(T).name()).find("awkward") != std::string::npos) {
-    return std::string("awkward type");
-  }
-
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  if (std::is_arithmetic<T>::value) {
-    std::string parameters(type_to_name<T>() + "\", ");
-    if (std::is_same<T, char>::value) {
-      parameters = std::string("uint8\", \"parameters\": { \"__array__\": \"char\" }, ");
+  template <typename T>
+  std::string
+  type_to_form(int64_t form_key_id) {
+    if (std::string(typeid(T).name()).find("awkward") != std::string::npos) {
+      return std::string("awkward type");
     }
-    return "{\"class\": \"NumpyArray\", \"primitive\": \""
-      + parameters + "\"form_key\": \"" + form_key.str() + "\"}";
-  }
-  else if (is_specialization<T, std::complex>::value) {
-    return "{\"class\": \"NumpyArray\", \"primitive\": \""
-      + type_to_name<T>() + "\", \"form_key\": \"" + form_key.str() + "\"}";
-  }
 
-  typedef typename T::value_type value_type;
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
 
-  if (is_iterable<T>) {
-    std::string parameters("");
-    if (std::is_same<value_type, char>::value) {
-      parameters = std::string(" \"parameters\": { \"__array__\": \"string\" }, ");
+    if (std::is_arithmetic<T>::value) {
+      std::string parameters(type_to_name<T>() + "\", ");
+      if (std::is_same<T, char>::value) {
+        parameters = std::string(
+            "uint8\", \"parameters\": { \"__array__\": \"char\" }, ");
+      }
+      return "{\"class\": \"NumpyArray\", \"primitive\": \"" + parameters +
+             "\"form_key\": \"" + form_key.str() + "\"}";
+    } else if (is_specialization<T, std::complex>::value) {
+      return "{\"class\": \"NumpyArray\", \"primitive\": \"" +
+             type_to_name<T>() + "\", \"form_key\": \"" + form_key.str() +
+             "\"}";
     }
-    return "{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", \"content\":"
-      + type_to_form<value_type>(form_key_id)
-      + ", " + parameters + "\"form_key\": \"" + form_key.str() + "\"}";
-  }
-  return "unsupported type";
-}
 
-template <size_t INDEX>
-struct visit_impl {
-  template <typename FIELD, typename FUNCTION>
-    static void visit(FIELD& contents, size_t index, FUNCTION fun) {
+    typedef typename T::value_type value_type;
+
+    if (is_iterable<T>) {
+      std::string parameters("");
+      if (std::is_same<value_type, char>::value) {
+        parameters =
+            std::string(" \"parameters\": { \"__array__\": \"string\" }, ");
+      }
+      return "{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", "
+             "\"content\":" +
+             type_to_form<value_type>(form_key_id) + ", " + parameters +
+             "\"form_key\": \"" + form_key.str() + "\"}";
+    }
+    return "unsupported type";
+  }
+
+  template <size_t INDEX>
+  struct visit_impl {
+    template <typename FIELD, typename FUNCTION>
+    static void
+    visit(FIELD& contents, size_t index, FUNCTION fun) {
       if (index == INDEX - 1) {
         fun(std::get<INDEX - 1>(contents));
-      }
-      else {
+      } else {
         visit_impl<INDEX - 1>::visit(contents, index, fun);
       }
     }
-};
+  };
 
-template <>
-struct visit_impl<0> {
-  template <typename FIELD, typename FUNCTION>
-  static void visit(FIELD& /* contents */, size_t /* index */, FUNCTION /* fun */) { assert(false); }
-};
+  template <>
+  struct visit_impl<0> {
+    template <typename FIELD, typename FUNCTION>
+    static void
+    visit(FIELD& /* contents */, size_t /* index */, FUNCTION /* fun */) {
+      assert(false);
+    }
+  };
 
-template <typename FUNCTION, typename... FIELDs>
-void
-visit_at(std::tuple<FIELDs...> const& contents, size_t index, FUNCTION fun) {
-  visit_impl<sizeof...(FIELDs)>::visit(contents, index, fun);
-}
+  template <typename FUNCTION, typename... FIELDs>
+  void
+  visit_at(std::tuple<FIELDs...> const& contents, size_t index, FUNCTION fun) {
+    visit_impl<sizeof...(FIELDs)>::visit(contents, index, fun);
+  }
 
-template <typename FUNCTION, typename... FIELDs>
-void
-visit_at(std::tuple<FIELDs...>& contents, size_t index, FUNCTION fun) {
-  visit_impl<sizeof...(FIELDs)>::visit(contents, index, fun);
-}
+  template <typename FUNCTION, typename... FIELDs>
+  void
+  visit_at(std::tuple<FIELDs...>& contents, size_t index, FUNCTION fun) {
+    visit_impl<sizeof...(FIELDs)>::visit(contents, index, fun);
+  }
 
-}
+}  // namespace awkward
 
-#endif // AWKWARD_UTILS_H_
+#endif  // AWKWARD_UTILS_H_

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -16,61 +16,61 @@ namespace awkward {
 template <typename T>
 const std::string
 type_to_name() {
-    return typeid(T).name();
+  return typeid(T).name();
 }
 
 template <>
 const std::string
 type_to_name<bool>() {
-    return "bool";
+  return "bool";
 }
 
 template <>
 const std::string
 type_to_name<int8_t>() {
-    return "int8";
+  return "int8";
 }
 
 template <>
 const std::string
 type_to_name<int16_t>() {
-    return "int16";
+  return "int16";
 }
 
 template <>
 const std::string
 type_to_name<int32_t>() {
-    return "int32";
+  return "int32";
 }
 
 template <>
 const std::string
 type_to_name<int64_t>() {
-    return "int64";
+  return "int64";
 }
 
 template <>
 const std::string
 type_to_name<uint8_t>() {
-    return "uint8";
+  return "uint8";
 }
 
 template <>
 const std::string
 type_to_name<uint16_t>() {
-    return "uint16";
+  return "uint16";
 }
 
 template <>
 const std::string
 type_to_name<uint32_t>() {
-    return "uint32";
+  return "uint32";
 }
 
 template <>
 const std::string
 type_to_name<uint64_t>() {
-    return "uint64";
+  return "uint64";
 }
 
 template <>
@@ -82,51 +82,79 @@ type_to_name<float>() {
 template <>
 const std::string
 type_to_name<double>() {
-    return "float64";
+  return "float64";
 }
 
 template <>
 const std::string
 type_to_name<char>() {
-    return "char";
+  return "char";
 }
 
 template <>
 const std::string
 type_to_name<std::complex<float>>() {
-    return "complex64";
+  return "complex64";
 }
 
 template <>
 const std::string
 type_to_name<std::complex<double>>() {
-    return "complex128";
+  return "complex128";
 }
 
-template <typename PRIMITIVE>
+template <typename T>
 const std::string
 type_to_numpy_like() {
-  if (std::is_same<PRIMITIVE, uint8_t>::value)
-    return "u8";
-  else if (std::is_same<PRIMITIVE, int8_t>::value)
-    return "i8";
-  else if (std::is_same<PRIMITIVE, uint32_t>::value)
-    return "u32";
-  else if (std::is_same<PRIMITIVE, int32_t>::value)
-    return "i32";
-  else if (std::is_same<PRIMITIVE, int64_t>::value)
-    return "i64";
+  return type_to_name<T>();
+}
+
+template <>
+const std::string
+type_to_numpy_like<uint8_t>() {
+  return "u8";
+}
+
+template <>
+const std::string
+type_to_numpy_like<int8_t>() {
+  return "i8";
+}
+
+template <>
+const std::string
+type_to_numpy_like<uint32_t>() {
+  return "u32";
+}
+
+template <>
+const std::string
+type_to_numpy_like<int32_t>() {
+  return "i32";
+}
+
+template <>
+const std::string
+type_to_numpy_like<int64_t>() {
+  return "i64";
 }
 
 template <typename, typename = void>
 constexpr bool is_iterable{};
 
+// std::void_t is part of C++17, define it ourselves until we switch to it
+template<typename...>
+  struct voider { using type = void; };
+
+template<typename... T>
+  using void_t = typename voider<T...>::type;
+
 template <typename T>
 constexpr bool is_iterable<
-    T,
-    std::void_t< decltype(std::declval<T>().begin()),
-                 decltype(std::declval<T>().end())
-    >
+  T,
+  void_t< decltype(std::declval<T>().begin()),
+          decltype(std::declval<T>().end())
+  >
 > = true;
 
 template <typename Test, template <typename...> class Ref>

--- a/src/awkward/_v2/cpp-headers/rdataframe_jagged_builders.h
+++ b/src/awkward/_v2/cpp-headers/rdataframe_jagged_builders.h
@@ -7,145 +7,148 @@
 #include <string>
 #include "awkward/utils.h"
 
-
 namespace awkward {
 
-template <typename T, typename DATA>
-class CppBuffers {
-public:
-  CppBuffers(ROOT::RDF::RResultPtr<std::vector<T>>& result)
-    : result_(result) {
+  template <typename T, typename DATA>
+  class CppBuffers {
+  public:
+    CppBuffers(ROOT::RDF::RResultPtr<std::vector<T>>& result)
+        : result_(result) {
       offsets_.reserve(3);
       data_.reserve(1024);
     }
 
-  ~CppBuffers() {
-  }
+    ~CppBuffers() {}
 
-  int64_t
-  offsets_length(int64_t level) {
-    return static_cast<int64_t>(offsets_[level].size());
-  }
-
-  int64_t
-  data_length() {
-    return data_.size();
-  }
-
-  void copy_offsets(void* to_buffer, int64_t length, int64_t level) {
-    auto ptr = reinterpret_cast<int64_t *>(to_buffer);
-    int64_t i = 0;
-    for (auto const& it : offsets_[level]) {
-      ptr[i++] = it;
+    int64_t
+    offsets_length(int64_t level) {
+      return static_cast<int64_t>(offsets_[level].size());
     }
-  }
 
-  void copy_data(void* to_buffer, int64_t length) {
-    auto ptr = reinterpret_cast<DATA*>(to_buffer);
-    int64_t i = 0;
-    for (auto const& it : data_) {
-      ptr[i++] = it;
+    int64_t
+    data_length() {
+      return data_.size();
     }
-  }
 
-  std::pair<int64_t, int64_t>
-  offsets_and_flatten_2() {
-    int64_t i = 0;
-    std::vector<int64_t> offsets;
-    offsets.reserve(1024);
-    for (auto const& vec : result_) {
-      offsets.emplace_back(i);
-      i += vec.size();
-      data_.insert(data_.end(), vec.begin(), vec.end());
+    void
+    copy_offsets(void* to_buffer, int64_t length, int64_t level) {
+      auto ptr = reinterpret_cast<int64_t*>(to_buffer);
+      int64_t i = 0;
+      for (auto const& it : offsets_[level]) {
+        ptr[i++] = it;
+      }
     }
-    offsets.emplace_back(i);
 
-    offsets_.emplace_back(offsets);
+    void
+    copy_data(void* to_buffer, int64_t length) {
+      auto ptr = reinterpret_cast<DATA*>(to_buffer);
+      int64_t i = 0;
+      for (auto const& it : data_) {
+        ptr[i++] = it;
+      }
+    }
 
-    return {static_cast<int64_t>(offsets_.size()), static_cast<int64_t>(offsets_[0].size())};
-  }
-
-  std::pair<int64_t, int64_t>
-  offsets_and_flatten_3() {
-    int64_t i = 0;
-    int64_t j = 0;
-    std::vector<int64_t> offsets;
-    offsets.reserve(1024);
-    std::vector<int64_t> inner_offsets;
-    inner_offsets.reserve(1024);
-    for (auto const& vec_of_vecs : result_) {
-      offsets.emplace_back(i);
-      i += vec_of_vecs.size();
-
-      for (auto const& vec : vec_of_vecs) {
-        inner_offsets.emplace_back(j);
-        j += vec.size();
+    std::pair<int64_t, int64_t>
+    offsets_and_flatten_2() {
+      int64_t i = 0;
+      std::vector<int64_t> offsets;
+      offsets.reserve(1024);
+      for (auto const& vec : result_) {
+        offsets.emplace_back(i);
+        i += vec.size();
         data_.insert(data_.end(), vec.begin(), vec.end());
       }
-      inner_offsets.emplace_back(j);
-    }
-    offsets.emplace_back(i);
-
-    offsets_.emplace_back(offsets);
-    offsets_.emplace_back(inner_offsets);
-
-    return {static_cast<int64_t>(offsets_.size()), static_cast<int64_t>(offsets_[0].size())};
-  }
-
-  std::pair<int64_t, int64_t>
-  offsets_and_flatten_4() {
-    int64_t i = 0;
-    int64_t j = 0;
-    int64_t k = 0;
-    std::vector<int64_t> offsets;
-    std::vector<int64_t> inner_offsets;
-    std::vector<int64_t> inner_inner_offsets;
-    for (auto const& vec_of_vecs_of_vecs : result_) {
       offsets.emplace_back(i);
-      i += vec_of_vecs_of_vecs.size();
 
-      for (auto const& vec_of_vecs : vec_of_vecs_of_vecs) {
-        inner_offsets.emplace_back(j);
-        j += vec_of_vecs.size();
+      offsets_.emplace_back(offsets);
 
-        for (auto const&vec : vec_of_vecs) {
-          inner_inner_offsets.emplace_back(k);
-          k += vec.size();
+      return {static_cast<int64_t>(offsets_.size()),
+              static_cast<int64_t>(offsets_[0].size())};
+    }
+
+    std::pair<int64_t, int64_t>
+    offsets_and_flatten_3() {
+      int64_t i = 0;
+      int64_t j = 0;
+      std::vector<int64_t> offsets;
+      offsets.reserve(1024);
+      std::vector<int64_t> inner_offsets;
+      inner_offsets.reserve(1024);
+      for (auto const& vec_of_vecs : result_) {
+        offsets.emplace_back(i);
+        i += vec_of_vecs.size();
+
+        for (auto const& vec : vec_of_vecs) {
+          inner_offsets.emplace_back(j);
+          j += vec.size();
           data_.insert(data_.end(), vec.begin(), vec.end());
         }
-        inner_inner_offsets.emplace_back(k);
+        inner_offsets.emplace_back(j);
       }
-      inner_offsets.emplace_back(j);
+      offsets.emplace_back(i);
+
+      offsets_.emplace_back(offsets);
+      offsets_.emplace_back(inner_offsets);
+
+      return {static_cast<int64_t>(offsets_.size()),
+              static_cast<int64_t>(offsets_[0].size())};
     }
-    offsets.emplace_back(i);
 
-    offsets_.emplace_back(offsets);
-    offsets_.emplace_back(inner_offsets);
-    offsets_.emplace_back(inner_inner_offsets);
+    std::pair<int64_t, int64_t>
+    offsets_and_flatten_4() {
+      int64_t i = 0;
+      int64_t j = 0;
+      int64_t k = 0;
+      std::vector<int64_t> offsets;
+      std::vector<int64_t> inner_offsets;
+      std::vector<int64_t> inner_inner_offsets;
+      for (auto const& vec_of_vecs_of_vecs : result_) {
+        offsets.emplace_back(i);
+        i += vec_of_vecs_of_vecs.size();
 
-    return {static_cast<int64_t>(offsets_.size()), static_cast<int64_t>(offsets_[0].size())};
-  }
+        for (auto const& vec_of_vecs : vec_of_vecs_of_vecs) {
+          inner_offsets.emplace_back(j);
+          j += vec_of_vecs.size();
 
-  int64_t
-  result_distance() {
-    return std::distance(result_.begin(), result_.end());
-  }
+          for (auto const& vec : vec_of_vecs) {
+            inner_inner_offsets.emplace_back(k);
+            k += vec.size();
+            data_.insert(data_.end(), vec.begin(), vec.end());
+          }
+          inner_inner_offsets.emplace_back(k);
+        }
+        inner_offsets.emplace_back(j);
+      }
+      offsets.emplace_back(i);
 
-  void
-  fill_data_array(void* to_buffer) {
-    int64_t i = 0;
-    DATA* ptr = reinterpret_cast<DATA*>(to_buffer);
-    for (auto const& it : result_) {
-      ptr[i++] = it;
+      offsets_.emplace_back(offsets);
+      offsets_.emplace_back(inner_offsets);
+      offsets_.emplace_back(inner_inner_offsets);
+
+      return {static_cast<int64_t>(offsets_.size()),
+              static_cast<int64_t>(offsets_[0].size())};
     }
-  }
 
-private:
-  ROOT::RDF::RResultPtr<std::vector<T>>& result_;
-  std::vector<std::vector<int64_t>> offsets_;
-  std::vector<DATA> data_;
-};
+    int64_t
+    result_distance() {
+      return std::distance(result_.begin(), result_.end());
+    }
 
-}
+    void
+    fill_data_array(void* to_buffer) {
+      int64_t i = 0;
+      DATA* ptr = reinterpret_cast<DATA*>(to_buffer);
+      for (auto const& it : result_) {
+        ptr[i++] = it;
+      }
+    }
 
-#endif // AWKWARD_RDATAFRAME_JAGGED_BUILDERS_H_
+  private:
+    ROOT::RDF::RResultPtr<std::vector<T>>& result_;
+    std::vector<std::vector<int64_t>> offsets_;
+    std::vector<DATA> data_;
+  };
+
+}  // namespace awkward
+
+#endif  // AWKWARD_RDATAFRAME_JAGGED_BUILDERS_H_

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -11,10 +11,11 @@
 #include "awkward/builder/UnknownBuilder.h"
 
 #include "awkward/builder/ArrayBuilder.h"
+#include "awkward/ArrayBuilderOptions.h"
 
 namespace awkward {
-  ArrayBuilder::ArrayBuilder(const int64_t initial)
-      : builder_(UnknownBuilder::fromempty(initial)) { }
+  ArrayBuilder::ArrayBuilder(const ArrayBuilderOptions& options)
+      : builder_(UnknownBuilder::fromempty(options)) { }
 
   const std::string
   ArrayBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -11,10 +11,10 @@
 #include "awkward/builder/UnknownBuilder.h"
 
 #include "awkward/builder/ArrayBuilder.h"
-#include "awkward/ArrayBuilderOptions.h"
+#include "awkward/BuilderOptions.h"
 
 namespace awkward {
-  ArrayBuilder::ArrayBuilder(const ArrayBuilderOptions& options)
+  ArrayBuilder::ArrayBuilder(const BuilderOptions& options)
       : builder_(UnknownBuilder::fromempty(options)) { }
 
   const std::string

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -11,14 +11,14 @@
 
 namespace awkward {
   const BuilderPtr
-  BoolBuilder::fromempty(const int64_t initial) {
-    return std::make_shared<BoolBuilder>(initial,
-                                         std::move(GrowableBuffer<uint8_t>::empty(initial)));
+  BoolBuilder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<BoolBuilder>(options,
+                                         std::move(GrowableBuffer<uint8_t>::empty(options)));
   }
 
-  BoolBuilder::BoolBuilder(const int64_t initial,
+  BoolBuilder::BoolBuilder(const BuilderOptions& options,
                            GrowableBuffer<uint8_t> buffer)
-      : initial_(initial)
+      : options_(options)
       , buffer_(std::move(buffer)) { }
 
   const std::string
@@ -57,7 +57,7 @@ namespace awkward {
 
   const BuilderPtr
   BoolBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
     return std::move(out);
   }
@@ -70,49 +70,49 @@ namespace awkward {
 
   const BuilderPtr
   BoolBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->integer(x);
     return std::move(out);
   }
 
   const BuilderPtr
   BoolBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->real(x);
     return std::move(out);
   }
 
   const BuilderPtr
   BoolBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->complex(x);
     return std::move(out);
   }
 
   const BuilderPtr
   BoolBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   BoolBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
     return std::move(out);
   }
 
   const BuilderPtr
   BoolBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
     return std::move(out);
   }
@@ -126,7 +126,7 @@ namespace awkward {
 
   const BuilderPtr
   BoolBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
     return std::move(out);
   }
@@ -147,7 +147,7 @@ namespace awkward {
 
   const BuilderPtr
   BoolBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
     return std::move(out);
   }

--- a/src/libawkward/builder/Complex128Builder.cpp
+++ b/src/libawkward/builder/Complex128Builder.cpp
@@ -11,30 +11,30 @@
 
 namespace awkward {
   const BuilderPtr
-  Complex128Builder::fromempty(const int64_t initial) {
-    return std::make_shared<Complex128Builder>(initial,
-                                              GrowableBuffer<std::complex<double>>::empty(initial));
+  Complex128Builder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<Complex128Builder>(options,
+                                              GrowableBuffer<std::complex<double>>::empty(options));
   }
 
   const BuilderPtr
-  Complex128Builder::fromint64(const int64_t initial,
+  Complex128Builder::fromint64(const BuilderOptions& options,
                                const GrowableBuffer<int64_t>& old) {
     return std::make_shared<Complex128Builder>(
-      initial,
+      options,
       std::move(GrowableBuffer<int64_t>::copy_as<std::complex<double>>(old)));
   }
 
   const BuilderPtr
-  Complex128Builder::fromfloat64(const int64_t initial,
+  Complex128Builder::fromfloat64(const BuilderOptions& options,
                                  const GrowableBuffer<double>& old) {
     return std::make_shared<Complex128Builder>(
-      initial,
+      options,
       std::move(GrowableBuffer<double>::copy_as<std::complex<double>>(old)));
   }
 
-  Complex128Builder::Complex128Builder(const int64_t initial,
+  Complex128Builder::Complex128Builder(const BuilderOptions& options,
                                        GrowableBuffer<std::complex<double>> buffer)
-      : initial_(initial)
+      : options_(options)
       , buffer_(std::move(buffer)) { }
 
   const std::string
@@ -73,14 +73,14 @@ namespace awkward {
 
   const BuilderPtr
   Complex128Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
     return std::move(out);
   }
 
   const BuilderPtr
   Complex128Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
     return std::move(out);
   }
@@ -105,28 +105,28 @@ namespace awkward {
 
   const BuilderPtr
   Complex128Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   Complex128Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   Complex128Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
     return std::move(out);
   }
 
   const BuilderPtr
   Complex128Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
     return std::move(out);
   }
@@ -140,7 +140,7 @@ namespace awkward {
 
   const BuilderPtr
   Complex128Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
     return std::move(out);
   }
@@ -161,7 +161,7 @@ namespace awkward {
 
   const BuilderPtr
   Complex128Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
     return std::move(out);
   }

--- a/src/libawkward/builder/DatetimeBuilder.cpp
+++ b/src/libawkward/builder/DatetimeBuilder.cpp
@@ -15,17 +15,17 @@
 
 namespace awkward {
   const BuilderPtr
-  DatetimeBuilder::fromempty(const int64_t initial, const std::string& units) {
-    GrowableBuffer<int64_t> content = GrowableBuffer<int64_t>::empty(initial);
-    return std::make_shared<DatetimeBuilder>(initial,
+  DatetimeBuilder::fromempty(const BuilderOptions& options, const std::string& units) {
+    GrowableBuffer<int64_t> content = GrowableBuffer<int64_t>::empty(options);
+    return std::make_shared<DatetimeBuilder>(options,
                                              std::move(content),
                                              units);
   }
 
-  DatetimeBuilder::DatetimeBuilder(const int64_t initial,
+  DatetimeBuilder::DatetimeBuilder(const BuilderOptions& options,
                                    GrowableBuffer<int64_t> content,
                                    const std::string& units)
-      : initial_(initial)
+      : options_(options)
       , content_(std::move(content))
       , units_(units) { }
 
@@ -82,35 +82,35 @@ namespace awkward {
 
   const BuilderPtr
   DatetimeBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
     return std::move(out);
   }
 
   const BuilderPtr
   DatetimeBuilder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
     return std::move(out);
   }
 
   const BuilderPtr
   DatetimeBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->integer(x);
     return std::move(out);
   }
 
   const BuilderPtr
   DatetimeBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->real(x);
     return std::move(out);
   }
 
   const BuilderPtr
   DatetimeBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->complex(x);
     return std::move(out);
   }
@@ -122,7 +122,7 @@ namespace awkward {
       return nullptr;
     }
     else {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->datetime(x, unit);
       return std::move(out);
     }
@@ -135,7 +135,7 @@ namespace awkward {
       return nullptr;
     }
     else {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->timedelta(x, unit);
       return std::move(out);
     }
@@ -143,14 +143,14 @@ namespace awkward {
 
   const BuilderPtr
   DatetimeBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
     return std::move(out);
   }
 
   const BuilderPtr
   DatetimeBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
     return std::move(out);
   }
@@ -164,7 +164,7 @@ namespace awkward {
 
   const BuilderPtr
   DatetimeBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
     return std::move(out);
   }
@@ -185,7 +185,7 @@ namespace awkward {
 
   const BuilderPtr
   DatetimeBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
     return std::move(out);
   }

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -12,22 +12,22 @@
 
 namespace awkward {
   const BuilderPtr
-  Float64Builder::fromempty(const int64_t initial) {
-    return std::make_shared<Float64Builder>(initial,
-                                            GrowableBuffer<double>::empty(initial));
+  Float64Builder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<Float64Builder>(options,
+                                            GrowableBuffer<double>::empty(options));
   }
 
   const BuilderPtr
-  Float64Builder::fromint64(const int64_t initial,
+  Float64Builder::fromint64(const BuilderOptions& options,
                             const GrowableBuffer<int64_t>& old) {
     return std::make_shared<Float64Builder>(
-      initial,
+      options,
       std::move(GrowableBuffer<int64_t>::copy_as<double>(old)));
   }
 
-  Float64Builder::Float64Builder(const int64_t initial,
+  Float64Builder::Float64Builder(const BuilderOptions& options,
                                  GrowableBuffer<double> buffer)
-      : initial_(initial)
+      : options_(options)
       , buffer_(std::move(buffer)) { }
 
   GrowableBuffer<double>
@@ -72,14 +72,14 @@ namespace awkward {
 
   const BuilderPtr
   Float64Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
     return std::move(out);
   }
 
   const BuilderPtr
   Float64Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
     return std::move(out);
   }
@@ -98,35 +98,35 @@ namespace awkward {
 
   const BuilderPtr
   Float64Builder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromfloat64(initial_, std::move(buffer_));
+    BuilderPtr out = Complex128Builder::fromfloat64(options_, std::move(buffer_));
     out.get()->complex(x);
     return std::move(out);
   }
 
   const BuilderPtr
   Float64Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   Float64Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   Float64Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
     return std::move(out);
   }
 
   const BuilderPtr
   Float64Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
     return std::move(out);
   }
@@ -140,7 +140,7 @@ namespace awkward {
 
   const BuilderPtr
   Float64Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
     return std::move(out);
   }
@@ -161,7 +161,7 @@ namespace awkward {
 
   const BuilderPtr
   Float64Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
     return std::move(out);
   }

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -13,14 +13,14 @@
 
 namespace awkward {
   const BuilderPtr
-  Int64Builder::fromempty(const int64_t initial) {
-    return std::make_shared<Int64Builder>(initial,
-                                          GrowableBuffer<int64_t>::empty(initial));
+  Int64Builder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<Int64Builder>(options,
+                                          GrowableBuffer<int64_t>::empty(options));
   }
 
-  Int64Builder::Int64Builder(const int64_t initial,
+  Int64Builder::Int64Builder(const BuilderOptions& options,
                              GrowableBuffer<int64_t> buffer)
-      : initial_(initial)
+      : options_(options)
       , buffer_(std::move(buffer)) { }
 
   GrowableBuffer<int64_t>
@@ -65,14 +65,14 @@ namespace awkward {
 
   const BuilderPtr
   Int64Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
     return std::move(out);
   }
 
   const BuilderPtr
   Int64Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
     return std::move(out);
   }
@@ -85,42 +85,42 @@ namespace awkward {
 
   const BuilderPtr
   Int64Builder::real(double x) {
-    BuilderPtr out = Float64Builder::fromint64(initial_, buffer_);
+    BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
     out.get()->real(x);
     return std::move(out);
   }
 
   const BuilderPtr
   Int64Builder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromint64(initial_, buffer_);
+    BuilderPtr out = Complex128Builder::fromint64(options_, buffer_);
     out.get()->complex(x);
     return std::move(out);
   }
 
   const BuilderPtr
   Int64Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   Int64Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   Int64Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
     return std::move(out);
   }
 
   const BuilderPtr
   Int64Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
     return std::move(out);
   }
@@ -134,7 +134,7 @@ namespace awkward {
 
   const BuilderPtr
   Int64Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
     return std::move(out);
   }
@@ -155,7 +155,7 @@ namespace awkward {
 
   const BuilderPtr
   Int64Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
     return std::move(out);
   }

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -12,20 +12,20 @@
 
 namespace awkward {
   const BuilderPtr
-  ListBuilder::fromempty(const int64_t initial) {
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(initial);
+  ListBuilder::fromempty(const BuilderOptions& options) {
+    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
     offsets.append(0);
-    return std::make_shared<ListBuilder>(initial,
+    return std::make_shared<ListBuilder>(options,
                                          std::move(offsets),
-                                         UnknownBuilder::fromempty(initial),
+                                         UnknownBuilder::fromempty(options),
                                          false);
   }
 
-  ListBuilder::ListBuilder(const int64_t initial,
+  ListBuilder::ListBuilder(const BuilderOptions& options,
                            GrowableBuffer<int64_t> offsets,
                            const BuilderPtr& content,
                            bool begun)
-      : initial_(initial)
+      : options_(options)
       , offsets_(std::move(offsets))
       , content_(content)
       , begun_(begun) { }
@@ -70,7 +70,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::null() {
     if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
       out.get()->null();
       return std::move(out);
     }
@@ -83,7 +83,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::boolean(bool x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->boolean(x);
       return std::move(out);
     }
@@ -96,7 +96,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::integer(int64_t x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->integer(x);
       return std::move(out);
     }
@@ -109,7 +109,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::real(double x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->real(x);
       return std::move(out);
     }
@@ -122,7 +122,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::complex(std::complex<double> x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->complex(x);
       return std::move(out);
     }
@@ -135,7 +135,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::datetime(int64_t x, const std::string& unit) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->datetime(x, unit);
       return std::move(out);
     }
@@ -148,7 +148,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::timedelta(int64_t x, const std::string& unit) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->timedelta(x, unit);
       return std::move(out);
     }
@@ -161,7 +161,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->string(x, length, encoding);
       return std::move(out);
     }
@@ -202,7 +202,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::begintuple(int64_t numfields) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->begintuple(numfields);
       return std::move(out);
     }
@@ -241,7 +241,7 @@ namespace awkward {
   const BuilderPtr
   ListBuilder::beginrecord(const char* name, bool check) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginrecord(name, check);
       return std::move(out);
     }

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -9,26 +9,26 @@
 
 namespace awkward {
   const BuilderPtr
-  OptionBuilder::fromnulls(const int64_t initial,
+  OptionBuilder::fromnulls(const BuilderOptions& options,
                            int64_t nullcount,
                            const BuilderPtr& content) {
     return std::make_shared<OptionBuilder>(
-      initial,
-      GrowableBuffer<int64_t>::full(initial,
+      options,
+      GrowableBuffer<int64_t>::full(options,
                                     -1,
                                     nullcount),
      content);
   }
 
   const BuilderPtr
-  OptionBuilder::fromvalids(const int64_t initial,
+  OptionBuilder::fromvalids(const BuilderOptions& options,
                             const BuilderPtr& content) {
-    return std::make_shared<OptionBuilder>(initial,
-                                           GrowableBuffer<int64_t>::arange(initial, content->length()),
+    return std::make_shared<OptionBuilder>(options,
+                                           GrowableBuffer<int64_t>::arange(options, content->length()),
                                            content);
   }
 
-  OptionBuilder::OptionBuilder(const int64_t initial,
+  OptionBuilder::OptionBuilder(const BuilderOptions& options,
                                GrowableBuffer<int64_t> index,
                                const BuilderPtr content)
     : index_(std::move(index))

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -13,8 +13,8 @@
 
 namespace awkward {
   const BuilderPtr
-  RecordBuilder::fromempty(const int64_t initial) {
-    return std::make_shared<RecordBuilder>(initial,
+  RecordBuilder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<RecordBuilder>(options,
                                            std::vector<BuilderPtr>(),
                                            std::vector<std::string>(),
                                            std::vector<const char*>(),
@@ -26,7 +26,7 @@ namespace awkward {
                                            -1);
   }
 
-  RecordBuilder::RecordBuilder(const int64_t initial,
+  RecordBuilder::RecordBuilder(const BuilderOptions& options,
                                const std::vector<BuilderPtr>& contents,
                                const std::vector<std::string>& keys,
                                const std::vector<const char*>& pointers,
@@ -36,7 +36,7 @@ namespace awkward {
                                bool begun,
                                int64_t nextindex,
                                int64_t nexttotry)
-      : initial_(initial)
+      : options_(options)
       , contents_(contents)
       , keys_(keys)
       , pointers_(pointers)
@@ -115,7 +115,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::null() {
     if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
       out.get()->null();
       return std::move(out);
     }
@@ -136,7 +136,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::boolean(bool x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->boolean(x);
       return std::move(out);
     }
@@ -157,7 +157,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::integer(int64_t x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->integer(x);
       return std::move(out);
     }
@@ -178,7 +178,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::real(double x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->real(x);
       return std::move(out);
     }
@@ -199,7 +199,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::complex(std::complex<double> x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->complex(x);
       return std::move(out);
     }
@@ -220,7 +220,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::datetime(int64_t x, const std::string& unit) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->datetime(x, unit);
       return std::move(out);
     }
@@ -241,7 +241,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::timedelta(int64_t x, const std::string& unit) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->timedelta(x, unit);
       return std::move(out);
     }
@@ -262,7 +262,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->string(x, length, encoding);
       return std::move(out);
     }
@@ -286,7 +286,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::beginlist() {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginlist();
       return std::move(out);
     }
@@ -327,7 +327,7 @@ namespace awkward {
   const BuilderPtr
   RecordBuilder::begintuple(int64_t numfields) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->begintuple(numfields);
       return std::move(out);
     }
@@ -405,7 +405,7 @@ namespace awkward {
       nexttotry_ = 0;
     }
     else if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginrecord(name, check);
       return std::move(out);
     }
@@ -463,13 +463,13 @@ namespace awkward {
       nextindex_ = keys_size_;
       nexttotry_ = 0;
       if (length_ == 0) {
-        contents_.push_back(UnknownBuilder::fromempty(initial_));
+        contents_.push_back(UnknownBuilder::fromempty(options_));
       }
       else {
         contents_.push_back(
-          OptionBuilder::fromnulls(initial_,
+          OptionBuilder::fromnulls(options_,
                                    length_,
-                                   UnknownBuilder::fromempty(initial_)));
+                                   UnknownBuilder::fromempty(options_)));
       }
       keys_.push_back(std::string(key));
       pointers_.push_back(key);
@@ -509,13 +509,13 @@ namespace awkward {
       nextindex_ = keys_size_;
       nexttotry_ = 0;
       if (length_ == 0) {
-        contents_.emplace_back(UnknownBuilder::fromempty(initial_));
+        contents_.emplace_back(UnknownBuilder::fromempty(options_));
       }
       else {
         contents_.emplace_back(
-          OptionBuilder::fromnulls(initial_,
+          OptionBuilder::fromnulls(options_,
                                    length_,
-                                   UnknownBuilder::fromempty(initial_)));
+                                   UnknownBuilder::fromempty(options_)));
       }
       keys_.emplace_back(std::string(key));
       pointers_.emplace_back(nullptr);

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -12,22 +12,22 @@
 
 namespace awkward {
   const BuilderPtr
-  StringBuilder::fromempty(const int64_t initial,
+  StringBuilder::fromempty(const BuilderOptions& options,
                            const char* encoding) {
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(initial);
+    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
     offsets.append(0);
-    GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(initial);
-    return std::make_shared<StringBuilder>(initial,
+    GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
+    return std::make_shared<StringBuilder>(options,
                                            std::move(offsets),
                                            std::move(content),
                                            encoding);
   }
 
-  StringBuilder::StringBuilder(const int64_t initial,
+  StringBuilder::StringBuilder(const BuilderOptions& options,
                                GrowableBuffer<int64_t> offsets,
                                GrowableBuffer<uint8_t> content,
                                const char* encoding)
-      : initial_(initial)
+      : options_(options)
       , offsets_(std::move(offsets))
       , content_(std::move(content))
       , encoding_(encoding) { }
@@ -100,49 +100,49 @@ namespace awkward {
 
   const BuilderPtr
   StringBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
     return std::move(out);
   }
 
   const BuilderPtr
   StringBuilder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
     return std::move(out);
   }
 
   const BuilderPtr
   StringBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->integer(x);
     return std::move(out);
   }
 
   const BuilderPtr
   StringBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->real(x);
     return std::move(out);
   }
 
   const BuilderPtr
   StringBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->complex(x);
     return std::move(out);
   }
 
   const BuilderPtr
   StringBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
     return std::move(out);
   }
 
   const BuilderPtr
   StringBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
     return std::move(out);
   }
@@ -165,7 +165,7 @@ namespace awkward {
 
   const BuilderPtr
   StringBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
     return std::move(out);
   }
@@ -179,7 +179,7 @@ namespace awkward {
 
   const BuilderPtr
   StringBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
     return std::move(out);
   }
@@ -200,7 +200,7 @@ namespace awkward {
 
   const BuilderPtr
   StringBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
     return std::move(out);
   }

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -12,20 +12,20 @@
 
 namespace awkward {
   const BuilderPtr
-  TupleBuilder::fromempty(const int64_t initial) {
-    return std::make_shared<TupleBuilder>(initial,
+  TupleBuilder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<TupleBuilder>(options,
                                           std::vector<BuilderPtr>(),
                                           -1,
                                           false,
                                           -1);
   }
 
-  TupleBuilder::TupleBuilder(const int64_t initial,
+  TupleBuilder::TupleBuilder(const BuilderOptions& options,
                              const std::vector<BuilderPtr>& contents,
                              int64_t length,
                              bool begun,
                              size_t nextindex)
-      : initial_(initial)
+      : options_(options)
       , contents_(contents)
       , length_(length)
       , begun_(begun)
@@ -81,7 +81,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::null() {
     if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
       out.get()->null();
       return std::move(out);
     }
@@ -102,7 +102,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::boolean(bool x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->boolean(x);
       return std::move(out);
     }
@@ -123,7 +123,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::integer(int64_t x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->integer(x);
       return std::move(out);
     }
@@ -144,7 +144,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::real(double x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->real(x);
       return std::move(out);
     }
@@ -165,7 +165,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::complex(std::complex<double> x) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->complex(x);
       return std::move(out);
     }
@@ -186,7 +186,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::datetime(int64_t x, const std::string& unit) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->datetime(x, unit);
       return std::move(out);
     }
@@ -207,7 +207,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::timedelta(int64_t x, const std::string& unit) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->timedelta(x, unit);
       return std::move(out);
     }
@@ -228,7 +228,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::string(const char* x, int64_t length, const char* encoding) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->string(x, length, encoding);
       return std::move(out);
     }
@@ -252,7 +252,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::beginlist() {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginlist();
       return std::move(out);
     }
@@ -294,7 +294,7 @@ namespace awkward {
   TupleBuilder::begintuple(int64_t numfields) {
     if (length_ == -1) {
       for (int64_t i = 0;  i < numfields;  i++) {
-        contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(initial_)));
+        contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
       }
       length_ = 0;
     }
@@ -304,7 +304,7 @@ namespace awkward {
       nextindex_ = -1;
     }
     else if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->begintuple(numfields);
       return std::move(out);
     }
@@ -380,7 +380,7 @@ namespace awkward {
   const BuilderPtr
   TupleBuilder::beginrecord(const char* name, bool check) {
     if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(initial_, shared_from_this());
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginrecord(name, check);
       return std::move(out);
     }

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -19,20 +19,20 @@
 
 namespace awkward {
   const BuilderPtr
-  UnionBuilder::fromsingle(const int64_t initial,
+  UnionBuilder::fromsingle(const BuilderOptions& options,
                            const BuilderPtr& firstcontent) {
     std::vector<BuilderPtr> contents({ firstcontent });
-    return std::make_shared<UnionBuilder>(initial,
-                                          GrowableBuffer<int8_t>::full(initial, 0, firstcontent->length()),
-                                          GrowableBuffer<int64_t>::arange(initial, firstcontent->length()),
+    return std::make_shared<UnionBuilder>(options,
+                                          GrowableBuffer<int8_t>::full(options, 0, firstcontent->length()),
+                                          GrowableBuffer<int64_t>::arange(options, firstcontent->length()),
                                           contents);
   }
 
-  UnionBuilder::UnionBuilder(const int64_t initial,
+  UnionBuilder::UnionBuilder(const BuilderOptions& options,
                              GrowableBuffer<int8_t> tags,
                              GrowableBuffer<int64_t> index,
                              std::vector<BuilderPtr>& contents)
-      : initial_(initial)
+      : options_(options)
       , tags_(std::move(tags))
       , index_(std::move(index))
       , contents_(contents)
@@ -92,7 +92,7 @@ namespace awkward {
   const BuilderPtr
   UnionBuilder::null() {
     if (current_ == -1) {
-      BuilderPtr out = OptionBuilder::fromvalids(initial_, shared_from_this());
+      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
       out.get()->null();
       return std::move(out);
     }
@@ -109,7 +109,7 @@ namespace awkward {
         return dynamic_cast<BoolBuilder*>(p.get());
       });
       if (tofill == contents_.end()) {
-        contents_.emplace_back(BoolBuilder::fromempty(initial_));
+        contents_.emplace_back(BoolBuilder::fromempty(options_));
         tofill = --contents_.end();
       }
       int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
@@ -131,7 +131,7 @@ namespace awkward {
         return dynamic_cast<Int64Builder*>(p.get());
       });
       if (tofill == contents_.end()) {
-        contents_.emplace_back(Int64Builder::fromempty(initial_));
+        contents_.emplace_back(Int64Builder::fromempty(options_));
         tofill = --contents_.end();
       }
       int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
@@ -158,11 +158,11 @@ namespace awkward {
         });
         if (tofill != contents_.end()) {
           *tofill = Float64Builder::fromint64(
-              initial_,
+              options_,
               std::move(static_cast<Int64Builder*>(tofill->get())->buffer()));
         }
         else {
-          contents_.emplace_back(Float64Builder::fromempty(initial_));
+          contents_.emplace_back(Float64Builder::fromempty(options_));
           tofill = --contents_.end();
         }
       }
@@ -190,7 +190,7 @@ namespace awkward {
         });
         if (tofill != contents_.end()) {
           *tofill = std::move(Complex128Builder::fromfloat64(
-              initial_,
+              options_,
               std::move(static_cast<Float64Builder*>(tofill->get())->buffer())));
         }
       }
@@ -200,11 +200,11 @@ namespace awkward {
         });
         if (tofill != contents_.end()) {
           *tofill = std::move(Complex128Builder::fromint64(
-              initial_,
+              options_,
               std::move(static_cast<Int64Builder*>(tofill->get())->buffer())));
         }
         else {
-          contents_.emplace_back(Complex128Builder::fromempty(initial_));
+          contents_.emplace_back(Complex128Builder::fromempty(options_));
           tofill = --contents_.end();
         }
       }
@@ -228,7 +228,7 @@ namespace awkward {
         return raw != 0 && raw->units() == unit;
       });
       if (tofill == contents_.end()) {
-        contents_.emplace_back(DatetimeBuilder::fromempty(initial_, unit));
+        contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
         tofill = --contents_.end();
       }
       int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
@@ -251,7 +251,7 @@ namespace awkward {
         return raw != 0 && raw->units() == unit;
       });
       if (tofill == contents_.end()) {
-        contents_.emplace_back(DatetimeBuilder::fromempty(initial_, unit));
+        contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
         tofill = --contents_.end();
       }
       int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
@@ -274,7 +274,7 @@ namespace awkward {
         return raw != 0 && raw->encoding() == encoding;
       });
       if (tofill == contents_.end()) {
-        contents_.emplace_back(StringBuilder::fromempty(initial_, encoding));
+        contents_.emplace_back(StringBuilder::fromempty(options_, encoding));
         tofill = --contents_.end();
       }
       int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
@@ -296,7 +296,7 @@ namespace awkward {
         return dynamic_cast<ListBuilder*>(p.get());
       });
       if (tofill == contents_.end()) {
-        contents_.emplace_back(ListBuilder::fromempty(initial_));
+        contents_.emplace_back(ListBuilder::fromempty(options_));
         tofill = --contents_.end();
       }
       tofill->get()->beginlist();
@@ -335,7 +335,7 @@ namespace awkward {
         return raw != nullptr  &&  (raw->length() == -1  ||  raw->numfields() == numfields);
       });
       if (tofill == contents_.end()) {
-        contents_.emplace_back(TupleBuilder::fromempty(initial_));
+        contents_.emplace_back(TupleBuilder::fromempty(options_));
         tofill = --contents_.end();
       }
       tofill->get()->begintuple(numfields);
@@ -389,7 +389,7 @@ namespace awkward {
                  (!check  &&  raw->nameptr() == name)));
       });
       if (tofill == contents_.end()) {
-        contents_.emplace_back(RecordBuilder::fromempty(initial_));
+        contents_.emplace_back(RecordBuilder::fromempty(options_));
         tofill = --contents_.end();
       }
       tofill->get()->beginrecord(name, check);

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -19,13 +19,13 @@
 
 namespace awkward {
   const BuilderPtr
-  UnknownBuilder::fromempty(const int64_t initial) {
-    return std::make_shared<UnknownBuilder>(initial, 0);
+  UnknownBuilder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<UnknownBuilder>(options, 0);
   }
 
-  UnknownBuilder::UnknownBuilder(const int64_t initial,
+  UnknownBuilder::UnknownBuilder(const BuilderOptions& options,
                                  int64_t nullcount)
-      : initial_(initial)
+      : options_(options)
       , nullcount_(nullcount) { }
 
   const std::string
@@ -80,9 +80,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::boolean(bool x) {
-    BuilderPtr out = BoolBuilder::fromempty(initial_);
+    BuilderPtr out = BoolBuilder::fromempty(options_);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->boolean(x);
     return std::move(out);
@@ -90,9 +90,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::integer(int64_t x) {
-    BuilderPtr out = Int64Builder::fromempty(initial_);
+    BuilderPtr out = Int64Builder::fromempty(options_);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->integer(x);
     return std::move(out);
@@ -100,9 +100,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::real(double x) {
-    BuilderPtr out = Float64Builder::fromempty(initial_);
+    BuilderPtr out = Float64Builder::fromempty(options_);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->real(x);
     return std::move(out);
@@ -110,9 +110,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromempty(initial_);
+    BuilderPtr out = Complex128Builder::fromempty(options_);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->complex(x);
     return std::move(out);
@@ -120,9 +120,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = DatetimeBuilder::fromempty(initial_, unit);
+    BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->datetime(x, unit);
     return std::move(out);
@@ -130,9 +130,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = DatetimeBuilder::fromempty(initial_, unit);
+    BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->timedelta(x, unit);
     return std::move(out);
@@ -140,9 +140,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = StringBuilder::fromempty(initial_, encoding);
+    BuilderPtr out = StringBuilder::fromempty(options_, encoding);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->string(x, length, encoding);
     return std::move(out);
@@ -150,9 +150,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::beginlist() {
-    BuilderPtr out = ListBuilder::fromempty(initial_);
+    BuilderPtr out = ListBuilder::fromempty(options_);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->beginlist();
     return std::move(out);
@@ -167,9 +167,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = TupleBuilder::fromempty(initial_);
+    BuilderPtr out = TupleBuilder::fromempty(options_);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->begintuple(numfields);
     return std::move(out);
@@ -191,9 +191,9 @@ namespace awkward {
 
   const BuilderPtr
   UnknownBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = RecordBuilder::fromempty(initial_);
+    BuilderPtr out = RecordBuilder::fromempty(options_);
     if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(initial_, nullcount_, out);
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->beginrecord(name, check);
     return std::move(out);

--- a/src/libawkward/io/uproot.cpp
+++ b/src/libawkward/io/uproot.cpp
@@ -53,12 +53,12 @@ namespace awkward {
     uint8_t* data_ptr = reinterpret_cast<uint8_t*>(data.data());
     int32_t* byte_offsets_ptr = byte_offsets.data();
 
-    const int64_t initial(1024);
+    awkward::BuilderOptions options { 1024, 1 };
 
     Index64 offsets1(byte_offsets.length());
     int64_t* offsets1_ptr = offsets1.data();
-    GrowableBuffer<int64_t> offsets2 = GrowableBuffer<int64_t>::empty(initial);
-    GrowableBuffer<T> content = GrowableBuffer<T>::empty(initial);
+    GrowableBuffer<int64_t> offsets2 = GrowableBuffer<int64_t>::empty(options);
+    GrowableBuffer<T> content = GrowableBuffer<T>::empty(options);
 
     offsets1_ptr[0] = 0;
     offsets2.append(0);

--- a/src/python/content.cpp
+++ b/src/python/content.cpp
@@ -1025,7 +1025,7 @@ py::class_<ak::ArrayBuilder>
 make_ArrayBuilder(const py::handle& m, const std::string& name) {
   return (py::class_<ak::ArrayBuilder>(m, name.c_str())
       .def(py::init([](const int64_t initial, double resize) -> ak::ArrayBuilder {
-        return ak::ArrayBuilder(initial);
+        return ak::ArrayBuilder({initial, resize});
       }), py::arg("initial") = 1024, py::arg("resize") = 1.5)
       .def_property_readonly("_ptr",
                              [](const ak::ArrayBuilder* self) -> size_t {

--- a/tests-cpp/CMakeLists.txt
+++ b/tests-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(addtest_nolibs name filename)
   if(BUILD_TESTING)
-    target_compile_features(awkward-parent INTERFACE cxx_std_17)
+    target_compile_features(awkward-parent INTERFACE cxx_std_14)
 
     add_executable(${name} ${filename})
     target_link_libraries(${name} PRIVATE awkward-parent)

--- a/tests-cpp/test_1494-layout-builder.cpp
+++ b/tests-cpp/test_1494-layout-builder.cpp
@@ -2,8 +2,6 @@
 
 #include "awkward/LayoutBuilder.h"
 
-static const unsigned initial = 10;
-
 template <class NODE, class PRIMITIVE, class LENGTH>
 void dump(NODE&& node, PRIMITIVE&& ptr, LENGTH&& length) {
   std::cout << node << ": ";
@@ -34,13 +32,13 @@ empty_buffers(std::map<std::string, size_t> &names_nbytes)
 using UserDefinedMap = std::map<std::size_t, std::string>;
 
 template<class PRIMITIVE>
-using NumpyBuilder = awkward::LayoutBuilder::Numpy<initial, PRIMITIVE>;
+using NumpyBuilder = awkward::LayoutBuilder::Numpy<PRIMITIVE>;
 
 template<class PRIMITIVE, class BUILDER>
-using ListOffsetBuilder = awkward::LayoutBuilder::ListOffset<initial, PRIMITIVE, BUILDER>;
+using ListOffsetBuilder = awkward::LayoutBuilder::ListOffset<PRIMITIVE, BUILDER>;
 
 template<class PRIMITIVE, class BUILDER>
-using ListBuilder = awkward::LayoutBuilder::List<initial, PRIMITIVE, BUILDER>;
+using ListBuilder = awkward::LayoutBuilder::List<PRIMITIVE, BUILDER>;
 
 using EmptyBuilder = awkward::LayoutBuilder::Empty;
 
@@ -60,25 +58,25 @@ template <unsigned SIZE, class BUILDER>
 using RegularBuilder = awkward::LayoutBuilder::Regular<SIZE, BUILDER>;
 
 template<class PRIMITIVE, class BUILDER>
-using IndexedBuilder = awkward::LayoutBuilder::Indexed<initial, PRIMITIVE, BUILDER>;
+using IndexedBuilder = awkward::LayoutBuilder::Indexed<PRIMITIVE, BUILDER>;
 
 template<class PRIMITIVE, class BUILDER>
-using IndexedOptionBuilder = awkward::LayoutBuilder::IndexedOption<initial, PRIMITIVE, BUILDER>;
+using IndexedOptionBuilder = awkward::LayoutBuilder::IndexedOption<PRIMITIVE, BUILDER>;
 
 template<class BUILDER>
 using UnmaskedBuilder = awkward::LayoutBuilder::Unmasked<BUILDER>;
 
 template<bool VALID_WHEN, class BUILDER>
-using ByteMaskedBuilder = awkward::LayoutBuilder::ByteMasked<initial, VALID_WHEN, BUILDER>;
+using ByteMaskedBuilder = awkward::LayoutBuilder::ByteMasked<VALID_WHEN, BUILDER>;
 
 template<bool VALID_WHEN, bool LSB_ORDER, class BUILDER>
-using BitMaskedBuilder = awkward::LayoutBuilder::BitMasked<initial, VALID_WHEN, LSB_ORDER, BUILDER>;
+using BitMaskedBuilder = awkward::LayoutBuilder::BitMasked<VALID_WHEN, LSB_ORDER, BUILDER>;
 
 template<class... BUILDERS>
-using UnionBuilder8_U32 = awkward::LayoutBuilder::Union<initial, int8_t, uint32_t, BUILDERS...>;
+using UnionBuilder8_U32 = awkward::LayoutBuilder::Union<int8_t, uint32_t, BUILDERS...>;
 
 template<class... BUILDERS>
-using UnionBuilder8_64 = awkward::LayoutBuilder::Union<initial, int8_t, int64_t, BUILDERS...>;
+using UnionBuilder8_64 = awkward::LayoutBuilder::Union<int8_t, int64_t, BUILDERS...>;
 
 
 void
@@ -1796,6 +1794,9 @@ int main(int /* argc */, char ** /* argv */) {
   test_char_form();
   test_string_form();
   test_categorical_form();
+
+  awkward::Options<int64_t, int64_t> options(1024, 1);
+  std::cout << options.initial() << " " << options.resize() << std::endl;
 
   return 0;
 }

--- a/tests-cpp/test_1494-layout-builder.cpp
+++ b/tests-cpp/test_1494-layout-builder.cpp
@@ -1795,8 +1795,5 @@ int main(int /* argc */, char ** /* argv */) {
   test_string_form();
   test_categorical_form();
 
-  awkward::Options<int64_t, int64_t> options(1024, 1);
-  std::cout << options.initial() << " " << options.resize() << std::endl;
-
   return 0;
 }

--- a/tests-cpp/test_1542-array-builder.cpp
+++ b/tests-cpp/test_1542-array-builder.cpp
@@ -7,7 +7,7 @@
 
 int main(int /* argc */, const char ** /* argv */) {
 
-  auto a = awkward::ArrayBuilder(10);
+  auto a = awkward::ArrayBuilder({10, 1});
   for (int64_t i = 0; i < 100; i++) {
     a.integer(1);
     a.integer(2);

--- a/tests-cpp/test_1542-growable-buffer.cpp
+++ b/tests-cpp/test_1542-growable-buffer.cpp
@@ -1,5 +1,6 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+#include "awkward/ArrayBuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 
 #include <complex>
@@ -7,9 +8,9 @@
 
 void test_full() {
   size_t data_size = 100;
-  size_t initial = 25;
+  awkward::ArrayBuilderOptions options { 25, 1 };
 
-  auto buffer = awkward::GrowableBuffer<int16_t>::full(initial, -2, data_size);
+  auto buffer = awkward::GrowableBuffer<int16_t>::full(options, -2, data_size);
 
   int16_t* ptr = new int16_t[buffer.length()];
   buffer.concatenate(ptr);
@@ -21,9 +22,9 @@ void test_full() {
 
 void test_arange() {
   size_t data_size = 25;
-  size_t initial = 50;
+  awkward::ArrayBuilderOptions options { 50, 1 };
 
-  auto buffer = awkward::GrowableBuffer<int64_t>::arange(initial, data_size);
+  auto buffer = awkward::GrowableBuffer<int64_t>::arange(options, data_size);
 
   int64_t* ptr = new int64_t[buffer.length()];
   buffer.concatenate(ptr);
@@ -35,9 +36,9 @@ void test_arange() {
 
 void test_zeros() {
   size_t data_size = 100;
-  size_t initial = 100;
+  awkward::ArrayBuilderOptions options { 100, 1 };
 
-  auto buffer = awkward::GrowableBuffer<uint32_t>::zeros(initial, data_size);
+  auto buffer = awkward::GrowableBuffer<uint32_t>::zeros(options, data_size);
 
   uint32_t* ptr = new uint32_t[buffer.length()];
   buffer.concatenate(ptr);
@@ -49,11 +50,12 @@ void test_zeros() {
 
 void test_float() {
   size_t data_size = 18;
-  size_t initial = 4;
+  awkward::ArrayBuilderOptions options { 4, 1 };
+
   float data[18] = {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
                     2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9};
 
-  auto buffer = awkward::GrowableBuffer<float>::empty(initial);
+  auto buffer = awkward::GrowableBuffer<float>::empty(options);
 
   for (size_t i = 0; i < data_size; i++) {
     buffer.append(data[i]);
@@ -69,10 +71,11 @@ void test_float() {
 
 void test_int64() {
   size_t data_size = 10;
-  size_t initial = 8;
+  awkward::ArrayBuilderOptions options { 8, 1 };
+
   float data[10] = {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
 
-  auto buffer = awkward::GrowableBuffer<int64_t>::empty(initial);
+  auto buffer = awkward::GrowableBuffer<int64_t>::empty(options);
 
   for (size_t i = 0; i < data_size; i++) {
     buffer.append(data[i]);
@@ -88,11 +91,12 @@ void test_int64() {
 
 void test_bool() {
   size_t data_size = 12;
-  size_t initial = 5;
+  awkward::ArrayBuilderOptions options { 5, 1 };
+
   bool data[12] = {false, true, false, false, true, false, true,
                    true, false, true, false, false};
 
-  auto buffer = awkward::GrowableBuffer<bool>(initial);
+  auto buffer = awkward::GrowableBuffer<bool>(options);
 
   for (size_t i = 0; i < data_size; i++) {
     buffer.append(data[i]);
@@ -108,10 +112,11 @@ void test_bool() {
 
 void test_double() {
   size_t data_size = 9;
-  size_t initial = 6;
+  awkward::ArrayBuilderOptions options { 6, 1 };
+
   double data[9] = {1.01, 2.02, 3.03, 4.04, 5.05, 6.06, 7.07, 8.08, 9.09};
 
-  auto buffer = awkward::GrowableBuffer<double>::empty(initial);
+  auto buffer = awkward::GrowableBuffer<double>::empty(options);
 
   for (size_t i = 0; i < data_size; i++) {
     buffer.append(data[i]);
@@ -127,11 +132,12 @@ void test_double() {
 
 void test_complex() {
   size_t data_size = 10;
-  size_t initial = 3;
+  awkward::ArrayBuilderOptions options { 3, 1 };
+
   std::complex<double> data[10] = {{0, 0}, {1.1, 0.1}, {2.2, 0.2}, {3.3, 0.3}, {4.4, 0.4},
                                    {5.5, 0.5}, {6.6, 0.6}, {7.7, 0.7}, {8.8, 0.8}, {9.9, 0.9}};
 
-  auto buffer = awkward::GrowableBuffer<std::complex<double>>::empty(initial);
+  auto buffer = awkward::GrowableBuffer<std::complex<double>>::empty(options);
   for (size_t i = 0; i < data_size; i++) {
     buffer.append(data[i]);
   }
@@ -146,11 +152,12 @@ void test_complex() {
 
 void test_extend() {
   size_t data_size = 15;
-  size_t initial = 5;
+  awkward::ArrayBuilderOptions options { 5, 1 };
+
   double data[15] = {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
                      2.1, 2.2, 2.3, 2.4, 2.5, 2.6};
 
-  auto buffer = awkward::GrowableBuffer<double>::empty(initial);
+  auto buffer = awkward::GrowableBuffer<double>::empty(options);
 
   buffer.extend(data, data_size);
 
@@ -164,14 +171,15 @@ void test_extend() {
 
 void test_append_and_get_ref() {
   size_t data_size = 15;
-  size_t initial = 5;
+  awkward::ArrayBuilderOptions options { 5, 1 };
+
   double data[15] = {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
                      2.1, 2.2, 2.3, 2.4, 2.5, 2.6};
 
   int val;
   int& ref = val;
 
-  auto buffer = awkward::GrowableBuffer<double>::empty(initial);
+  auto buffer = awkward::GrowableBuffer<double>::empty(options);
 
   for (size_t i = 0; i < buffer.length(); i++) {
     ref = buffer.append_and_get_ref(data[i]);

--- a/tests-cpp/test_1542-growable-buffer.cpp
+++ b/tests-cpp/test_1542-growable-buffer.cpp
@@ -1,6 +1,6 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#include "awkward/ArrayBuilderOptions.h"
+#include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 
 #include <complex>
@@ -8,7 +8,7 @@
 
 void test_full() {
   size_t data_size = 100;
-  awkward::ArrayBuilderOptions options { 25, 1 };
+  awkward::BuilderOptions options { 25, 1 };
 
   auto buffer = awkward::GrowableBuffer<int16_t>::full(options, -2, data_size);
 
@@ -22,7 +22,7 @@ void test_full() {
 
 void test_arange() {
   size_t data_size = 25;
-  awkward::ArrayBuilderOptions options { 50, 1 };
+  awkward::BuilderOptions options { 50, 1 };
 
   auto buffer = awkward::GrowableBuffer<int64_t>::arange(options, data_size);
 
@@ -36,7 +36,7 @@ void test_arange() {
 
 void test_zeros() {
   size_t data_size = 100;
-  awkward::ArrayBuilderOptions options { 100, 1 };
+  awkward::BuilderOptions options { 100, 1 };
 
   auto buffer = awkward::GrowableBuffer<uint32_t>::zeros(options, data_size);
 
@@ -50,7 +50,7 @@ void test_zeros() {
 
 void test_float() {
   size_t data_size = 18;
-  awkward::ArrayBuilderOptions options { 4, 1 };
+  awkward::BuilderOptions options { 4, 1 };
 
   float data[18] = {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
                     2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9};
@@ -71,7 +71,7 @@ void test_float() {
 
 void test_int64() {
   size_t data_size = 10;
-  awkward::ArrayBuilderOptions options { 8, 1 };
+  awkward::BuilderOptions options { 8, 1 };
 
   float data[10] = {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
 
@@ -91,7 +91,7 @@ void test_int64() {
 
 void test_bool() {
   size_t data_size = 12;
-  awkward::ArrayBuilderOptions options { 5, 1 };
+  awkward::BuilderOptions options {5, 1};
 
   bool data[12] = {false, true, false, false, true, false, true,
                    true, false, true, false, false};
@@ -112,7 +112,7 @@ void test_bool() {
 
 void test_double() {
   size_t data_size = 9;
-  awkward::ArrayBuilderOptions options { 6, 1 };
+  awkward::BuilderOptions options { 6, 1 };
 
   double data[9] = {1.01, 2.02, 3.03, 4.04, 5.05, 6.06, 7.07, 8.08, 9.09};
 
@@ -132,7 +132,7 @@ void test_double() {
 
 void test_complex() {
   size_t data_size = 10;
-  awkward::ArrayBuilderOptions options { 3, 1 };
+  awkward::BuilderOptions options { 3, 1 };
 
   std::complex<double> data[10] = {{0, 0}, {1.1, 0.1}, {2.2, 0.2}, {3.3, 0.3}, {4.4, 0.4},
                                    {5.5, 0.5}, {6.6, 0.6}, {7.7, 0.7}, {8.8, 0.8}, {9.9, 0.9}};
@@ -152,7 +152,7 @@ void test_complex() {
 
 void test_extend() {
   size_t data_size = 15;
-  awkward::ArrayBuilderOptions options { 5, 1 };
+  awkward::BuilderOptions options { 5, 1 };
 
   double data[15] = {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
                      2.1, 2.2, 2.3, 2.4, 2.5, 2.6};
@@ -171,7 +171,7 @@ void test_extend() {
 
 void test_append_and_get_ref() {
   size_t data_size = 15;
-  awkward::ArrayBuilderOptions options { 5, 1 };
+  awkward::BuilderOptions options { 5, 1 };
 
   double data[15] = {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
                      2.1, 2.2, 2.3, 2.4, 2.5, 2.6};

--- a/tests-cpp/test_1560-builder-options.cpp
+++ b/tests-cpp/test_1560-builder-options.cpp
@@ -1,0 +1,14 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#include "awkward/BuilderOptions.h"
+#include <cassert>
+
+int main(int /* argc */, char ** /* argv */) {
+
+  awkward::Options<int64_t, double> options(1024, 1.0);
+  
+  assert(options.initial() == 1024);
+  assert(options.resize() == 1.0);
+
+  return 0;
+}

--- a/tests-cpp/test_1560-builder-options.cpp
+++ b/tests-cpp/test_1560-builder-options.cpp
@@ -6,7 +6,7 @@
 int main(int /* argc */, char ** /* argv */) {
 
   awkward::Options<int64_t, double> options(1024, 1.0);
-  
+
   assert(options.initial() == 1024);
   assert(options.resize() == 1.0);
 

--- a/tests-cpp/test_1560-builder-options.cpp
+++ b/tests-cpp/test_1560-builder-options.cpp
@@ -5,7 +5,7 @@
 
 int main(int /* argc */, char ** /* argv */) {
 
-  awkward::Options<int64_t, double> options(1024, 1.0);
+  awkward::BuilderOptions options(1024, 1.0);
 
   assert(options.initial() == 1024);
   assert(options.resize() == 1.0);


### PR DESCRIPTION
`ArrayBuilder`, `LayoutBuilder`, and `GrowableBuffer` are using `BuildOptions` now. There two options defined at the moment - an `initial` which is `int64_t` and a `resize` factor which is `double`. The `Options` is a tuple and can accept other parameters. A test is added.

This PR also drops requirements on C++ version for `LayoutBuilder` from C++17 to C++14. Both `GrowableBuffer` and `BuildOptions` can be used with C++11. 

`BitMasked` mask is fixed.