### PR TITLE
fix: to_list must follow __getitem__ implementations, even in Records

### DIFF
--- a/src/awkward/_v2/_util.py
+++ b/src/awkward/_v2/_util.py
@@ -483,11 +483,6 @@ def arrayclass(layout, behavior):
         cls = behavior[arr]
         if isinstance(cls, type) and issubclass(cls, ak._v2.highlevel.Array):
             return cls
-    rec = layout.parameter("__record__")
-    if isstr(rec):
-        cls = behavior[".", rec]
-        if isinstance(cls, type) and issubclass(cls, ak._v2.highlevel.Array):
-            return cls
     deeprec = layout.purelist_parameter("__record__")
     if isstr(deeprec):
         cls = behavior["*", deeprec]
@@ -554,11 +549,6 @@ def numba_array_typer(layouttype, behavior):
         typer = behavior["__numba_typer__", arr]
         if callable(typer):
             return typer
-    rec = layouttype.parameters.get("__record__")
-    if isstr(rec):
-        typer = behavior["__numba_typer__", ".", rec]
-        if callable(typer):
-            return typer
     deeprec = layouttype.parameters.get("__record__")
     if isstr(deeprec):
         typer = behavior["__numba_typer__", "*", deeprec]
@@ -572,11 +562,6 @@ def numba_array_lower(layouttype, behavior):
     arr = layouttype.parameters.get("__array__")
     if isstr(arr):
         lower = behavior["__numba_lower__", arr]
-        if callable(lower):
-            return lower
-    rec = layouttype.parameters.get("__record__")
-    if isstr(rec):
-        lower = behavior["__numba_lower__", ".", rec]
         if callable(lower):
             return lower
     deeprec = layouttype.parameters.get("__record__")

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -1409,14 +1409,16 @@ class Content:
 
     def _to_list_custom(self, behavior, json_conversions):
         if self.is_RecordType:
+            getitem = ak._v2._util.recordclass(self, behavior).__getitem__
             overloaded = (
-                ak._v2._util.recordclass(self, behavior).__getitem__
-                is not ak._v2.highlevel.Record.__getitem__
+                getitem is not ak._v2.highlevel.Record.__getitem__
+                and not getattr(getitem, "ignore_in_to_list", False)
             )
         else:
+            getitem = ak._v2._util.arrayclass(self, behavior).__getitem__
             overloaded = (
-                ak._v2._util.arrayclass(self, behavior).__getitem__
-                is not ak._v2.highlevel.Array.__getitem__
+                getitem is not ak._v2.highlevel.Array.__getitem__
+                and not getattr(getitem, "ignore_in_to_list", False)
             )
 
         if overloaded:

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -3,6 +3,7 @@
 import numbers
 import math
 import copy
+from collections.abc import Sized, Iterable
 
 import awkward as ak
 import awkward._v2._reducers
@@ -1378,10 +1379,11 @@ class Content:
             complex_real_string = None
             complex_imag_string = None
         elif (
-            isinstance(complex_record_fields, (tuple, list))
+            isinstance(complex_record_fields, Sized)
+            and isinstance(complex_record_fields, Iterable)
             and len(complex_record_fields) == 2
-            and isinstance(complex_record_fields[0], str)
-            and isinstance(complex_record_fields[1], str)
+            and ak._v2._util.isstr(complex_record_fields[0])
+            and ak._v2._util.isstr(complex_record_fields[1])
         ):
             complex_real_string, complex_imag_string = complex_record_fields
         else:

