### PR TITLE
fix: don't project `categorical` in `ak._v2.packed`

### DIFF
--- a/src/awkward/_v2/contents/indexedarray.py
+++ b/src/awkward/_v2/contents/indexedarray.py
@@ -1244,7 +1244,16 @@ class IndexedArray(Content):
             raise ak._v2._util.error(AssertionError(result))
 
     def packed(self):
-        return self.project().packed()
+        if self.parameter("__array__") == "categorical":
+            return IndexedArray(
+                self._index,
+                self._content.packed(),
+                identifier=self._identifier,
+                parameters=self._parameters,
+                nplike=self._nplike,
+            )
+        else:
+            return self.project().packed()
 
     def _to_list(self, behavior, json_conversions):
         out = self._to_list_custom(behavior, json_conversions)
@@ -1261,8 +1270,8 @@ class IndexedArray(Content):
         return IndexedArray(
             index,
             content,
-            identifier=self.identifier,
-            parameters=self.parameters,
+            identifier=self._identifier,
+            parameters=self._parameters,
             nplike=nplike,
         )
 

--- a/tests/v2/test_1688-pack-categorical.py
+++ b/tests/v2/test_1688-pack-categorical.py
@@ -9,9 +9,16 @@ numpy = ak.nplike.Numpy.instance()
 
 def test():
     this = ak._v2.to_categorical(["one", "two", "one", "three", "one", "four"])
+    assert ak._v2.is_categorical(this)
     # Ensure packing by itself doesn't change the type
-    assert ak._v2.packed(this).type == this.type
+    this_packed = ak._v2.packed(this)
+    assert this_packed.type == this.type
     # Ensure the categories match between the two
-    assert ak._v2.all(ak._v2.categories(ak._v2.packed(this)) == ak._v2.categories(this))
+    assert ak._v2.all(ak._v2.categories(this_packed) == ak._v2.categories(this))
+
     # Ensure the inner types match (ignoring the length change)
-    assert ak._v2.packed(this[:-1]).type.content == this.type.content
+    this_subset_packed = ak._v2.packed(this[:-1])
+    assert ak._v2.is_categorical(this_subset_packed)
+    assert this_subset_packed.type.content == this.type.content
+    # Ensure the categories match between the two
+    assert ak._v2.all(ak._v2.categories(this_subset_packed) == ak._v2.categories(this))

--- a/tests/v2/test_1688-pack-categorical.py
+++ b/tests/v2/test_1688-pack-categorical.py
@@ -1,0 +1,17 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+numpy = ak.nplike.Numpy.instance()
+
+
+def test():
+    this = ak._v2.to_categorical(["one", "two", "one", "three", "one", "four"])
+    # Ensure packing by itself doesn't change the type
+    assert ak._v2.packed(this).type == this.type
+    # Ensure the categories match between the two
+    assert ak._v2.all(ak._v2.categories(ak._v2.packed(this)) == ak._v2.categories(this))
+    # Ensure the inner types match (ignoring the length change)
+    assert ak._v2.packed(this[:-1]).type.content == this.type.content


### PR DESCRIPTION
Fixes #1688 by only packing the `Indexed[Option]Array`'s contents if it is a categorical type.

In the long run, it would be nice if we could mark a layout node as non-transient so that we can implement support for this without hard-coding a test for `__array__ == "categorical"`