### PR TITLE
ak.concatenate of identical Forms preserves the Form

### DIFF
--- a/src/awkward/_v2/contents/bitmaskedarray.py
+++ b/src/awkward/_v2/contents/bitmaskedarray.py
@@ -446,7 +446,18 @@ class BitMaskedArray(Content):
     def mergemany(self, others):
         if len(others) == 0:
             return self
-        return self.toIndexedOptionArray64().mergemany(others)
+
+        out = self.toIndexedOptionArray64().mergemany(others)
+
+        if all(
+            isinstance(x, BitMaskedArray)
+            and x._valid_when == self._valid_when
+            and x._lsb_order == self._lsb_order
+            for x in others
+        ):
+            return out.toBitMaskedArray(self._valid_when, self._lsb_order)
+        else:
+            return out
 
     def fill_none(self, value):
         return self.toIndexedOptionArray64().fill_none(value)

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -647,12 +647,12 @@ class ByteMaskedArray(Content):
                     parameters, x._parameters, True
                 )
                 masks.append(x._mask.data)
-                tail_contents.append(x._content[:self.length])
+                tail_contents.append(x._content[: self.length])
                 length += x.length
 
             return ByteMaskedArray(
                 ak._v2.index.Index8(self._nplike.concatenate(masks)),
-                self._content[:self.length].mergemany(tail_contents),
+                self._content[: self.length].mergemany(tail_contents),
                 self._valid_when,
                 None,
                 parameters,

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -2,6 +2,7 @@
 
 import json
 import copy
+import math
 
 import awkward as ak
 from awkward._v2.index import Index
@@ -183,21 +184,38 @@ class ByteMaskedArray(Content):
             )
 
     def toBitMaskedArray(self, valid_when, lsb_order):
-        import awkward._v2._connect.pyarrow
+        if not self._nplike.known_data:
+            if self._nplike.known_shape:
+                excess_length = int(math.ceil(self.length / 8.0))
+            else:
+                excess_length = ak._v2._typetracer.UnknownLength
+            return ak._v2.contents.BitMaskedArray(
+                ak._v2.index.IndexU8(self._nplike.empty(excess_length, dtype=np.uint8)),
+                self._content,
+                valid_when,
+                self.length,
+                lsb_order,
+                self._identifier,
+                self._parameters,
+                self._nplike,
+            )
 
-        bytearray = self.mask_as_bool(valid_when, self._nplike).view(np.uint8)
-        bitarray = awkward._v2._connect.pyarrow.packbits(bytearray, lsb_order)
+        else:
+            import awkward._v2._connect.pyarrow
 
-        return ak._v2.contents.BitMaskedArray(
-            ak._v2.index.IndexU8(bitarray),
-            self._content,
-            valid_when,
-            self.length,
-            lsb_order,
-            self._identifier,
-            self._parameters,
-            self._nplike,
-        )
+            bytearray = self.mask_as_bool(valid_when, self._nplike).view(np.uint8)
+            bitarray = awkward._v2._connect.pyarrow.packbits(bytearray, lsb_order)
+
+            return ak._v2.contents.BitMaskedArray(
+                ak._v2.index.IndexU8(bitarray),
+                self._content,
+                valid_when,
+                self.length,
+                lsb_order,
+                self._identifier,
+                self._parameters,
+                self._nplike,
+            )
 
     def mask_as_bool(self, valid_when=None, nplike=None):
         if valid_when is None:
@@ -615,7 +633,34 @@ class ByteMaskedArray(Content):
     def mergemany(self, others):
         if len(others) == 0:
             return self
-        return self.toIndexedOptionArray64().mergemany(others)
+
+        if all(
+            isinstance(x, ByteMaskedArray) and x._valid_when == self._valid_when
+            for x in others
+        ):
+            parameters = self._parameters
+            masks = [self._mask.data]
+            tail_contents = []
+            length = 0
+            for x in others:
+                parameters = ak._v2._util.merge_parameters(
+                    parameters, x._parameters, True
+                )
+                masks.append(x._mask.data)
+                tail_contents.append(x._content[:self.length])
+                length += x.length
+
+            return ByteMaskedArray(
+                ak._v2.index.Index8(self._nplike.concatenate(masks)),
+                self._content[:self.length].mergemany(tail_contents),
+                self._valid_when,
+                None,
+                parameters,
+                self._nplike,
+            )
+
+        else:
+            return self.toIndexedOptionArray64().mergemany(others)
 
     def fill_none(self, value):
         return self.toIndexedOptionArray64().fill_none(value)

--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -169,6 +169,36 @@ class ByteMaskedArray(Content):
             index, self._content, self._identifier, self._parameters, self._nplike
         )
 
