### PR TITLE
docs: fix typos

### DIFF
--- a/docs-jupyter/2020-01-22-numba-demo-EVALUATED.ipynb
+++ b/docs-jupyter/2020-01-22-numba-demo-EVALUATED.ipynb
@@ -545,7 +545,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our field has always had this problem. Even before Fortran had objects (or a multi-line `IF` statement!), specialized physics software added the ability to operate on data structures. This is an exerpt from [Initiation to Hydra (1974)](https://cds.cern.ch/record/864527) by R.K. Böck, describing the concept of a non-numerical data structure to a physics audience.\n",
+    "Our field has always had this problem. Even before Fortran had objects (or a multi-line `IF` statement!), specialized physics software added the ability to operate on data structures. This is an excerpt from [Initiation to Hydra (1974)](https://cds.cern.ch/record/864527) by R.K. Böck, describing the concept of a non-numerical data structure to a physics audience.\n",
     "\n",
     "<img src=\"img/hydra-2.png\" style=\"width: 500px;\">"
    ]

--- a/docs-jupyter/2020-01-22-numba-demo-UNEVALUATED.ipynb
+++ b/docs-jupyter/2020-01-22-numba-demo-UNEVALUATED.ipynb
@@ -360,7 +360,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our field has always had this problem. Even before Fortran had objects (or a multi-line `IF` statement!), specialized physics software added the ability to operate on data structures. This is an exerpt from [Initiation to Hydra (1974)](https://cds.cern.ch/record/864527) by R.K. Böck, describing the concept of a non-numerical data structure to a physics audience.\n",
+    "Our field has always had this problem. Even before Fortran had objects (or a multi-line `IF` statement!), specialized physics software added the ability to operate on data structures. This is an excerpt from [Initiation to Hydra (1974)](https://cds.cern.ch/record/864527) by R.K. Böck, describing the concept of a non-numerical data structure to a physics audience.\n",
     "\n",
     "<img src=\"img/hydra-2.png\" style=\"width: 500px;\">"
    ]

--- a/docs-jupyter/2020-04-08-eic-jlab.ipynb
+++ b/docs-jupyter/2020-04-08-eic-jlab.ipynb
@@ -789,7 +789,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Uproot is _not_ agressive about caching: if you call `arrays` many times (for many small batches), it will read from the file every time.\n",
+    "Uproot is _not_ aggressive about caching: if you call `arrays` many times (for many small batches), it will read from the file every time.\n",
     "\n",
     "You can avoid frequent re-reading by assigning arrays to variables, but then you'd have to manage all those variables.\n",
     "\n",
@@ -2719,7 +2719,7 @@
     }
    ],
    "source": [
-    "# Absolute value of all smear origin vertexes\n",
+    "# Absolute value of all smear origin vertices\n",
     "abs(events.prt.smear.orig.vtx)"
    ]
   },
@@ -2782,7 +2782,7 @@
     }
    ],
    "source": [
-    "# Distances between the first and last particle vertexes in the first 100 events\n",
+    "# Distances between the first and last particle vertices in the first 100 events\n",
     "events.prt.vtx[:100, 0] - events.prt.vtx[:100, -1]"
    ]
   },
@@ -3373,7 +3373,7 @@
        "        outermost, `1` is the first level of nested lists, etc., and\n",
        "        negative `axis` counts from the innermost: `-1` is the innermost,\n",
        "        `-2` is the next level up, etc.\n",
-       "    keepdims (bool): If False, this reducer descreases the number of\n",
+       "    keepdims (bool): If False, this reducer decreases the number of\n",
        "        dimensions by 1; if True, the reduced values are wrapped in a new\n",
        "        length-1 dimension so that the result of this operation may be\n",
        "        broadcasted with the original array.\n",
@@ -3477,7 +3477,7 @@
        "        outermost, `1` is the first level of nested lists, etc., and\n",
        "        negative `axis` counts from the innermost: `-1` is the innermost,\n",
        "        `-2` is the next level up, etc.\n",
-       "    keepdims (bool): If False, this reducer descreases the number of\n",
+       "    keepdims (bool): If False, this reducer decreases the number of\n",
        "        dimensions by 1; if True, the reduced values are wrapped in a new\n",
        "        length-1 dimension so that the result of this operation may be\n",
        "        broadcasted with the original array.\n",
@@ -4269,7 +4269,7 @@
        "        outermost, `1` is the first level of nested lists, etc., and\n",
        "        negative `axis` counts from the innermost: `-1` is the innermost,\n",
        "        `-2` is the next level up, etc.\n",
