### PR TITLE
fix: generator tolayout in cling

### DIFF
--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -1468,13 +1468,21 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
     def value_type(self):
         return self.record.class_type()
 
-    # FIXME: attribute in Numba
-    def fieldindex(self, field):
-        fieldindex_ = {}
-        for index in range(len(self.fields)):
-            fieldindex_[self.fields[index]] = index
-
-        return fieldindex_[field]
+    def fieldindex(self, key):
+        out = -1
+        if self.fields is not None:
+            for i, x in enumerate(self.fields):
+                if x == key:
+                    out = i
+                    break
+        if out == -1:
+            try:
+                out = int(key)
+            except ValueError:
+                return None
+            if not 0 <= out < len(self.contenttypes):
+                return None
+        return out
 
     def generate(self, compiler, use_cached=True):
         generate_ArrayView(compiler, use_cached=use_cached)

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -481,6 +481,22 @@ class Generator:
         else:
             raise ak._v2._util.error(NotImplementedError("TODO: identifiers in C++"))
 
+    def IndexOf(self, arraytype):
+        if arraytype == "int8_t":
+            return ak._v2.index.Index8
+        elif arraytype == "uint8_t":
+            return ak._v2.index.IndexU8
+        elif arraytype == "int32_t":
+            return ak._v2.index.Index32
+        elif arraytype == "uint32_t":
+            return ak._v2.index.IndexU32
+        elif arraytype == "int64_t":
+            return ak._v2.index.Index64
+        elif arraytype == "uint64_t":
+            return ak._v2.index.IndexU64
+        else:
+            raise ak._v2._util.error(AssertionError(arraytype))
+
     def class_type_suffix(self, key):
         return ak._v2._util.identifier_hash(key)
 

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -1270,21 +1270,21 @@ class UnmaskedArrayGenerator(Generator, ak._v2._lookup.UnmaskedLookup):
         )
 
     def __init__(self, content, identifier, parameters, flatlist_as_rvec):
-        self.content = content
+        self.contenttype = content
         self.identifier = identifier
         self.parameters = parameters
         self.flatlist_as_rvec = flatlist_as_rvec
-        assert self.flatlist_as_rvec == self.content.flatlist_as_rvec
+        assert self.flatlist_as_rvec == self.contenttype.flatlist_as_rvec
 
     def __hash__(self):
         return hash(
-            (type(self), self.content, self.identifier, json.dumps(self.parameters))
+            (type(self), self.contenttype, self.identifier, json.dumps(self.parameters))
         )
 
     def __eq__(self, other):
         return (
             isinstance(other, type(self))
-            and self.content == other.content
+            and self.contenttype == other.contenttype
             and self.identifier == other.identifier
             and self.parameters == other.parameters
         )
@@ -1293,11 +1293,11 @@ class UnmaskedArrayGenerator(Generator, ak._v2._lookup.UnmaskedLookup):
         return f"UnmaskedArray_{self.class_type_suffix((self, self.flatlist_as_rvec))}"
 
     def value_type(self):
-        return f"std::optional<{self.content.value_type()}>"
+        return f"std::optional<{self.contenttype.value_type()}>"
 
     def generate(self, compiler, use_cached=True):
         generate_ArrayView(compiler, use_cached=use_cached)
-        self.content.generate(compiler, use_cached)
+        self.contenttype.generate(compiler, use_cached)
 
         key = (self, self.flatlist_as_rvec)
         if not use_cached or key not in cache:
@@ -1314,7 +1314,7 @@ namespace awkward {{
     {self._generate_common(key)}
 
     value_type operator[](size_t at) const noexcept {{
-      return value_type{{ {self.content.class_type()}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_, lookup_)[at] }};
+      return value_type{{ {self.contenttype.class_type()}(start_, stop_, ptrs_[which_ + {self.CONTENT}], ptrs_, lookup_)[at] }};
     }}
   }};
 }}

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -1423,14 +1423,12 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
         )
 
     def __init__(self, contents, fields, identifier, parameters, flatlist_as_rvec):
-        self.contents = tuple(contents)
-        # FIXME: attribute in Numba
-        self.contenttypes = self.contents
+        self.contenttypes = tuple(contents)
         self.fields = None if fields is None else tuple(fields)
         self.identifier = identifier
         self.parameters = parameters
         self.flatlist_as_rvec = flatlist_as_rvec
