### PR TITLE
Feat: raise `AttributeError` for public Array attributes

### DIFF
--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -1044,7 +1044,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     def __delitem__(self, where):
         """
         Args:
-            where (str): Field name to add to records in the array.
+            where (str): Field name to remove from records in the array.
 
         Removes a field from records in the array.
         """
@@ -1062,6 +1062,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
     def __getattr__(self, where):
         """
+        Args:
+            where (str): Attribute name to lookup
+
         Whenever possible, fields can be accessed as attributes.
 
         For example, the fields of an `array` like
@@ -1089,15 +1092,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
              keyword.
 
         Note that while fields can be accessed as attributes, they cannot be
-        *assigned* as attributes: the following doesn't work.
-
-            array.z = new_field
-
-        Always use
-
-            array["z"] = new_field
-
-        to add a field.
+        *assigned* as attributes. See #ak.Array.__setitem__ for more.
         """
         if where in dir(type(self)):
             return super().__getattribute__(where)
@@ -1114,6 +1109,45 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                     )
             else:
                 raise ak._v2._util.error(AttributeError(f"no field named {where!r}"))
+
+    def __setattr__(self, name, value):
+        """
+        Args:
+            where (str): Attribute name to set
+
+        Set an attribute on the array.
+
+        Only existing public attributes e.g. #ak.Array.layout, or private
+        attributes (with leading underscores), can be set.
+
+        Fields are not assignable to as attributes, i.e. the following doesn't work:
+
+            array.z = new_field
+
+        Instead, always use #ak.Array.__setitem__:
+
+            array["z"] = new_field
+
+        or #ak.with_field:
+
+            array = ak.with_field(array, new_field, "z")
+
+        to add or modify a field.
+        """
+        if name in dir(type(self)) or name.startswith("_"):
+            super().__setattr__(name, value)
+        elif name in self._layout.fields:
+            raise ak._v2._util.error(
+                AttributeError(
+                    "fields cannot be set as attributes. use #__setitem__ or #ak.with_field"
+                )
+            )
+        else:
+            raise ak._v2._util.error(
+                AttributeError(
+                    "only private attributes (started with an underscore) can be set on arrays"
+                )
+            )
 
     def __dir__(self):
         """

--- a/tests/v2/test_1511-set-attribute.py
+++ b/tests/v2/test_1511-set-attribute.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import awkward as ak  # noqa: F401
+import numpy as np
+
+
+def test():
+    record = ak._v2.contents.RecordArray(
+        [ak._v2.contents.NumpyArray(np.arange(10))], ["x"]
+    )
+    array = ak._v2.Array(record)
+
+    with pytest.raises(AttributeError):
+        array.x = 10
+
+    with pytest.raises(AttributeError):
+        array.not_an_existing_attribute = 10
+
+    array._not_an_existing_attribute = 10
+    assert array._not_an_existing_attribute == 10


### PR DESCRIPTION
Fixes #1511 

As discussed in the issue, the new behaviour is:
- existing public _class_ attributes can be assigned to (though the attribute itself may not be writable, e.g. with a read-only data descriptor)
- private attributes can be assigned to, and will never attempt to set a field
- fields can never be set

We might have some hidden issues if users employ underscore-prefixed fields. Right now, setting these attributes will write to the `ak.Array` object. However, this shadowing is already accepted when we read from an attribute - class attributes take precedence over fields, just as they do in this PR for writing. Are we happy with this? 