### PR TITLE
refactor: from_rdataframe to use LayoutBuilder

### DIFF
--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -67,7 +67,11 @@ def from_rdataframe(data_frame, column):
         form = ak._v2.forms.from_json(form_str)
         list_depth = form.purelist_depth
         if list_depth > 4:
-            raise ak._v2._util.error(NotImplementedError)
+            raise ak._v2._util.error(
+                NotImplementedError(
+                    "Retrieving arbitrary depth nested containers is not implemented yet."
+                )
+            )
 
         def supported(form):
             if form.purelist_depth == 1:

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -104,7 +104,7 @@ def from_rdataframe(data_frame, column):
                 )
             return buffers
 
-        dtype = form_dtype(form)
+        data_type = cpp_type_of[form_dtype(form).name]
 
         # pull in the CppBuffers (after which we can import from it)
         CppBuffers = cppyy.gbl.awkward.CppBuffers[column_type]
@@ -112,9 +112,7 @@ def from_rdataframe(data_frame, column):
 
         if isinstance(form, ak._v2.forms.NumpyForm):
 
-            NumpyBuilder = cppyy.gbl.awkward.LayoutBuilder.Numpy[
-                cpp_type_of[dtype.name]
-            ]
+            NumpyBuilder = cppyy.gbl.awkward.LayoutBuilder.Numpy[data_type]
             builder = NumpyBuilder()
             builder_type = type(builder).__cpp_name__
 
@@ -126,7 +124,7 @@ def from_rdataframe(data_frame, column):
             # NOTE: list_depth == 2 or 1 if its the list of strings
             ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
                 "int64_t",
-                f"awkward::LayoutBuilder::Numpy<{cpp_type_of[dtype.name]}",
+                f"awkward::LayoutBuilder::Numpy<{data_type}",
             ]
             builder = ListOffsetBuilder()
             builder_type = type(builder).__cpp_name__
@@ -136,7 +134,7 @@ def from_rdataframe(data_frame, column):
         elif list_depth == 3:
             ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
                 "int64_t",
-                f"awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::Numpy<{cpp_type_of[dtype.name]}>",
+                f"awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::Numpy<{data_type}>",
             ]
             builder = ListOffsetBuilder()
             builder_type = type(builder).__cpp_name__
@@ -146,7 +144,7 @@ def from_rdataframe(data_frame, column):
         else:
             ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
                 "int64_t",
-                f"awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::Numpy<{cpp_type_of[dtype.name]}>>",
+                f"awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::Numpy<{data_type}>>",
             ]
             builder = ListOffsetBuilder()
             builder_type = type(builder).__cpp_name__
@@ -155,9 +153,7 @@ def from_rdataframe(data_frame, column):
 
         names_nbytes = cpp_buffers_self.names_nbytes[builder_type](builder)
         buffers = empty_buffers(cpp_buffers_self, names_nbytes)
