### PR TITLE
refactor: move categorical functions to operations

### DIFF
--- a/src/awkward/_v2/behaviors/categorical.py
+++ b/src/awkward/_v2/behaviors/categorical.py
@@ -14,7 +14,7 @@ class CategoricalBehavior(Array):
 class _HashableDict:
     def __init__(self, obj):
         self.keys = tuple(sorted(obj))
-        self.values = tuple(_hashable(obj[k]) for k in self.keys)
+        self.values = tuple(as_hashable(obj[k]) for k in self.keys)
         self.hash = hash((_HashableDict,) + self.keys, self.values)
 
     def __hash__(self):
@@ -40,11 +40,11 @@ class _HashableList:
         return isinstance(other, _HashableList) and self.values == other.values
 
 
-def _hashable(obj):
+def as_hashable(obj):
     if isinstance(obj, dict):
         return _HashableDict(obj)
     elif isinstance(obj, tuple):
-        return tuple(_hashable(x) for x in obj)
+        return tuple(as_hashable(x) for x in obj)
     elif isinstance(obj, list):
         return _HashableList(obj)
     else:
@@ -74,8 +74,8 @@ def _categorical_equal(one, two):
     else:
         one_list = ak._v2.operations.to_list(one_content)
         two_list = ak._v2.operations.to_list(two_content)
-        one_hashable = [_hashable(x) for x in one_list]
-        two_hashable = [_hashable(x) for x in two_list]
+        one_hashable = [as_hashable(x) for x in one_list]
+        two_hashable = [as_hashable(x) for x in two_list]
         two_lookup = {x: i for i, x in enumerate(two_hashable)}
 
         one_to_two = ak.nplike.numpy.empty(len(one_hashable) + 1, dtype=np.int64)
@@ -105,226 +105,6 @@ def _apply_ufunc(ufunc, method, inputs, kwargs):
             nextinputs.append(x)
 
     return getattr(ufunc, method)(*nextinputs, **kwargs)
