### PR TITLE
chore: drop 3.6 support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -146,7 +146,8 @@ jobs:
           - '3.9'
           - '3.8'
           - '3.7'
-        numpy-package: "numpy"
+        numpy-package:
+          - "numpy"
         include:
           - python-version: '3.7'
             numpy-package: "oldest-supported-numpy"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -146,9 +146,10 @@ jobs:
           - '3.9'
           - '3.8'
           - '3.7'
+        numpy-package: "numpy"
         include:
           - python-version: '3.7'
-            numpy-version: 1.13.1
+            numpy-package: "oldest-supported-numpy"
 
     runs-on: ubuntu-20.04
 
@@ -166,7 +167,7 @@ jobs:
         with:
           key: >-
             ${{ github.job
-            }}-${{matrix.python-version}}-${{matrix.numpy-version}}
+            }}-${{matrix.python-version}}-${{matrix.numpy-package}}
 
       - name: Use ccache
         run: |
@@ -179,12 +180,7 @@ jobs:
           python-version: '${{ matrix.python-version }}'
 
       - name: Install NumPy
-        run: |
-          if [[ -z "${NUMPY_VERSION}" ]]; then
-            python -m pip install numpy;
-          else
-            python -m pip install "numpy==${NUMPY_VERSION}";
-          fi
+        run: python -m pip install "${{ matrix.numpy-package }}"
 
       - name: Build
         run: 'python -m pip install -v .[test,dev]'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,6 @@ jobs:
           - '3.9'
           - '3.8'
           - '3.7'
-          - '3.6'
 
         python-architecture:
           - x64
@@ -91,7 +90,6 @@ jobs:
           - '3.9'
           - '3.8'
           - '3.7'
-          - '3.6'
 
     runs-on: macOS-11
 
@@ -148,11 +146,6 @@ jobs:
           - '3.9'
           - '3.8'
           - '3.7'
-          - '3.6'
-
-        include:
-          - python-version: '3.6'
-            numpy-version: 1.13.1
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -146,6 +146,9 @@ jobs:
           - '3.9'
           - '3.8'
           - '3.7'
+        include:
+          - python-version: '3.7'
+            numpy-version: 1.13.1
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ jobs:
     - uses: pypa/cibuildwheel@v2.9.0
       env:
         CIBW_ARCHS_MACOS: universal2
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-        CIBW_BUILD: cp39-win_amd64 cp36-manylinux_x86_64 cp38-macosx_universal2
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+        CIBW_BUILD: cp39-win_amd64 cp37-manylinux_x86_64 cp38-macosx_universal2
 
     - uses: pypa/cibuildwheel@v2.9.0
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,6 @@ jobs:
     - uses: pypa/cibuildwheel@v2.9.0
       env:
         CIBW_ARCHS_MACOS: universal2
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BUILD: cp39-win_amd64 cp37-manylinux_x86_64 cp38-macosx_universal2
 
     - uses: pypa/cibuildwheel@v2.9.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.9.0
       env:
         CIBW_ARCHS_MACOS: universal2
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BUILD: cp39-win_amd64 cp37-manylinux_x86_64 cp38-macosx_universal2
 
     - uses: pypa/cibuildwheel@v2.9.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,12 +34,6 @@ jobs:
         build: ["cp*", "pp*"]
 
         include:
-        - os: ubuntu-latest
-          type: ManyLinux1
-          arch: auto64
-          build: "cp{36,37,38}-*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-
         - os: macos-latest
           type: "Universal"
           arch: universal2
@@ -51,7 +45,7 @@ jobs:
 
         - os: windows-latest
           arch: auto32
-          build: "cp{36,37,38,39}-*"
+          build: "cp{37,38,39}-*"
 
 
     steps:
@@ -76,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [36, 37, 38, 39, 310, 311]
+        python: [37, 38, 39, 310, 311]
         arch: [aarch64]
     steps:
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,6 +57,7 @@ jobs:
       env:
         CIBW_BUILD: ${{ matrix.build }}
         CIBW_ARCHS: ${{ matrix.arch }}
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,7 +56,6 @@ jobs:
     - uses: pypa/cibuildwheel@v2.9.0
       env:
         CIBW_BUILD: ${{ matrix.build }}
-        CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
         CIBW_ARCHS: ${{ matrix.arch }}
 
     - name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,7 +57,6 @@ jobs:
       env:
         CIBW_BUILD: ${{ matrix.build }}
         CIBW_ARCHS: ${{ matrix.arch }}
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   rev: "v2.37.3"
   hooks:
   - id: pyupgrade
