### PR TITLE
chore: include Python 3.11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,6 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - '3.11-dev'
           - '3.10'
           - '3.9'
           - '3.8'
@@ -85,6 +86,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - '3.11-dev'
           - '3.10'
           - '3.9'
           - '3.8'
@@ -141,6 +143,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - '3.11-dev'
           - '3.10'
           - '3.9'
           - '3.8'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,11 +58,15 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v2.8.1
+    - uses: pypa/cibuildwheel@v2.9.0
       env:
         CIBW_ARCHS_MACOS: universal2
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
         CIBW_BUILD: cp39-win_amd64 cp36-manylinux_x86_64 cp38-macosx_universal2
+
+    - uses: pypa/cibuildwheel@v2.9.0
+      env:
+        CIBW_BUILD: cp311-manylinux_x86_64
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,12 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: universal2
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-        CIBW_BUILD: cp39-win_amd64 cp36-manylinux_x86_64 cp38-macosx_universal2 cp311-manylinux_x86_64
+        CIBW_BUILD: cp39-win_amd64 cp36-manylinux_x86_64 cp38-macosx_universal2
+
+    - uses: pypa/cibuildwheel@v2.9.0
+      if: matrix.os == 'ubuntu-latest'
+      env:
+        CIBW_BUILD: cp311-manylinux_x86_64
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,11 +62,7 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: universal2
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-        CIBW_BUILD: cp39-win_amd64 cp36-manylinux_x86_64 cp38-macosx_universal2
-
-    - uses: pypa/cibuildwheel@v2.9.0
-      env:
-        CIBW_BUILD: cp311-manylinux_x86_64
+        CIBW_BUILD: cp39-win_amd64 cp36-manylinux_x86_64 cp38-macosx_universal2 cp311-manylinux_x86_64
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v2.8.1
+    - uses: pypa/cibuildwheel@v2.9.0
       env:
         CIBW_BUILD: ${{ matrix.build }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [36, 37, 38, 39, 310]
+        python: [36, 37, 38, 39, 310, 311]
         arch: [aarch64]
     steps:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
   rev: v2.0.0
   hooks:
   - id: setup-cfg-fmt
+    args: [--include-version-classifiers, --max-py-version=3.11]
 
 - repo: https://github.com/asottile/pyupgrade
   rev: "v2.37.3"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
 nox.options.sessions = ["lint", "tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ filterwarnings = [
   "ignore:the imp module is deprecated in favour of importlib:DeprecationWarning",  # move to importlib to fix (setuptools issue)
   "ignore:The NumPy module was reloaded:UserWarning",
   "ignore:.*np\\.MachAr.*:DeprecationWarning",  # until https://github.com/numba/numba/issues/7758 is fixed
+  "ignore:module 'sre_parse' is deprecated:DeprecationWarning", # From lark & Python 3.11
 ]
 log_cli_level = "info"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ filterwarnings = [
   "ignore:the imp module is deprecated in favour of importlib:DeprecationWarning",  # move to importlib to fix (setuptools issue)
   "ignore:The NumPy module was reloaded:UserWarning",
   "ignore:.*np\\.MachAr.*:DeprecationWarning",  # until https://github.com/numba/numba/issues/7758 is fixed
-  "ignore:module 'sre_parse' is deprecated:DeprecationWarning", # From lark & Python 3.11
+  "ignore:module 'sre_.*' is deprecated:DeprecationWarning", # From lark & Python 3.11
 ]
 log_cli_level = "info"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ jaxlib>=0.1.57,!=0.1.68;sys_platform != "win32" and python_version > "3.6" and p
 numba>=0.50.0;python_version < "3.11"
 numexpr
 pandas>=0.24.0
-pyarrow>=7.0.0;python_version > "3.6" and sys_platform != "win32"
+pyarrow>=7.0.0;python_version > "3.6" and sys_platform != "win32" and python_version < "3.11"
 PyYAML

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ fsspec;python_version > "3.6" and sys_platform != "win32"
 jax>=0.2.7;sys_platform != "win32" and python_version > "3.6" and python_version < "3.11"
 jaxlib>=0.1.57,!=0.1.68;sys_platform != "win32" and python_version > "3.6" and python_version < "3.11"
 numba>=0.50.0;python_version < "3.11"
-numexpr
+numexpr;python_version < "3.11"
 pandas>=0.24.0
 pyarrow>=7.0.0;python_version > "3.6" and sys_platform != "win32" and python_version < "3.11"
 PyYAML

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 autograd
 flake8
 fsspec;python_version > "3.6" and sys_platform != "win32"
-jax>=0.2.7;sys_platform != "win32" and python_version > "3.6"
-jaxlib>=0.1.57,!=0.1.68;sys_platform != "win32" and python_version > "3.6"
-numba>=0.50.0;python_version<"3.11"
+jax>=0.2.7;sys_platform != "win32" and python_version > "3.6" and python_version < "3.11"
+jaxlib>=0.1.57,!=0.1.68;sys_platform != "win32" and python_version > "3.6" and python_version < "3.11"
+numba>=0.50.0;python_version < "3.11"
 numexpr
 pandas>=0.24.0
 pyarrow>=7.0.0;python_version > "3.6" and sys_platform != "win32"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ flake8
 fsspec;python_version > "3.6" and sys_platform != "win32"
 jax>=0.2.7;sys_platform != "win32" and python_version > "3.6"
 jaxlib>=0.1.57,!=0.1.68;sys_platform != "win32" and python_version > "3.6"
-numba>=0.50.0
+numba>=0.50.0;python_version<"3.11"
 numexpr
 pandas>=0.24.0
 pyarrow>=7.0.0;python_version > "3.6" and sys_platform != "win32"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,12 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Information Analysis
     Topic :: Scientific/Engineering :: Mathematics


### PR DESCRIPTION
Testing this out now that NumPy supports Python 3.11 with binary wheels.
