### PR TITLE
perf: `ak.concatenate` should flatten for first axis, single-array

### DIFF
--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -1200,21 +1200,3 @@ def to_arraylib(module, array, allow_missing):
         raise ak._v2._util.error(
             ValueError(f"{module.__name__} is not supported by to_arraylib")
         )
-
-
-def is_numpy_buffer(array):
-    import numpy as np
-
-    return isinstance(array, np.ndarray)
-
-
-def is_cupy_buffer(array):
-    return type(array).__module__.startswith("cupy.")
-
-
-def is_jax_buffer(array):
-    return type(array).__module__.startswith("jaxlib.")
-
-
-def is_jax_tracer(tracer):
-    return type(tracer).__module__.startswith("jax.")

--- a/src/awkward/_v2/index.py
+++ b/src/awkward/_v2/index.py
@@ -160,12 +160,12 @@ class Index:
 
     def __getitem__(self, where):
         out = self._data[where]
-        from awkward.nplike import is_jax_buffer
-        from awkward.nplike import is_cupy_buffer
 
         if hasattr(out, "shape") and len(out.shape) != 0:
             return Index(out, metadata=self.metadata, nplike=self.nplike)
-        elif (is_jax_buffer(out) or is_cupy_buffer(out)) and len(out.shape) == 0:
+        elif (ak.nplike.is_jax_buffer(out) or ak.nplike.is_cupy_buffer(out)) and len(
+            out.shape
+        ) == 0:
             return out.item()
         else:
             return out

--- a/src/awkward/_v2/index.py
+++ b/src/awkward/_v2/index.py
@@ -160,7 +160,8 @@ class Index:
 
     def __getitem__(self, where):
         out = self._data[where]
-        from awkward._v2._util import is_cupy_buffer, is_jax_buffer
+        from awkward.nplike import is_jax_buffer
+        from awkward.nplike import is_cupy_buffer
 
         if hasattr(out, "shape") and len(out.shape) != 0:
             return Index(out, metadata=self.metadata, nplike=self.nplike)

