### PR TITLE
ci: run semantic-pr-title in concurrency group

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -8,6 +8,10 @@ on:
       - synchronize
   workflow_dispatch:
 
+concurrency:
+  group: semantic-pr-title-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
The semantic-pr-title workflow does not currently run in a concurrency group. This means that subsequent pushes do not cancel in-progress actions. The following PR fixes this.