### PR TITLE
feat: retrieve multiple columns from RDataFrame in a single event loop

### DIFF
--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -11,16 +11,22 @@ import ctypes
 import os
 from awkward._v2.types.numpytype import primitive_to_dtype
 
-cpp_type_of = {
+_primitive_to_cpp_type_dict = {
+    "bool": "bool",
     "int8": "int8_t",
     "uint8": "uint8_t",
+    "int16": "int16_t",
+    "uint16": "uint16_t",
     "int32": "int32_t",
     "uint32": "uint32_t",
     "int64": "int64_t",
     "uint64": "uint64_t",
     "float32": "float",
     "float64": "double",
+    "complex64": "std::complex<float>",
     "complex128": "std::complex<double>",
+    "datetime64": "std::time_t",
+    "timedelta64": "std::difftime",
 }
 
 np = ak.nplike.NumpyMetadata.instance()
@@ -178,7 +184,7 @@ def from_rdataframe(data_frame, columns):
 
             list_depth = form.purelist_depth
 
-            data_type = cpp_type_of[form_dtype(form).name]
+            data_type = _primitive_to_cpp_type_dict[form_dtype(form).name]
 
             # pull in the CppBuffers (after which we can import from it)
             CppBuffers = cppyy.gbl.awkward.CppBuffers[col_type]

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -158,7 +158,8 @@ def from_rdataframe(data_frame, columns):
             awkward_contents[col] = layout
 
         else:  # Convert the C++ vectors to Awkward arrays
-            form = ak._v2.forms.from_json(ROOT.awkward.type_to_form[col_type](0))
+            form_str = ROOT.awkward.type_to_form[col_type](0)
+            form = ak._v2.forms.from_json(form_str)
 
             list_depth = form.purelist_depth
             form_dtype_name = form_dtype(form).name

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -107,7 +107,8 @@ def from_rdataframe(data_frame, columns):
             # the associated RLoopManager.
             lookup = result_ptrs[col].begin().lookup()
             generator = lookup[col].generator
-            contents[col] = generator.tolayout(lookup, 0, ())
+            layout = generator.tolayout(lookup[col], 0, ())
+            contents[col] = layout
 
         else:  # Convert the C++ vectors to Awkward arrays
             form = ak._v2.forms.from_json(ROOT.awkward.type_to_form[col_type](0))

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -43,140 +43,137 @@ done = compiler(
 assert done is True
 
 
-def from_rdataframe(data_frame, column):
-    def _wrap_as_record_array(array):
-        layout = array.layout if isinstance(array, ak._v2.highlevel.Array) else array
-        return ak._v2._util.wrap(
-            ak._v2.contents.RecordArray(
-                fields=[column],
-                contents=[layout],
-            ),
-            highlevel=True,
-        )
-
-    # Cast input node to base RNode type
-    data_frame_rnode = cppyy.gbl.ROOT.RDF.AsRNode(data_frame)
-
-    column_type = data_frame_rnode.GetColumnType(column)
-    form_str = ROOT.awkward.type_to_form[column_type](0)
-
-    # 'Take' is a lazy action:
-    result_ptrs = data_frame_rnode.Take[column_type](column)
-
-    if form_str.startswith("{"):
-        form = ak._v2.forms.from_json(form_str)
-        list_depth = form.purelist_depth
-        if list_depth > 4:
-            raise ak._v2._util.error(
-                NotImplementedError(
-                    "Retrieving arbitrary depth nested containers is not implemented yet."
-                )
+def from_rdataframe(data_frame, columns):
+    def supported(form):
+        if form.purelist_depth == 1:
+            # special case for a list of strings form
+            return isinstance(
+                form, (ak._v2.forms.ListOffsetForm, ak._v2.forms.NumpyForm)
+            )
+        else:
+            return isinstance(form, ak._v2.forms.ListOffsetForm) and supported(
+                form.content
             )
 
-        def supported(form):
-            if form.purelist_depth == 1:
-                # special case for a list of strings form
-                return isinstance(
-                    form, (ak._v2.forms.ListOffsetForm, ak._v2.forms.NumpyForm)
-                )
-            else:
-                return isinstance(form, ak._v2.forms.ListOffsetForm) and supported(
-                    form.content
-                )
-
-        if not supported(form):
-            raise ak._v2._util.error(NotImplementedError)
-
-        def form_dtype(form):
-            if form.purelist_depth == 1:
-                # special case for a list of strings form
-                return (
-                    primitive_to_dtype(form.content.primitive)
-                    if isinstance(form, ak._v2.forms.ListOffsetForm)
-                    else primitive_to_dtype(form.primitive)
-                )
-            else:
-                return form_dtype(form.content)
-
-        def empty_buffers(cpp_buffers_self, names_nbytes):
-            buffers = {}
-            for item in names_nbytes:
-                buffers[item.first] = ak.nplike.numpy.empty(item.second)
-                cpp_buffers_self.append(
-                    item.first,
-                    buffers[item.first].ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)),
-                )
-            return buffers
-
-        data_type = cpp_type_of[form_dtype(form).name]
-
-        # pull in the CppBuffers (after which we can import from it)
-        CppBuffers = cppyy.gbl.awkward.CppBuffers[column_type]
-        cpp_buffers_self = CppBuffers(result_ptrs)
-
-        if isinstance(form, ak._v2.forms.NumpyForm):
-
-            NumpyBuilder = cppyy.gbl.awkward.LayoutBuilder.Numpy[data_type]
-            builder = NumpyBuilder()
-            builder_type = type(builder).__cpp_name__
-
-            cpp_buffers_self.fill_from[builder_type](builder)
-
-        elif isinstance(form, ak._v2.forms.ListOffsetForm) and isinstance(
-            form.content, ak._v2.forms.NumpyForm
-        ):
-            # NOTE: list_depth == 2 or 1 if its the list of strings
-            ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
-                "int64_t",
-                f"awkward::LayoutBuilder::Numpy<{data_type}",
-            ]
-            builder = ListOffsetBuilder()
-            builder_type = type(builder).__cpp_name__
-
-            cpp_buffers_self.fill_offsets_and_flatten_2[builder_type](builder)
-
-        elif list_depth == 3:
-            ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
-                "int64_t",
-                f"awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::Numpy<{data_type}>",
-            ]
-            builder = ListOffsetBuilder()
-            builder_type = type(builder).__cpp_name__
-
-            cpp_buffers_self.fill_offsets_and_flatten_3[builder_type](builder)
-
+    def form_dtype(form):
+        if form.purelist_depth == 1:
+            # special case for a list of strings form
+            return (
+                primitive_to_dtype(form.content.primitive)
+                if isinstance(form, ak._v2.forms.ListOffsetForm)
+                else primitive_to_dtype(form.primitive)
+            )
         else:
-            ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
-                "int64_t",
-                f"awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::Numpy<{data_type}>>",
-            ]
-            builder = ListOffsetBuilder()
-            builder_type = type(builder).__cpp_name__
+            return form_dtype(form.content)
 
-            cpp_buffers_self.fill_offsets_and_flatten_4[builder_type](builder)
+    def empty_buffers(cpp_buffers_self, names_nbytes):
+        buffers = {}
+        for item in names_nbytes:
+            buffers[item.first] = ak.nplike.numpy.empty(item.second)
+            cpp_buffers_self.append(
+                item.first,
+                buffers[item.first].ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)),
+            )
+        return buffers
 
-        names_nbytes = cpp_buffers_self.names_nbytes[builder_type](builder)
-        buffers = empty_buffers(cpp_buffers_self, names_nbytes)
-        cpp_buffers_self.to_char_buffers[builder_type, data_type](builder)
+    # Register Take action for each column
+    # 'Take' is a lazy action:
+    result_ptrs = {}
+    column_types = {}
+    for col in columns:
+        column_types[col] = data_frame.GetColumnType(col)
+        result_ptrs[col] = data_frame.Take[column_types[col]](col)
 
-        array = ak._v2.from_buffers(
-            form,
-            builder.length(),
-            buffers,
-        )
-        return _wrap_as_record_array(array)
+    contents = {}
+    for col in columns:
+        col_type = column_types[col]
+        if ROOT.awkward.is_awkward_type[col_type]():  # Retrieve Awkward arrays
 
-    elif form_str == "awkward type":
+            # ROOT::RDF::RResultPtr<T>::begin Returns an iterator to the beginning of
+            # the contained object if this makes sense, throw a compilation error otherwise.
+            #
+            # Does not trigger event loop and execution of all actions booked in
+            # the associated RLoopManager.
+            lookup = result_ptrs[col].begin().lookup()
+            generator = lookup[col].generator
+            contents[col] = generator.tolayout(lookup, 0, ())
 
-        # ROOT::RDF::RResultPtr<T>::begin Returns an iterator to the beginning of
-        # the contained object if this makes sense, throw a compilation error otherwise.
-        #
-        # Does not trigger event loop and execution of all actions booked in
-        # the associated RLoopManager.
-        lookup = result_ptrs.begin().lookup()
-        generator = lookup[column].generator
-        layout = generator.tolayout(lookup[column], 0, ())
+        else:  # Convert the C++ vectors to Awkward arrays
+            form = ak._v2.forms.from_json(ROOT.awkward.type_to_form[col_type](0))
 
-        return _wrap_as_record_array(layout)
-    else:
-        raise ak._v2._util.error(NotImplementedError)
+            if not supported(form):
+                raise ak._v2._util.error(
+                    NotImplementedError,
+                    f"`from_rdataframe` doesn't support the {form} form yet.",
+                )
+
+            list_depth = form.purelist_depth
+
+            data_type = cpp_type_of[form_dtype(form).name]
+
+            # pull in the CppBuffers (after which we can import from it)
+            CppBuffers = cppyy.gbl.awkward.CppBuffers[col_type]
+            cpp_buffers_self = CppBuffers(result_ptrs[col])
+
+            if isinstance(form, ak._v2.forms.NumpyForm):
+
+                NumpyBuilder = cppyy.gbl.awkward.LayoutBuilder.Numpy[data_type]
+                builder = NumpyBuilder()
+                builder_type = type(builder).__cpp_name__
+
+                cpp_buffers_self.fill_from[builder_type, col_type](
+                    builder, result_ptrs[col]
+                )
+
+                names_nbytes = cpp_buffers_self.names_nbytes[builder_type](builder)
+                buffers = empty_buffers(cpp_buffers_self, names_nbytes)
+                cpp_buffers_self.to_char_buffers[builder_type](builder)
+
+            elif isinstance(form, ak._v2.forms.ListOffsetForm) and isinstance(
+                form.content, ak._v2.forms.NumpyForm
+            ):
+                # NOTE: list_depth == 2 or 1 if its the list of strings
+                ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
+                    "int64_t",
+                    f"awkward::LayoutBuilder::Numpy<{data_type}",
+                ]
+                builder = ListOffsetBuilder()
+                builder_type = type(builder).__cpp_name__
+
+                cpp_buffers_self.fill_offsets_and_flatten_2[builder_type](builder)
+
+            elif list_depth == 3:
+                ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
+                    "int64_t",
+                    f"awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::Numpy<{data_type}>",
+                ]
+                builder = ListOffsetBuilder()
+                builder_type = type(builder).__cpp_name__
+
+                cpp_buffers_self.fill_offsets_and_flatten_3[builder_type](builder)
+
+            else:
+                ListOffsetBuilder = cppyy.gbl.awkward.LayoutBuilder.ListOffset[
+                    "int64_t",
+                    f"awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::ListOffset<int64_t, awkward::LayoutBuilder::Numpy<{data_type}>>",
+                ]
+                builder = ListOffsetBuilder()
+                builder_type = type(builder).__cpp_name__
+
+                cpp_buffers_self.fill_offsets_and_flatten_4[builder_type](builder)
+
+            names_nbytes = cpp_buffers_self.names_nbytes[builder_type](builder)
+            buffers = empty_buffers(cpp_buffers_self, names_nbytes)
+            cpp_buffers_self.to_char_buffers[builder_type](builder)
+
+            array = ak._v2.from_buffers(
+                form,
+                builder.length(),
+                buffers,
+            )
+            contents[col] = array.layout
+
+    return ak._v2._util.wrap(
+        ak._v2.contents.RecordArray(list(contents.values()), list(contents.keys())),
+        highlevel=True,
+    )

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -195,12 +195,16 @@ def from_rdataframe(data_frame, columns):
                 builder = ListOffsetBuilder()
                 builder_type = type(builder).__cpp_name__
 