-        cpp_buffers_self.to_char_buffers[builder_type, cpp_type_of[dtype.name]](
-            builder
-        )
+        cpp_buffers_self.to_char_buffers[builder_type, data_type](builder)
 
         array = ak._v2.from_buffers(
             form,

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -108,7 +108,7 @@ def from_rdataframe(data_frame, column):
         buffers = {}
 
         # pull in the CppBuffers (after which we can import from it)
-        CppBuffers = cppyy.gbl.awkward.CppBuffers[column_type, cpp_type_of[dtype.name]]
+        CppBuffers = cppyy.gbl.awkward.CppBuffers[column_type]
         cpp_buffers_self = CppBuffers(result_ptrs)
 
         if isinstance(form, ak._v2.forms.NumpyForm):

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -37,7 +37,7 @@ compiler = ROOT.gInterpreter.Declare
 
 done = compiler(
     """
-#include "rdataframe_jagged_builders.h"
+#include "rdataframe/jagged_builders.h"
 """
 )
 assert done is True

--- a/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/_v2/cpp-headers/awkward/GrowableBuffer.h
@@ -339,9 +339,9 @@ namespace awkward {
     /// Although the #length increments every time #append is called,
     /// it is always less than or equal to #reserved because of
     /// allocations of new panels.
-    int64_t
+    size_t
     length() const {
-      return length_ + (int64_t)ptr_->current_length();
+      return length_ + ptr_->current_length();
     }
 
     /// @brief Return options of this GrowableBuffer.
@@ -465,7 +465,7 @@ namespace awkward {
     const BuilderOptions options_;
 
     /// @brief Filled panels data length.
-    int64_t length_;
+    size_t length_;
 
     /// @brief The first panel.
     std::unique_ptr<Panel<PRIMITIVE>> panel_;

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -35,7 +35,7 @@ namespace awkward {
       /// @brief Converts index as field string.
       std::string
       index_as_field() const {
-        return std::to_string(static_cast<size_t>(index));
+        return std::to_string(reinterpret_cast<size_t>(index));
       }
 
       /// @brief The index of a Record field.
@@ -138,8 +138,18 @@ namespace awkward {
       /// using the same name and size (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        data_.concatenate(static_cast<PRIMITIVE*>(
+        data_.concatenate(reinterpret_cast<PRIMITIVE*>(
             buffers["node" + std::to_string(id_) + "-data"]));
+        }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        data_.concatenate(reinterpret_cast<PRIMITIVE*>(
+          buffers["node" + std::to_string(id_) + "-data"]));
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -306,9 +316,20 @@ namespace awkward {
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        offsets_.concatenate(static_cast<PRIMITIVE*>(
+        offsets_.concatenate(reinterpret_cast<PRIMITIVE*>(
             buffers["node" + std::to_string(id_) + "-offsets"]));
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        offsets_.concatenate(reinterpret_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-offsets"]));
+        content_.to_char_buffers(buffers);
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -480,11 +501,24 @@ namespace awkward {
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        starts_.concatenate(static_cast<PRIMITIVE*>(
+        starts_.concatenate(reinterpret_cast<PRIMITIVE*>(
             buffers["node" + std::to_string(id_) + "-starts"]));
-        stops_.concatenate(static_cast<PRIMITIVE*>(
+        stops_.concatenate(reinterpret_cast<PRIMITIVE*>(
             buffers["node" + std::to_string(id_) + "-stops"]));
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        starts_.concatenate(reinterpret_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-starts"]));
+        stops_.concatenate(reinterpret_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-stops"]));
+        content_.to_char_buffers(buffers);
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -574,6 +608,13 @@ namespace awkward {
 
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {}
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {}
 
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
@@ -669,6 +710,13 @@ namespace awkward {
 
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {}
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {}
 
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
@@ -871,6 +919,18 @@ namespace awkward {
           });
       }
 
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [&buffers](auto& content) {
+            content.builder.to_char_buffers(buffers);
+          });
+      }
+
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
@@ -1069,6 +1129,18 @@ namespace awkward {
           });
       }
 
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [&buffers](auto& content) {
+            content.to_char_buffers(buffers);
+          });
+      }
+
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
@@ -1235,6 +1307,15 @@ namespace awkward {
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        content_.to_char_buffers(buffers);
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -1410,9 +1491,20 @@ namespace awkward {
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        index_.concatenate(static_cast<PRIMITIVE*>(
+        index_.concatenate(reinterpret_cast<PRIMITIVE*>(
             buffers["node" + std::to_string(id_) + "-index"]));
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        index_.concatenate(reinterpret_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-index"]));
+        content_.to_char_buffers(buffers);
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -1599,9 +1691,20 @@ namespace awkward {
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        index_.concatenate(static_cast<PRIMITIVE*>(
+        index_.concatenate(reinterpret_cast<PRIMITIVE*>(
             buffers["node" + std::to_string(id_) + "-index"]));
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        index_.concatenate(reinterpret_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-index"]));
+        content_.to_char_buffers(buffers);
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -1737,6 +1840,15 @@ namespace awkward {
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        content_.to_char_buffers(buffers);
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -1926,9 +2038,20 @@ namespace awkward {
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        mask_.concatenate(static_cast<int8_t*>(
+        mask_.concatenate(reinterpret_cast<int8_t*>(
             buffers["node" + std::to_string(id_) + "-mask"]));
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        mask_.concatenate(reinterpret_cast<int8_t*>(
+            buffers["node" + std::to_string(id_) + "-mask"]));
+        content_.to_char_buffers(buffers);
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -2164,11 +2287,24 @@ namespace awkward {
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        mask_.concatenate_from(static_cast<uint8_t*>(
+        mask_.concatenate_from(reinterpret_cast<uint8_t*>(
             buffers["node" + std::to_string(id_) + "-mask"]), 0, 1);
-        mask_.append(static_cast<uint8_t*>(
+        mask_.append(reinterpret_cast<uint8_t*>(
             buffers["node" + std::to_string(id_) + "-mask"]), mask_.length() - 1, 0, 1);
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        mask_.concatenate_from(reinterpret_cast<uint8_t*>(
+            buffers["node" + std::to_string(id_) + "-mask"]), 0, 1);
+        mask_.append(reinterpret_cast<uint8_t*>(
+            buffers["node" + std::to_string(id_) + "-mask"]), mask_.length() - 1, 0, 1);
+        content_.to_char_buffers(buffers);
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -2419,14 +2555,33 @@ namespace awkward {
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
         auto index_sequence((std::index_sequence_for<BUILDERS...>()));
 
-        tags_.concatenate(static_cast<TAGS*>(
+        tags_.concatenate(reinterpret_cast<TAGS*>(
             buffers["node" + std::to_string(id_) + "-tags"]));
-        index_.concatenate(static_cast<INDEX*>(
+        index_.concatenate(reinterpret_cast<INDEX*>(
             buffers["node" + std::to_string(id_) + "-index"]));
 
         for (size_t i = 0; i < contents_count_; i++)
           visit_at(contents_, i, [&buffers](auto& content) {
             content.to_buffers(buffers);
+          });
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        auto index_sequence((std::index_sequence_for<BUILDERS...>()));
+
+        tags_.concatenate(reinterpret_cast<TAGS*>(
+            buffers["node" + std::to_string(id_) + "-tags"]));
+        index_.concatenate(reinterpret_cast<INDEX*>(
+            buffers["node" + std::to_string(id_) + "-index"]));
+
+        for (size_t i = 0; i < contents_count_; i++)
+          visit_at(contents_, i, [&buffers](auto& content) {
+            content.to_char_buffers(buffers);
           });
       }
 

--- a/src/awkward/_v2/cpp-headers/rdataframe/jagged_builders.h
+++ b/src/awkward/_v2/cpp-headers/rdataframe/jagged_builders.h
@@ -106,6 +106,23 @@ namespace awkward {
       }
     }
 
+    template<class BUILDER, typename ITERABLE>
+    void
+    recurse_fill_from(int64_t level, BUILDER& builder, ITERABLE& result) const {
+      if (level == 0) {
+        for (auto it : result) {
+          builder.append(it);
+        }
+      }
+      else {
+        auto& next_builder = builder.begin_list();
+        for (auto& it : result) {
+          recurse_fill_from(level - 1, next_builder, it);
+        }
+        next_builder.end_list();
+      }
+    }
+
   private:
     ROOT::RDF::RResultPtr<std::vector<T>>& result_;
     std::map<std::string, size_t> map_names_nbytes_;

--- a/src/awkward/_v2/cpp-headers/rdataframe_jagged_builders.h
+++ b/src/awkward/_v2/cpp-headers/rdataframe_jagged_builders.h
@@ -33,9 +33,9 @@ namespace awkward {
     }
 
     void
-    check_buffers() {
-      std::cout << "CPPBuffers check buffers: " << buffers_uint8_ptr_.size() << "!!! ";
-      for (auto it : buffers_uint8_ptr_) {
+    check_buffers() const {
+      std::cout << "CPPBuffers check buffers: " << buffers_uint8_ptr_.size() << ".";
+      for (auto const& it : buffers_uint8_ptr_) {
         uint8_t* data = it.second;
         for (int i = 0; i < map_names_nbytes_[it.first]; i++) {
           std::cout << (int64_t)data[i] << ",";
@@ -46,7 +46,7 @@ namespace awkward {
 
     template<class BUILDER>
     void
-    fill_from(BUILDER& builder) {
+    fill_from(BUILDER& builder) const {
       for (auto it : result_) {
         builder.append(it);
       }
@@ -60,7 +60,7 @@ namespace awkward {
 
     template<class BUILDER>
     void
-    fill_offsets_and_flatten_2(BUILDER& builder) {
+    fill_offsets_and_flatten_2(BUILDER& builder) const {
       for (auto const& vec : result_) {
         auto& subbuilder = builder.begin_list();
         for (auto it : vec) {
@@ -72,7 +72,7 @@ namespace awkward {
 
     template<class BUILDER>
     void
-    fill_offsets_and_flatten_3(BUILDER& builder) {
+    fill_offsets_and_flatten_3(BUILDER& builder) const {
       for (auto const& vec_of_vecs : result_) {
         auto& builder1 = builder.begin_list();
         for (auto const& vec : vec_of_vecs) {
@@ -88,12 +88,12 @@ namespace awkward {
 
     template<class BUILDER>
     void
-    fill_offsets_and_flatten_4(BUILDER& builder) {
+    fill_offsets_and_flatten_4(BUILDER& builder) const {
       for (auto const& vec_of_vecs_of_vecs : result_) {
         auto& builder1 = builder.begin_list();
         for (auto const& vec_of_vecs : vec_of_vecs_of_vecs) {
           auto& builder2 = builder1.begin_list();
-          for (auto vec : vec_of_vecs) {
+          for (auto const& vec : vec_of_vecs) {
             auto& builder3 = builder2.begin_list();
             for (auto it : vec) {
               builder3.append(it);

--- a/src/awkward/_v2/cpp-headers/rdataframe_jagged_builders.h
+++ b/src/awkward/_v2/cpp-headers/rdataframe_jagged_builders.h
@@ -5,6 +5,8 @@
 
 #include <stdlib.h>
 #include <string>
+#include "awkward/GrowableBuffer.h"
+#include "awkward/LayoutBuilder.h"
 #include "awkward/utils.h"
 
 namespace awkward {

--- a/src/awkward/_v2/cpp-headers/rdataframe_jagged_builders.h
+++ b/src/awkward/_v2/cpp-headers/rdataframe_jagged_builders.h
@@ -11,7 +11,7 @@
 
 namespace awkward {
 
-  template <typename T, typename DATA>
+  template <typename T>
   class CppBuffers {
   public:
     CppBuffers(ROOT::RDF::RResultPtr<std::vector<T>>& result)
@@ -109,7 +109,6 @@ namespace awkward {
   private:
     ROOT::RDF::RResultPtr<std::vector<T>>& result_;
     std::map<std::string, size_t> map_names_nbytes_;
-    std::map<std::string, void*> buffers_void_ptr_;
     std::map<std::string, uint8_t*> buffers_uint8_ptr_;
 
   };

--- a/src/libawkward/Content.cpp
+++ b/src/libawkward/Content.cpp
@@ -244,7 +244,7 @@ namespace awkward {
                                            FormKey(nullptr),
                                            std::vector<int64_t>(),
                                            8,
-                                           "M8" + primitive.substr(10, -1),
+                                           "M8" + primitive.substr(10, std::string::npos),
                                            util::dtype::datetime64);
       }
       else if (primitive.find("timedelta64") == 0) {
@@ -253,7 +253,7 @@ namespace awkward {
                                            FormKey(nullptr),
                                            std::vector<int64_t>(),
                                            8,
-                                           "m8" + primitive.substr(11, -1),
+                                           "m8" + primitive.substr(11, std::string::npos),
                                            util::dtype::timedelta64);
       }
       else {

--- a/tests/v2/test_1620-layout-builders.py
+++ b/tests/v2/test_1620-layout-builders.py
@@ -4,14 +4,12 @@ import pytest  # noqa: F401
 import numpy as np  # noqa: F401
 import awkward._v2 as ak  # noqa: F401
 
-import awkward._v2._lookup  # noqa: E402
-import awkward._v2._connect.cling  # noqa: E402
-
 
 ROOT = pytest.importorskip("ROOT")
 
 
 compiler = ROOT.gInterpreter.Declare
+
 
 def test_data_frame_integers():
     ak_array_in = ak.Array([1, 2, 3, 4, 5])
@@ -42,7 +40,7 @@ def test_data_frame_double():
 
 
 def test_data_frame_char():
-    ak_array_in = ak.Array(['a', 'b', 'c', 'd', 'e'])
+    ak_array_in = ak.Array(["a", "b", "c", "d", "e"])
 
     data_frame = ak.to_rdataframe({"x": ak_array_in})
 
@@ -68,6 +66,7 @@ def test_data_frame_complex():
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
+
 def test_data_frame_listoffset_integers():
     ak_array_in = ak.Array([[1], [2, 3, 4], [5]])
 
@@ -83,11 +82,13 @@ def test_data_frame_listoffset_integers():
 
 
 def test_data_frame_listoffset_listoffset_double():
-    ak_array_in = ak.Array([
-        [[1.1, 2.2, 3.3]],
-        [[4.4, 5.5]],
-        [[6.6], [7.7, 8.8, 9.9]],
-    ])
+    ak_array_in = ak.Array(
+        [
+            [[1.1, 2.2, 3.3]],
+            [[4.4, 5.5]],
+            [[6.6], [7.7, 8.8, 9.9]],
+        ]
+    )
 
     data_frame = ak.to_rdataframe({"x": ak_array_in})
 
@@ -102,16 +103,24 @@ def test_data_frame_listoffset_listoffset_double():
 
 
 def test_data_frame_vec_of_vec():
-    array = ak.Array([
-    [{"x": 1.1, "y": [1]}, {"x": None, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}],
-    [],
-    [{"x": None, "y": [1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}]
-])
-#] * 10000)
+    array = ak.Array(
+        [
+            [
+                {"x": 1.1, "y": [1]},
+                {"x": None, "y": [1, 2]},
+                {"x": 3.3, "y": [1, 2, 3]},
+            ],
+            [],
+            [{"x": None, "y": [1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}],
+        ]
+    )
+    # ] * 10000)
 
     rdf2 = ak.to_rdataframe({"array": array})
     # Note when dimensions R and C are large, the following code suffers from potential performance penalties caused by frequent reallocation of memory by the push_back() function. This should be used only when vector dimensions are not known in advance.
-    rdf3 = rdf2.Define("output", """
+    rdf3 = rdf2.Define(
+        "output",
+        """
     std::vector<std::vector<double>> tmp1;
 
     for (auto record : array) {
@@ -122,15 +131,18 @@ def test_data_frame_vec_of_vec():
         tmp1.push_back(tmp2);
     }
     return tmp1;
-    """)
+    """,
+    )
 
     assert rdf3.GetColumnType("output") == "vector<vector<double> >"
-    out = ak.from_rdataframe(
+    out = ak.from_rdataframe(  # noqa: F841
         rdf3,
         column="output",
     )
 
-    rdf3 = rdf2.Define("output2", """
+    rdf3 = rdf2.Define(
+        "output2",
+        """
     std::vector<std::vector<std::vector<double>>> tmp1;
 
     for (auto record : array) {
@@ -147,9 +159,10 @@ def test_data_frame_vec_of_vec():
         tmp1.push_back(tmp2);
     }
     return tmp1;
-    """)
+    """,
+    )
     assert rdf3.GetColumnType("output2") == "vector<vector<vector<double> > >"
-    out = ak.from_rdataframe(
+    out = ak.from_rdataframe(  # noqa: F841
         rdf3,
         column="output2",
     )

--- a/tests/v2/test_1620-layout-builders.py
+++ b/tests/v2/test_1620-layout-builders.py
@@ -1,0 +1,155 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward._v2 as ak  # noqa: F401
+
+import awkward._v2._lookup  # noqa: E402
+import awkward._v2._connect.cling  # noqa: E402
+
+
+ROOT = pytest.importorskip("ROOT")
+
+
+compiler = ROOT.gInterpreter.Declare
+
+def test_data_frame_integers():
+    ak_array_in = ak.Array([1, 2, 3, 4, 5])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_in})
+
+    assert data_frame.GetColumnType("x") == "int64_t"
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        column="x",
+    )
+    assert ak_array_in.to_list() == ak_array_out["x"].to_list()
+
+
+def test_data_frame_double():
+    ak_array_in = ak.Array([1.1, 2.2, 3.3, 4.4, 5.5])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_in})
+
+    assert data_frame.GetColumnType("x") == "double"
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        column="x",
+    )
+    assert ak_array_in.to_list() == ak_array_out["x"].to_list()
+
+
+def test_data_frame_char():
+    ak_array_in = ak.Array(['a', 'b', 'c', 'd', 'e'])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_in})
+
+    assert data_frame.GetColumnType("x") == "std::string"
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        column="x",
+    )
+    assert ak_array_in.to_list() == ak_array_out["x"].to_list()
+
+
+def test_data_frame_complex():
+    ak_array_in = ak.Array([1.1 + 0.1j, 2.2 + 0.2j, 3.3 + 0.3j, 4.4 + 0.4j, 5.5 + 0.5j])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_in})
+
+    assert data_frame.GetColumnType("x") == "std::complex<double>"
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        column="x",
+    )
+    assert ak_array_in.to_list() == ak_array_out["x"].to_list()
+
+def test_data_frame_listoffset_integers():
+    ak_array_in = ak.Array([[1], [2, 3, 4], [5]])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_in})
+
+    assert data_frame.GetColumnType("x") == "ROOT::VecOps::RVec<int64_t>"
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        column="x",
+    )
+    assert ak_array_in.to_list() == ak_array_out["x"].to_list()
+
+
+def test_data_frame_listoffset_listoffset_double():
+    ak_array_in = ak.Array([
+        [[1.1, 2.2, 3.3]],
+        [[4.4, 5.5]],
+        [[6.6], [7.7, 8.8, 9.9]],
+    ])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_in})
+
+    # awkward::ListArray_ type
+    # assert data_frame.GetColumnType("x") == "ROOT::VecOps::RVec<double>"
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        column="x",
+    )
+    assert ak_array_in.to_list() == ak_array_out["x"].to_list()
+
+
+def test_data_frame_vec_of_vec():
+    array = ak.Array([
+    [{"x": 1.1, "y": [1]}, {"x": None, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}],
+    [],
+    [{"x": None, "y": [1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}]
+])
+#] * 10000)
+
+    rdf2 = ak.to_rdataframe({"array": array})
+    # Note when dimensions R and C are large, the following code suffers from potential performance penalties caused by frequent reallocation of memory by the push_back() function. This should be used only when vector dimensions are not known in advance.
+    rdf3 = rdf2.Define("output", """
+    std::vector<std::vector<double>> tmp1;
+
+    for (auto record : array) {
+        std::vector<double> tmp2;
+        for (auto number : record.y()) {
+            tmp2.push_back(number * number);
+        }
+        tmp1.push_back(tmp2);
+    }
+    return tmp1;
+    """)
+
+    assert rdf3.GetColumnType("output") == "vector<vector<double> >"
+    out = ak.from_rdataframe(
+        rdf3,
+        column="output",
+    )
+
+    rdf3 = rdf2.Define("output2", """
+    std::vector<std::vector<std::vector<double>>> tmp1;
+
+    for (auto record : array) {
+        std::vector<std::vector<double>> tmp2;
+        double x_number = record.x().value_or(0.0);
+        for (auto number : record.y()) {
+            std::vector<double> tmp3;
+            for (int i = 0; i <= x_number; i++) {
+                double value = x_number * number;
+                tmp3.push_back(value);
+            }
+            tmp2.push_back(tmp3);
+        }
+        tmp1.push_back(tmp2);
+    }
+    return tmp1;
+    """)
+    assert rdf3.GetColumnType("output2") == "vector<vector<vector<double> > >"
+    out = ak.from_rdataframe(
+        rdf3,
+        column="output2",
+    )


### PR DESCRIPTION
- [x] Extend `LayoutBuilder` API to support user-allocated `char` buffers
- [x] Replace `static_cast` with `reinterpret_cast` in `GrowableBuffer` and `LayoutBuilder`s
- [x] Cleanup some warnings
- [x] Replace `from_rdataframe` data accumulation to `std::vectors` with `LayoutBuilder`s
- [x] Add tests