+    def toByteMaskedArray(self, valid_when):
+        if valid_when == self._valid_when:
+            return self
+        else:
+            return ByteMaskedArray(
+                ak._v2.Index8(~self._mask.data),
+                self._content,
+                valid_when,
+                self._identifier,
+                self._parameters,
+                self._nplike,
+            )
+
+    def toBitMaskedArray(self, valid_when, lsb_order):
+        import awkward._v2._connect.pyarrow
+
+        bytearray = self.mask_as_bool(valid_when, self._nplike).view(np.uint8)
+        bitarray = awkward._v2._connect.pyarrow.packbits(bytearray, lsb_order)
+
+        return ak._v2.contents.BitMaskedArray(
+            ak._v2.index.IndexU8(bitarray),
+            self._content,
+            valid_when,
+            self.length,
+            lsb_order,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
+
     def mask_as_bool(self, valid_when=None, nplike=None):
         if valid_when is None:
             valid_when = self._valid_when

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -802,6 +802,13 @@ class Content:
 
         return (head, tail)
 
+    def dummy(self):
+        raise ak._v2._util.error(
+            NotImplementedError(
+                "FIXME: need to implement 'dummy', which makes an array of length 1 and an arbitrary value (0?) for this array type"
+            )
+        )
+
     def local_index(self, axis):
         return self._local_index(axis, 0)
 

--- a/src/awkward/_v2/contents/indexedoptionarray.py
+++ b/src/awkward/_v2/contents/indexedoptionarray.py
@@ -139,7 +139,7 @@ class IndexedOptionArray(Content):
 
         carry = self._index.data
         too_negative = carry < -1
-        if self._nplike.any(too_negative):
+        if self._nplike.any(too_negative, prefer=False):
             carry = carry.copy()
             carry[too_negative] = -1
         carry = ak._v2.index.Index(carry)

--- a/src/awkward/_v2/contents/listarray.py
+++ b/src/awkward/_v2/contents/listarray.py
@@ -156,7 +156,20 @@ class ListArray(Content):
     def toListOffsetArray64(self, start_at_zero=False):
         starts = self._starts.data
         stops = self._stops.data
-        if self._nplike.index_nplike.array_equal(starts[1:], stops[:-1]):
+
+        if not self._nplike.known_data:
+            offsets = self._nplike.index_nplike.empty(
+                starts.shape[0] + 1, dtype=starts.dtype
+            )
+            return ListOffsetArray(
+                ak._v2.index.Index(offsets, nplike=self._nplike),
+                self._content,
+                self._identifier,
+                self._parameters,
+                self._nplike,
+            )
+
+        elif self._nplike.index_nplike.array_equal(starts[1:], stops[:-1]):
             offsets = self._nplike.index_nplike.empty(
                 starts.shape[0] + 1, dtype=starts.dtype
             )
@@ -166,7 +179,7 @@ class ListArray(Content):
                 offsets[:-1] = starts
                 offsets[-1] = stops[-1]
             return ListOffsetArray(
-                ak._v2.index.Index(offsets, nplike=self.nplike),
+                ak._v2.index.Index(offsets, nplike=self._nplike),
                 self._content,
                 self._identifier,
                 self._parameters,

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -751,7 +751,17 @@ class ListOffsetArray(Content):
         listarray = ak._v2.contents.listarray.ListArray(
             self.starts, self.stops, self._content, None, self._parameters, self._nplike
         )
-        return listarray.mergemany(others)
+        out = listarray.mergemany(others)
+
+        return out
+
+        # if all(
+        #     isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+        #     for x in others
+        # ):
+        #     return out.toListOffsetArray64(False)
+        # else:
+        #     return out
 
     def fill_none(self, value):
         return ListOffsetArray(

--- a/src/awkward/_v2/contents/listoffsetarray.py
+++ b/src/awkward/_v2/contents/listoffsetarray.py
@@ -753,15 +753,13 @@ class ListOffsetArray(Content):
         )
         out = listarray.mergemany(others)
 
-        return out
-
-        # if all(
-        #     isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
-        #     for x in others
-        # ):
-        #     return out.toListOffsetArray64(False)
-        # else:
-        #     return out
+        if all(
+            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            for x in others
+        ):
+            return out.toListOffsetArray64(False)
+        else:
+            return out
 
     def fill_none(self, value):
         return ListOffsetArray(

--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -698,7 +698,7 @@ class RegularArray(Content):
                 zeros_length += x._length
 
             return RegularArray(
-                self._content.mergemany(tail_contents),
+                self._content[: self._length * self._size].mergemany(tail_contents),
                 self._size,
                 zeros_length,
                 None,

--- a/src/awkward/_v2/contents/unmaskedarray.py
+++ b/src/awkward/_v2/contents/unmaskedarray.py
@@ -8,6 +8,7 @@ from awkward._v2.forms.unmaskedform import UnmaskedForm
 from awkward._v2.forms.form import _parameters_equal
 
 np = ak.nplike.NumpyMetadata.instance()
+numpy = ak.nplike.Numpy.instance()
 
 
 class UnmaskedArray(Content):
@@ -91,23 +92,41 @@ class UnmaskedArray(Content):
             self._nplike,
         )
 
-    def toByteMaskedArray(self):
-        return ak._v2.contents.bytemaskedarray.ByteMaskedArray(
-            ak._v2.index.Index8(
-                self.mask_as_bool(valid_when=True).view(np.int8), nplike=self.nplike
-            ),
-            self._content,
-            True,
-            self._identifier,
-            self._parameters,
-            self._nplike,
-        )
-
     def toIndexedOptionArray64(self):
         arange = self._nplike.index_nplike.arange(self._content.length, dtype=np.int64)
         return ak._v2.contents.indexedoptionarray.IndexedOptionArray(
             ak._v2.index.Index64(arange, nplike=self.nplike),
             self._content,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
+
+    def toByteMaskedArray(self, valid_when):
+        return ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+            ak._v2.index.Index8(
+                self.mask_as_bool(valid_when).view(np.int8), nplike=self.nplike
+            ),
+            self._content,
+            valid_when,
+            self._identifier,
+            self._parameters,
+            self._nplike,
+        )
+
+    def toBitMaskedArray(self, valid_when, lsb_order):
+        bitlength = int(numpy.ceil(self._content.length / 8.0))
+        if valid_when:
+            bitmask = self._nplike.full(bitlength, np.uint8(255), dtype=np.uint8)
+        else:
+            bitmask = self._nplike.zeros(bitlength, dtype=np.uint8)
+
+        return ak._v2.contents.BitMaskedArray(
+            ak._v2.index.IndexU8(bitmask),
+            self._content,
+            valid_when,
+            self.length,
+            lsb_order,
             self._identifier,
             self._parameters,
             self._nplike,

--- a/src/awkward/_v2/contents/unmaskedarray.py
+++ b/src/awkward/_v2/contents/unmaskedarray.py
@@ -319,7 +319,25 @@ class UnmaskedArray(Content):
     def mergemany(self, others):
         if len(others) == 0:
             return self
-        return self.toIndexedOptionArray64().mergemany(others)
+
+        if all(isinstance(x, UnmaskedArray) for x in others):
+            parameters = self._parameters
+            tail_contents = []
+            for x in others:
+                parameters = ak._v2._util.merge_parameters(
+                    parameters, x._parameters, True
+                )
+                tail_contents.append(x._content)
+
+            return UnmaskedArray(
+                self._content.mergemany(tail_contents),
+                None,
+                parameters,
+                self._nplike,
+            )
+
+        else:
+            return self.toIndexedOptionArray64().mergemany(others)
 
     def fill_none(self, value):
         return self._content.fill_none(value)

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -348,6 +348,7 @@ class NumpyLike(Singleton):
 
     def all(self, *args, **kwargs):
         # array
+        kwargs.pop("prefer", None)
         return self._module.all(*args, **kwargs)
 
     def any(self, *args, **kwargs):

--- a/tests/v2/test_1604-preserve-form-in-concatenate.py
+++ b/tests/v2/test_1604-preserve-form-in-concatenate.py
@@ -7,11 +7,24 @@ import awkward as ak  # noqa: F401
 from awkward._v2.forms import ListOffsetForm, NumpyForm
 
 
-# def test_ListOffsetArray():
-#     a = ak._v2.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4]])
-#     b = ak._v2.Array([[5.5], [6.6, 7.7, 8.8, 9.9]])
-#     c = ak._v2.concatenate([a, b])
-#     assert c.layout.form == ListOffsetForm("i64", NumpyForm("float64"))
+def test_ListOffsetArray():
+    a = ak._v2.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4]])
+    b = ak._v2.Array([[5.5], [6.6, 7.7, 8.8, 9.9]])
+    c = ak._v2.concatenate([a, b])
+    ctt = ak._v2.concatenate([a.layout.typetracer, b.layout.typetracer])
+    assert c.layout.form == ListOffsetForm("i64", NumpyForm("float64"))
+    assert c.layout.form == ctt.layout.form
+
+
+def test_ListOffsetArray_ListOffsetArray():
+    a = ak._v2.Array([[[0.0, 1.1, 2.2], []], [[3.3, 4.4]]])
+    b = ak._v2.Array([[[5.5], [6.6, 7.7, 8.8, 9.9]]])
+    c = ak._v2.concatenate([a, b])
+    ctt = ak._v2.concatenate([a.layout.typetracer, b.layout.typetracer])
+    assert c.layout.form == ListOffsetForm(
+        "i64", ListOffsetForm("i64", NumpyForm("float64"))
+    )
+    assert c.layout.form == ctt.layout.form
 
 
 def test_OptionType_transformations():
@@ -34,7 +47,9 @@ def test_OptionType_transformations():
             assert bitmaskedarray.lsb_order is lsb_order
             assert ak._v2.Array(bitmaskedarray).tolist() == expected
 
-    unmaskedarray = ak._v2.contents.UnmaskedArray(ak._v2.contents.NumpyArray(np.arange(13)))
+    unmaskedarray = ak._v2.contents.UnmaskedArray(
+        ak._v2.contents.NumpyArray(np.arange(13))
+    )
 
     for valid_when in [False, True]:
         bytemaskedarray = unmaskedarray.toByteMaskedArray(valid_when)
@@ -49,7 +64,6 @@ def test_OptionType_transformations():
             assert bitmaskedarray.valid_when is valid_when
             assert bitmaskedarray.lsb_order is lsb_order
             assert ak._v2.Array(bitmaskedarray).tolist() == list(range(13))
-
 
 
 # def test_BitMaskedArray():
@@ -85,4 +99,3 @@ def test_OptionType_transformations():
 #         length=13,
 #         lsb_order=False,
 #     )
-

--- a/tests/v2/test_1604-preserve-form-in-concatenate.py
+++ b/tests/v2/test_1604-preserve-form-in-concatenate.py
@@ -4,7 +4,13 @@ import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward as ak  # noqa: F401
 
-from awkward._v2.forms import ListOffsetForm, ByteMaskedForm, BitMaskedForm, NumpyForm
+from awkward._v2.forms import (
+    ListOffsetForm,
+    ByteMaskedForm,
+    BitMaskedForm,
+    UnmaskedForm,
+    NumpyForm,
+)
 
 
 def test_ListOffsetArray():
@@ -161,4 +167,20 @@ def test_BitMaskedArray():
     assert c.layout.valid_when
     assert not c.layout.lsb_order
     assert c.layout.form == BitMaskedForm("u8", NumpyForm("float64"), True, False)
+    assert c.layout.form == ctt.layout.form
+
+
+def test_UnmaskedArray():
+    a = ak._v2.contents.unmaskedarray.UnmaskedArray(
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+    )
+    b = ak._v2.contents.unmaskedarray.UnmaskedArray(
+        ak._v2.contents.numpyarray.NumpyArray(np.array([7.7, 8.8, 9.9])),
+    )
+    c = ak._v2.concatenate([a, b])
+    ctt = ak._v2.concatenate([a.typetracer, b.typetracer])
+
+    assert c.tolist() == [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]
+    assert isinstance(c.layout, ak._v2.contents.UnmaskedArray)
+    assert c.layout.form == UnmaskedForm(NumpyForm("float64"))
     assert c.layout.form == ctt.layout.form

--- a/tests/v2/test_1604-preserve-form-in-concatenate.py
+++ b/tests/v2/test_1604-preserve-form-in-concatenate.py
@@ -9,7 +9,9 @@ from awkward._v2.forms import (
     ByteMaskedForm,
     BitMaskedForm,
     UnmaskedForm,
+    IndexedForm,
     NumpyForm,
+    EmptyForm,
 )
 
 
@@ -183,4 +185,33 @@ def test_UnmaskedArray():
     assert c.tolist() == [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]
     assert isinstance(c.layout, ak._v2.contents.UnmaskedArray)
     assert c.layout.form == UnmaskedForm(NumpyForm("float64"))
+    assert c.layout.form == ctt.layout.form
+
+
+def test_EmptyArray():
+    a = ak._v2.contents.emptyarray.EmptyArray()
+    c = ak._v2.concatenate([a, a])
+    ctt = ak._v2.concatenate([a.typetracer, a.typetracer])
+
+    assert c.tolist() == []
+    assert isinstance(c.layout, ak._v2.contents.EmptyArray)
+    assert c.layout.form == EmptyForm()
+    assert c.layout.form == ctt.layout.form
+
+
+def test_IndexedArray():
+    a = ak._v2.contents.indexedarray.IndexedArray(
+        ak._v2.index.Index(np.array([5, 4, 3, 2, 1, 0], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+    )
+    b = ak._v2.contents.indexedarray.IndexedArray(
+        ak._v2.index.Index(np.array([0, 1, 2], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([7.7, 8.8, 9.9])),
+    )
+    c = ak._v2.concatenate([a, b])
+    ctt = ak._v2.concatenate([a.typetracer, b.typetracer])
+
+    assert c.tolist() == [6.6, 5.5, 4.4, 3.3, 2.2, 1.1, 7.7, 8.8, 9.9]
+    assert isinstance(c.layout, ak._v2.contents.IndexedArray)
+    assert c.layout.form == IndexedForm("i64", NumpyForm("float64"))
     assert c.layout.form == ctt.layout.form

--- a/tests/v2/test_1604-preserve-form-in-concatenate.py
+++ b/tests/v2/test_1604-preserve-form-in-concatenate.py
@@ -1,0 +1,88 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+from awkward._v2.forms import ListOffsetForm, NumpyForm
+
+
+# def test_ListOffsetArray():
+#     a = ak._v2.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4]])
+#     b = ak._v2.Array([[5.5], [6.6, 7.7, 8.8, 9.9]])
+#     c = ak._v2.concatenate([a, b])
+#     assert c.layout.form == ListOffsetForm("i64", NumpyForm("float64"))
+
+
+def test_OptionType_transformations():
+    expected = [1, 2, None, 4, 5, 6, 7, 8, 9, None, None, None, 123]
+    indexedoptionarray = ak._v2.from_iter(expected, highlevel=False)
+
+    assert isinstance(indexedoptionarray, ak._v2.contents.IndexedOptionArray)
+
+    for valid_when in [False, True]:
+        bytemaskedarray = indexedoptionarray.toByteMaskedArray(valid_when)
+        assert isinstance(bytemaskedarray, ak._v2.contents.ByteMaskedArray)
+        assert bytemaskedarray.valid_when is valid_when
+        assert ak._v2.Array(bytemaskedarray).tolist() == expected
+
+    for valid_when in [False, True]:
+        for lsb_order in [False, True]:
+            bitmaskedarray = indexedoptionarray.toBitMaskedArray(valid_when, lsb_order)
+            assert isinstance(bitmaskedarray, ak._v2.contents.BitMaskedArray)
+            assert bitmaskedarray.valid_when is valid_when
+            assert bitmaskedarray.lsb_order is lsb_order
+            assert ak._v2.Array(bitmaskedarray).tolist() == expected
+
+    unmaskedarray = ak._v2.contents.UnmaskedArray(ak._v2.contents.NumpyArray(np.arange(13)))
+
+    for valid_when in [False, True]:
+        bytemaskedarray = unmaskedarray.toByteMaskedArray(valid_when)
+        assert isinstance(bytemaskedarray, ak._v2.contents.ByteMaskedArray)
+        assert bytemaskedarray.valid_when is valid_when
+        assert ak._v2.Array(bytemaskedarray).tolist() == list(range(13))
+
+    for valid_when in [False, True]:
+        for lsb_order in [False, True]:
+            bitmaskedarray = unmaskedarray.toBitMaskedArray(valid_when, lsb_order)
+            assert isinstance(bitmaskedarray, ak._v2.contents.BitMaskedArray)
+            assert bitmaskedarray.valid_when is valid_when
+            assert bitmaskedarray.lsb_order is lsb_order
+            assert ak._v2.Array(bitmaskedarray).tolist() == list(range(13))
+
+
+
+# def test_BitMaskedArray():
+#     v2a = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+#         ak._v2.index.Index(
+#             np.packbits(
+#                 np.array(
+#                     [
+#                         1,
+#                         1,
+#                         1,
+#                         1,
+#                         0,
+#                         0,
+#                         0,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                         0,
+#                         1,
+#                     ],
+#                     np.uint8,
+#                 )
+#             )
+#         ),
+#         ak._v2.contents.numpyarray.NumpyArray(
+#             np.array(
+#                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+#             )
+#         ),
+#         valid_when=True,
+#         length=13,
+#         lsb_order=False,
+#     )
+


### PR DESCRIPTION
@douglasdavis, this should help with concatenating arrays in dask-awkward: if the Forms of all items being passed to `ak.concatenate` are the same, then the concatenated array will also have that Form. It's a new constraint on `ak.concatenate`.

You were seeing this as unconcatenated ListOffsetArrays turning into a concatenated ListArray, but that was only one of the ways it could have had surprising results. The others are in the various forms of option-type.

(I was touching the `ak.concatenate` logic for #1604, anyway.)