-                if not hasattr(cppyy.gbl, f"fill_offsets_and_flatten{list_depth}"):
-                    done = cppyy.cppdef(cpp_fill_function(list_depth))
+                if not hasattr(
+                    cppyy.gbl.awkward, f"fill_offsets_and_flatten{list_depth}"
+                ):
+                    done = cppyy.cppdef(
+                        "namespace awkward {" + cpp_fill_function(list_depth) + "}"
+                    )
                     assert done is True
 
                 fill_from_func = getattr(
-                    cppyy.gbl, f"fill_offsets_and_flatten{list_depth}"
+                    cppyy.gbl.awkward, f"fill_offsets_and_flatten{list_depth}"
                 )
                 fill_from_func[builder_type, col_type](builder, result_ptrs[col])
             else:

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -12,8 +12,12 @@ import os
 from awkward._v2.types.numpytype import primitive_to_dtype
 
 cpp_type_of = {
+    "float32": "float",
     "float64": "double",
+    "int32": "int32_t",
+    "uint32": "uint32_t",
     "int64": "int64_t",
+    "uint64": "uint64_t",
     "complex128": "std::complex<double>",
     "uint8": "uint8_t",
 }

--- a/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/from_rdataframe.py
@@ -55,14 +55,6 @@ assert done is True
 
 
 def from_rdataframe(data_frame, columns):
-    def supported(form):
-        if isinstance(form, ak._v2.forms.NumpyForm) and form.inner_shape == ():
-            return True
-        else:
-            return isinstance(form, ak._v2.forms.ListOffsetForm) and supported(
-                form.content
-            )
-
     def form_dtype(form):
         if isinstance(form, ak._v2.forms.NumpyForm) and form.inner_shape == ():
             return primitive_to_dtype(form.primitive)
@@ -168,15 +160,9 @@ def from_rdataframe(data_frame, columns):
         else:  # Convert the C++ vectors to Awkward arrays
             form = ak._v2.forms.from_json(ROOT.awkward.type_to_form[col_type](0))
 
-            if not supported(form):
-                raise ak._v2._util.error(
-                    NotImplementedError,
-                    f"`from_rdataframe` doesn't support the {form} form yet.",
-                )
-
             list_depth = form.purelist_depth
-
-            data_type = cpp_type_of[form_dtype(form).name]
+            form_dtype_name = form_dtype(form).name
+            data_type = cpp_type_of[form_dtype_name]
 
             # pull in the CppBuffers (after which we can import from it)
             CppBuffers = cppyy.gbl.awkward.CppBuffers[col_type]