--- a/src/awkward/_v2/operations/ak_to_layout.py
+++ b/src/awkward/_v2/operations/ak_to_layout.py
@@ -85,13 +85,21 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif (
-        type(array).__module__.startswith("cupy.") and type(array).__name__ == "ndarray"
-    ):
+    elif ak.nplike.is_cupy_buffer(array) and type(array).__name__ == "ndarray":
         if not issubclass(array.dtype.type, numpytype):
             raise ak._v2._util.error(ValueError(f"dtype {array.dtype!r} not allowed"))
         return _impl(
             ak._v2.operations.from_cupy(array, regulararray=True, highlevel=False),
+            allow_record,
+            allow_other,
+            numpytype,
+        )
+
+    elif ak.nplike.is_jax_buffer(array) and type(array).__name__ == "DeviceArray":
+        if not issubclass(array.dtype.type, numpytype):
+            raise ak._v2._util.error(ValueError(f"dtype {array.dtype!r} not allowed"))
+        return _impl(
+            ak._v2.operations.from_jax(array, regulararray=True, highlevel=False),
             allow_record,
             allow_other,
             numpytype,

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -18,7 +18,6 @@ def of(*arrays):
         if nplike is not None:
             nplikes.add(nplike)
         else:
-            from awkward._v2._util import is_numpy_buffer, is_cupy_buffer, is_jax_buffer
 
             if is_numpy_buffer(array):
                 nplikes.add(ak.nplike.Numpy.instance())
@@ -411,7 +410,6 @@ class NumpyKernel:
     @staticmethod
     def _cast(x, t):
         if issubclass(t, ctypes._Pointer):
-            from awkward._v2._util import is_numpy_buffer, is_cupy_buffer, is_jax_buffer
 
             if is_numpy_buffer(x):
                 return ctypes.cast(x.ctypes.data, t)
@@ -432,8 +430,6 @@ class NumpyKernel:
 
     def __call__(self, *args):
         assert len(args) == len(self._kernel.argtypes)
-
-        from awkward._v2._util import is_jax_tracer
 
         if not any(is_jax_tracer(arg) for arg in args):
             return self._kernel(
@@ -902,3 +898,21 @@ class Jax(NumpyLike):
     def argmax(self, *args, **kwargs):
         out = self._module.argmax(*args, **kwargs)
         return out
+
+
+def is_numpy_buffer(array):
+    import numpy as np
+
+    return isinstance(array, np.ndarray)
+
+
+def is_cupy_buffer(array):
+    return type(array).__module__.startswith("cupy.")
+
+
+def is_jax_buffer(array):
+    return type(array).__module__.startswith("jaxlib.")
+
+
+def is_jax_tracer(tracer):
+    return type(tracer).__module__.startswith("jax.")

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -17,14 +17,12 @@ def of(*arrays):
         nplike = getattr(array, "nplike", None)
         if nplike is not None:
             nplikes.add(nplike)
-        else:
-
-            if is_numpy_buffer(array):
-                nplikes.add(ak.nplike.Numpy.instance())
-            elif is_cupy_buffer(array):
-                nplikes.add(ak.nplike.Cupy.instance())
-            elif is_jax_buffer(array):
-                nplikes.add(ak.nplike.Jax.instance())
+        elif is_numpy_buffer(array):
+            nplikes.add(ak.nplike.Numpy.instance())
+        elif is_cupy_buffer(array):
+            nplikes.add(ak.nplike.Cupy.instance())
+        elif is_jax_buffer(array):
+            nplikes.add(ak.nplike.Jax.instance())
 
     if any(isinstance(x, ak._v2._typetracer.TypeTracer) for x in nplikes):
         return ak._v2._typetracer.TypeTracer.instance()

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -884,6 +884,15 @@ def is_jax_tracer(tracer):
 
 
 def of(*arrays, default_cls=Numpy):
+    """
+    Args:
+        *arrays: iterable of possible array objects
+        default_cls: default NumpyLike class if no array objects found
+
+    Return the #ak.nplike.NumpyLike that is best-suited to operating upon the given
+    iterable of arrays. Return an instance of the `default_cls` if no known array types
+    are found.
+    """
     nplikes = set()
     for array in arrays:
         nplike = getattr(array, "nplike", None)

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -866,9 +866,7 @@ class Jax(NumpyLike):
 
 
 def is_numpy_buffer(array):
-    import numpy as np
-
-    return isinstance(array, np.ndarray)
+    return isinstance(array, numpy.ndarray)
 
 
 def is_cupy_buffer(array):

--- a/tests/v2/test_1049-concatenate-single-array.py
+++ b/tests/v2/test_1049-concatenate-single-array.py
@@ -1,0 +1,50 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import awkward as ak  # noqa: F401
+import numpy as np
+
+
+def test_single_numpy_array():
+    array = np.arange(4 * 3 * 2).reshape(4, 3, 2)
+    result = ak._v2.to_numpy(ak._v2.concatenate(array))
+    assert result.tolist() == [
+        [0, 1],
+        [2, 3],
+        [4, 5],
+        [6, 7],
+        [8, 9],
+        [10, 11],
+        [12, 13],
+        [14, 15],
+        [16, 17],
+        [18, 19],
+        [20, 21],
+        [22, 23],
+    ]
+
+
+def test_single_awkward_array():
+    array = ak._v2.from_iter([[1, 2, 3], [4, 5, 6, 7], [8, 9]])
+    result = ak._v2.concatenate(array)
+    assert result.tolist() == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+def test_single_jax_array():
+    jnp = pytest.importorskip("jax.numpy")
+    array = jnp.arange(4 * 3 * 2).reshape(4, 3, 2)
+    result = ak._v2.concatenate(array)
+    assert result.tolist() == [
+        [0, 1],
+        [2, 3],
+        [4, 5],
+        [6, 7],
+        [8, 9],
+        [10, 11],
+        [12, 13],
+        [14, 15],
+        [16, 17],
+        [18, 19],
+        [20, 21],
+        [22, 23],
+    ]


### PR DESCRIPTION
This PR does the following:
- move `is_XXX_buffer` to `awkward.nplike`
- add case for Jax arrays to `to_layout`
- allow caller to specify fallback `NumpyLike` if `ak.nplike.of` does not find an array

During the development of this PR, I noticed that we seem to allow records to be passed to `ak.concatenate`. Is this intentional? It doesn't seem right to me, but I've not looked at this code in a while.

We can't test that this is faster than `ak.concatenate(list(array))`, but that seems reasonable.

I might add logic to check for array dimension correctness in `ak.concatenate` rather than delegating this to `ak.flatten`. Additionally, in its present form, I chose to treat this as a fast-path rather than an exclusive case, so I'm using an early return rather than `if: else:`.

Fixes #1049