-       "    keepdims (bool): If False, this reducer descreases the number of\n",
+       "    keepdims (bool): If False, this reducer decreases the number of\n",
        "        dimensions by 1; if True, the reduced values are wrapped in a new\n",
        "        length-1 dimension so that the result of this operation may be\n",
        "        broadcasted with the original array.\n",
@@ -5222,7 +5222,7 @@
     "At all levels of a physics analysis, we need to compare objects drawn from different collections.\n",
     "\n",
     "   * **Gen-reco matching:** to associate a reconstructed particle with its generator-level parameters.\n",
-    "   * **Cleaning:** assocating soft photons with a reconstructed electron or leptons to a jet.\n",
+    "   * **Cleaning:** associating soft photons with a reconstructed electron or leptons to a jet.\n",
     "   * **Bump-hunting:** looking for mass peaks in pairs of particles.\n",
     "   * **Dalitz analysis:** looking for resonance structure in triples of particles.\n",
     "\n",
@@ -5848,7 +5848,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can improve the peak by selecting for opposite charges and large vertexes."
+    "We can improve the peak by selecting for opposite charges and large vertices."
    ]
   },
   {
@@ -7530,7 +7530,7 @@
     "\n",
     "Array-at-a-time operations let us manipulate dynamically typed data with compiled code (and in some cases, benefit from hardware vectorization). However, they're complicated. Finding the closest photon to each electron is more complicated than it seems it ought to be.\n",
     "\n",
-    "Some of these things are simpler in imperative (step-by-step scalar-at-a-time) code. Imperative Python code is slow because it has to check the data type of every object it enounters (among other things); compiled code is faster because these checks are performed once during a compilation step for any number of identically typed values.\n",
+    "Some of these things are simpler in imperative (step-by-step scalar-at-a-time) code. Imperative Python code is slow because it has to check the data type of every object it encounters (among other things); compiled code is faster because these checks are performed once during a compilation step for any number of identically typed values.\n",
     "\n",
     "We can get the best of both worlds by Just-In-Time (JIT) compiling the code. [Numba](http://numba.pydata.org/) is a NumPy-centric JIT compiler for Python."
    ]
@@ -9551,7 +9551,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There's only one row MultiIndex, so pion #1 in each event is the same row as kaon #1. That assocation is probably meaningless.\n",
+    "There's only one row MultiIndex, so pion #1 in each event is the same row as kaon #1. That association is probably meaningless.\n",
     "\n",
     "The issue is that a single Pandas DataFrame represents *less* information than an Awkward Array. In general, we would need a collection of DataFrames to losslessly encode an Awkward Array. (Pandas represents the data in [database normal form](https://en.wikipedia.org/wiki/Database_normalization); Awkward represents it in objects.)"
    ]
@@ -10088,7 +10088,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[NumExpr](https://numexpr.readthedocs.io/en/latest/user_guide.html) can calcuate pure numerical expressions faster than NumPy because it does so in one pass. (It has a low-overhead virtual machine.)\n",
+    "[NumExpr](https://numexpr.readthedocs.io/en/latest/user_guide.html) can calculate pure numerical expressions faster than NumPy because it does so in one pass. (It has a low-overhead virtual machine.)\n",
     "\n",
     "NumExpr doesn't recognize Awkward Arrays, but we have a wrapper for it."
    ]

--- a/docs-sphinx/ak.behavior.rst
+++ b/docs-sphinx/ak.behavior.rst
@@ -503,7 +503,7 @@ Custom type names
 =================
 
 To make the string type appear as ``string`` in type representations, a
-``"__typestr__"`` behavior is overriden (in ``ak.behaviors.string``):
+``"__typestr__"`` behavior is overridden (in ``ak.behaviors.string``):
 
 .. code-block:: python
 

--- a/docs-sphinx/ak.layout.ArrayBuilder.rst
+++ b/docs-sphinx/ak.layout.ArrayBuilder.rst
@@ -4,7 +4,7 @@ ak.layout.ArrayBuilder
 The low-level ArrayBuilder that builds :doc:`ak.layout.Content` arrays. This
 object is wrapped by :doc:`_auto/ak.ArrayBuilder`.
 