-
-
-def is_categorical(array):
-    """
-    Args:
-        array: A possibly-categorical Awkward Array.
-
-    If the `array` is categorical (contains #ak.layout.IndexedArray or
-    #ak.layout.IndexedOptionArray labeled with parameter
-    `"__array__" = "categorical"`), then this function returns True;
-    otherwise, it returns False.
-
-    See also #ak.categories, #ak.to_categorical, #ak.from_categorical.
-    """
-
-    layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
-    return layout.purelist_parameter("__array__") == "categorical"
-
-
-def categories(array, highlevel=True):
-    """
-    Args:
-        array: A possibly-categorical Awkward Array.
-        highlevel (bool): If True, return an #ak.Array; otherwise, return
-            a low-level #ak.layout.Content subclass.
-
-    If the `array` is categorical (contains #ak.layout.IndexedArray or
-    #ak.layout.IndexedOptionArray labeled with parameter
-    `"__array__" = "categorical"`), then this function returns its categories.
-
-    See also #ak.is_categorical, #ak.to_categorical, #ak.from_categorical.
-    """
-
-    output = [None]
-
-    def action(layout, **kwargs):
-        if layout.parameter("__array__") == "categorical":
-            output[0] = layout.content
-            return layout
-
-        else:
-            return None
-
-    layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
-    layout.recursively_apply(action)
-
-    if output[0] is None:
-        return None
-    elif highlevel:
-        return ak._v2._util.wrap(output[0], ak._v2._util.behavior_of(array))
-    else:
-        return output[0]
-
-
-def to_categorical(array, highlevel=True):
-    """
-    Args:
-        array: Data convertible to an Awkward Array
-        highlevel (bool): If True, return an #ak.Array; otherwise, return
-            a low-level #ak.layout.Content subclass.
-
-    Creates a categorical dataset, which has the following properties:
-
-       * only distinct values (categories) are stored in their entirety,
-       * pointers to those distinct values are represented by integers
-         (an #ak.layout.IndexedArray or #ak.layout.IndexedOptionArray
-         labeled with parameter `"__array__" = "categorical"`.
-
-    This is equivalent to R's "factor", Pandas's "categorical", and
-    Arrow/Parquet's "dictionary encoding." It differs from generic uses of
-    #ak.layout.IndexedArray and #ak.layout.IndexedOptionArray in Awkward
-    Arrays by the guarantee of no duplicate categories and the `"categorical"`
-    parameter.
-
-        >>> array = ak.Array([["one", "two", "three"], [], ["three", "two"]])
-        >>> categorical = ak.to_categorical(array)
-        >>> categorical
-        <Array [['one', 'two', ... 'three', 'two']] type='3 * var * categorical[type=str...'>
-        >>> ak.type(categorical)
-        3 * var * categorical[type=string]
-        >>> ak.to_list(categorical) == ak.to_list(array)
-        True
-        >>> ak.categories(categorical)
-        <Array ['one', 'two', 'three'] type='3 * string'>
-        >>> ak.is_categorical(categorical)
-        True
-        >>> ak.from_categorical(categorical)
-        <Array [['one', 'two', ... 'three', 'two']] type='3 * var * string'>
-
-    This function descends through nested lists, but not into the fields of
-    records, so records can be categories. To make categorical record
-    fields, split up the record, apply this function to each desired field,
-    and #ak.zip the results together.
-
-        >>> records = ak.Array([
-        ...     {"x": 1.1, "y": "one"},
-        ...     {"x": 2.2, "y": "two"},
-        ...     {"x": 3.3, "y": "three"},
-        ...     {"x": 2.2, "y": "two"},
-        ...     {"x": 1.1, "y": "one"}
-        ... ])
-        >>> records
-        <Array [{x: 1.1, y: 'one'}, ... y: 'one'}] type='5 * {"x": float64, "y": string}'>
-        >>> categorical_records = ak.zip({
-        ...     "x": ak.to_categorical(records["x"]),
-        ...     "y": ak.to_categorical(records["y"]),
-        ... })
-        >>> categorical_records
-        <Array [{x: 1.1, y: 'one'}, ... y: 'one'}] type='5 * {"x": categorical[type=floa...'>
-        >>> ak.type(categorical_records)
-        5 * {"x": categorical[type=float64], "y": categorical[type=string]}
-        >>> ak.to_list(categorical_records) == ak.to_list(records)
-        True
-
-    The check for uniqueness is currently implemented in a Python loop, so
-    conversion to categorical should be regarded as expensive. (This can
-    change, but it would always be an _n log(n)_ operation.)
-
-    See also #ak.is_categorical, #ak.categories, #ak.from_categorical.
-    """
-
-    def action(layout, **kwargs):
-        if layout.purelist_depth == 1:
-            if layout.is_OptionType:
-                layout = layout.simplify_optiontype()
-            if layout.is_IndexedType and layout.is_OptionType:
-                content = layout.content
-                cls = ak._v2.contents.IndexedOptionArray
-            elif layout.is_IndexedType:
-                content = layout.content
-                cls = ak._v2.contents.IndexedArray
-            elif layout.is_OptionType:
-                content = layout.content
-                cls = ak._v2.contents.IndexedOptionArray
-            else:
-                content = layout
-                cls = ak._v2.contents.IndexedArray
-
-            content_list = ak._v2.operations.to_list(content)
-            hashable = [_hashable(x) for x in content_list]
-
-            lookup = {}
-            is_first = ak.nplike.numpy.empty(len(hashable), dtype=np.bool_)
-            mapping = ak.nplike.numpy.empty(len(hashable), dtype=np.int64)
-            for i, x in enumerate(hashable):
-                if x in lookup:
-                    is_first[i] = False
-                    mapping[i] = lookup[x]
-                else:
-                    is_first[i] = True
-                    lookup[x] = j = len(lookup)
-                    mapping[i] = j
-
-            if layout.is_IndexedType and layout.is_OptionType:
-                original_index = ak.nplike.numpy.asarray(layout.index)
-                index = mapping[original_index]
-                index[original_index < 0] = -1
-                index = ak._v2.index.Index64(index)
-
-            elif layout.is_IndexedType:
-                original_index = ak.nplike.numpy.asarray(layout.index)
-                index = ak._v2.index.Index64(mapping[original_index])
-
-            elif layout.is_OptionType:
-                mask = ak.nplike.numpy.asarray(layout.mask_as_bool(valid_when=False))
-                mapping[mask.view(np.bool_)] = -1
-                index = ak._v2.index.Index64(mapping)
-
-            else:
-                index = ak._v2.index.Index64(mapping)
-
-            out = cls(index, content[is_first], parameters={"__array__": "categorical"})
-            return out
-
-        else:
-            return None
-
-    layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = layout.recursively_apply(action)
-    if highlevel:
-        out = ak._v2._util.wrap(out, ak._v2._util.behavior_of(array))
-        return out
-    else:
-        return out
-
-
-def from_categorical(array, highlevel=True):
-    """
-    Args:
-        array: Awkward Array from which to remove the 'categorical' parameter.
-        highlevel (bool): If True, return an #ak.Array; otherwise, return
-            a low-level #ak.layout.Content subclass.
-
-    This function replaces categorical data with non-categorical data (by
-    removing the label that declares it as such).
-
-    This is a metadata-only operation; the running time does not scale with the
-    size of the dataset. (Conversion to categorical is expensive; conversion
-    from categorical is cheap.)
-
-    See also #ak.is_categorical, #ak.categories, #ak.to_categorical,
-    #ak.from_categorical.
-    """
-
-    def action(layout, **kwargs):
-        if layout.parameter("__array__") == "categorical":
-            out = ak._v2.operations.with_parameter(
-                layout, "__array__", None, highlevel=False
-            )
-            return out
-
-        else:
-            return None
-
-    layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = layout.recursively_apply(action)
-    if highlevel:
-        return ak._v2._util.wrap(out, ak._v2._util.behavior_of(array))
-    else:
-        return out
 
 
 def register(behavior):

