### PR TITLE
fix: ensure `behavior` is taken from wrapped array in `ak.Array`

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -198,6 +198,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         elif isinstance(data, Array):
             layout = data._layout
+            behavior = ak._util.behavior_of(data, behavior=behavior)
 
         elif isinstance(data, np.ndarray) and data.dtype != np.dtype("O"):
             layout = ak.operations.from_numpy(data, highlevel=False)

--- a/tests/test_1709-ak-array-constructor-behavior.py
+++ b/tests/test_1709-ak-array-constructor-behavior.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+import awkward as ak  # noqa: F401
+
+
+numpy = ak.nplike.Numpy.instance()
+
+
+class MyBehavior(ak.Array):
+    ...
+
+
+def test():
+    behavior = {"MyBehavior": MyBehavior}
+    array = ak.with_parameter([1, 2, 3], "__array__", "MyBehavior", behavior=behavior)
+    assert isinstance(array, MyBehavior)
+
+    shallow_copy = ak.Array(array)
+    assert isinstance(shallow_copy, MyBehavior)


### PR DESCRIPTION
Fixes #1709 