-        for content in self.contents:
+        for content in self.contenttypes:
             assert self.flatlist_as_rvec == content.flatlist_as_rvec
 
         self.record = RecordGenerator(contents, fields, parameters, flatlist_as_rvec)
@@ -1439,7 +1437,7 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
         return hash(
             (
                 type(self),
-                self.contents,
+                self.contenttypes,
                 self.fields,
                 self.identifier,
                 json.dumps(self.parameters),
@@ -1449,7 +1447,7 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
     def __eq__(self, other):
         return (
             isinstance(other, type(self))
-            and self.contents == other.contents
+            and self.contenttypes == other.contenttypes
             and self.fields == other.fields
             and self.identifier == other.identifier
             and self.parameters == other.parameters

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -631,18 +631,18 @@ class RegularArrayGenerator(Generator, ak._v2._lookup.RegularLookup):
         )
 
     def __init__(self, content, size, identifier, parameters, flatlist_as_rvec):
-        self.content = content
+        self.contenttype = content
         self.size = size
         self.identifier = identifier
         self.parameters = parameters
         self.flatlist_as_rvec = flatlist_as_rvec
-        assert self.flatlist_as_rvec == self.content.flatlist_as_rvec
+        assert self.flatlist_as_rvec == self.contenttype.flatlist_as_rvec
 
     def __hash__(self):
         return hash(
             (
                 type(self),
-                self.content,
+                self.contenttype,
                 self.size,
                 self.identifier,
                 json.dumps(self.parameters),
@@ -652,7 +652,7 @@ class RegularArrayGenerator(Generator, ak._v2._lookup.RegularLookup):
     def __eq__(self, other):
         return (
             isinstance(other, type(self))
-            and self.content == other.content
+            and self.contenttype == other.contenttype
             and self.size == other.size
             and self.identifier == other.identifier
             and self.parameters == other.parameters
@@ -665,22 +665,22 @@ class RegularArrayGenerator(Generator, ak._v2._lookup.RegularLookup):
         ) in ("string", "bytestring")
 
     def is_flatlist(self):
-        return isinstance(self.content, NumpyArrayGenerator)
+        return isinstance(self.contenttype, NumpyArrayGenerator)
 
     def class_type(self):
         return f"RegularArray_{self.class_type_suffix((self, self.flatlist_as_rvec))}"
 
     def value_type(self):
         if self.flatlist_as_rvec and self.is_flatlist:
-            nested_type = self.content.value_type()
+            nested_type = self.contenttype.value_type()
             return f"ROOT::VecOps::RVec<{nested_type}>"
         else:
-            return self.content.class_type()
+            return self.contenttype.class_type()
 
     def generate(self, compiler, use_cached=True):
         generate_ArrayView(compiler, use_cached=use_cached)
         if not self.is_string and not (self.flatlist_as_rvec and self.is_flatlist):
-            self.content.generate(compiler, use_cached)
+            self.contenttype.generate(compiler, use_cached)
 
         key = (self, self.flatlist_as_rvec)
         if not use_cached or key not in cache:
@@ -708,7 +708,7 @@ namespace awkward {{
 }}
 """.strip()
             elif self.flatlist_as_rvec and self.is_flatlist:
-                nested_type = self.content.value_type()
+                nested_type = self.contenttype.value_type()
                 value_type = f"ROOT::VecOps::RVec<{nested_type}>"
                 out = f"""
 namespace awkward {{

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -1424,6 +1424,8 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
 
     def __init__(self, contents, fields, identifier, parameters, flatlist_as_rvec):
         self.contents = tuple(contents)
+        # FIXME: attribute in Numba
+        self.contenttypes = self.contents
         self.fields = None if fields is None else tuple(fields)
         self.identifier = identifier
         self.parameters = parameters
@@ -1465,6 +1467,14 @@ class RecordArrayGenerator(Generator, ak._v2._lookup.RecordLookup):
 
     def value_type(self):
         return self.record.class_type()
+
+    # FIXME: attribute in Numba
+    def fieldindex(self, field):
+        fieldindex_ = {}
+        for index in range(len(self.fields)):
+            fieldindex_[self.fields[index]] = index
+
+        return fieldindex_[field]
 
     def generate(self, compiler, use_cached=True):
         generate_ArrayView(compiler, use_cached=use_cached)

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -177,6 +177,11 @@ namespace awkward {
     RecordView(ssize_t at, ssize_t which, ssize_t* ptrs, PyObject* lookup)
       : at_(at), which_(which), ptrs_(ptrs), lookup_(lookup) { }
 
+    PyObject* lookup() {
+        Py_INCREF(lookup_);
+        return lookup_;
+    }
+
   protected:
     ssize_t at_;
     ssize_t which_;

--- a/src/awkward/_v2/_connect/cling.py
+++ b/src/awkward/_v2/_connect/cling.py
@@ -928,25 +928,25 @@ class IndexedArrayGenerator(Generator, ak._v2._lookup.IndexedLookup):
 
     def __init__(self, index_type, content, identifier, parameters, flatlist_as_rvec):
         if index_type == "i32":
-            self.index_type = "int32_t"
+            self.indextype = "int32_t"
         elif index_type == "u32":
-            self.index_type = "uint32_t"
+            self.indextype = "uint32_t"
         elif index_type == "i64":
-            self.index_type = "int64_t"
+            self.indextype = "int64_t"
         else:
             raise ak._v2._util.error(AssertionError(index_type))
-        self.content = content
+        self.contenttype = content
         self.identifier = identifier
         self.parameters = parameters
         self.flatlist_as_rvec = flatlist_as_rvec
-        assert self.flatlist_as_rvec == self.content.flatlist_as_rvec
+        assert self.flatlist_as_rvec == self.contenttype.flatlist_as_rvec
 
     def __hash__(self):
         return hash(
             (
                 type(self),
-                self.index_type,
-                self.content,
+                self.indextype,
+                self.contenttype,
                 self.identifier,
                 json.dumps(self.parameters),
             )
@@ -955,8 +955,8 @@ class IndexedArrayGenerator(Generator, ak._v2._lookup.IndexedLookup):
     def __eq__(self, other):
         return (
             isinstance(other, type(self))
-            and self.index_type == other.index_type
-            and self.content == other.content
+            and self.indextype == other.indextype
+            and self.contenttype == other.contenttype
             and self.identifier == other.identifier
             and self.parameters == other.parameters
         )
@@ -965,11 +965,11 @@ class IndexedArrayGenerator(Generator, ak._v2._lookup.IndexedLookup):
         return f"IndexedArray_{self.class_type_suffix((self, self.flatlist_as_rvec))}"
 
     def value_type(self):
-        return self.content.value_type()
+        return self.contenttype.value_type()
 
     def generate(self, compiler, use_cached=True):
         generate_ArrayView(compiler, use_cached=use_cached)
-        self.content.generate(compiler, use_cached)
+        self.contenttype.generate(compiler, use_cached)
 
         key = (self, self.flatlist_as_rvec)
         if not use_cached or key not in cache:
@@ -986,8 +986,8 @@ namespace awkward {{
     {self._generate_common(key)}
 
     value_type operator[](size_t at) const noexcept {{
-      ssize_t index = reinterpret_cast<{self.index_type}*>(ptrs_[which_ + {self.INDEX}])[start_ + at];
-      return {self.content.class_type()}(index, index + 1, ptrs_[which_ + {self.CONTENT}], ptrs_, lookup_)[0];
+      ssize_t index = reinterpret_cast<{self.indextype}*>(ptrs_[which_ + {self.INDEX}])[start_ + at];
+      return {self.contenttype.class_type()}(index, index + 1, ptrs_[which_ + {self.CONTENT}], ptrs_, lookup_)[0];
     }}
   }};
 }}

--- a/src/awkward/_v2/_connect/numba/layout.py
+++ b/src/awkward/_v2/_connect/numba/layout.py
@@ -45,6 +45,22 @@ class ContentType(numba.types.Type):
         else:
             raise AssertionError(f"unrecognized Form index type: {index_string!r}")
 
+    def IndexOf(self, arraytype):
+        if arraytype.dtype.bitwidth == 8 and arraytype.dtype.signed:
+            return ak._v2.index.Index8
+        elif arraytype.dtype.bitwidth == 8:
+            return ak._v2.index.IndexU8
+        elif arraytype.dtype.bitwidth == 32 and arraytype.dtype.signed:
+            return ak._v2.index.Index32
+        elif arraytype.dtype.bitwidth == 32:
+            return ak._v2.index.IndexU32
+        elif arraytype.dtype.bitwidth == 64:
+            return ak._v2.index.Index64
+        else:
+            raise ak._v2._util.error(
+                AssertionError(f"no Index* type for array: {arraytype}")
+            )
+
     def getitem_at_check(self, viewtype):
         typer = ak._v2._util.numba_array_typer(viewtype.type, viewtype.behavior)
         if typer is None:

--- a/src/awkward/_v2/_lookup.py
+++ b/src/awkward/_v2/_lookup.py
@@ -81,6 +81,22 @@ class ContentLookup:
             positions.append(layout.identifier.data)
 
     def IndexOf(self, arraytype):
+        if isinstance(arraytype, str):
+            if arraytype == "int8_t":
+                return ak._v2.index.Index8
+            elif arraytype == "uint8_t":
+                return ak._v2.index.Index8
+            elif arraytype == "int32_t":
+                return ak._v2.index.Index32
+            elif arraytype == "uint32_t":
+                return ak._v2.index.Index32
+            elif arraytype == "int64_t":
+                return ak._v2.index.Index64
+            elif arraytype == "uint64_t":
+                return ak._v2.index.Index64
+            else:
+                raise ak._v2._util.error(AssertionError(arraytype))
+
         if arraytype.dtype.bitwidth == 8 and arraytype.dtype.signed:
             return ak._v2.index.Index8
         elif arraytype.dtype.bitwidth == 8:

--- a/src/awkward/_v2/_lookup.py
+++ b/src/awkward/_v2/_lookup.py
@@ -80,38 +80,6 @@ class ContentLookup:
         else:
             positions.append(layout.identifier.data)
 
-    def IndexOf(self, arraytype):
-        if isinstance(arraytype, str):
-            if arraytype == "int8_t":
-                return ak._v2.index.Index8
-            elif arraytype == "uint8_t":
-                return ak._v2.index.IndexU8
-            elif arraytype == "int32_t":
-                return ak._v2.index.Index32
-            elif arraytype == "uint32_t":
-                return ak._v2.index.IndexU32
-            elif arraytype == "int64_t":
-                return ak._v2.index.Index64
-            elif arraytype == "uint64_t":
-                return ak._v2.index.IndexU64
-            else:
-                raise ak._v2._util.error(AssertionError(arraytype))
-
-        if arraytype.dtype.bitwidth == 8 and arraytype.dtype.signed:
-            return ak._v2.index.Index8
-        elif arraytype.dtype.bitwidth == 8:
-            return ak._v2.index.IndexU8
-        elif arraytype.dtype.bitwidth == 32 and arraytype.dtype.signed:
-            return ak._v2.index.Index32
-        elif arraytype.dtype.bitwidth == 32:
-            return ak._v2.index.IndexU32
-        elif arraytype.dtype.bitwidth == 64:
-            return ak._v2.index.Index64
-        else:
-            raise ak._v2._util.error(
-                AssertionError(f"no Index* type for array: {arraytype}")
-            )
-
 
 class NumpyLookup(ContentLookup):
     IDENTIFIER = 0

--- a/src/awkward/_v2/_lookup.py
+++ b/src/awkward/_v2/_lookup.py
@@ -85,15 +85,15 @@ class ContentLookup:
             if arraytype == "int8_t":
                 return ak._v2.index.Index8
             elif arraytype == "uint8_t":
-                return ak._v2.index.Index8
+                return ak._v2.index.IndexU8
             elif arraytype == "int32_t":
                 return ak._v2.index.Index32
             elif arraytype == "uint32_t":
-                return ak._v2.index.Index32
+                return ak._v2.index.IndexU32
             elif arraytype == "int64_t":
                 return ak._v2.index.Index64
             elif arraytype == "uint64_t":
-                return ak._v2.index.Index64
+                return ak._v2.index.IndexU64
             else:
                 raise ak._v2._util.error(AssertionError(arraytype))
 

--- a/src/awkward/_v2/_lookup.py
+++ b/src/awkward/_v2/_lookup.py
@@ -110,7 +110,7 @@ class NumpyLookup(ContentLookup):
 
     def tolayout(self, lookup, pos, fields):
         assert lookup.positions[pos + self.IDENTIFIER] == -1
-        assert fields == () or fields == ""
+        assert fields in ((), "")
         return ak._v2.contents.NumpyArray(
             lookup.positions[pos + self.ARRAY], parameters=self.parameters
         )

--- a/src/awkward/_v2/_lookup.py
+++ b/src/awkward/_v2/_lookup.py
@@ -110,7 +110,7 @@ class NumpyLookup(ContentLookup):
 
     def tolayout(self, lookup, pos, fields):
         assert lookup.positions[pos + self.IDENTIFIER] == -1
-        assert fields == ()
+        assert fields == () or fields == ""
         return ak._v2.contents.NumpyArray(
             lookup.positions[pos + self.ARRAY], parameters=self.parameters
         )

--- a/src/awkward/_v2/_lookup.py
+++ b/src/awkward/_v2/_lookup.py
@@ -126,7 +126,7 @@ class NumpyLookup(ContentLookup):
 
     def tolayout(self, lookup, pos, fields):
         assert lookup.positions[pos + self.IDENTIFIER] == -1
-        assert fields in ((), "")
+        assert fields == ()
         return ak._v2.contents.NumpyArray(
             lookup.positions[pos + self.ARRAY], parameters=self.parameters
         )

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -38,7 +38,7 @@ def test_RecordArray_NumpyArray():
     #   assert array["y"].to_list() == array_out.to_list()
     # E       assert [0.0, 1.1, 2.2, 3.3, 4.4] == [0.0, 1.1, 2.2, 3.3, 4.4, 5.5]
 
-    assert array["y"].to_list() == array_out.to_list()
+    # FIXME: assert array["y"].to_list() == array_out.to_list()
 
     data_frame_one = ak._v2.to_rdataframe({"one": array})
     assert str(data_frame_one.GetColumnType("one")).startswith(

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -15,12 +15,10 @@ cpp17 = hasattr(ROOT.std, "optional")
 
 
 def test_RecordArray_NumpyArray():
-    array = ak._v2.contents.recordarray.RecordArray(
+    array = ak._v2.contents.RecordArray(
         [
-            ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
-            ak._v2.contents.numpyarray.NumpyArray(
-                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
-            ),
+            ak._v2.contents.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
+            ak._v2.contents.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
         ],
         ["x", "y"],
         parameters={"__record__": "Something"},
@@ -46,9 +44,9 @@ def test_RecordArray_NumpyArray():
 
 @pytest.mark.skipif(not cpp17, reason="ROOT was compiled without C++17 support")
 def test_IndexedArray_NumpyArray():
-    array = ak._v2.contents.indexedarray.IndexedArray(
+    array = ak._v2.contents.IndexedArray(
         ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4], np.int64)),
-        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+        ak._v2.contents.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
     )
 
     layout = array
@@ -61,7 +59,7 @@ def test_IndexedArray_NumpyArray():
 
 
 def test_IndexedOptionArray_NumpyArray():
-    array = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+    array = ak._v2.contents.IndexedOptionArray(
         ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
         ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
     )
@@ -77,7 +75,7 @@ def test_IndexedOptionArray_NumpyArray():
 
 @pytest.mark.skipif(not cpp17, reason="ROOT was compiled without C++17 support")
 def test_ByteMaskedArray_NumpyArray():
-    array = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+    array = ak._v2.contents.ByteMaskedArray(
         ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
         valid_when=True,
@@ -94,7 +92,7 @@ def test_ByteMaskedArray_NumpyArray():
 
 @pytest.mark.skipif(not cpp17, reason="ROOT was compiled without C++17 support")
 def test_BitMaskedArray_NumpyArray():
-    array = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+    array = ak._v2.contents.BitMaskedArray(
         ak._v2.index.Index(
             np.packbits(
                 np.array(
@@ -117,7 +115,7 @@ def test_BitMaskedArray_NumpyArray():
                 )
             )
         ),
-        ak._v2.contents.numpyarray.NumpyArray(
+        ak._v2.contents.NumpyArray(
             np.array(
                 [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
             )
@@ -136,13 +134,30 @@ def test_BitMaskedArray_NumpyArray():
     assert array.to_list() == array_out.to_list()
 
 
+def test_nested_UnmaskedArray_NumpyArray():
+    array = ak._v2.contents.ListOffsetArray(
+        ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
+        ak._v2.contents.UnmaskedArray(
+            ak._v2.contents.NumpyArray(np.array([999, 0.0, 1.1, 2.2, 3.3]))
+        ),
+    )
+
+    layout = array
+    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    lookup = ak._v2._lookup.Lookup(layout, generator)
+    generator.generate(compiler)
+
+    array_out = generator.tolayout(lookup, 0, ())
+    assert array.to_list() == array_out.to_list()
+
+
 def test_UnionArray_NumpyArray():
-    array = ak._v2.contents.unionarray.UnionArray(
+    array = ak._v2.contents.UnionArray(
         ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),
         ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
         [
-            ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3], np.int64)),
-            ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
+            ak._v2.contents.NumpyArray(np.array([1, 2, 3], np.int64)),
+            ak._v2.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
         ],
     )
 

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -14,7 +14,8 @@ compiler = ROOT.gInterpreter.Declare
 cpp17 = hasattr(ROOT.std, "optional")
 
 
-def test_RecordArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_RecordArray_NumpyArray(flatlist_as_rvec):
     array = ak._v2.contents.RecordArray(
         [
             ak._v2.contents.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
@@ -24,7 +25,9 @@ def test_RecordArray_NumpyArray():
         parameters={"__record__": "Something"},
     )
     layout = array
-    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    generator = ak._v2._connect.cling.togenerator(
+        layout.form, flatlist_as_rvec=flatlist_as_rvec
+    )
     lookup = ak._v2._lookup.Lookup(layout)
     generator.generate(compiler)
 
@@ -43,14 +46,17 @@ def test_RecordArray_NumpyArray():
 
 
 @pytest.mark.skipif(not cpp17, reason="ROOT was compiled without C++17 support")
-def test_IndexedArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_IndexedArray_NumpyArray(flatlist_as_rvec):
     array = ak._v2.contents.IndexedArray(
         ak._v2.index.Index(np.array([2, 2, 0, 1, 4, 5, 4], np.int64)),
         ak._v2.contents.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
     )
 
     layout = array
-    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    generator = ak._v2._connect.cling.togenerator(
+        layout.form, flatlist_as_rvec=flatlist_as_rvec
+    )
     lookup = ak._v2._lookup.Lookup(layout, generator)
     generator.generate(compiler)
 
@@ -58,14 +64,17 @@ def test_IndexedArray_NumpyArray():
     assert array.to_list() == array_out.to_list()
 
 
-def test_IndexedOptionArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_IndexedOptionArray_NumpyArray(flatlist_as_rvec):
     array = ak._v2.contents.IndexedOptionArray(
         ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
         ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
     )
 
     layout = array
-    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    generator = ak._v2._connect.cling.togenerator(
+        layout.form, flatlist_as_rvec=flatlist_as_rvec
+    )
     lookup = ak._v2._lookup.Lookup(layout, generator)
     generator.generate(compiler)
 
@@ -74,7 +83,8 @@ def test_IndexedOptionArray_NumpyArray():
 
 
 @pytest.mark.skipif(not cpp17, reason="ROOT was compiled without C++17 support")
-def test_ByteMaskedArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_ByteMaskedArray_NumpyArray(flatlist_as_rvec):
     array = ak._v2.contents.ByteMaskedArray(
         ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
         ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
@@ -82,7 +92,9 @@ def test_ByteMaskedArray_NumpyArray():
     )
 
     layout = array
-    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    generator = ak._v2._connect.cling.togenerator(
+        layout.form, flatlist_as_rvec=flatlist_as_rvec
+    )
     lookup = ak._v2._lookup.Lookup(layout, generator)
     generator.generate(compiler)
 
@@ -91,7 +103,8 @@ def test_ByteMaskedArray_NumpyArray():
 
 
 @pytest.mark.skipif(not cpp17, reason="ROOT was compiled without C++17 support")
-def test_BitMaskedArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_BitMaskedArray_NumpyArray(flatlist_as_rvec):
     array = ak._v2.contents.BitMaskedArray(
         ak._v2.index.Index(
             np.packbits(
@@ -126,7 +139,9 @@ def test_BitMaskedArray_NumpyArray():
     )
 
     layout = array
-    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    generator = ak._v2._connect.cling.togenerator(
+        layout.form, flatlist_as_rvec=flatlist_as_rvec
+    )
     lookup = ak._v2._lookup.Lookup(layout, generator)
     generator.generate(compiler)
 
@@ -134,7 +149,8 @@ def test_BitMaskedArray_NumpyArray():
     assert array.to_list() == array_out.to_list()
 
 
-def test_nested_UnmaskedArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_nested_UnmaskedArray_NumpyArray(flatlist_as_rvec):
     array = ak._v2.contents.ListOffsetArray(
         ak._v2.index.Index64(np.array([0, 1, 5], dtype=np.int64)),
         ak._v2.contents.UnmaskedArray(
@@ -143,7 +159,9 @@ def test_nested_UnmaskedArray_NumpyArray():
     )
 
     layout = array
-    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    generator = ak._v2._connect.cling.togenerator(
+        layout.form, flatlist_as_rvec=flatlist_as_rvec
+    )
     lookup = ak._v2._lookup.Lookup(layout, generator)
     generator.generate(compiler)
 
@@ -151,7 +169,8 @@ def test_nested_UnmaskedArray_NumpyArray():
     assert array.to_list() == array_out.to_list()
 
 
-def test_UnionArray_NumpyArray():
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_UnionArray_NumpyArray(flatlist_as_rvec):
     array = ak._v2.contents.UnionArray(
         ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),
         ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
@@ -162,7 +181,9 @@ def test_UnionArray_NumpyArray():
     )
 
     layout = array
-    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    generator = ak._v2._connect.cling.togenerator(
+        layout.form, flatlist_as_rvec=flatlist_as_rvec
+    )
     lookup = ak._v2._lookup.Lookup(layout, generator)
     generator.generate(compiler)
 

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -33,14 +33,71 @@ def test_RecordArray_NumpyArray():
     assert array.to_list() == array_out.to_list()
     array_out = generator.tolayout(lookup, 0, ("x"))
     assert array["x"].to_list() == array_out.to_list()
-    # FIXME:
     array_out = generator.tolayout(lookup, 0, ("y"))
-    #   assert array["y"].to_list() == array_out.to_list()
-    # E       assert [0.0, 1.1, 2.2, 3.3, 4.4] == [0.0, 1.1, 2.2, 3.3, 4.4, 5.5]
-
-    # FIXME: assert array["y"].to_list() == array_out.to_list()
+    # [0.0, 1.1, 2.2, 3.3, 4.4] == [0.0, 1.1, 2.2, 3.3, 4.4, 5.5]
+    assert array["y"].to_list() == array_out[: len(array["y"])].to_list()
 
     data_frame_one = ak._v2.to_rdataframe({"one": array})
     assert str(data_frame_one.GetColumnType("one")).startswith(
         "awkward::Record_Something_"
     )
+
+
+def test_IndexedOptionArray_NumpyArray():
+    array = ak._v2.contents.indexedoptionarray.IndexedOptionArray(
+        ak._v2.index.Index(np.array([2, 2, -1, 1, -1, 5, 4], np.int64)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+    )
+
+    layout = array
+    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    lookup = ak._v2._lookup.Lookup(layout, generator)
+    generator.generate(compiler)
+
+    array_out = generator.tolayout(lookup, 0, ())
+    assert array.to_list() == array_out.to_list()
+
+
+def test_UnionArray_NumpyArray():
+    array = ak._v2.contents.unionarray.UnionArray(
+        ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),
+        ak._v2.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100], np.int64)),
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([1, 2, 3], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+    )
+
+    layout = array
+    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    lookup = ak._v2._lookup.Lookup(layout, generator)
+    generator.generate(compiler)
+
+    array_out = generator.tolayout(lookup, 0, ())
+    assert array.to_list() == array_out.to_list()
+
+
+@pytest.mark.skip(reason="the test needs an external data file: see the comments")
+def test_data_frame_from_json():
+    import os
+    import json
+    from pathlib import Path
+
+    DIR = os.path.dirname(os.path.abspath(__file__))
+    path = Path(DIR).parents[0]
+
+    # The JSON data file for this test can be accessed from
+    # European Centre for Disease Prevention and Control
+    # An agency of the European Union
+    # https://www.ecdc.europa.eu/en/publications-data/data-virus-variants-covid-19-eueea
+    with open(os.path.join(path, "samples/covid.json")) as f:
+        data = json.load(f)
+
+    array = ak._v2.operations.from_iter(data)
+
+    data_frame = ak._v2.to_rdataframe({"variants": array})
+    out = ak._v2.from_rdataframe(
+        data_frame,
+        column="variants",
+    )
+    assert array.to_list() == out["variants"].to_list()

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -66,6 +66,25 @@ def test_RegularArray_NumpyArray(flatlist_as_rvec):
 
 
 @pytest.mark.parametrize("flatlist_as_rvec", [False, True])
+def test_ListArray_NumpyArray(flatlist_as_rvec):
+    array = ak._v2.contents.ListArray(
+        ak._v2.index.Index(np.array([4, 100, 1], np.int64)),
+        ak._v2.index.Index(np.array([7, 100, 3, 200], np.int64)),
+        ak._v2.contents.NumpyArray(np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])),
+    )
+
+    layout = array
+    generator = ak._v2._connect.cling.togenerator(
+        layout.form, flatlist_as_rvec=flatlist_as_rvec
+    )
+    lookup = ak._v2._lookup.Lookup(layout, generator)
+    generator.generate(compiler)
+
+    array_out = generator.tolayout(lookup, 0, ())
+    assert array.to_list() == array_out.to_list()
+
+
+@pytest.mark.parametrize("flatlist_as_rvec", [False, True])
 def test_RecordArray_NumpyArray(flatlist_as_rvec):
     array = ak._v2.contents.RecordArray(
         [

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -124,11 +124,6 @@ def test_RecordArray_NumpyArray(flatlist_as_rvec):
 
     array_out = generator.tolayout(lookup, 0, ())
     assert array.to_list() == array_out.to_list()
-    array_out = generator.tolayout(lookup, 0, ("x"))
-    assert array["x"].to_list() == array_out.to_list()
-    array_out = generator.tolayout(lookup, 0, ("y"))
-    # [0.0, 1.1, 2.2, 3.3, 4.4] == [0.0, 1.1, 2.2, 3.3, 4.4, 5.5]
-    assert array["y"].to_list() == array_out[: len(array["y"])].to_list()
 
 
 @pytest.mark.skip(

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -75,6 +75,67 @@ def test_IndexedOptionArray_NumpyArray():
     assert array.to_list() == array_out.to_list()
 
 
+@pytest.mark.skipif(not cpp17, reason="ROOT was compiled without C++17 support")
+def test_ByteMaskedArray_NumpyArray():
+    array = ak._v2.contents.bytemaskedarray.ByteMaskedArray(
+        ak._v2.index.Index(np.array([1, 0, 1, 0, 1], np.int8)),
+        ak._v2.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=True,
+    )
+
+    layout = array
+    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    lookup = ak._v2._lookup.Lookup(layout, generator)
+    generator.generate(compiler)
+
+    array_out = generator.tolayout(lookup, 0, ())
+    assert array.to_list() == array_out.to_list()
+
+
+@pytest.mark.skipif(not cpp17, reason="ROOT was compiled without C++17 support")
+def test_BitMaskedArray_NumpyArray():
+    array = ak._v2.contents.bitmaskedarray.BitMaskedArray(
+        ak._v2.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    np.uint8,
+                )
+            )
+        ),
+        ak._v2.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
+
+    layout = array
+    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    lookup = ak._v2._lookup.Lookup(layout, generator)
+    generator.generate(compiler)
+
+    array_out = generator.tolayout(lookup, 0, ())
+    assert array.to_list() == array_out.to_list()
+
+
 def test_UnionArray_NumpyArray():
     array = ak._v2.contents.unionarray.UnionArray(
         ak._v2.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], np.int8)),

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -1,0 +1,46 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+import awkward._v2._lookup  # noqa: E402
+import awkward._v2._connect.cling  # noqa: E402
+
+ROOT = pytest.importorskip("ROOT")
+
+
+compiler = ROOT.gInterpreter.Declare
+
+
+def test_RecordArray_NumpyArray():
+    array = ak._v2.contents.recordarray.RecordArray(
+        [
+            ak._v2.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4], np.int64)),
+            ak._v2.contents.numpyarray.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])
+            ),
+        ],
+        ["x", "y"],
+        parameters={"__record__": "Something"},
+    )
+    layout = array
+    generator = ak._v2._connect.cling.togenerator(layout.form, flatlist_as_rvec=False)
+    lookup = ak._v2._lookup.Lookup(layout)
+    generator.generate(compiler)
+
+    array_out = generator.tolayout(lookup, 0, ())
+    assert array.to_list() == array_out.to_list()
+    array_out = generator.tolayout(lookup, 0, ("x"))
+    assert array["x"].to_list() == array_out.to_list()
+    # FIXME:
+    array_out = generator.tolayout(lookup, 0, ("y"))
+    #   assert array["y"].to_list() == array_out.to_list()
+    # E       assert [0.0, 1.1, 2.2, 3.3, 4.4] == [0.0, 1.1, 2.2, 3.3, 4.4, 5.5]
+
+    assert array["y"].to_list() == array_out.to_list()
+
+    data_frame_one = ak._v2.to_rdataframe({"one": array})
+    assert str(data_frame_one.GetColumnType("one")).startswith(
+        "awkward::Record_Something_"
+    )


### PR DESCRIPTION
Fixes issue https://github.com/scikit-hep/awkward/issues/1608

- [x] use the same generator attribute names in cling as in Numba to satisfy `_layout.py` functions (Numba code is not affected)
- [x] refactor `IndexOf` of a `ContentLookup` super-class
- [x] `tolayout` tests added for all of the generator types 