--- a/src/awkward/_v2/operations/__init__.py
+++ b/src/awkward/_v2/operations/__init__.py
@@ -10,6 +10,7 @@ from awkward._v2.operations.ak_argsort import argsort
 from awkward._v2.operations.ak_backend import backend
 from awkward._v2.operations.ak_broadcast_arrays import broadcast_arrays
 from awkward._v2.operations.ak_cartesian import cartesian
+from awkward._v2.operations.ak_categories import categories
 from awkward._v2.operations.ak_combinations import combinations
 from awkward._v2.operations.ak_concatenate import concatenate
 from awkward._v2.operations.ak_copy import copy
@@ -25,6 +26,7 @@ from awkward._v2.operations.ak_from_arrow import from_arrow
 from awkward._v2.operations.ak_from_arrow_schema import from_arrow_schema
 from awkward._v2.operations.ak_from_avro_file import from_avro_file
 from awkward._v2.operations.ak_from_buffers import from_buffers
+from awkward._v2.operations.ak_from_categorical import from_categorical
 from awkward._v2.operations.ak_from_cupy import from_cupy
 from awkward._v2.operations.ak_from_iter import from_iter
 from awkward._v2.operations.ak_from_jax import from_jax
@@ -35,6 +37,7 @@ from awkward._v2.operations.ak_from_rdataframe import from_rdataframe
 from awkward._v2.operations.ak_from_regular import from_regular
 from awkward._v2.operations.ak_full_like import full_like
 from awkward._v2.operations.ak_isclose import isclose
+from awkward._v2.operations.ak_is_categorical import is_categorical
 from awkward._v2.operations.ak_is_none import is_none
 from awkward._v2.operations.ak_is_tuple import is_tuple
 from awkward._v2.operations.ak_is_valid import is_valid
@@ -68,6 +71,7 @@ from awkward._v2.operations.ak_to_arrow_table import to_arrow_table
 from awkward._v2.operations.ak_to_backend import to_backend
 from awkward._v2.operations.ak_to_buffers import to_buffers
 from awkward._v2.operations.ak_to_cupy import to_cupy
+from awkward._v2.operations.ak_to_categorical import to_categorical
 from awkward._v2.operations.ak_to_jax import to_jax
 from awkward._v2.operations.ak_to_json import to_json
 from awkward._v2.operations.ak_to_layout import to_layout

