### PR TITLE
Fix: allow empty `RecordArray`s in `ak.to_layout`

### DIFF
--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -2258,7 +2258,7 @@ def to_arrow(
                 recurse(x[: len(layout)], mask, is_option) for x in layout.contents
             ]
 
-            min_list_len = min(map(len, values))
+            min_list_len = min(map(len, values), default=len(layout))
 
             types = pyarrow.struct(
                 [

--- a/tests/test_1578-to_arrow-empty-recordarray.py
+++ b/tests/test_1578-to_arrow-empty-recordarray.py
@@ -4,6 +4,8 @@ import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
+pytest.importorskip("pyarrow")
+
 
 def test():
     layout = ak.layout.RecordArray([], keys=[], length=3)

--- a/tests/test_1578-to_arrow-empty-recordarray.py
+++ b/tests/test_1578-to_arrow-empty-recordarray.py
@@ -1,0 +1,12 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    layout = ak.layout.RecordArray([], keys=[], length=3)
+    struct = ak.to_arrow(layout)
+    assert len(struct) == len(layout) == 3
+    assert struct.tolist() == [{}, {}, {}]

--- a/tests/v2/test_1578-to_arrow-empty-recordarray.py
+++ b/tests/v2/test_1578-to_arrow-empty-recordarray.py
@@ -1,0 +1,12 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    layout = ak._v2.contents.RecordArray([], fields=[], length=3)
+    struct = ak._v2.to_arrow(layout)
+    assert len(struct) == len(layout) == 3
+    assert struct.tolist() == [{}, {}, {}]

--- a/tests/v2/test_1578-to_arrow-empty-recordarray.py
+++ b/tests/v2/test_1578-to_arrow-empty-recordarray.py
@@ -4,6 +4,8 @@ import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
+pytest.importorskip("pyarrow")
+
 
 def test():
     layout = ak._v2.contents.RecordArray([], fields=[], length=3)


### PR DESCRIPTION
Fixes #1578 