### PR TITLE
feat: Drop `ak.behavior['.', 'Name'] = cls`, which isn't working/isn't tested.

### DIFF
--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -483,11 +483,6 @@ def arrayclass(layout, behavior):
         cls = behavior[arr]
         if isinstance(cls, type) and issubclass(cls, ak._v2.highlevel.Array):
             return cls
-    rec = layout.parameter("__record__")
-    if isstr(rec):
-        cls = behavior[".", rec]
-        if isinstance(cls, type) and issubclass(cls, ak._v2.highlevel.Array):
-            return cls
     deeprec = layout.purelist_parameter("__record__")
     if isstr(deeprec):
         cls = behavior["*", deeprec]
@@ -554,11 +549,6 @@ def numba_array_typer(layouttype, behavior):
         typer = behavior["__numba_typer__", arr]
         if callable(typer):
             return typer
-    rec = layouttype.parameters.get("__record__")
-    if isstr(rec):
-        typer = behavior["__numba_typer__", ".", rec]
-        if callable(typer):
-            return typer
     deeprec = layouttype.parameters.get("__record__")
     if isstr(deeprec):
         typer = behavior["__numba_typer__", "*", deeprec]
@@ -572,11 +562,6 @@ def numba_array_lower(layouttype, behavior):
     arr = layouttype.parameters.get("__array__")
     if isstr(arr):
         lower = behavior["__numba_lower__", arr]
-        if callable(lower):
-            return lower
-    rec = layouttype.parameters.get("__record__")
-    if isstr(rec):
-        lower = behavior["__numba_lower__", ".", rec]
         if callable(lower):
             return lower
     deeprec = layouttype.parameters.get("__record__")


### PR DESCRIPTION
This feature had only one test in v1 and was untested in v2. It was also implemented incorrectly (`layout.parameter("__record__")` where `layout` is a list wouldn't see the record's parameter; you'd need a variant of `purelist_parameter` that only goes one level deep).

But it seems like this is unwanted: I've never heard of anybody using this feature, not Vector and not Coffea, which are the two heaviest users of behavioral overrides. (Early on, I was thinking of regular expressions: `.` for a single character and `*` for a sequence. However, we now have a lot more experience with how these things are used in the wild.)

I'm making this its own pull request so that it will be highly visible, and we can consider reverting it, though we'd have to do more than that: we'd have to make it not-broken.

One thing that should go with this: references to

```python
ak.behavior[".", "Name"] = Class
```

need to be removed from any forward-looking (v2) documentation.