### PR TITLE
ci: Upgrade Linux 18.04 -> 20.04 and DOS line endings.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -151,7 +151,7 @@ jobs:
           - python-version: '3.6'
             numpy-version: 1.13.1
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     env:
       PIP_ONLY_BINARY: cmake


### PR DESCRIPTION
This doesn't actually change the whole file, just the

https://github.com/scikit-hep/awkward/blob/c045715fd4fe62fdb100960506c76fd63aa9038e/.github/workflows/build-test.yml#L154

line. What changes the whole file is the DOS → Unix line endings.

Addresses [scheduled brown-outs](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) of Ubuntu 18.04: