### PR TITLE
fix: don't assume trailing `.` for module name in `is_XXX_buffer`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,9 +10,6 @@ recursive-include tests-cuda-kernels *.py
 recursive-include tests-cuda *.py
 recursive-include tests-spec *.py
 
-recursive-include dlpack *.c *.cc *.h *.in
-include dlpack/LICENSE dlpack/CMakeLists.txt
-
 recursive-include rapidjson/include *
 recursive-include rapidjson *.cmake *.in CMakeLists.txt
 include rapidjson/license.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,6 @@ ignore = [
     "**/Makefile",
     "rapidjson/*.md",
     "rapidjson/docker/*",
-    "dlpack/apps/**",
-    "dlpack/**/*.md",
     "rapidjson/**/*.json",
     "rapidjson/**/*.yml",
     "rapidjson/**/*.js",

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ numba_extensions =
 extend-select = C,B,B9,T,AK1
 extend-ignore = E203,E501,B950,E266
 max-complexity = 100
-exclude = studies, pybind11, rapidjson, dlpack, docs-*, src/awkward/_typeparser/generated_parser.py, awkward/_typeparser/generated_parser.py
+exclude = studies, pybind11, rapidjson, docs-*, src/awkward/_typeparser/generated_parser.py, awkward/_typeparser/generated_parser.py
 per-file-ignores =
     tests/*: T, AK1
     dev/*: T, T201, AK1

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -850,22 +850,50 @@ class Jax(NumpyLike):
         return out
 
 
-def is_numpy_buffer(array):
-    return isinstance(array, numpy.ndarray)
+def is_numpy_buffer(obj) -> bool:
+    """
+    Args:
+        obj: object to test
+
+    Return `True` if the given object is a numpy buffer, otherwise `False`.
+
+    """
+    return isinstance(obj, numpy.ndarray)
 
 
-def is_cupy_buffer(array):
-    module, _, suffix = type(array).__module__.partition(".")
+def is_cupy_buffer(obj) -> bool:
+    """
+    Args:
+        obj: object to test
+
+    Return `True` if the given object is a cupy buffer, otherwise `False`.
+
+    """
+    module, _, suffix = type(obj).__module__.partition(".")
     return module == "cupy"
 
 
-def is_jax_buffer(array):
-    module, _, suffix = type(array).__module__.partition(".")
+def is_jax_buffer(obj) -> bool:
+    """
+    Args:
+        obj: object to test
+
+    Return `True` if the given object is a jax buffer, otherwise `False`.
+
+    """
+    module, _, suffix = type(obj).__module__.partition(".")
     return module == "jaxlib"
 
 
-def is_jax_tracer(tracer):
-    module, _, suffix = type(tracer).__module__.partition(".")
+def is_jax_tracer(obj) -> bool:
+    """
+    Args:
+        obj: object to test
+
+    Return `True` if the given object is a jax tracer, otherwise `False`.
+
+    """
+    module, _, suffix = type(obj).__module__.partition(".")
     return module == "jax"
 
 

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -855,15 +855,18 @@ def is_numpy_buffer(array):
 
 
 def is_cupy_buffer(array):
-    return type(array).__module__.startswith("cupy.")
+    module, _, suffix = type(array).__module__.partition(".")
+    return module == "cupy"
 
 
 def is_jax_buffer(array):
-    return type(array).__module__.startswith("jaxlib.")
+    module, _, suffix = type(array).__module__.partition(".")
+    return module == "jaxlib"
 
 
 def is_jax_tracer(tracer):
-    return type(tracer).__module__.startswith("jax.")
+    module, _, suffix = type(tracer).__module__.partition(".")
+    return module == "jax"
 
 
 def nplike_of(*arrays, default_cls=Numpy):


### PR DESCRIPTION
`ak.nplike.of` was not correctly identifying CuPy arrays, because it was testing `cls.__module__.startswith("cupy.")` instead of `cls.__module__.startswith("cupy")`. I've made this logic more robust by first partitioning the string by the first `.`.

Fixes #1742 