### PR TITLE
fix: improve `ak.from_iter` performance for long (axis=0) arrays

### DIFF
--- a/src/awkward/_v2/operations/ak_from_iter.py
+++ b/src/awkward/_v2/operations/ak_from_iter.py
@@ -83,12 +83,11 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
             )
 
     builder = ak.layout.ArrayBuilder(initial=initial, resize=resize)
-    for x in iterable:
-        builder.fromiter(x)
+    builder.fromiter(iterable)
 
     formstr, length, buffers = builder.to_buffers()
     form = ak._v2.forms.from_json(formstr)
 
     return ak._v2.operations.from_buffers(
         form, length, buffers, highlevel=highlevel, behavior=behavior
-    )
+    )[0]

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -887,10 +887,8 @@ def from_iter(
             )
 
     out = ak.layout.ArrayBuilder(initial=initial, resize=resize)
-    for x in iterable:
-        out.fromiter(x)
-    layout = out.snapshot()
-    return ak._util.maybe_wrap(layout, behavior, highlevel)
+    out.fromiter(iterable)
+    return ak._util.maybe_wrap(out[0], behavior, highlevel)
 
 
 def to_list(array):


### PR DESCRIPTION
Fixes #1588