-(Method names in the high-level interface have been chnaged to include
+(Method names in the high-level interface have been changed to include
 underscores after "begin" and "end," but that hasn't happened in the
 low-level interface, yet or possibly at all.)
 

--- a/docs-sphinx/ak.layout.Content.rst
+++ b/docs-sphinx/ak.layout.Content.rst
@@ -214,7 +214,7 @@ Returns a copy of the array node and its children.
    * If ``copyidentities``, then :doc:`ak.layout.Identities` buffers are also
      copied.
 
-If all three flags are False, then only (small) C++ and Pyhton objects are
+If all three flags are False, then only (small) C++ and Python objects are
 copied, not (large) array buffers.
 
 ak.layout.Content.fieldindex

--- a/docs-sphinx/ak.layout.Index.rst
+++ b/docs-sphinx/ak.layout.Index.rst
@@ -58,4 +58,4 @@ ak.layout.Index.__repr__
 
 .. py:method:: ak.layout.Index.__repr__()
 
-A string representation of the Index (single-line XML, trucated middle).
+A string representation of the Index (single-line XML, truncated middle).

--- a/docs-sphinx/awkwardforth.rst
+++ b/docs-sphinx/awkwardforth.rst
@@ -209,7 +209,7 @@ Here is an example of a ForthMachine with an output (``<-`` writes data from the
     >>> np.asarray(vm["x"])
     array([999], dtype=int32)
 
-(Note: always view outputs as NumPy arrays. In Awkward 1.x, outputs were returned as NumpyArray objects, but now they are returned as NumPy arrays. Wraping the output in ``np.asarray`` makes your code version-independent.)
+(Note: always view outputs as NumPy arrays. In Awkward 1.x, outputs were returned as NumpyArray objects, but now they are returned as NumPy arrays. Wrapping the output in ``np.asarray`` makes your code version-independent.)
 
 A ForthMachine can have an arbitrary number of variables, inputs, and outputs, and an arbitrary number of user-defined words, with index orders defined by the order of declaration (relevant for fast C++ access).
 
@@ -406,7 +406,7 @@ In both styles, you have to make sure that the "``(``", "``)``", and "``\``" cha
 Literal integers
 ****************
 
-Literal integers in the source code put an integer on the stack. AwkwardForth has no floating point types, so only ``-?[0-9]+`` are allowed, no ``.`` or ``e``. If the number is prefixed by ``0x``, then the number is parsed as hexidecimal, with ``-?[0-9a-f]`` allowed.
+Literal integers in the source code put an integer on the stack. AwkwardForth has no floating point types, so only ``-?[0-9]+`` are allowed, no ``.`` or ``e``. If the number is prefixed by ``0x``, then the number is parsed as hexadecimal, with ``-?[0-9a-f]`` allowed.
 
 .. code-block:: python
 

--- a/docs-src/how-to-convert-python.md
+++ b/docs-src/how-to-convert-python.md
@@ -344,7 +344,7 @@ ak.behavior["bytestring"]
 ak.behavior[np.equal, "string", "string"]
 ```
 
-The fact that strings are really just variable-length lists is worth keeping in mind, since they might behave in unexpectedly list-like ways. If you notice any behavior that ought to be overloded for strings, recommend it as a [feature request](https://github.com/scikit-hep/awkward-1.0/issues/new?assignees=&labels=feature&template=feature-request.md&title=).
+The fact that strings are really just variable-length lists is worth keeping in mind, since they might behave in unexpectedly list-like ways. If you notice any behavior that ought to be overloaded for strings, recommend it as a [feature request](https://github.com/scikit-hep/awkward-1.0/issues/new?assignees=&labels=feature&template=feature-request.md&title=).
 
 +++
 

--- a/docs-src/how-to-convert-uproot.md
+++ b/docs-src/how-to-convert-uproot.md
@@ -238,7 +238,7 @@ From Awkward to ROOT with Uproot 3
 
 Since ROOT file-writing is only implemented in Uproot 3, you'll need to take into consideration whether an array is flat, and therefore NumPy, or jagged, and therefore Awkward 0 (i.e. "old library").
 
-To open a flie for writing, use `uproot.recreate`, rather than `uproot.open`.
+To open a file for writing, use `uproot.recreate`, rather than `uproot.open`.
 
 ```{code-cell}
 file = uproot3.recreate("/tmp/example.root")

--- a/docs-src/how-to-create-arraybuilder.md
+++ b/docs-src/how-to-create-arraybuilder.md
@@ -162,7 +162,7 @@ arbitrary_nesting(builder, 5)
 builder
 ```
 
-Often, you'll know the exact depth of nesting you want. The Python `with` statement can be used to restrict the generality (nd free you from having to remember to `end` what you `begin`).
+Often, you'll know the exact depth of nesting you want. The Python `with` statement can be used to restrict the generality (and free you from having to remember to `end` what you `begin`).
 
 ```{code-cell}
 builder = ak.ArrayBuilder()

--- a/docs-src/how-to-create-layoutbuilder.md
+++ b/docs-src/how-to-create-layoutbuilder.md
@@ -59,7 +59,7 @@ form = """
   """
 ```
 
-When a layout builder is created from this form, it cannot be modified. The builder accepts only data types spcified in the form: `float64`, `bool`, or `int64`. The appending data builder methods are restricted to `float64`, `boolean`, and `int64`. The methods have similar to the data type names.
+When a layout builder is created from this form, it cannot be modified. The builder accepts only data types specified in the form: `float64`, `bool`, or `int64`. The appending data builder methods are restricted to `float64`, `boolean`, and `int64`. The methods have similar to the data type names.
 
 ```{code-cell}
 builder = ak.layout.LayoutBuilder32(form)

--- a/docs-src/how-to-differentiate-using-jax.md
+++ b/docs-src/how-to-differentiate-using-jax.md
@@ -14,7 +14,7 @@ kernelspec:
 Differentiation using JAX
 =========================
 
-Currently, all the functions which contain slicing or numpy ufuncs are supported by Awkward Arrays and can be differentiated by JAX. We do not support any specialized funtions like `ak.sum()` or `ak.prod()`. These are planned to be implemented in the near future. Since, the GPU support for Awkward Arrays is only partially complete, we have to configure JAX to use CPU only. We can do this by:
+Currently, all the functions which contain slicing or numpy ufuncs are supported by Awkward Arrays and can be differentiated by JAX. We do not support any specialized functions like `ak.sum()` or `ak.prod()`. These are planned to be implemented in the near future. Since, the GPU support for Awkward Arrays is only partially complete, we have to configure JAX to use CPU only. We can do this by:
 
 ```{code-cell}
 import jax

--- a/docs-src/what-is-awkward.md
+++ b/docs-src/what-is-awkward.md
@@ -348,7 +348,7 @@ The reasons for this speedup are all related to Awkward Array's data structure, 
 
    * only a single block of memory needs to be fetched from memory into the CPU cache (no "pointer chasing"),
    * data for fields other than the one being operated upon are not in the same buffer, so they don't even need to be loaded ("columnar," rather than "record-oriented"),
-   * the data type can be evaluated once before applying a precompiled opeation to a whole array buffer, rather than once before each element of a Python list.
+   * the data type can be evaluated once before applying a precompiled operation to a whole array buffer, rather than once before each element of a Python list.
 
 This memory layout is especially good for applying one operation on all values in the array, thinking about the result, and then applying another. This is the "interactive" style of data analysis that you're probably familiar with from NumPy and Pandas, especially if you use Jupyter notebooks. It does have a performance cost, however: array buffers need to be allocated and filled after each step of the process, and some of those might never be used again.
 

--- a/studies/jax_getitem.py
+++ b/studies/jax_getitem.py
@@ -94,7 +94,7 @@ class DifferentiableArray(ak.Array):
                 elif isinstance(layout, ak._util.indexedtypes):
                     return fetch_indices_and_fieldloc_layout(layout.project())
                 elif isinstance(layout, ak._util.uniontypes):
-                    raise ValueError("Can't differntiate an UnionArray type {0}".format(layout))
+                    raise ValueError("Can't differentiate an UnionArray type {0}".format(layout))
                 elif isinstance(layout, ak._util.recordtypes):
                     indices = []
                     for content in layout.contents:
@@ -139,7 +139,7 @@ class DifferentiableArray(ak.Array):
                 elif isinstance(layout, ak._util.listtypes):
                     return fetch_children_tracer(layout.content, preslice_identities)
                 elif isinstance(layout, ak._util.uniontypes):
-                    raise ValueError("Can't differntiate an UnionArray type {0}".format(layout))
+                    raise ValueError("Can't differentiate an UnionArray type {0}".format(layout))
                 elif isinstance(layout, ak._util.recordtypes):
                     children = []
                     for content in layout.contents:

--- a/tests/test_0084-start-unionarray.py
+++ b/tests/test_0084-start-unionarray.py
@@ -103,7 +103,7 @@ def test_getitem():
         "tw",
         [1.1, 2.2],
         [],
-        "thre",
+        "three",
         [4.4],
         "fiv",
         "fou",

--- a/tests/test_0110-various-cleanups.py
+++ b/tests/test_0110-various-cleanups.py
@@ -108,11 +108,11 @@ def test_string_equal():
             ["one", "Two", "", "threE", "four", "", "five", "siX"],
         ),
         (
-            ["one", "two", "", "thre", "four", "", "five", "six", ""],
+            ["one", "two", "", "three", "four", "", "five", "six", ""],
             ["one", "two", "", "three", "four", "", "five", "six", ""],
         ),
         (
-            ["one", "two", "", "thre", "four", "", "five", "six"],
+            ["one", "two", "", "three", "four", "", "five", "six"],
             ["one", "two", "", "three", "four", "", "five", "six"],
         ),
         (


### PR DESCRIPTION
Found via `codespell -L fo,ue,nwo,subjet,unio **/*.{md,py,rst,ipynb}`