### PR TITLE
fix: allow char arrays to change dtype

### DIFF
--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -645,19 +645,30 @@ class NumpyArray(Content):
         return out2, nextoffsets[: outlength[0]]
 
     def numbers_to_type(self, name):
+        dtype = primitive_to_dtype(name)
         if (
             self.parameter("__array__") == "string"
             or self.parameter("__array__") == "bytestring"
-            or self.parameter("__array__") == "char"
-            or self.parameter("__array__") == "byte"
+            or dtype == self._data.dtype
         ):
             return self
         else:
-            dtype = primitive_to_dtype(name)
+            # Char/byte arrays are no longer char/byte arrays
+            # if the dtype changes
+            if (
+                self.parameter("__array__") == "char"
+                or self.parameter("__array__") == "byte"
+            ):
+                # Remove `__array__`
+                parameters = copy.copy(self._parameters)
+                del parameters["__array__"]
+            else:
+                parameters = self._parameters
+
             return NumpyArray(
                 self._nplike.asarray(self._data, dtype=dtype),
                 self._identifier,
-                self._parameters,
+                parameters,
                 self._nplike,
             )
 

--- a/src/awkward/_v2/contents/numpyarray.py
+++ b/src/awkward/_v2/contents/numpyarray.py
@@ -646,11 +646,7 @@ class NumpyArray(Content):
 
     def numbers_to_type(self, name):
         dtype = primitive_to_dtype(name)
-        if (
-            self.parameter("__array__") == "string"
-            or self.parameter("__array__") == "bytestring"
-            or dtype == self._data.dtype
-        ):
+        if dtype == self._data.dtype:
             return self
         else:
             # Char/byte arrays are no longer char/byte arrays


### PR DESCRIPTION
Fixes #1622 by removing the `__array__` parameter for char arrays. 

This PR needs tests, and also changes the existing behaviour: string/bytestring `__array__` parameters are no longer pertinent to this logic.