--- a/src/awkward/_v2/operations/ak_categories.py
+++ b/src/awkward/_v2/operations/ak_categories.py
@@ -2,8 +2,6 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-
 
 def categories(array, highlevel=True):
     """

--- a/src/awkward/_v2/operations/ak_categories.py
+++ b/src/awkward/_v2/operations/ak_categories.py
@@ -1,0 +1,47 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+np = ak.nplike.NumpyMetadata.instance()
+
+
+def categories(array, highlevel=True):
+    """
+    Args:
+        array: A possibly-categorical Awkward Array.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.layout.Content subclass.
+
+    If the `array` is categorical (contains #ak.layout.IndexedArray or
+    #ak.layout.IndexedOptionArray labeled with parameter
+    `"__array__" = "categorical"`), then this function returns its categories.
+
+    See also #ak.is_categorical, #ak.to_categorical, #ak.from_categorical.
+    """
+    with ak._v2._util.OperationErrorContext(
+        "ak._v2.categories",
+        dict(array=array, highlevel=highlevel),
+    ):
+        return _impl(array, highlevel)
+
+
+def _impl(array, highlevel):
+    output = [None]
+
+    def action(layout, **kwargs):
+        if layout.parameter("__array__") == "categorical":
+            output[0] = layout.content
+            return layout
+
+        else:
+            return None
+
+    layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
+    layout.recursively_apply(action)
+
+    if output[0] is None:
+        return None
+    elif highlevel:
+        return ak._v2._util.wrap(output[0], ak._v2._util.behavior_of(array))
+    else:
+        return output[0]

--- a/src/awkward/_v2/operations/ak_from_categorical.py
+++ b/src/awkward/_v2/operations/ak_from_categorical.py
@@ -1,0 +1,48 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+np = ak.nplike.NumpyMetadata.instance()
+
+
+def from_categorical(array, highlevel=True):
+    """
+    Args:
+        array: Awkward Array from which to remove the 'categorical' parameter.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.layout.Content subclass.
+
+    This function replaces categorical data with non-categorical data (by
+    removing the label that declares it as such).
+
+    This is a metadata-only operation; the running time does not scale with the
+    size of the dataset. (Conversion to categorical is expensive; conversion
+    from categorical is cheap.)
+
+    See also #ak.is_categorical, #ak.categories, #ak.to_categorical,
+    #ak.from_categorical.
+    """
+    with ak._v2._util.OperationErrorContext(
+        "ak._v2.from_categorical",
+        dict(array=array, highlevel=highlevel),
+    ):
+        return _impl(array, highlevel)
+
+
+def _impl(array, highlevel):
+    def action(layout, **kwargs):
+        if layout.parameter("__array__") == "categorical":
+            out = ak._v2.operations.with_parameter(
+                layout, "__array__", None, highlevel=False
+            )
+            return out
+
+        else:
+            return None
+
+    layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
+    out = layout.recursively_apply(action)
+    if highlevel:
+        return ak._v2._util.wrap(out, ak._v2._util.behavior_of(array))
+    else:
+        return out

--- a/src/awkward/_v2/operations/ak_from_categorical.py
+++ b/src/awkward/_v2/operations/ak_from_categorical.py
@@ -2,8 +2,6 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-
 
 def from_categorical(array, highlevel=True):
     """

