### PR TITLE
fix: ak.from_iter should interpret top-level tuples as ak.Array (v1 and v2).

### DIFF
--- a/src/awkward/_v2/operations/ak_from_iter.py
+++ b/src/awkward/_v2/operations/ak_from_iter.py
@@ -82,6 +82,9 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
                 )
             )
 
+    if isinstance(iterable, tuple):
+        iterable = list(iterable)
+
     builder = ak.layout.ArrayBuilder(initial=initial, resize=resize)
     builder.fromiter(iterable)
 

--- a/src/awkward/operations/convert.py
+++ b/src/awkward/operations/convert.py
@@ -886,6 +886,9 @@ def from_iter(
                 + ak._util.exception_suffix(__file__)
             )
 
+    if isinstance(iterable, tuple):
+        iterable = list(iterable)
+
     out = ak.layout.ArrayBuilder(initial=initial, resize=resize)
     out.fromiter(iterable)
     return ak._util.maybe_wrap(out[0], behavior, highlevel)

--- a/tests/test_1642-from_iter-of-tuples.py
+++ b/tests/test_1642-from_iter-of-tuples.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    assert isinstance(ak._v2.from_iter((1, 2, 3)), ak._v2.Array)
+    assert ak._v2.from_iter((1, 2, 3)).tolist() == [1, 2, 3]
+    assert ak._v2.Array((1, 2, 3)).tolist() == [1, 2, 3]
+    with pytest.raises(TypeError):
+        ak._v2.Record((1, 2, 3))
+    with pytest.raises(TypeError):
+        ak._v2.Record([1, 2, 3])
+
+    assert isinstance(ak._v2.from_iter({"one": 1, "two": 2}), ak._v2.Record)
+    assert ak._v2.from_iter({"one": 1, "two": 2}).tolist() == {"one": 1, "two": 2}
+    with pytest.raises(TypeError):
+        ak._v2.Array({"one": 1, "two": 2})
+    assert ak._v2.Record({"one": 1, "two": 2}).tolist() == {"one": 1, "two": 2}

--- a/tests/test_1642-from_iter-of-tuples.py
+++ b/tests/test_1642-from_iter-of-tuples.py
@@ -6,16 +6,16 @@ import awkward as ak  # noqa: F401
 
 
 def test():
-    assert isinstance(ak._v2.from_iter((1, 2, 3)), ak._v2.Array)
-    assert ak._v2.from_iter((1, 2, 3)).tolist() == [1, 2, 3]
-    assert ak._v2.Array((1, 2, 3)).tolist() == [1, 2, 3]
+    assert isinstance(ak.from_iter((1, 2, 3)), ak.Array)
+    assert ak.from_iter((1, 2, 3)).tolist() == [1, 2, 3]
+    assert ak.Array((1, 2, 3)).tolist() == [1, 2, 3]
     with pytest.raises(TypeError):
-        ak._v2.Record((1, 2, 3))
+        ak.Record((1, 2, 3))
     with pytest.raises(TypeError):
-        ak._v2.Record([1, 2, 3])
+        ak.Record([1, 2, 3])
 
-    assert isinstance(ak._v2.from_iter({"one": 1, "two": 2}), ak._v2.Record)
-    assert ak._v2.from_iter({"one": 1, "two": 2}).tolist() == {"one": 1, "two": 2}
+    assert isinstance(ak.from_iter({"one": 1, "two": 2}), ak.Record)
+    assert ak.from_iter({"one": 1, "two": 2}).tolist() == {"one": 1, "two": 2}
     with pytest.raises(TypeError):
-        ak._v2.Array({"one": 1, "two": 2})
-    assert ak._v2.Record({"one": 1, "two": 2}).tolist() == {"one": 1, "two": 2}
+        ak.Array({"one": 1, "two": 2})
+    assert ak.Record({"one": 1, "two": 2}).tolist() == {"one": 1, "two": 2}

--- a/tests/v2/test_1642-from_iter-of-tuples.py
+++ b/tests/v2/test_1642-from_iter-of-tuples.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    assert isinstance(ak._v2.from_iter((1, 2, 3)), ak._v2.Array)
+    assert ak._v2.from_iter((1, 2, 3)).tolist() == [1, 2, 3]
+    assert ak._v2.Array((1, 2, 3)).tolist() == [1, 2, 3]
+    with pytest.raises(TypeError):
+        ak._v2.Record((1, 2, 3))
+    with pytest.raises(TypeError):
+        ak._v2.Record([1, 2, 3])
+
+    assert isinstance(ak._v2.from_iter({"one": 1, "two": 2}), ak._v2.Record)
+    assert ak._v2.from_iter({"one": 1, "two": 2}).tolist() == {"one": 1, "two": 2}
+    with pytest.raises(TypeError):
+        ak._v2.Array({"one": 1, "two": 2})
+    assert ak._v2.Record({"one": 1, "two": 2}).tolist() == {"one": 1, "two": 2}


### PR DESCRIPTION
This was accidentally the behavior before #1614, and some libraries assumed it. Now the policy is as described in test_1642-from_iter-of-tuples (both v1 and v2).