### PR TITLE
fix: Record is not in contents, but in record

### DIFF
--- a/docs-sphinx/index.rst
+++ b/docs-sphinx/index.rst
@@ -152,7 +152,7 @@ Navigation
    * :class:`ak.contents.ListArray`: splits its nested content into variable-length lists with full generality (may use its content non-contiguously, overlapping, or out-of-order).
    * :class:`ak.contents.ListOffsetArray`: splits its nested content into variable-length lists, assuming contiguous, non-overlapping, in-order content.
    * :class:`ak.contents.RecordArray`: represents a logical array of records with a "struct of arrays" layout in memory.
-   * :class:`ak.contents.Record`: represents a single record (not a subclass of :class:`ak.contents.Content` in Python).
+   * :class:`ak.record.Record`: represents a single record (not a subclass of :class:`ak.contents.Content` in Python).
    * :class:`ak.contents.IndexedArray`: rearranges and/or duplicates its content by lazily applying an integer index.
    * :class:`ak.contents.IndexedOptionArray`: same as :class:`ak.contents.IndexedArray` with missing values as negative indexes.
    * :class:`ak.contents.ByteMaskedArray`: represents its content with missing values with an 8-bit boolean mask.

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1451,7 +1451,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 class Record(NDArrayOperatorsMixin):
     """
     Args:
-        data (#ak.contents.Record, #ak.Record, str, or dict):
+        data (#ak.record.Record, #ak.Record, str, or dict):
             Data to wrap or convert into a record.
             If a string, the data are assumed to be JSON.
             If a dict, calls #ak.from_iter, which assumes all inner
@@ -1532,19 +1532,19 @@ class Record(NDArrayOperatorsMixin):
     @property
     def layout(self):
         """
-        The #ak.contents.Record that contains composable #ak.contents.Content
+        The #ak.record.Record that contains composable #ak.contents.Content
         elements to determine how the array is structured.
 
         See #ak.Array.layout for a more complete description.
 
-        The #ak.contents.Record is not a subclass of #ak.contents.Content in
+        The #ak.record.Record is not a subclass of #ak.contents.Content in
         Python (note: [Record](../_static/classawkward_1_1Record.html) *is* a
         subclass of [Content](../_static/classawkward_1_1Content.html) in
-        C++!) and it is not composable with them: #ak.contents.Record contains
+        C++!) and it is not composable with them: #ak.record.Record contains
         one #ak.contents.RecordArray (which is a #ak.contents.Content), but
-        #ak.contents.Content nodes cannot contain a #ak.contents.Record.
+        #ak.contents.Content nodes cannot contain a #ak.record.Record.
 
-        A #ak.contents.Record is not an independent entity from its
+        A #ak.record.Record is not an independent entity from its
         #ak.contents.RecordArray; it's really just a marker indicating which
         element to select. The XML representation reflects that:
 

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -566,7 +566,7 @@ class Cupy(NumpyLike):
                 ak.highlevel.Array,
                 ak.highlevel.Record,
                 ak.contents.Content,
-                ak.contents.Record,
+                ak.record.Record,
             ),
         ):
             out = ak.operations.ak_to_cupy.to_cupy(array)
@@ -600,7 +600,7 @@ class Cupy(NumpyLike):
                 ak.highlevel.Array,
                 ak.highlevel.Record,
                 ak.contents.Content,
-                ak.contents.Record,
+                ak.record.Record,
             ),
         ):
             out = ak.operations.ak_to_cupy.to_cupy(array)
@@ -730,7 +730,7 @@ class Jax(NumpyLike):
                 ak.Record,
                 ak.ArrayBuilder,
                 ak.contents.Content,
-                ak.contents.Record,
+                ak.record.Record,
                 ak._ext.ArrayBuilder,
             ),
         ):
@@ -782,7 +782,7 @@ class Jax(NumpyLike):
                 ak.highlevel.Array,
                 ak.highlevel.Record,
                 ak.contents.Content,
-                ak.contents.Record,
+                ak.record.Record,
             ),
         ):
             out = ak.operations.ak_to_jax.to_jax(array)

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -16,7 +16,7 @@ def from_iter(
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
         allow_record (bool): If True, the outermost element may be a record
-            (returning #ak.Record or #ak.contents.Record type, depending on
+            (returning #ak.Record or #ak.record.Record type, depending on
             `highlevel`); if False, the outermost element must be an array.
         initial (int): Initial size (in bytes) of buffers used by the
             [ak::ArrayBuilder](_static/classawkward_1_1ArrayBuilder.html).

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -6,7 +6,7 @@ import awkward as ak
 def is_tuple(array):
     """
     Args:
-        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.contents.Record, #ak.ArrayBuilder):
+        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):
             Array or record to check.
 
     If `array` is a record, this returns True if the record is a tuple.

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -6,7 +6,7 @@ import awkward as ak
 def is_valid(array, exception=False):
     """
     Args:
-        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.contents.Record, #ak.ArrayBuilder):
+        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):
             Array or record to check.
         exception (bool): If True, validity errors raise exceptions.
 

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -26,7 +26,7 @@ def packed(array, highlevel=True, behavior=None):
     - #ak.contents.ByteMaskedArray becomes an #ak.contents.IndexedOptionArray if it contains records, stays a #ak.contents.ByteMaskedArray otherwise
     - #ak.contents.BitMaskedArray becomes an #ak.contents.IndexedOptionArray if it contains records, stays a #ak.contents.BitMaskedArray otherwise
     - #ak.contents.UnionArray gets projected contents
-    - #ak.contents.Record becomes a record over a single-item #ak.contents.RecordArray
+    - #ak.record.Record becomes a record over a single-item #ak.contents.RecordArray
 
     Example:
 

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -17,20 +17,20 @@ def to_layout(
     """
     Args:
         array: Data to convert into a low-level #ak.contents.Content layout
-            or maybe #ak.contents.Record, its record equivalent, or other types.
-        allow_record (bool): If True, allow #ak.contents.Record as an output;
+            or maybe #ak.record.Record, its record equivalent, or other types.
+        allow_record (bool): If True, allow #ak.record.Record as an output;
             otherwise, if the output would be a scalar record, raise an error.
         allow_other (bool): If True, allow non-Awkward outputs; otherwise,
             if the output would be another type, raise an error.
         numpytype (tuple of NumPy types): Dtypes to allow from NumPy arrays.
 
     Converts `array` (many types supported, including all Awkward Arrays and
-    Records) into a #ak.contents.Content and maybe #ak.contents.Record or
+    Records) into a #ak.contents.Content and maybe #ak.record.Record or
     other types.
 
     This function is usually used to sanitize inputs for other functions; it
     would rarely be used in a data analysis because #ak.contents.Content and
-    #ak.contents.Record are lower-level than #ak.Array.
+    #ak.record.Record are lower-level than #ak.Array.
     """
     with ak._util.OperationErrorContext(
         "ak.to_layout",

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -6,7 +6,7 @@ import awkward as ak
 def validity_error(array, exception=False):
     """
     Args:
-        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.contents.Record, #ak.ArrayBuilder):
+        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):
             Array or record to check.
         exception (bool): If True, validity errors raise exceptions.
 


### PR DESCRIPTION
This is popped up during CUDA testing: `ak.contents.Record` is in `ak.record.Record`