--- a/src/awkward/_v2/highlevel.py
+++ b/src/awkward/_v2/highlevel.py
@@ -3127,3 +3127,8 @@ class LayoutBuilder(Sized):
         can't be used in Numba.
         """
         return self.Record(self, name)
+
+
+def ignore_in_to_list(getitem_function):
+    getitem_function.ignore_in_to_list = True
+    return getitem_function

--- a/src/awkward/_v2/operations/ak_from_json.py
+++ b/src/awkward/_v2/operations/ak_from_json.py
@@ -3,6 +3,7 @@
 import pathlib
 import json
 from urllib.parse import urlparse
+from collections.abc import Sized, Iterable
 
 import awkward as ak
 
@@ -415,10 +416,11 @@ def _record_to_complex(layout, complex_record_fields):
         return layout
 
     elif (
-        isinstance(complex_record_fields, tuple)
+        isinstance(complex_record_fields, Sized)
+        and isinstance(complex_record_fields, Iterable)
         and len(complex_record_fields) == 2
-        and isinstance(complex_record_fields[0], str)
-        and isinstance(complex_record_fields[1], str)
+        and ak._v2._util.isstr(complex_record_fields[0])
+        and ak._v2._util.isstr(complex_record_fields[1])
     ):
 
         def action(node, **kwargs):

--- a/tests/v2/test_1650-Record-to_list-should-listify-itself.py
+++ b/tests/v2/test_1650-Record-to_list-should-listify-itself.py
@@ -1,0 +1,145 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import numpy as np  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+def test_record_nochange():
+    class Point(ak._v2.Record):
+        def __getitem__(self, where):
+            return super().__getitem__(where)
+
+    array = ak._v2.Array(
+        [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]],
+        with_name="point",
+        behavior={"point": Point},
+    )
+
+    assert array.tolist() == [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]]
+    assert array[0].tolist() == [{"rho": 1, "phi": 1.0}]
+    assert array[0, 0].tolist() == {"rho": 1, "phi": 1.0}
+
+
+def test_array_nochange():
+    class PointArray(ak._v2.Array):
+        def __getitem__(self, where):
+            return super().__getitem__(where)
+
+    array = ak._v2.Array(
+        [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]],
+        with_name="point",
+        behavior={("*", "point"): PointArray},
+    )
+
+    assert array.tolist() == [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]]
+    assert array[0].tolist() == [{"rho": 1, "phi": 1.0}]
+    assert array[0, 0].tolist() == {"rho": 1, "phi": 1.0}
+
+
+def test_record_changed():
+    class Point(ak._v2.Record):
+        def __getitem__(self, where):
+            return str(super().__getitem__(where))
+
+    array = ak._v2.Array(
+        [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]],
+        with_name="point",
+        behavior={"point": Point},
+    )
+
+    assert array.tolist() == [
+        [{"rho": "1", "phi": "1.0"}],
+        [],
+        [{"rho": "2", "phi": "2.0"}],
+    ]
+    assert array[0].tolist() == [{"rho": "1", "phi": "1.0"}]
+    assert array[0, 0].tolist() == {"rho": "1", "phi": "1.0"}
+
+
+def test_array_changed():
+    class PointArray(ak._v2.Array):
+        def __getitem__(self, where):
+            return str(super().__getitem__(where))
+
+    array = ak._v2.Array(
+        [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]],
+        with_name="point",
+        behavior={("*", "point"): PointArray},
+    )
+
+    assert array.tolist() == ["[{rho: 1, phi: 1}]", "[]", "[{rho: 2, phi: 2}]"]
+    assert array[0] == "[{rho: 1, phi: 1}]"
+    assert array[0, 0] == "{rho: 1, phi: 1}"
+
+
+def test_record_to_Array():
+    class Point(ak._v2.Record):
+        def __getitem__(self, where):
+            return ak._v2.Array([1, 2, 3])
+
+    array = ak._v2.Array(
+        [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]],
+        with_name="point",
+        behavior={"point": Point},
+    )
+
+    assert array.tolist() == [
+        [{"rho": [1, 2, 3], "phi": [1, 2, 3]}],
+        [],
+        [{"rho": [1, 2, 3], "phi": [1, 2, 3]}],
+    ]
+    assert array[0].tolist() == [{"rho": [1, 2, 3], "phi": [1, 2, 3]}]
+    assert array[0, 0].tolist() == {"rho": [1, 2, 3], "phi": [1, 2, 3]}
+
+
+def test_array_to_Array():
+    class PointArray(ak._v2.Array):
+        def __getitem__(self, where):
+            return ak._v2.Array([1, 2, 3])
+
+    array = ak._v2.Array(
+        [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]],
+        with_name="point",
+        behavior={("*", "point"): PointArray},
+    )
+
+    assert array.tolist() == [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
+    assert array[0].tolist() == [1, 2, 3]
+    assert array[0, 0].tolist() == [1, 2, 3]
+
+
+def test_record_to_ndarray():
+    class Point(ak._v2.Record):
+        def __getitem__(self, where):
+            return np.array([1, 2, 3])
+
+    array = ak._v2.Array(
+        [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]],
+        with_name="point",
+        behavior={"point": Point},
+    )
+
+    assert array.tolist() == [
+        [{"rho": [1, 2, 3], "phi": [1, 2, 3]}],
+        [],
+        [{"rho": [1, 2, 3], "phi": [1, 2, 3]}],
+    ]
+    assert array[0].tolist() == [{"rho": [1, 2, 3], "phi": [1, 2, 3]}]
+    assert array[0, 0].tolist() == {"rho": [1, 2, 3], "phi": [1, 2, 3]}
+
+
+def test_array_to_ndarray():
+    class PointArray(ak._v2.Array):
+        def __getitem__(self, where):
+            return np.array([1, 2, 3])
+
+    array = ak._v2.Array(
+        [[{"rho": 1, "phi": 1.0}], [], [{"rho": 2, "phi": 2.0}]],
+        with_name="point",
+        behavior={("*", "point"): PointArray},
+    )
+
+    assert array.tolist() == [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
+    assert array[0].tolist() == [1, 2, 3]
+    assert array[0, 0].tolist() == [1, 2, 3]


### PR DESCRIPTION
The `to_list` implementation has to behave like a recursive iteration through an ak.Array/ak.Record, replacing all lists with Python `list`, all records with Python `dict`, and all missing values with `None`. Iteration means calling `__getitem__` for each index, so if `__getitem__` is overloaded (though `ak.behavior`), we should see the consequence of that in the `to_list` output.

The v1 `to_list` was implemented this way, but with the un-overloaded `__getitem__`, that results in a lot of indirection and type-checking that can be avoided, because we know the type of our array. A vectorized implementation, optimized for un-overloaded `__getitem__`, was first implemented in ee0c2cb6b38669597fd6f90d9d351219ed186f05, which acted in vectorized strides over each node in the layout tree. Then #1418 fixed the case of small slices of a large array (don't vectorize over the whole thing, just the part you see).

The explicit check for `cls.__getitem__ is ak._v2.highlevel.Array.__getitem__` is correct: that part of the code wants to know if we are in the optimized, un-overloaded case, or something else. If something else, we do what would be the straightforward implementation of `to_list`: calling `__getitem__` on every item. This allows the overloaded `__getitem__` to do whatever it wants, returning any type that it wants, and `to_list` behaves as it should.

What was missing in #1600 was (a) an equivalent implementation for `Record`, and (b) continuing to recurse `to_list` over the output of `__getitem__`. This PR fixes those two things, with special care in `ak._v2.record.Record` to prevent infinite recursion.