### PR TITLE
fix: carry parameters through broadcasting

### DIFF
--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -296,7 +296,7 @@ def _one_to_one_parameters_factory(
     The requested number of outputs is compared against the length of the given
     `inputs`. If the two values match, then a list of parameter objects is returned,
     where each element of the returned list corresponds to the parameters of the
-    content at the same position in the `contents` sequence. If the length of the
+    content at the same position in the `inputs` sequence. If the length of the
     given contents does not match the requested list length, a ValueError is raised.
     """
     # Find the parameters of the inputs, with None values for non-Contents
@@ -314,7 +314,7 @@ def _one_to_one_parameters_factory(
     return apply
 
 
-def _no_parameters_factory(
+def _none_parameters_factory(
     inputs: Sequence,
 ) -> BroadcastParameterFactory:
     """
@@ -339,7 +339,7 @@ BROADCAST_RULE_TO_FACTORY_IMPL = {
     BroadcastParameterRule.INTERSECT: _intersection_parameters_factory,
     BroadcastParameterRule.ALL_OR_NOTHING: _all_or_nothing_parameters_factory,
     BroadcastParameterRule.ONE_TO_ONE: _one_to_one_parameters_factory,
-    BroadcastParameterRule.NONE: _no_parameters_factory,
+    BroadcastParameterRule.NONE: _none_parameters_factory,
 }
 
 

--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -306,7 +306,8 @@ def _one_to_one_parameters_factory(
         if n_outputs != len(inputs):
             raise ak._v2._util.error(
                 ValueError(
-                    'Cannot apply `"ONE_TO_ONE"` for actions which change the number of outputs.'
+                    "cannot follow one-to-one parameter broadcasting rule for actions "
+                    "which change the number of outputs."
                 )
             )
         return input_parameters

--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -726,7 +726,11 @@ def apply_step(
                     options,
                 )
                 assert isinstance(outcontent, tuple)
-                return tuple(RegularArray(x, maxsize, length) for x in outcontent)
+                parameters = parameters_factory(len(outcontent))
+                return tuple(
+                    RegularArray(x, maxsize, length, parameters=p)
+                    for x, p in zip(outcontent, parameters)
+                )
 
             elif not nplike.known_data or not nplike.known_shape:
                 offsets = None

--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -265,7 +265,7 @@ def _intersection_parameters_factory(
     # If we encounter None-parameters, then we stop early
     # as there can be no intersection.
     for parameters in input_parameters:
-        if parameters is None:
+        if ak._v2.forms.form._parameters_is_empty(parameters):
             break
         else:
             parameters_to_intersect.append(parameters.items())

--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -7,7 +7,7 @@ import enum
 import functools
 import itertools
 import operator
-from typing import Any, Callable
+from typing import Any, Callable, Dict, List, Union
 from collections.abc import Sequence
 
 import awkward as ak
@@ -180,7 +180,7 @@ class Sentinel:
             return f"{self._name}"
 
 
-BroadcastParameterFactory = Callable[[int], list[dict[str, Any] | None]]
+BroadcastParameterFactory = Callable[[int], List[Union[Dict[str, Any], None]]]
 
 NO_PARAMETERS = Sentinel("NO_PARAMETERS", __name__)
 

--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -573,11 +573,15 @@ def apply_step(
 
                 assert numoutputs is not None
 
+            parameters = parameters_factory(numoutputs)
             return tuple(
                 UnionArray(
-                    Index8(tags), Index64(index), [x[i] for x in outcontents]
+                    Index8(tags),
+                    Index64(index),
+                    [x[i] for x in outcontents],
+                    parameters=p,
                 ).simplify_uniontype()
-                for i in range(numoutputs)
+                for i, p in enumerate(parameters)
             )
 
         # Any option-types?
@@ -641,8 +645,10 @@ def apply_step(
                 options,
             )
             assert isinstance(outcontent, tuple)
+            parameters = parameters_factory(len(outcontent))
             return tuple(
-                IndexedOptionArray(index, x).simplify_optiontype() for x in outcontent
+                IndexedOptionArray(index, x, parameters=p).simplify_optiontype()
+                for x, p in zip(outcontent, parameters)
             )
 
         # Any list-types?

--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -180,9 +180,9 @@ class Sentinel:
             return f"{self._name}"
 
 
-BroadcastParameterFactory = Callable[[int], List[Union[Dict[str, Any], None]]]
-
 NO_PARAMETERS = Sentinel("NO_PARAMETERS", __name__)
+
+BroadcastParameterFactory = Callable[[int], List[Union[Dict[str, Any], None]]]
 
 
 def _parameters_of(obj: Any, default: Any = NO_PARAMETERS) -> Any:
@@ -254,13 +254,12 @@ def _intersection_parameters_factory(
     `[None, None, ...]`; otherwise, the computed parameter dictionary is repeated,
     i.e. `[parameters, parameters, ...]`.
     """
-    intersected_parameters = None
-    parameters_to_intersect = []
-
     input_parameters = [
         p for p in (_parameters_of(c) for c in inputs) if p is not NO_PARAMETERS
     ]
 
+    intersected_parameters = None
+    parameters_to_intersect = []
     # Build a list of set-like dict.items() views.
     # If we encounter None-parameters, then we stop early
     # as there can be no intersection.

--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -864,7 +864,6 @@ def apply_step(
                             first = x
                             break
 
-                # Find intended
                 offsets = first._compact_offsets64(True)
 
                 nextinputs = []

--- a/src/awkward/_v2/_broadcasting.py
+++ b/src/awkward/_v2/_broadcasting.py
@@ -248,7 +248,7 @@ def _intersection_parameters_factory(
         inputs: sequence of #ak._v2.contents.Content or other objects
 
     Return a callable that creates an appropriately sized list of parameter objects.
-    The parameter objects within this list are built using an "all or nothing rule":
+    The parameter objects within this list are built using an "intersection rule":
 
     The intersection of `content._parameters.items()` for each content is computed.
     If any parameter dictionaries are None, then a list of Nones is returned, i.e.
@@ -291,10 +291,10 @@ def _one_to_one_parameters_factory(
         inputs: sequence of #ak._v2.contents.Content or other objects
 
     Return a callable that creates an appropriately sized list of parameter objects.
-    The parameter objects within this list are built using an "all or nothing rule":
+    The parameter objects within this list are built using a "one-to-one rule":
 
-    The request number of outputs is compared against the length of the given
-    `contents`. If the two values match, then a list of parameter objects is returned,
+    The requested number of outputs is compared against the length of the given
+    `inputs`. If the two values match, then a list of parameter objects is returned,
     where each element of the returned list corresponds to the parameters of the
     content at the same position in the `contents` sequence. If the length of the
     given contents does not match the requested list length, a ValueError is raised.

--- a/src/awkward/_v2/contents/content.py
+++ b/src/awkward/_v2/contents/content.py
@@ -12,6 +12,7 @@ from awkward._v2.tmp_for_testing import v1_to_v2
 np = ak.nplike.NumpyMetadata.instance()
 numpy = ak.nplike.Numpy.instance()
 
+# FIXME: use common Sentinel class for this
 unset = object()
 
 

--- a/src/awkward/_v2/forms/form.py
+++ b/src/awkward/_v2/forms/form.py
@@ -217,6 +217,14 @@ def _parameters_update(one, two):
 
 
 def _parameters_is_empty(parameters: dict[str, Any] | None) -> bool:
+    """
+    Args:
+        parameters (dict or None): parameters dictionary, or None
+
+    Return True if the parameters dictionary is considered empty, either because it is
+    None, or because it does not have any meaningful (non-None) values; otherwise,
+    return False.
+    """
     if parameters is None:
         return True
 

--- a/src/awkward/_v2/forms/form.py
+++ b/src/awkward/_v2/forms/form.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import json
+from typing import Any
 
 import awkward as ak
 
@@ -212,6 +214,17 @@ def _parameters_update(one, two):
     for k, v in two.items():
         if v is not None:
             one[k] = v
+
+
+def _parameters_is_empty(parameters: dict[str, Any] | None) -> bool:
+    if parameters is None:
+        return True
+
+    for item in parameters.values():
+        if item is not None:
+            return False
+
+    return True
 
 
 class Form:

--- a/src/awkward/_v2/operations/ak_broadcast_arrays.py
+++ b/src/awkward/_v2/operations/ak_broadcast_arrays.py
@@ -156,7 +156,10 @@ def _impl(arrays, kwargs):
             ("depth_limit", None),
             ("left_broadcast", True),
             ("right_broadcast", True),
-            ("broadcast_parameters_rule", "ONE_TO_ONE"),
+            (
+                "broadcast_parameters_rule",
+                ak._v2._broadcasting.BroadcastParameterRule.ONE_TO_ONE,
+            ),
         ],
     )
 

--- a/src/awkward/_v2/operations/ak_broadcast_arrays.py
+++ b/src/awkward/_v2/operations/ak_broadcast_arrays.py
@@ -146,6 +146,7 @@ def _impl(arrays, kwargs):
         depth_limit,
         left_broadcast,
         right_broadcast,
+        broadcast_parameters_rule,
     ) = ak._v2._util.extra(
         (),
         kwargs,
@@ -155,6 +156,7 @@ def _impl(arrays, kwargs):
             ("depth_limit", None),
             ("left_broadcast", True),
             ("right_broadcast", True),
+            ("broadcast_parameters_rule", "ONE_TO_ONE"),
         ],
     )
 
@@ -181,6 +183,7 @@ def _impl(arrays, kwargs):
         behavior,
         left_broadcast=left_broadcast,
         right_broadcast=right_broadcast,
+        broadcast_parameters_rule=broadcast_parameters_rule,
         numpy_to_regular=True,
     )
     assert isinstance(out, tuple)

--- a/src/awkward/_v2/operations/ak_transform.py
+++ b/src/awkward/_v2/operations/ak_transform.py
@@ -13,6 +13,7 @@ def transform(
     depth_context=None,
     lateral_context=None,
     allow_records=True,
+    broadcast_parameters_rule="intersect",
     left_broadcast=True,
     right_broadcast=True,
     numpy_to_regular=False,
@@ -42,6 +43,11 @@ def transform(
             `lateral_context` after the transformation.
         allow_records (bool): If False and the recursive walk encounters any
             #ak._v2.contents.RecordArray nodes, an error is raised.
+        broadcast_parameters_rule (str): Rule for broadcasting parameters, one of:
+            - `"intersect"`
+            - `"all_or_nothing"`
+            - `"one_to_one"`
+            - `"none"`
         left_broadcast (bool): If `more_arrays` are provided, the parameter
             determines whether the arrays are left-broadcasted, which is
             Awkward-like broadcasting.
@@ -346,6 +352,33 @@ def transform(
     #ak._v2.broadcast_arrays would return. See #ak._v2.broadcast_arrays for an
     explanation of `left_broadcast` and `right_broadcast`.
 
+    Broadcasting Parameters
+    =======================
+    When broadcasting multiple arrays with parameters, there are different ways of
+    assigning parameters to the outputs. The assignment of array parameters happens
+    at every level above the transformation action.
+
+    The method of parameter assignment used by the broadcasting routine is controlled
+    by the `broadcast_parameters_rule` option, which can take one of the following
+    values:
+
+    `"intersect"`
+        The parameters of each output array will correspond to the intersection
+        of the parameters from each of the input arrays.
+
+    `"all_or_nothing"`
+        If the parameters of the input arrays are all equal, then they will be used
+        for each output array. Otherwise, the output arrays will not be given
+        parameters.
+
+    `"one_to_one"`
+        If the number of output arrays matches the number of input arrays, then the
+        output arrays are given the parameters of the input arrays. Otherwise, a
+        ValueError is raised.
+
+    `"none"`
+        The output arrays will not be given parameters.
+
     See also: #ak.is_valid and #ak.valid_when to check the validity of transformed
     outputs.
     """
@@ -358,6 +391,7 @@ def transform(
             depth_context=depth_context,
             lateral_context=lateral_context,
             allow_records=allow_records,
+            broadcast_parameters_rule=broadcast_parameters_rule,
             left_broadcast=left_broadcast,
             right_broadcast=right_broadcast,
             numpy_to_regular=numpy_to_regular,
@@ -374,6 +408,7 @@ def transform(
             depth_context,
             lateral_context,
             allow_records,
+            broadcast_parameters_rule,
             left_broadcast,
             right_broadcast,
             numpy_to_regular,
@@ -391,6 +426,7 @@ def _impl(
     depth_context,
     lateral_context,
     allow_records,
+    broadcast_parameters_rule,
     left_broadcast,
     right_broadcast,
     numpy_to_regular,
@@ -416,6 +452,7 @@ def _impl(
         "keep_parameters": True,
         "return_array": return_array,
         "function_name": "ak._v2.transform",
+        "broadcast_parameters_rule": broadcast_parameters_rule,
     }
 
     if len(more_layouts) == 0:

--- a/tests/v2/test_1672-broadcast-parameters.py
+++ b/tests/v2/test_1672-broadcast-parameters.py
@@ -175,6 +175,28 @@ def test_broadcast_float_int_2d_right_broadcast():
     assert that.content.parameters == that_next.content.parameters
 
 
+def test_broadcast_float_int_2d_regular():
+    this = ak._v2.contents.RegularArray(
+        ak._v2.contents.NumpyArray(numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
+        size=2,
+        parameters={"name": "this"},
+    )
+    that = ak._v2.contents.RegularArray(
+        ak._v2.contents.NumpyArray(numpy.array([1, 9], dtype="int64")),
+        size=1,
+        parameters={"name": "that"},
+    )
+    this_next, that_next = ak._v2.operations.ak_broadcast_arrays.broadcast_arrays(
+        this, that, highlevel=False
+    )
+
+    assert this.parameters == this_next.parameters
+    assert that.parameters == that_next.parameters
+
+    assert this.content.parameters == this_next.content.parameters
+    assert that.content.parameters == that_next.content.parameters
+
+
 def test_broadcast_string_self():
     this = ak._v2.Array(["one", "two", "one", "nine"])
     that = this

--- a/tests/v2/test_1672-broadcast-parameters.py
+++ b/tests/v2/test_1672-broadcast-parameters.py
@@ -1,0 +1,118 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+@pytest.mark.skip("string broadcasting is broken")
+def test_broadcast_strings_1d():
+    this = ak._v2.Array(["one", "two", "one", "nine"])
+    that = ak._v2.with_parameter(
+        ak._v2.Array(["two", "one", "four", "three"]), "reason", "because!"
+    )
+    this_next, that_next = ak._v2.operations.ak_broadcast_arrays.broadcast_arrays(
+        this, that
+    )
+
+    assert this.layout.parameters == this_next.layout.parameters
+    assert that.layout.parameters == that_next.layout.parameters
+
+
+@pytest.mark.skip("string broadcasting is broken")
+def test_broadcast_strings_1d_right_broadcast():
+    this = ak._v2.Array(["one", "two", "one", "nine"])
+    that = ak._v2.operations.ak_to_regular.to_regular(
+        ak._v2.with_parameter(ak._v2.Array(["two"]), "reason", "because!"), axis=1
+    )
+    this_next, that_next = ak._v2.operations.ak_broadcast_arrays.broadcast_arrays(
+        this, that
+    )
+
+    assert this.layout.parameters == this_next.layout.parameters
+    assert that.layout.parameters == that_next.layout.parameters
+
+
+@pytest.mark.skip("string broadcasting is broken")
+def test_broadcast_strings_2d():
+    this = ak._v2.Array([["one", "two", "one"], ["nine"]])
+    that = ak._v2.to_regular(
+        ak._v2.with_parameter(ak._v2.Array([["two"], ["three"]]), "reason", "because!"),
+        axis=1,
+    )
+    this_next, that_next = ak._v2.operations.ak_broadcast_arrays.broadcast_arrays(
+        this, that
+    )
+
+    assert this.layout.parameters == this_next.layout.parameters
+    assert that.layout.parameters == that_next.layout.parameters
+
+    assert this.layout.content.parameters == this_next.layout.content.parameters
+    assert that.layout.content.parameters == that_next.layout.content.parameters
+
+
+@pytest.mark.skip("string broadcasting is broken")
+def test_broadcast_string_int():
+    this = ak._v2.Array(["one", "two", "one", "nine"])
+    that = ak._v2.operations.ak_with_parameter.with_parameter(
+        ak._v2.Array([1, 2, 1, 9]), "kind", "integer"
+    )
+    this_next, that_next = ak._v2.operations.ak_broadcast_arrays.broadcast_arrays(
+        this, that
+    )
+
+    assert this.layout.parameters == this_next.layout.parameters
+    assert that.layout.parameters == that_next.layout.parameters
+
+
+def test_broadcast_float_int():
+    this = ak._v2.operations.ak_with_parameter.with_parameter(
+        ak._v2.Array([1.0, 2.0, 3.0, 4.0]), "name", "this"
+    )
+    that = ak._v2.operations.ak_with_parameter.with_parameter(
+        ak._v2.Array([1, 2, 1, 9]), "name", "that"
+    )
+    this_next, that_next = ak._v2.operations.ak_broadcast_arrays.broadcast_arrays(
+        this, that
+    )
+
+    assert this.layout.parameters == this_next.layout.parameters
+    assert that.layout.parameters == that_next.layout.parameters
+
+
+def test_broadcast_float_int_2d():
+    this = ak._v2.operations.ak_with_parameter.with_parameter(
+        ak._v2.Array([[1.0, 2.0, 3.0], [4.0]]), "name", "this"
+    )
+    that = ak._v2.operations.ak_with_parameter.with_parameter(
+        ak._v2.Array([[1, 2, 1], [9]]), "name", "that"
+    )
+    this_next, that_next = ak._v2.operations.ak_broadcast_arrays.broadcast_arrays(
+        this, that
+    )
+
+    assert this.layout.parameters == this_next.layout.parameters
+    assert that.layout.parameters == that_next.layout.parameters
+
+    assert this.layout.content.parameters == this_next.layout.content.parameters
+    assert that.layout.content.parameters == that_next.layout.content.parameters
+
+
+def test_broadcast_float_int_2d_right_broadcast():
+    this = ak._v2.operations.ak_with_parameter.with_parameter(
+        ak._v2.Array([[1.0, 2.0, 3.0], [4.0]]), "name", "this"
+    )
+    that = ak._v2.operations.ak_to_regular.to_regular(
+        ak._v2.operations.ak_with_parameter.with_parameter(
+            ak._v2.Array([[1], [9]]), "name", "that"
+        ),
+        axis=1,
+    )
+    this_next, that_next = ak._v2.operations.ak_broadcast_arrays.broadcast_arrays(
+        this, that
+    )
+
+    assert this.layout.parameters == this_next.layout.parameters
+    assert that.layout.parameters == that_next.layout.parameters
+
+    assert this.layout.content.parameters == this_next.layout.content.parameters
+    assert that.layout.content.parameters == that_next.layout.content.parameters


### PR DESCRIPTION
Fixes #1672 

@jpivarski and I discussed the ramifications of this on Zoom. We have always been setting the parameters to None in 

This PR introduces a new `broadcast_parameters_rule` enumeration that selects from the following rules:
- `"intersect"`
   Take the intersection of the broadcasted input parameters.
- `"all_or_nothing"`
   Take the first content's parameters if they are equal to all of the other content's parameters, otherwise `None`.
- `"one_to_one"`
   Assert that the broadcast output matches the broadcast inputs, and if so, take the corresponding parameters (by position).
- `"none"`
   Always set parameters to `None` (previous behaviour)
   
  