### PR TITLE
fix: include `self._length` in `RegularArray.mergemany`

### DIFF
--- a/src/awkward/_v2/contents/regulararray.py
+++ b/src/awkward/_v2/contents/regulararray.py
@@ -707,7 +707,7 @@ class RegularArray(Content):
         elif all(x.is_RegularType and x.size == self.size for x in others):
             parameters = self._parameters
             tail_contents = []
-            zeros_length = 0
+            zeros_length = self._length
             for x in others:
                 parameters = ak._v2._util.merge_parameters(
                     parameters, x._parameters, True

--- a/tests/v2/test_1644-concatenate-zeros-length.py
+++ b/tests/v2/test_1644-concatenate-zeros-length.py
@@ -1,0 +1,12 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test():
+    x = ak._v2.from_numpy(np.empty((5, 0), dtype=np.float64), regulararray=True)
+    y = ak._v2.from_numpy(np.empty((8, 0), dtype=np.float64), regulararray=True)
+    z = ak._v2.concatenate([x, y], axis=0)
+    assert len(z) == 13


### PR DESCRIPTION
Fixes #1644 