### PR TITLE
refactor!: disable iteration of records

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1657,8 +1657,8 @@ class Record(NDArrayOperatorsMixin):
     def _ipython_key_completions_(self):
         return self._layout.array.fields
 
-    def __iter__(self):
-        yield from self._layout.array.fields
+    # Disable iteration (and prevent old-style iteration from being used)
+    __iter__ = None
 
     @property
     def type(self):


### PR DESCRIPTION
Fixes #1582 by making `ak.highlevel.Record` non-iterable. Nothing else is changed, as the v2 `builder_from_iter` supports anything that implements a `to_list` or `tolist` method, such as `ak.Record` and `ak.record.Record`