--- a/src/awkward/_v2/operations/ak_is_categorical.py
+++ b/src/awkward/_v2/operations/ak_is_categorical.py
@@ -2,8 +2,6 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-
 
 def is_categorical(array):
     """

--- a/src/awkward/_v2/operations/ak_is_categorical.py
+++ b/src/awkward/_v2/operations/ak_is_categorical.py
@@ -1,0 +1,29 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+np = ak.nplike.NumpyMetadata.instance()
+
+
+def is_categorical(array):
+    """
+    Args:
+        array: A possibly-categorical Awkward Array.
+
+    If the `array` is categorical (contains #ak.layout.IndexedArray or
+    #ak.layout.IndexedOptionArray labeled with parameter
+    `"__array__" = "categorical"`), then this function returns True;
+    otherwise, it returns False.
+
+    See also #ak.categories, #ak.to_categorical, #ak.from_categorical.
+    """
+    with ak._v2._util.OperationErrorContext(
+        "ak._v2.is_categorical",
+        dict(array=array),
+    ):
+        return _impl(array)
+
+
+def _impl(array):
+    layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
+    return layout.purelist_parameter("__array__") == "categorical"

--- a/src/awkward/_v2/operations/ak_to_categorical.py
+++ b/src/awkward/_v2/operations/ak_to_categorical.py
@@ -1,0 +1,146 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+np = ak.nplike.NumpyMetadata.instance()
+
+
+def to_categorical(array, highlevel=True):
+    """
+    Args:
+        array: Data convertible to an Awkward Array
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.layout.Content subclass.
+
+    Creates a categorical dataset, which has the following properties:
+
+       * only distinct values (categories) are stored in their entirety,
+       * pointers to those distinct values are represented by integers
+         (an #ak.layout.IndexedArray or #ak.layout.IndexedOptionArray
+         labeled with parameter `"__array__" = "categorical"`.
+
+    This is equivalent to R's "factor", Pandas's "categorical", and
+    Arrow/Parquet's "dictionary encoding." It differs from generic uses of
+    #ak.layout.IndexedArray and #ak.layout.IndexedOptionArray in Awkward
+    Arrays by the guarantee of no duplicate categories and the `"categorical"`
+    parameter.
+
+        >>> array = ak.Array([["one", "two", "three"], [], ["three", "two"]])
+        >>> categorical = ak.to_categorical(array)
+        >>> categorical
+        <Array [['one', 'two', ... 'three', 'two']] type='3 * var * categorical[type=str...'>
+        >>> ak.type(categorical)
+        3 * var * categorical[type=string]
+        >>> ak.to_list(categorical) == ak.to_list(array)
+        True
+        >>> ak.categories(categorical)
+        <Array ['one', 'two', 'three'] type='3 * string'>
+        >>> ak.is_categorical(categorical)
+        True
+        >>> ak.from_categorical(categorical)
+        <Array [['one', 'two', ... 'three', 'two']] type='3 * var * string'>
+
+    This function descends through nested lists, but not into the fields of
+    records, so records can be categories. To make categorical record
+    fields, split up the record, apply this function to each desired field,
+    and #ak.zip the results together.
+
+        >>> records = ak.Array([
+        ...     {"x": 1.1, "y": "one"},
+        ...     {"x": 2.2, "y": "two"},
+        ...     {"x": 3.3, "y": "three"},
+        ...     {"x": 2.2, "y": "two"},
+        ...     {"x": 1.1, "y": "one"}
+        ... ])
+        >>> records
+        <Array [{x: 1.1, y: 'one'}, ... y: 'one'}] type='5 * {"x": float64, "y": string}'>
+        >>> categorical_records = ak.zip({
+        ...     "x": ak.to_categorical(records["x"]),
+        ...     "y": ak.to_categorical(records["y"]),
+        ... })
+        >>> categorical_records
+        <Array [{x: 1.1, y: 'one'}, ... y: 'one'}] type='5 * {"x": categorical[type=floa...'>
+        >>> ak.type(categorical_records)
+        5 * {"x": categorical[type=float64], "y": categorical[type=string]}
+        >>> ak.to_list(categorical_records) == ak.to_list(records)
+        True
+
+    The check for uniqueness is currently implemented in a Python loop, so
+    conversion to categorical should be regarded as expensive. (This can
+    change, but it would always be an _n log(n)_ operation.)
+
+    See also #ak.is_categorical, #ak.categories, #ak.from_categorical.
+    """
+    with ak._v2._util.OperationErrorContext(
+        "ak._v2.to_categorical",
+        dict(array=array, highlevel=highlevel),
+    ):
+        return _impl(array, highlevel)
+
+
+def _impl(array, highlevel):
+    def action(layout, **kwargs):
+        if layout.purelist_depth == 1:
+            if layout.is_OptionType:
+                layout = layout.simplify_optiontype()
+            if layout.is_IndexedType and layout.is_OptionType:
+                content = layout.content
+                cls = ak._v2.contents.IndexedOptionArray
+            elif layout.is_IndexedType:
+                content = layout.content
+                cls = ak._v2.contents.IndexedArray
+            elif layout.is_OptionType:
+                content = layout.content
+                cls = ak._v2.contents.IndexedOptionArray
+            else:
+                content = layout
+                cls = ak._v2.contents.IndexedArray
+
+            content_list = ak._v2.operations.to_list(content)
+            hashable = [
+                ak._v2.behaviors.categorical.as_hashable(x) for x in content_list
+            ]
+
+            lookup = {}
+            is_first = ak.nplike.numpy.empty(len(hashable), dtype=np.bool_)
+            mapping = ak.nplike.numpy.empty(len(hashable), dtype=np.int64)
+            for i, x in enumerate(hashable):
+                if x in lookup:
+                    is_first[i] = False
+                    mapping[i] = lookup[x]
+                else:
+                    is_first[i] = True
+                    lookup[x] = j = len(lookup)
+                    mapping[i] = j
+
+            if layout.is_IndexedType and layout.is_OptionType:
+                original_index = ak.nplike.numpy.asarray(layout.index)
+                index = mapping[original_index]
+                index[original_index < 0] = -1
+                index = ak._v2.index.Index64(index)
+
+            elif layout.is_IndexedType:
+                original_index = ak.nplike.numpy.asarray(layout.index)
+                index = ak._v2.index.Index64(mapping[original_index])
+
+            elif layout.is_OptionType:
+                mask = ak.nplike.numpy.asarray(layout.mask_as_bool(valid_when=False))
+                mapping[mask.view(np.bool_)] = -1
+                index = ak._v2.index.Index64(mapping)
+
+            else:
+                index = ak._v2.index.Index64(mapping)
+
+            out = cls(index, content[is_first], parameters={"__array__": "categorical"})
+            return out
+
+        else:
+            return None
+
+    layout = ak._v2.operations.to_layout(array, allow_record=False, allow_other=False)
+    out = layout.recursively_apply(action)
+    if highlevel:
+        out = ak._v2._util.wrap(out, ak._v2._util.behavior_of(array))
+        return out
+    else:
+        return out

--- a/tests/v2/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/v2/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -207,14 +207,16 @@ def test_option_two_extra():
 
 def test_to_categorical_numbers():
     array = ak._v2.Array([1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3])
-    assert not ak._v2.behaviors.categorical.is_categorical(array)
-    categorical = ak._v2.behaviors.categorical.to_categorical(array)
-    assert ak._v2.behaviors.categorical.is_categorical(categorical)
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(array)
+    categorical = ak._v2.operations.ak_to_categorical.to_categorical(array)
+    assert ak._v2.operations.ak_is_categorical.is_categorical(categorical)
     assert to_list(array) == categorical.tolist()
     assert to_list(categorical.layout.content) == [1.1, 2.2, 3.3]
-    not_categorical = ak._v2.behaviors.categorical.from_categorical(categorical)
-    assert not ak._v2.behaviors.categorical.is_categorical(not_categorical)
-    assert ak._v2.behaviors.categorical.categories(categorical).tolist() == [
+    not_categorical = ak._v2.operations.ak_from_categorical.from_categorical(
+        categorical
+    )
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(not_categorical)
+    assert ak._v2.operations.ak_categories.categories(categorical).tolist() == [
         1.1,
         2.2,
         3.3,
@@ -223,13 +225,15 @@ def test_to_categorical_numbers():
 
 def test_to_categorical_nested():
     array = ak._v2.Array([["one", "two", "three"], [], ["one", "two"], ["three"]])
-    assert not ak._v2.behaviors.categorical.is_categorical(array)
-    categorical = ak._v2.behaviors.categorical.to_categorical(array)
-    assert ak._v2.behaviors.categorical.is_categorical(categorical)
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(array)
+    categorical = ak._v2.operations.ak_to_categorical.to_categorical(array)
+    assert ak._v2.operations.ak_is_categorical.is_categorical(categorical)
     assert to_list(array) == categorical.tolist()
-    not_categorical = ak._v2.behaviors.categorical.from_categorical(categorical)
-    assert not ak._v2.behaviors.categorical.is_categorical(not_categorical)
-    assert ak._v2.behaviors.categorical.categories(categorical).tolist() == [
+    not_categorical = ak._v2.operations.ak_from_categorical.from_categorical(
+        categorical
+    )
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(not_categorical)
+    assert ak._v2.operations.ak_categories.categories(categorical).tolist() == [
         "one",
         "two",
         "three",
@@ -240,14 +244,16 @@ def test_to_categorical():
     array = ak._v2.Array(
         ["one", "two", "three", "one", "two", "three", "one", "two", "three"]
     )
-    assert not ak._v2.behaviors.categorical.is_categorical(array)
-    categorical = ak._v2.behaviors.categorical.to_categorical(array)
-    assert ak._v2.behaviors.categorical.is_categorical(categorical)
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(array)
+    categorical = ak._v2.operations.ak_to_categorical.to_categorical(array)
+    assert ak._v2.operations.ak_is_categorical.is_categorical(categorical)
     assert to_list(array) == categorical.tolist()
     assert to_list(categorical.layout.content) == ["one", "two", "three"]
-    not_categorical = ak._v2.behaviors.categorical.from_categorical(categorical)
-    assert not ak._v2.behaviors.categorical.is_categorical(not_categorical)
-    assert ak._v2.behaviors.categorical.categories(categorical).tolist() == [
+    not_categorical = ak._v2.operations.ak_from_categorical.from_categorical(
+        categorical
+    )
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(not_categorical)
+    assert ak._v2.operations.ak_categories.categories(categorical).tolist() == [
         "one",
         "two",
         "three",
@@ -271,14 +277,16 @@ def test_to_categorical_none():
             None,
         ]
     )
-    assert not ak._v2.behaviors.categorical.is_categorical(array)
-    categorical = ak._v2.behaviors.categorical.to_categorical(array)
-    assert ak._v2.behaviors.categorical.is_categorical(categorical)
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(array)
+    categorical = ak._v2.operations.ak_to_categorical.to_categorical(array)
+    assert ak._v2.operations.ak_is_categorical.is_categorical(categorical)
     assert to_list(array) == categorical.tolist()
     assert to_list(categorical.layout.content) == ["one", "two", "three"]
-    not_categorical = ak._v2.behaviors.categorical.from_categorical(categorical)
-    assert not ak._v2.behaviors.categorical.is_categorical(not_categorical)
-    assert ak._v2.behaviors.categorical.categories(categorical).tolist() == [
+    not_categorical = ak._v2.operations.ak_from_categorical.from_categorical(
+        categorical
+    )
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(not_categorical)
+    assert ak._v2.operations.ak_categories.categories(categorical).tolist() == [
         "one",
         "two",
         "three",
@@ -323,14 +331,16 @@ def test_to_categorical_masked():
     array = ak._v2.Array(
         ak._v2.contents.ByteMaskedArray(mask, content, valid_when=False)
     )
-    assert not ak._v2.behaviors.categorical.is_categorical(array)
-    categorical = ak._v2.behaviors.categorical.to_categorical(array)
-    assert ak._v2.behaviors.categorical.is_categorical(categorical)
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(array)
+    categorical = ak._v2.operations.ak_to_categorical.to_categorical(array)
+    assert ak._v2.operations.ak_is_categorical.is_categorical(categorical)
     assert to_list(array) == categorical.tolist()
     assert to_list(categorical.layout.content) == ["one", "two", "three"]
-    not_categorical = ak._v2.behaviors.categorical.from_categorical(categorical)
-    assert not ak._v2.behaviors.categorical.is_categorical(not_categorical)
-    assert ak._v2.behaviors.categorical.categories(categorical).tolist() == [
+    not_categorical = ak._v2.operations.ak_from_categorical.from_categorical(
+        categorical
+    )
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(not_categorical)
+    assert ak._v2.operations.ak_categories.categories(categorical).tolist() == [
         "one",
         "two",
         "three",
@@ -366,14 +376,16 @@ def test_to_categorical_masked_again():
     array = ak._v2.Array(
         ak._v2.contents.ByteMaskedArray(mask, indexedarray, valid_when=False)
     )
-    assert not ak._v2.behaviors.categorical.is_categorical(array)
-    categorical = ak._v2.behaviors.categorical.to_categorical(array)
-    assert ak._v2.behaviors.categorical.is_categorical(categorical)
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(array)
+    categorical = ak._v2.operations.ak_to_categorical.to_categorical(array)
+    assert ak._v2.operations.ak_is_categorical.is_categorical(categorical)
     assert to_list(array) == categorical.tolist()
     assert to_list(categorical.layout.content) == ["one", "two", "three"]
-    not_categorical = ak._v2.behaviors.categorical.from_categorical(categorical)
-    assert not ak._v2.behaviors.categorical.is_categorical(not_categorical)
-    assert ak._v2.behaviors.categorical.categories(categorical).tolist() == [
+    not_categorical = ak._v2.operations.ak_from_categorical.from_categorical(
+        categorical
+    )
+    assert not ak._v2.operations.ak_is_categorical.is_categorical(not_categorical)
+    assert ak._v2.operations.ak_categories.categories(categorical).tolist() == [
         "one",
         "two",
         "three",
@@ -385,7 +397,7 @@ def test_typestr():
     assert (
         str(
             ak._v2.operations.type(
-                ak._v2.behaviors.categorical.to_categorical(
+                ak._v2.operations.ak_to_categorical.to_categorical(
                     ak._v2.Array([1.1, 2.2, 2.2, 3.3])
                 )
             )
@@ -395,7 +407,7 @@ def test_typestr():
     assert (
         str(
             ak._v2.operations.type(
-                ak._v2.behaviors.categorical.to_categorical(
+                ak._v2.operations.ak_to_categorical.to_categorical(
                     ak._v2.Array([1.1, 2.2, None, 2.2, 3.3])
                 )
             )
@@ -405,7 +417,7 @@ def test_typestr():
     assert (
         str(
             ak._v2.operations.type(
-                ak._v2.behaviors.categorical.to_categorical(
+                ak._v2.operations.ak_to_categorical.to_categorical(
                     ak._v2.Array(["one", "two", "two", "three"])
                 )
             )
@@ -415,7 +427,7 @@ def test_typestr():
     assert (
         str(
             ak._v2.operations.type(
-                ak._v2.behaviors.categorical.to_categorical(
+                ak._v2.operations.ak_to_categorical.to_categorical(
                     ak._v2.Array(["one", "two", None, "two", "three"])
                 )
             )
@@ -432,7 +444,7 @@ def test_zip():
         {"x": 2.2, "y": "two"},
         {"x": 3.3, "y": "three"},
     ]
-    y = ak._v2.behaviors.categorical.to_categorical(y)
+    y = ak._v2.operations.ak_to_categorical.to_categorical(y)
     assert ak.zip({"x": x, "y": y}).tolist() == [
         {"x": 1.1, "y": "one"},
         {"x": 2.2, "y": "two"},

--- a/tests/v2/test_0404-array-validity-check.py
+++ b/tests/v2/test_0404-array-validity-check.py
@@ -200,7 +200,7 @@ def test_subranges_equal():
 
 def test_categorical():
     array = ak._v2.highlevel.Array(["1chchc", "1chchc", "2sss", "3", "4", "5"])
-    categorical = ak._v2.behaviors.categorical.to_categorical(array)
+    categorical = ak._v2.operations.ak_to_categorical.to_categorical(array)
 
     assert ak._v2.operations.is_valid(categorical) is True
     assert categorical.layout.is_unique() is False

--- a/tests/v2/test_0674-categorical-validation.py
+++ b/tests/v2/test_0674-categorical-validation.py
@@ -11,7 +11,7 @@ pyarrow = pytest.importorskip("pyarrow")
 def test_categorical_is_valid():
     # validate a categorical array by its content
     arr = ak._v2.Array([2019, 2020, 2021, 2020, 2019])
-    categorical = ak._v2.behaviors.categorical.to_categorical(arr)
+    categorical = ak._v2.operations.ak_to_categorical.to_categorical(arr)
     assert ak._v2.operations.is_valid(categorical)
 
 

--- a/tests/v2/test_0773-typeparser.py
+++ b/tests/v2/test_0773-typeparser.py
@@ -238,7 +238,7 @@ def test_arraytype_bytestring():
 
 def test_arraytype_categorical_1():
     text = str(
-        ak._v2.behaviors.categorical.to_categorical(
+        ak._v2.operations.ak_to_categorical.to_categorical(
             ak._v2.Array(["one", "one", "two", "three", "one", "three"])
         ).type
     )
@@ -249,7 +249,7 @@ def test_arraytype_categorical_1():
 
 def test_arraytype_categorical_2():
     text = str(
-        ak._v2.behaviors.categorical.to_categorical(
+        ak._v2.operations.ak_to_categorical.to_categorical(
             ak._v2.Array([1.1, 1.1, 2.2, 3.3, 1.1, 3.3])
         ).type
     )


### PR DESCRIPTION
Fixes #1670

I opted to just move these functions. Is this too much of a breaking change in your view @jpivarski? I'm not firm on what API guarantees we've made w.r.t imports.