--- a/src/awkward/_v2/_connect/rdataframe/to_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/to_rdataframe.py
@@ -256,6 +256,7 @@ namespace awkward {{
         }}
 
         void Initialise() {{
+            std::cout << "Initialise()" << std::endl;
             // initialize fEntryRanges
             const auto chunkSize = fSize / fNSlots;
             auto start = 0UL;
@@ -292,6 +293,7 @@ namespace awkward {{
         }}
 
         bool SetEntry(unsigned int slot, ULong64_t entry) {{
+            std::cout << "SetEntry " << slot << ": " << entry << std::endl;
             {cpp_code_entries}
             return true;
         }}

--- a/src/awkward/_v2/_connect/rdataframe/to_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/to_rdataframe.py
@@ -256,7 +256,6 @@ namespace awkward {{
         }}
 
         void Initialise() {{
-            std::cout << "Initialise()" << std::endl;
             // initialize fEntryRanges
             const auto chunkSize = fSize / fNSlots;
             auto start = 0UL;
@@ -293,7 +292,6 @@ namespace awkward {{
         }}
 
         bool SetEntry(unsigned int slot, ULong64_t entry) {{
-            std::cout << "SetEntry " << slot << ": " << entry << std::endl;
             {cpp_code_entries}
             return true;
         }}

--- a/src/awkward/_v2/_connect/rdataframe/to_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/to_rdataframe.py
@@ -314,6 +314,6 @@ namespace awkward {{
             (self.data_ptrs_list),
         )
 
-        rdf = rdf.Define("awkward_index_", "rdfentry_")
+        rdf = rdf.Define("awkward_index_", "(int64_t)rdfentry_")
 
         return rdf

--- a/src/awkward/_v2/_connect/rdataframe/to_rdataframe.py
+++ b/src/awkward/_v2/_connect/rdataframe/to_rdataframe.py
@@ -314,4 +314,6 @@ namespace awkward {{
             (self.data_ptrs_list),
         )
 
+        rdf = rdf.Define("awkward_index_", "rdfentry_")
+
         return rdf

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -1158,7 +1158,7 @@ namespace awkward {
           if (i != 0) {
             out << ", ";
           }
-          auto contents_form = [&out](auto& content) {
+          auto contents_form = [&out, &offset](auto& content) {
             out << content.form(offset);
           };
           visit_at(contents, i, contents_form);

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -155,9 +155,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const {
+      form(size_t offset = 0) const {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
 
         std::string params("");
         if (parameters_ == "") {
@@ -335,9 +335,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -345,7 +345,7 @@ namespace awkward {
         }
         return "{ \"class\": \"ListOffsetArray\", \"offsets\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
-               "\", \"content\": " + content_.form() + params +
+               "\", \"content\": " + content_.form(offset) + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -524,9 +524,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -535,7 +535,7 @@ namespace awkward {
         return "{ \"class\": \"ListArray\", \"starts\": \"" +
                type_to_numpy_like<PRIMITIVE>() + "\", \"stops\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
-               "\", \"content\": " + content_.form() + params +
+               "\", \"content\": " + content_.form(offset) + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -619,7 +619,7 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -721,9 +721,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -934,9 +934,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -953,7 +953,7 @@ namespace awkward {
                 << (!content_names_.empty() ? content_names_.at(content.index)
                                             : content.index_as_field())
                 << +"\": ";
-            out << content.builder.form();
+            out << content.builder.form(offset);
           };
           visit_at(contents, i, contents_form);
         }
@@ -1144,9 +1144,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -1159,7 +1159,7 @@ namespace awkward {
             out << ", ";
           }
           auto contents_form = [&out](auto& content) {
-            out << content.form();
+            out << content.form(offset);
           };
           visit_at(contents, i, contents_form);
         }
@@ -1321,16 +1321,16 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
           params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
         return "{ \"class\": \"RegularArray\", \"content\": " +
-               content_.form() + ", \"size\": " + std::to_string(size_) +
+               content_.form(offset) + ", \"size\": " + std::to_string(size_) +
                params + ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -1510,9 +1510,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -1520,7 +1520,7 @@ namespace awkward {
         }
         return "{ \"class\": \"IndexedArray\", \"index\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
-               "\", \"content\": " + content_.form() + params +
+               "\", \"content\": " + content_.form(offset) + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -1710,9 +1710,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -1720,7 +1720,7 @@ namespace awkward {
         }
         return "{ \"class\": \"IndexedOptionArray\", \"index\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
-               "\", \"content\": " + content_.form() + params +
+               "\", \"content\": " + content_.form(offset) + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -1854,16 +1854,16 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
           params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
         return "{ \"class\": \"UnmaskedArray\", \"content\": " +
-               content_.form() + params + ", \"form_key\": \"" +
+               content_.form(offset) + params + ", \"form_key\": \"" +
                form_key.str() + "\" }";
       }
 
@@ -2057,9 +2057,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key, form_valid_when;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         form_valid_when << std::boolalpha << valid_when_;
         std::string params("");
         if (parameters_ == "") {
@@ -2068,7 +2068,7 @@ namespace awkward {
         }
         return "{ \"class\": \"ByteMaskedArray\", \"mask\": \"i8\", "
                "\"content\": " +
-               content_.form() + ", \"valid_when\": " + form_valid_when.str() +
+               content_.form(offset) + ", \"valid_when\": " + form_valid_when.str() +
                params + ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -2310,9 +2310,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key, form_valid_when, form_lsb_order;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         form_valid_when << std::boolalpha << valid_when_;
         form_lsb_order << std::boolalpha << lsb_order_;
         std::string params("");
@@ -2322,7 +2322,7 @@ namespace awkward {
         }
         return "{ \"class\": \"BitMaskedArray\", \"mask\": \"u8\", "
                "\"content\": " +
-               content_.form() + ", \"valid_when\": " + form_valid_when.str() +
+               content_.form(offset) + ", \"valid_when\": " + form_valid_when.str() +
                ", \"lsb_order\": " + form_lsb_order.str() + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
@@ -2588,9 +2588,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form() const noexcept {
+      form(size_t offset = 0) const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_;
+        form_key << "node" << id_ + offset;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -2605,7 +2605,7 @@ namespace awkward {
             out << ", ";
           }
           auto contents_form = [&](auto& content) {
-            out << content.form();
+            out << content.form(offset);
           };
           visit_at(contents_, i, contents_form);
         }

--- a/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/_v2/cpp-headers/awkward/LayoutBuilder.h
@@ -155,9 +155,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const {
+      form() const {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
 
         std::string params("");
         if (parameters_ == "") {
@@ -335,9 +335,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -345,7 +345,7 @@ namespace awkward {
         }
         return "{ \"class\": \"ListOffsetArray\", \"offsets\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
-               "\", \"content\": " + content_.form(offset) + params +
+               "\", \"content\": " + content_.form() + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -524,9 +524,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -535,7 +535,7 @@ namespace awkward {
         return "{ \"class\": \"ListArray\", \"starts\": \"" +
                type_to_numpy_like<PRIMITIVE>() + "\", \"stops\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
-               "\", \"content\": " + content_.form(offset) + params +
+               "\", \"content\": " + content_.form() + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -619,7 +619,7 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -721,9 +721,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -934,9 +934,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -953,7 +953,7 @@ namespace awkward {
                 << (!content_names_.empty() ? content_names_.at(content.index)
                                             : content.index_as_field())
                 << +"\": ";
-            out << content.builder.form(offset);
+            out << content.builder.form();
           };
           visit_at(contents, i, contents_form);
         }
@@ -1144,9 +1144,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -1158,8 +1158,8 @@ namespace awkward {
           if (i != 0) {
             out << ", ";
           }
-          auto contents_form = [&out, &offset](auto& content) {
-            out << content.form(offset);
+          auto contents_form = [&out](auto& content) {
+            out << content.form();
           };
           visit_at(contents, i, contents_form);
         }
@@ -1321,16 +1321,16 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
           params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
         return "{ \"class\": \"RegularArray\", \"content\": " +
-               content_.form(offset) + ", \"size\": " + std::to_string(size_) +
+               content_.form() + ", \"size\": " + std::to_string(size_) +
                params + ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -1510,9 +1510,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -1520,7 +1520,7 @@ namespace awkward {
         }
         return "{ \"class\": \"IndexedArray\", \"index\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
-               "\", \"content\": " + content_.form(offset) + params +
+               "\", \"content\": " + content_.form() + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -1710,9 +1710,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -1720,7 +1720,7 @@ namespace awkward {
         }
         return "{ \"class\": \"IndexedOptionArray\", \"index\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
-               "\", \"content\": " + content_.form(offset) + params +
+               "\", \"content\": " + content_.form() + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -1854,16 +1854,16 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
           params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
         return "{ \"class\": \"UnmaskedArray\", \"content\": " +
-               content_.form(offset) + params + ", \"form_key\": \"" +
+               content_.form() + params + ", \"form_key\": \"" +
                form_key.str() + "\" }";
       }
 
@@ -2057,9 +2057,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key, form_valid_when;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         form_valid_when << std::boolalpha << valid_when_;
         std::string params("");
         if (parameters_ == "") {
@@ -2068,7 +2068,7 @@ namespace awkward {
         }
         return "{ \"class\": \"ByteMaskedArray\", \"mask\": \"i8\", "
                "\"content\": " +
-               content_.form(offset) + ", \"valid_when\": " + form_valid_when.str() +
+               content_.form() + ", \"valid_when\": " + form_valid_when.str() +
                params + ", \"form_key\": \"" + form_key.str() + "\" }";
       }
 
@@ -2310,9 +2310,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key, form_valid_when, form_lsb_order;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         form_valid_when << std::boolalpha << valid_when_;
         form_lsb_order << std::boolalpha << lsb_order_;
         std::string params("");
@@ -2322,7 +2322,7 @@ namespace awkward {
         }
         return "{ \"class\": \"BitMaskedArray\", \"mask\": \"u8\", "
                "\"content\": " +
-               content_.form(offset) + ", \"valid_when\": " + form_valid_when.str() +
+               content_.form() + ", \"valid_when\": " + form_valid_when.str() +
                ", \"lsb_order\": " + form_lsb_order.str() + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
       }
@@ -2588,9 +2588,9 @@ namespace awkward {
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
       std::string
-      form(size_t offset = 0) const noexcept {
+      form() const noexcept {
         std::stringstream form_key;
-        form_key << "node" << id_ + offset;
+        form_key << "node" << id_;
         std::string params("");
         if (parameters_ == "") {
         } else {
@@ -2605,7 +2605,7 @@ namespace awkward {
             out << ", ";
           }
           auto contents_form = [&](auto& content) {
-            out << content.form(offset);
+            out << content.form();
           };
           visit_at(contents_, i, contents_form);
         }

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -25,6 +25,14 @@ namespace awkward {
   /// is boolean.
   template <>
   const std::string
+  type_to_name<unsigned long>() {
+    return "uint64";
+  }
+
+  /// @brief Returns `bool` string when the primitive type
+  /// is boolean.
+  template <>
+  const std::string
   type_to_name<bool>() {
     return "bool";
   }

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -249,6 +249,13 @@ namespace awkward {
     return "unsupported type";
   }
 
+  /// @brief Check if an RDataFrame column is an Awkward Array.
+  template <typename T>
+  bool
+  is_awkward_type() {
+    return (std::string(typeid(T).name()).find("awkward") != std::string::npos);
+  }
+
   /// @class visit_impl
   ///
   /// @brief Class to index tuple at runtime.

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -17,15 +17,7 @@ namespace awkward {
   template <typename T>
   const std::string
   type_to_name() {
-    std::cout << "Type " << typeid(T).name() << " is not recognized." << std::endl;
-    return typeid(T).name();
-  }
-
-  /// @brief Returns `bool` string when the primitive type
-  /// is boolean.
-  template <>
-  const std::string
-  type_to_name<unsigned long>() {
+    std::cout << "Type " << typeid(T).name() << " is not recognized. Try uint64." << std::endl;
     return "uint64";
   }
 

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -18,7 +18,7 @@ namespace awkward {
   const std::string
   type_to_name() {
     std::cout << "Type " << typeid(T).name() << " is not recognized." << std::endl;
-    return "int64";
+    return typeid(T).name();
   }
 
   /// @brief Returns `bool` string when the primitive type

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -17,8 +17,8 @@ namespace awkward {
   template <typename T>
   const std::string
   type_to_name() {
-    std::cout << "Type " << typeid(T).name() << " is not recognized. Try uint64." << std::endl;
-    return "uint64";
+    std::cout << "Type " << typeid(T).name() << " is not recognized." << std::endl;
+    return "int64";
   }
 
   /// @brief Returns `bool` string when the primitive type

--- a/src/awkward/_v2/cpp-headers/awkward/utils.h
+++ b/src/awkward/_v2/cpp-headers/awkward/utils.h
@@ -1,7 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#ifndef AWKWARD_UTILS_H_
-#define AWKWARD_UTILS_H_
+#ifndef AWKWARD_CPP_HEADERS_UTILS_H_
+#define AWKWARD_CPP_HEADERS_UTILS_H_
 
 #include <iterator>
 #include <complex>
@@ -17,6 +17,7 @@ namespace awkward {
   template <typename T>
   const std::string
   type_to_name() {
+    std::cout << "Type " << typeid(T).name() << " is not recognized." << std::endl;
     return typeid(T).name();
   }
 
@@ -306,4 +307,4 @@ namespace awkward {
 
 }  // namespace awkward
 
-#endif  // AWKWARD_UTILS_H_
+#endif  // AWKWARD_CPP_HEADERS_UTILS_H_

--- a/src/awkward/_v2/cpp-headers/rdataframe/jagged_builders.h
+++ b/src/awkward/_v2/cpp-headers/rdataframe/jagged_builders.h
@@ -47,22 +47,8 @@ namespace awkward {
     template<class BUILDER, typename PRIMITIVE>
     void
     fill_from(BUILDER& builder, ROOT::RDF::RResultPtr<std::vector<PRIMITIVE>>& result) const {
-      std::cout << "fill_from " << std::endl;
       for (auto it : result) {
         builder.append(it);
-      }
-    }
-
-    template<class BUILDER1, typename PRIMITIVE1, class BUILDER2, typename PRIMITIVE2>
-    void
-    fill_from_2(BUILDER1& builder1, ROOT::RDF::RResultPtr<std::vector<PRIMITIVE1>>& result1,
-      BUILDER2& builder2, ROOT::RDF::RResultPtr<std::vector<PRIMITIVE2>>& result2) const {
-      std::cout << "fill_from 2 " << std::endl;
-      for (auto it : result1) {
-        builder1.append(it);
-      }
-      for (auto it : result2) {
-        builder2.append(it);
       }
     }
 
@@ -70,71 +56,6 @@ namespace awkward {
     void
     to_char_buffers(BUILDER& builder) {
       builder.to_char_buffers(buffers_uint8_ptr_);
-    }
-
-    template<class BUILDER>
-    void
-    fill_offsets_and_flatten_2(BUILDER& builder) const {
-      for (auto const& vec : result_) {
-        auto& subbuilder = builder.begin_list();
-        for (auto it : vec) {
-          subbuilder.append(it);
-        }
-        builder.end_list();
-      }
-    }
-
-    template<class BUILDER>
-    void
-    fill_offsets_and_flatten_3(BUILDER& builder) const {
-      for (auto const& vec_of_vecs : result_) {
-        auto& builder1 = builder.begin_list();
-        for (auto const& vec : vec_of_vecs) {
-          auto& builder2 = builder1.begin_list();
-          for (auto it : vec) {
-            builder2.append(it);
-          }
-          builder1.end_list();
-        }
-        builder.end_list();
-      }
-    }
-
-    template<class BUILDER>
-    void
-    fill_offsets_and_flatten_4(BUILDER& builder) const {
-      for (auto const& vec_of_vecs_of_vecs : result_) {
-        auto& builder1 = builder.begin_list();
-        for (auto const& vec_of_vecs : vec_of_vecs_of_vecs) {
-          auto& builder2 = builder1.begin_list();
-          for (auto const& vec : vec_of_vecs) {
-            auto& builder3 = builder2.begin_list();
-            for (auto it : vec) {
-              builder3.append(it);
-            }
-            builder2.end_list();
-          }
-          builder1.end_list();
-        }
-        builder.end_list();
-      }
-    }
-
-    template<class BUILDER, typename ITERABLE>
-    void
-    recurse_fill_from(int64_t level, BUILDER& builder, ITERABLE& result) const {
-      if (level == 0) {
-        for (auto it : result) {
-          builder.append(it);
-        }
-      }
-      else {
-        auto& next_builder = builder.begin_list();
-        for (auto& it : result) {
-          recurse_fill_from(level - 1, next_builder, it);
-        }
-        next_builder.end_list();
-      }
     }
 
   private:

--- a/src/awkward/_v2/cpp-headers/rdataframe/jagged_builders.h
+++ b/src/awkward/_v2/cpp-headers/rdataframe/jagged_builders.h
@@ -44,15 +44,29 @@ namespace awkward {
       std::cout << std::endl;
     }
 
-    template<class BUILDER>
+    template<class BUILDER, typename PRIMITIVE>
     void
-    fill_from(BUILDER& builder) const {
-      for (auto it : result_) {
+    fill_from(BUILDER& builder, ROOT::RDF::RResultPtr<std::vector<PRIMITIVE>>& result) const {
+      std::cout << "fill_from " << std::endl;
+      for (auto it : result) {
         builder.append(it);
       }
     }
 
-    template<class BUILDER, class PRIMITIVE>
+    template<class BUILDER1, typename PRIMITIVE1, class BUILDER2, typename PRIMITIVE2>
+    void
+    fill_from_2(BUILDER1& builder1, ROOT::RDF::RResultPtr<std::vector<PRIMITIVE1>>& result1,
+      BUILDER2& builder2, ROOT::RDF::RResultPtr<std::vector<PRIMITIVE2>>& result2) const {
+      std::cout << "fill_from 2 " << std::endl;
+      for (auto it : result1) {
+        builder1.append(it);
+      }
+      for (auto it : result2) {
+        builder2.append(it);
+      }
+    }
+
+    template<class BUILDER>
     void
     to_char_buffers(BUILDER& builder) {
       builder.to_char_buffers(buffers_uint8_ptr_);

--- a/src/awkward/_v2/operations/ak_from_rdataframe.py
+++ b/src/awkward/_v2/operations/ak_from_rdataframe.py
@@ -3,12 +3,12 @@
 import awkward as ak
 
 
-def from_rdataframe(data_frame, column):
+def from_rdataframe(data_frame, columns):
     """
     Args:
         data_frame (`ROOT.RDataFrame`): ROOT RDataFrame to convert into an
              Awkward Array.
-         column (str): A column to be converted to Awkward Array.
+         columns (str or tuple of str): A column or multiple columns to be converted to Awkward Array.
 
      Converts ROOT Data Frame columns into an Awkward Array.
 
@@ -18,22 +18,22 @@ def from_rdataframe(data_frame, column):
         "ak._v2.from_rdataframe",
         dict(
             data_frame=data_frame,
-            column=column,
+            columns=columns,
         ),
     ):
         return _impl(
             data_frame,
-            column,
+            columns,
         )
 
 
 def _impl(
     data_frame,
-    column,
+    columns,
 ):
     import awkward._v2._connect.rdataframe.from_rdataframe  # noqa: F401
 
     return ak._v2._connect.rdataframe.from_rdataframe.from_rdataframe(
         data_frame,
-        column,
+        columns,
     )

--- a/tests/v2/test_1374-to-rdataframe.py
+++ b/tests/v2/test_1374-to-rdataframe.py
@@ -26,7 +26,7 @@ def test_two_columns():
     data_frame = ak._v2.to_rdataframe(
         {"x": ak_array_1, "y": ak_array_2}, flatlist_as_rvec=True
     )
-    assert set(data_frame.GetColumnNames()) == {"x", "y"}
+    assert set(data_frame.GetColumnNames()) == {"x", "y", "awkward_index_"}
     assert data_frame.GetColumnType("x") == "ROOT::VecOps::RVec<int64_t>"
     assert data_frame.GetColumnType("y").startswith("awkward::ListArray_")
 
@@ -38,7 +38,7 @@ def test_two_columns_as_rvecs():
     )
 
     data_frame = ak._v2.to_rdataframe({"x": ak_array_1, "y": ak_array_2})
-    assert set(data_frame.GetColumnNames()) == {"x", "y"}
+    assert set(data_frame.GetColumnNames()) == {"x", "y", "awkward_index_"}
     assert data_frame.GetColumnType("x") == "double"
     assert data_frame.GetColumnType("y").startswith("awkward::Record_")
 
@@ -120,7 +120,7 @@ def test_two_columns_as_vecs():
     data_frame = ak._v2.operations.to_rdataframe(
         {"x": ak_array_1, "y": ak_array_2}, flatlist_as_rvec=False
     )
-    assert set(data_frame.GetColumnNames()) == {"x", "y"}
+    assert set(data_frame.GetColumnNames()) == {"x", "y", "awkward_index_"}
     assert data_frame.GetColumnType("x") == "double"
     assert data_frame.GetColumnType("y").startswith("awkward::Record_")
 
@@ -166,7 +166,7 @@ def test_two_columns_transform_filter():
     )
 
     data_frame = ak._v2.to_rdataframe({"one": example1, "two": example2})
-    assert set(data_frame.GetColumnNames()) == {"one", "two"}
+    assert set(data_frame.GetColumnNames()) == {"one", "two", "awkward_index_"}
 
     compiler(
         """
@@ -181,7 +181,12 @@ ROOT::RDF::RNode MyTransformation(ROOT::RDF::RNode df) {
     data_frame_transformed = ROOT.MyTransformation[data_frame.GetColumnType("one")](
         ROOT.RDF.AsRNode(data_frame)
     )
-    assert set(data_frame_transformed.GetColumnNames()) == {"neg_one", "one", "two"}
+    assert set(data_frame_transformed.GetColumnNames()) == {
+        "neg_one",
+        "one",
+        "two",
+        "awkward_index_",
+    }
     assert data_frame_transformed.Count().GetValue() == 5
 
     data_frame2 = data_frame.Filter("one > 2.5")
@@ -194,9 +199,9 @@ ROOT::RDF::RNode MyTransformation(ROOT::RDF::RNode df) {
 def test_jims_example1():
     array = ak._v2.Array([{"x": 1.1}, {"x": 2.2}, {"x": 3.3}, {"x": 4.4}, {"x": 5.5}])
     data_frame = ak._v2.to_rdataframe({"some_array": array})
-    assert set(data_frame.GetColumnNames()) == {"some_array"}
+    assert set(data_frame.GetColumnNames()) == {"some_array", "awkward_index_"}
     data_frame_y = data_frame.Define("y", "some_array.x()")
-    assert set(data_frame_y.GetColumnNames()) == {"some_array", "y"}
+    assert set(data_frame_y.GetColumnNames()) == {"some_array", "y", "awkward_index_"}
 
     cpp_list = ", ".join(str(e) for e in array.x.to_list())
 

--- a/tests/v2/test_1473-from-rdataframe.py
+++ b/tests/v2/test_1473-from-rdataframe.py
@@ -41,7 +41,7 @@ def test_to_from_data_frame_large():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert len(ak_array_in) == len(ak_array_out)
 
@@ -56,7 +56,7 @@ def test_data_frame_boolean():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out.to_list()
 
@@ -70,7 +70,7 @@ def test_data_frame_integers():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -84,7 +84,7 @@ def test_data_frame_real():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -100,7 +100,7 @@ def test_data_frame_complex():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -114,7 +114,7 @@ def test_data_frame_strings():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -128,7 +128,7 @@ def test_data_frame_vec_of_integers():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -142,7 +142,7 @@ def test_data_frame_vec_of_real():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -158,7 +158,7 @@ def test_data_frame_vec_of_complex():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -172,7 +172,7 @@ def test_data_frame_vec_of_strings():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -186,7 +186,7 @@ def test_data_frame_vec_of_vec_of_integers():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -200,7 +200,7 @@ def test_data_frame_vec_of_vec_of_real():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -216,7 +216,7 @@ def test_data_frame_vec_of_vec_of_complex():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -227,13 +227,13 @@ def test_rdata_frame_vecs_as_records():
 
     ak_array_x = ak._v2.from_rdataframe(
         data_frame_xy,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_x["x"].layout.form == ak._v2.forms.NumpyForm("float64")
 
     ak_record_array_x = ak._v2.from_rdataframe(
         data_frame_xy,
-        column="x",
+        columns=("x",),
     )
     assert ak_record_array_x.layout.form == ak._v2.forms.RecordForm(
         [ak._v2.forms.NumpyForm("float64")], "x"
@@ -241,7 +241,7 @@ def test_rdata_frame_vecs_as_records():
 
     ak_record_array_y = ak._v2.from_rdataframe(
         data_frame_xy,
-        column="y",
+        columns=("y",),
     )
     ak_array = ak._v2.zip([ak_record_array_x, ak_record_array_y])
     assert ak_array.layout.form == ak._v2.forms.RecordForm(
@@ -259,7 +259,7 @@ def test_rdata_frame_vecs_of_complex():
 
     ak_array_y = ak._v2.from_rdataframe(
         data_frame_xy,
-        column="y",
+        columns=("y",),
     )
     assert ak_array_y["y"].layout.form == ak._v2.forms.NumpyForm("complex128")
 
@@ -285,7 +285,7 @@ def test_rdata_frame_rvecs_as_records():
 
     array = ak._v2.from_rdataframe(
         data_frame_x_y_r,
-        column="r",
+        columns=("r",),
     )
 
     assert array.layout.form == ak._v2.forms.RecordForm(
@@ -303,7 +303,7 @@ def test_to_from_data_frame():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_out["x"].layout.content.is_contiguous is True
 
@@ -318,7 +318,7 @@ def test_to_from_data_frame_rvec_of_rvec():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
 
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
@@ -333,7 +333,7 @@ def test_to_from_data_frame_rvec_of_rvec_of_rvec():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
 
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()

--- a/tests/v2/test_1508-awkward-from-rdataframe.py
+++ b/tests/v2/test_1508-awkward-from-rdataframe.py
@@ -37,7 +37,7 @@ def test_refcount():
 
     array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert array.to_list() == array_out["x"].to_list()
 
@@ -122,7 +122,7 @@ def test_data_frame_vec_of_vec_of_integers():
 
     ak_array_out = ak._v2.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 

--- a/tests/v2/test_1613-generator-tolayout-records.py
+++ b/tests/v2/test_1613-generator-tolayout-records.py
@@ -334,6 +334,6 @@ def test_data_frame_from_json():
     data_frame = ak._v2.to_rdataframe({"variants": array})
     out = ak._v2.from_rdataframe(
         data_frame,
-        column="variants",
+        columns=("variants",),
     )
     assert array.to_list() == out["variants"].to_list()

--- a/tests/v2/test_1620-layout-builders.py
+++ b/tests/v2/test_1620-layout-builders.py
@@ -20,7 +20,7 @@ def test_data_frame_integers():
 
     ak_array_out = ak.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -34,7 +34,7 @@ def test_data_frame_double():
 
     ak_array_out = ak.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -48,7 +48,7 @@ def test_data_frame_char():
 
     ak_array_out = ak.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -62,7 +62,7 @@ def test_data_frame_complex():
 
     ak_array_out = ak.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -76,7 +76,7 @@ def test_data_frame_listoffset_integers():
 
     ak_array_out = ak.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -97,7 +97,7 @@ def test_data_frame_listoffset_listoffset_double():
 
     ak_array_out = ak.from_rdataframe(
         data_frame,
-        column="x",
+        columns=("x",),
     )
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
 
@@ -141,7 +141,7 @@ def test_data_frame_vec_of_vec():
     assert rdf3.GetColumnType("output") == "vector<vector<double> >"
     out = ak.from_rdataframe(
         rdf3,
-        column="output",
+        columns=("output",),
     )
     assert out["output"].to_list() == (array["y"] * array["y"] * 1.0).to_list()
 
@@ -172,7 +172,7 @@ def test_data_frame_vec_of_vec():
     assert rdf3.GetColumnType("output2") == "vector<vector<vector<double> > >"
     out = ak.from_rdataframe(  # noqa: F841
         rdf3,
-        column="output2",
+        columns=("output2",),
     )
     result = ak.Array(
         [

--- a/tests/v2/test_1625-multiple-columns-from-rdataframe.py
+++ b/tests/v2/test_1625-multiple-columns-from-rdataframe.py
@@ -1,0 +1,114 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward._v2 as ak  # noqa: F401
+
+
+ROOT = pytest.importorskip("ROOT")
+
+
+compiler = ROOT.gInterpreter.Declare
+
+
+def test_data_frame_vec_of_vec():
+    array = ak.Array(
+        [
+            [
+                {"x": 1.1, "y": [1]},
+                {"x": None, "y": [1, 2]},
+                {"x": 3.3, "y": [1, 2, 3]},
+            ],
+            [],
+            [{"x": None, "y": [1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}],
+        ]
+    )
+    # ] * 10000)
+
+    rdf2 = ak.to_rdataframe({"array": array})
+    # We create a matrix RxC here
+    # Note when dimensions R and C are large, the following code suffers
+    # from potential performance penalties caused by frequent reallocation
+    # of memory by the push_back() function. This should be used only when
+    # vector dimensions are not known in advance.
+    rdf3 = rdf2.Define(
+        "output",
+        """
+    std::vector<std::vector<double>> tmp1;
+
+    for (auto record : array) {
+        std::vector<double> tmp2;
+        for (auto number : record.y()) {
+            tmp2.push_back(number * number);
+        }
+        tmp1.push_back(tmp2);
+    }
+    return tmp1;
+    """,
+    )
+
+    assert rdf3.GetColumnType("output") == "vector<vector<double> >"
+
+    rdf3 = rdf2.Define(
+        "output2",
+        """
+    std::vector<std::vector<std::vector<double>>> tmp1;
+
+    for (auto record : array) {
+        std::vector<std::vector<double>> tmp2;
+        // we can check if it's None:
+        // if (record.x().has_value())
+        // or set it to 1 so that we do not scale:
+        double x_number = record.x().value_or(1);
+        for (auto number : record.y()) {
+            std::vector<double> tmp3;
+            for (int64_t i = 0; i < std::rint(x_number); i++) {
+                double value = x_number * number;
+                tmp3.push_back(value);
+            }
+            tmp2.push_back(tmp3);
+        }
+        tmp1.push_back(tmp2);
+    }
+    return tmp1;
+    """,
+    )
+    assert rdf3.GetColumnType("output2") == "vector<vector<vector<double> > >"
+    out = ak.from_rdataframe(  # noqa: F841
+        rdf3,
+        column=("output2", "output"),
+    )
+    assert out["output"].to_list() == (array["y"] * array["y"] * 1.0).to_list()
+    result = ak.Array(
+        [
+            [
+                [[1.1]],  # "x" is 1 - "y" values are unchanged, and each is nesed
+                [
+                    [1.0],
+                    [2.0],
+                ],  # "x" is None - "y" values are unchanged, and each is nesed
+                [
+                    [3.3, 3.3, 3.3],
+                    [6.6, 6.6, 6.6],
+                    [9.899999999999999, 9.899999999999999, 9.899999999999999],
+                ],  # "x" is 3.3 - "y" values are scaled by 3.3 and each is nesed 3 times
+            ],
+            [],
+            [
+                [
+                    [1.0],
+                    [2.0],
+                    [3.0],
+                    [4.0],
+                ],  # "x" is None - "y" values are unchanged, and each is nesed
+                [
+                    [5.5, 5.5, 5.5, 5.5, 5.5, 5.5],
+                    [11.0, 11.0, 11.0, 11.0, 11.0, 11.0],
+                    [16.5, 16.5, 16.5, 16.5, 16.5, 16.5],
+                    [22.0, 22.0, 22.0, 22.0, 22.0, 22.0],
+                    [27.5, 27.5, 27.5, 27.5, 27.5, 27.5],
+                ],  # "x" is 5.5 - "y" values are scaled by 5.5 and each is nesed 5 times
+            ],
+        ]
+    )
+    assert out["output2"].to_list() == result.to_list()

--- a/tests/v2/test_1625-multiple-columns-from-rdataframe.py
+++ b/tests/v2/test_1625-multiple-columns-from-rdataframe.py
@@ -178,21 +178,21 @@ def test_rdata_frame_rvecs_as_records():
         ),
     )
 
-    assert array["x"].layout.form == ak._v2.forms.ListOffsetForm(
-        "i64", ak._v2.forms.NumpyForm("float64")
+    assert array["x"].layout.form == ak.forms.ListOffsetForm(
+        "i64", ak.forms.NumpyForm("float64")
     )
-    assert array["y"].layout.form == ak._v2.forms.ListOffsetForm(
-        "i64", ak._v2.forms.NumpyForm("float64")
+    assert array["y"].layout.form == ak.forms.ListOffsetForm(
+        "i64", ak.forms.NumpyForm("float64")
     )
-    assert array["r"].layout.form == ak._v2.forms.ListOffsetForm(
-        "i64", ak._v2.forms.NumpyForm("float64")
+    assert array["r"].layout.form == ak.forms.ListOffsetForm(
+        "i64", ak.forms.NumpyForm("float64")
     )
 
-    assert array.layout.form == ak._v2.forms.RecordForm(
+    assert array.layout.form == ak.forms.RecordForm(
         [
-            ak._v2.forms.ListOffsetForm("i64", ak._v2.forms.NumpyForm("float64")),
-            ak._v2.forms.ListOffsetForm("i64", ak._v2.forms.NumpyForm("float64")),
-            ak._v2.forms.ListOffsetForm("i64", ak._v2.forms.NumpyForm("float64")),
+            ak.forms.ListOffsetForm("i64", ak.forms.NumpyForm("float64")),
+            ak.forms.ListOffsetForm("i64", ak.forms.NumpyForm("float64")),
+            ak.forms.ListOffsetForm("i64", ak.forms.NumpyForm("float64")),
         ],
         [
             "x",


### PR DESCRIPTION
Currently `from_rdataframe` function converts a selected column to a native Awkward Array. This function pulls one column at a time: this simplifies the interface and Awkward Arrays can be inexpensively joined with awkward `zip`.
This PR is extending this API as the users requested not to trigger RDF event loop multiple times.

- [x] Proposed change to `ak.from_rdataframe`:
from:
```python
out = ak.from_rdataframe(
    rdf,
    column="x",
)
```
to:
```python
out = ak.from_rdataframe(
    rdf,
    columns=("x", "y",),
)
```
- [x] Implement handling multiple columns in `jagged_builders`, generalise for any depth using a recursive function
- [x] Add tests