-    args: ["--py36-plus"]
+    args: ["--py37-plus"]
 
 - repo: https://github.com/psf/black
   rev: 22.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ As we change the code, we should keep in mind the following priorities, in this 
 
 Above all, the purpose of any programming language is to be read by humans; if we were only concerned with operating the machine, we would be flipping individual bits. It should be organized in stanzas that highlight similarities and differences by grouping them on the screen.
 
-We adhere to an 80-character line width, which is a [standard in the industry](https://github.com/scikit-hep/awkward-1.0/pull/183), despite the fact that we don't write punch-cards anymore. The standardized width allows several window columns to be examined side-by-side. Exceptions to the 80-character limit follow [PEP 8](https://www.python.org/dev/peps/pep-0008/): we don't split URLs or similar tokens that must be read as a unit.
+We adhere to an 80-character line width, which is a [stand<65;53;42Mard in the industry](https://github.com/scikit-hep/awkward-1.0/pull/183), despite the fact that we don't write punch-cards anymore. The standardized width allows several window columns to be examined side-by-side. Exceptions to the 80-character limit follow [PEP 8](https://www.python.org/dev/peps/pep-0008/): we don't split URLs or similar tokens that must be read as a unit.
 
 Unit tests do not need to adhere to the 80-character limit.
 
@@ -271,7 +271,7 @@ We target Python 3.7 and above. Import statements can assume Python 3 names, str
 
 If you see any outdated (pre-Python 3.7) code, you can safely clean them up. Some strings are not easier to read as f-strings or require some work to make them more readable; it should be a case-by-case basis.
 
-Python 3.7 will be the standard until it becomes "painful" to keep it (like, when CI and build tools no longer support it, or if we adopt type annotations).
+Awkward Array follows [CPython's EoL schedule](https://endoflife.date/python), and will drop support for out-of-date versions of Python accordingly.
 
 ### Third party dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,11 +267,11 @@ Templating is only used for integer specialization.
 
 ### Python standard
 
-We target Python 3.6 and above. Import statements can assume Python 3 names, string-checking can assume Python 3 meanings of `str` and `bytes`, Unicode literals don't need to be prefixed by `u`, and dict order can be assumed to be stable. Python's f-strings can now be used, but not with equals signs (e.g. `f"{something = }"` rather than `f"something = {something}"`) because that's a Python 3.8 feature (its main use is in debugging, anyway).
+We target Python 3.7 and above. Import statements can assume Python 3 names, string-checking can assume Python 3 meanings of `str` and `bytes`, Unicode literals don't need to be prefixed by `u`, and dict order can be assumed to be stable. Python's f-strings can now be used, but not with equals signs (e.g. `f"{something = }"` rather than `f"something = {something}"`) because that's a Python 3.8 feature (its main use is in debugging, anyway).
 
-If you see any outdated (pre-Python 3.6) code, you can safely clean them up. Some strings are not easier to read as f-strings or require some work to make them more readable; it should be a case-by-case basis.
+If you see any outdated (pre-Python 3.7) code, you can safely clean them up. Some strings are not easier to read as f-strings or require some work to make them more readable; it should be a case-by-case basis.
 
-Python 3.6 will be the standard until it becomes "painful" to keep it (like, when CI and build tools no longer support it, or if we adopt type annotations).
+Python 3.7 will be the standard until it becomes "painful" to keep it (like, when CI and build tools no longer support it, or if we adopt type annotations).
 
 ### Third party dependencies
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/awkward.svg)](https://pypi.org/project/awkward)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
-[![Python 3.6‒3.10](https://img.shields.io/badge/python-3.6%E2%80%923.10-blue)](https://www.python.org)
+[![Python 3.7‒3.10](https://img.shields.io/badge/python-3.7%E2%80%923.10-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Continuous integration tests](https://img.shields.io/azure-devops/build/jpivarski/Scikit-HEP/3/main?label=tests)](https://dev.azure.com/jpivarski/Scikit-HEP/_build)
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/awkward.svg)](https://pypi.org/project/awkward)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
-[![Python 3.7‒3.10](https://img.shields.io/badge/python-3.7%E2%80%923.10-blue)](https://www.python.org)
+[![Python 3.7‒3.11](https://img.shields.io/badge/python-3.7%E2%80%923.11-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Continuous integration tests](https://img.shields.io/azure-devops/build/jpivarski/Scikit-HEP/3/main?label=tests)](https://dev.azure.com/jpivarski/Scikit-HEP/_build)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/awkward.svg)](https://pypi.org/project/awkward)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
-[![Python 3.6‒3.10](https://img.shields.io/badge/python-3.6%E2%80%923.10-blue)](https://www.python.org)
+[![Python 3.7‒3.10](https://img.shields.io/badge/python-3.7%E2%80%923.10-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Build Test](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/awkward.svg)](https://pypi.org/project/awkward)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
-[![Python 3.7‒3.10](https://img.shields.io/badge/python-3.7%E2%80%923.10-blue)](https://www.python.org)
+[![Python 3.7‒3.11](https://img.shields.io/badge/python-3.7%E2%80%923.11-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Build Test](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml)
 

--- a/docs-sphinx/index.rst
+++ b/docs-sphinx/index.rst
@@ -20,8 +20,8 @@
    :alt: Conda-Forge
    :target: https://github.com/conda-forge/awkward-feedstock
 
-.. image:: https://img.shields.io/badge/python-3.6%E2%80%923.10-blue
-   :alt: Python 3.6‒3.10
+.. image:: https://img.shields.io/badge/python-3.7%E2%80%923.10-blue
+   :alt: Python 3.7‒3.10
    :target: https://www.python.org
 
 .. image:: https://img.shields.io/badge/license-BSD%203--Clause-blue.svg

--- a/docs-src/quickstart.md
+++ b/docs-src/quickstart.md
@@ -15,7 +15,7 @@ kernelspec:
 
 [![PyPI version](https://badge.fury.io/py/awkward.svg)](https://pypi.org/project/awkward)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
-[![Python 3.6‒3.10](https://img.shields.io/badge/python-3.6%E2%80%923.10-blue)](https://www.python.org)
+[![Python 3.7‒3.10](https://img.shields.io/badge/python-3.7%E2%80%923.10-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Continuous integration tests](https://img.shields.io/azure-devops/build/jpivarski/Scikit-HEP/3/main?label=tests)](https://dev.azure.com/jpivarski/Scikit-HEP/_build)
 

--- a/docs-src/requirements.txt
+++ b/docs-src/requirements.txt
@@ -10,5 +10,5 @@ matplotlib
 uproot
 uproot3
 jupyter-book
-jax>=0.2.7;python_version>="3.6" and sys_platform != "win32"
-jaxlib>=0.1.57;python_version>="3.6" and sys_platform != "win32"
+jax>=0.2.7;sys_platform != "win32"
+jaxlib>=0.1.57;sys_platform != "win32"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+ALL_PYTHONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 nox.options.sessions = ["lint", "tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ PIP_ONLY_BINARY = "cmake,numpy"
 
 [[tool.cibuildwheel.overrides]]
 select = "cp3?-*"
-manylinux-x86_64-image = "manylinux2010"
+manylinux-x86_64-image = "manylinux2014"
 
 
 [tool.pytest.ini_options]
@@ -79,7 +79,7 @@ filterwarnings = [
 log_cli_level = "info"
 
 [tool.pylint]
-master.py-version = "3.6"
+master.py-version = "3.7"
 master.jobs = "0"
 master.ignore-paths = [
   "src/awkward/_typeparser/generated_parser.py"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 autograd
 flake8
-fsspec;python_version > "3.6" and sys_platform != "win32"
-jax>=0.2.7;sys_platform != "win32" and python_version > "3.6" and python_version < "3.11"
-jaxlib>=0.1.57,!=0.1.68;sys_platform != "win32" and python_version > "3.6" and python_version < "3.11"
+fsspec;sys_platform != "win32"
+jax>=0.2.7;sys_platform != "win32" and python_version < "3.11"
+jaxlib>=0.1.57,!=0.1.68;sys_platform != "win32" and python_version < "3.11"
 numba>=0.50.0;python_version < "3.11"
 numexpr;python_version < "3.11"
 pandas>=0.24.0
-pyarrow>=7.0.0;python_version > "3.6" and sys_platform != "win32" and python_version < "3.11"
+pyarrow>=7.0.0;sys_platform != "win32" and python_version < "3.11"
 PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -46,7 +45,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     =src

--- a/src/awkward/_v2/_connect/jax/__init__.py
+++ b/src/awkward/_v2/_connect/jax/__init__.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-import sys
 
 try:
     import jax
@@ -54,13 +53,6 @@ def register_pytrees():
 def import_jax(name="Awkward Arrays with JAX"):
     if jax is None:
         raise ak._v2._util.error(ModuleNotFoundError(error_message.format(name)))
-
-    if not (sys.version_info.major == 3 and sys.version_info.minor >= 7):
-        raise ak._v2._util.error(
-            AssertionError(
-                "Using Awkward Arrays with JAX requires Python version >= 3.7"
-            )
-        )
 
     global pytrees_registered
 


### PR DESCRIPTION
- Replace text references to 3.6 with 3.7 where appropriate
- Remove CI 3.6 special-cases
- Replace manylinux1 with manylinux2014