### PR TITLE
refactor: rename `ak.nplike` → `ak.nplikes` & `nplikes.of` →`nplikes.nplike_of`

### DIFF
--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -674,7 +674,7 @@ def gencudakerneltests(specdict):
                 )
 
                 f.write(
-                    "import cupy\nimport pytest\n\nimport awkward as ak\nimport awkward._connect.cuda as ak_cu\n\ncupy_nplike = ak.nplike.Cupy.instance()\n\n"
+                    "import cupy\nimport pytest\n\nimport awkward as ak\nimport awkward._connect.cuda as ak_cu\n\ncupy_nplike = ak.nplikes.Cupy.instance()\n\n"
                 )
                 num = 1
                 if spec.tests == []:

--- a/docs-sphinx/prepare_docstrings.py
+++ b/docs-sphinx/prepare_docstrings.py
@@ -280,7 +280,7 @@ for filename in sorted(glob.glob("../src/awkward/**/*.py", recursive=True),
                         "awkwardforth.rst",
                         ])
 
-    if modulename.startswith("awkward._") or modulename == "awkward.nplike" or modulename == "awkward.types._awkward_datashape_parser":
+    if modulename.startswith("awkward._") or modulename == "awkward.nplikes" or modulename == "awkward.types._awkward_datashape_parser":
         continue  # don't show awkward._*, including _v2
 
     link = ("`{0} <https://github.com/scikit-hep/awkward-1.0/blob/"

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 # NumPy-like alternatives
-import awkward.nplike
+import awkward.nplikes
 
 # shims for C++ (now everything is compiled into one 'awkward._ext' module)
 import awkward._ext

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -30,8 +30,8 @@ from awkward.index import (  # IndexU8,  # noqa: F401; Index32,  # noqa: F401; I
 )
 from awkward.record import Record  # noqa: F401
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 optiontypes = (IndexedOptionArray, ByteMaskedArray, BitMaskedArray, UnmaskedArray)
 listtypes = (ListOffsetArray, ListArray, RegularArray)
@@ -48,7 +48,7 @@ def broadcast_pack(inputs, isscalar):
     nextinputs = []
     for x in inputs:
         if isinstance(x, Record):
-            index = ak.nplike.of(*inputs).full(maxlen, x.at, dtype=np.int64)
+            index = ak.nplikes.of(*inputs).full(maxlen, x.at, dtype=np.int64)
             nextinputs.append(RegularArray(x.array[index], maxlen, 1))
             isscalar.append(True)
         elif isinstance(x, Content):
@@ -1006,7 +1006,7 @@ def broadcast_and_apply(
     function_name=None,
     broadcast_parameters_rule=BroadcastParameterRule.INTERSECT,
 ):
-    nplike = ak.nplike.of(*inputs)
+    nplike = ak.nplikes.of(*inputs)
     isscalar = []
     out = apply_step(
         nplike,

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -48,7 +48,7 @@ def broadcast_pack(inputs, isscalar):
     nextinputs = []
     for x in inputs:
         if isinstance(x, Record):
-            index = ak.nplikes.of(*inputs).full(maxlen, x.at, dtype=np.int64)
+            index = ak.nplikes.nplike_for(*inputs).full(maxlen, x.at, dtype=np.int64)
             nextinputs.append(RegularArray(x.array[index], maxlen, 1))
             isscalar.append(True)
         elif isinstance(x, Content):
@@ -1006,7 +1006,7 @@ def broadcast_and_apply(
     function_name=None,
     broadcast_parameters_rule=BroadcastParameterRule.INTERSECT,
 ):
-    nplike = ak.nplikes.of(*inputs)
+    nplike = ak.nplikes.nplike_for(*inputs)
     isscalar = []
     out = apply_step(
         nplike,

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -48,7 +48,7 @@ def broadcast_pack(inputs, isscalar):
     nextinputs = []
     for x in inputs:
         if isinstance(x, Record):
-            index = ak.nplikes.nplike_for(*inputs).full(maxlen, x.at, dtype=np.int64)
+            index = ak.nplikes.nplike_of(*inputs).full(maxlen, x.at, dtype=np.int64)
             nextinputs.append(RegularArray(x.array[index], maxlen, 1))
             isscalar.append(True)
         elif isinstance(x, Content):
@@ -1006,7 +1006,7 @@ def broadcast_and_apply(
     function_name=None,
     broadcast_parameters_rule=BroadcastParameterRule.INTERSECT,
 ):
-    nplike = ak.nplikes.nplike_for(*inputs)
+    nplike = ak.nplikes.nplike_of(*inputs)
     isscalar = []
     out = apply_step(
         nplike,

--- a/src/awkward/_connect/cling.py
+++ b/src/awkward/_connect/cling.py
@@ -6,8 +6,8 @@ import re
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 cache = {}

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -84,7 +84,7 @@ def _replace_numpyarray_nodes(layout, buffers):
                 buffer,
                 layout.identifier,
                 layout.parameters,
-                nplike=ak.nplike.Jax.instance(),
+                nplike=ak.nplikes.Jax.instance(),
             )
 
     return layout.recursively_apply(action=replace_numpyarray_nodes)

--- a/src/awkward/_connect/jax/_reducers.py
+++ b/src/awkward/_connect/jax/_reducers.py
@@ -3,7 +3,7 @@
 import awkward as ak
 from awkward._connect.jax import import_jax
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class Reducer:

--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -8,7 +8,7 @@ import numba.core.typing.ctypes_utils
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def code_to_function(code, function_name, externals=None, debug=False):
@@ -871,7 +871,7 @@ def array_supported(dtype):
     ) or isinstance(dtype, (numba.types.NPDatetime, numba.types.NPTimedelta))
 
 
-@numba.extending.overload(ak.nplike.numpy.array)
+@numba.extending.overload(ak.nplikes.numpy.array)
 def overload_np_array(array, dtype=None):
     if isinstance(array, ArrayViewType):
         ndim = array.type.ndim
@@ -936,11 +936,11 @@ def array_impl(array, dtype=None):
                     "\n    ".join(fill_array),
                 ),
                 "array_impl",
-                {"numpy": ak.nplike.numpy},
+                {"numpy": ak.nplikes.numpy},
             )
 
 
-@numba.extending.type_callable(ak.nplike.numpy.asarray)
+@numba.extending.type_callable(ak.nplikes.numpy.asarray)
 def type_asarray(context):
     def typer(arrayview):
         if (
@@ -954,7 +954,7 @@ def type_asarray(context):
     return typer
 
 
-@numba.extending.lower_builtin(ak.nplike.numpy.asarray, ArrayViewType)
+@numba.extending.lower_builtin(ak.nplikes.numpy.asarray, ArrayViewType)
 def lower_asarray(context, builder, sig, args):
     rettype, (viewtype,) = sig.return_type, sig.args
     (viewval,) = args

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -6,7 +6,7 @@ import numba.core.typing.ctypes_utils
 
 import awkward as ak
 
-numpy = ak.nplike.Numpy.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 dynamic_addrs = {}
 

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -6,8 +6,8 @@ import numba
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 @numba.extending.typeof_impl.register(ak.contents.Content)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -26,10 +26,10 @@ implemented = {}
 
 def _to_rectilinear(arg):
     if isinstance(arg, tuple):
-        nplike = ak.nplikes.nplike_for(*arg)
+        nplike = ak.nplikes.nplike_of(*arg)
         return tuple(nplike.to_rectilinear(x) for x in arg)
     else:
-        nplike = ak.nplikes.nplike_for(arg)
+        nplike = ak.nplikes.nplike_of(arg)
         nplike.to_rectilinear(arg)
 
 
@@ -39,7 +39,7 @@ def array_function(func, types, args, kwargs):
         args = tuple(_to_rectilinear(x) for x in args)
         kwargs = {k: _to_rectilinear(v) for k, v in kwargs.items()}
         out = func(*args, **kwargs)
-        nplike = ak.nplikes.nplike_for(out)
+        nplike = ak.nplikes.nplike_of(out)
         if isinstance(out, nplike.ndarray) and len(out.shape) != 0:
             return ak.Array(out)
         else:
@@ -149,7 +149,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
             isinstance(x, NumpyArray) or not isinstance(x, ak.contents.Content)
             for x in inputs
         ):
-            nplike = ak.nplikes.nplike_for(*inputs)
+            nplike = ak.nplikes.nplike_of(*inputs)
 
             # Broadcast parameters against one another
             parameters_factory = ak._broadcasting.intersection_parameters_factory(

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -26,10 +26,10 @@ implemented = {}
 
 def _to_rectilinear(arg):
     if isinstance(arg, tuple):
-        nplike = ak.nplike.of(*arg)
+        nplike = ak.nplikes.of(*arg)
         return tuple(nplike.to_rectilinear(x) for x in arg)
     else:
-        nplike = ak.nplike.of(arg)
+        nplike = ak.nplikes.of(arg)
         nplike.to_rectilinear(arg)
 
 
@@ -39,7 +39,7 @@ def array_function(func, types, args, kwargs):
         args = tuple(_to_rectilinear(x) for x in args)
         kwargs = {k: _to_rectilinear(v) for k, v in kwargs.items()}
         out = func(*args, **kwargs)
-        nplike = ak.nplike.of(out)
+        nplike = ak.nplikes.of(out)
         if isinstance(out, nplike.ndarray) and len(out.shape) != 0:
             return ak.Array(out)
         else:
@@ -149,7 +149,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
             isinstance(x, NumpyArray) or not isinstance(x, ak.contents.Content)
             for x in inputs
         ):
-            nplike = ak.nplike.of(*inputs)
+            nplike = ak.nplikes.of(*inputs)
 
             # Broadcast parameters against one another
             parameters_factory = ak._broadcasting.intersection_parameters_factory(
@@ -164,7 +164,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                     else:
                         args.append(x)
 
-                if isinstance(nplike, ak.nplike.Jax):
+                if isinstance(nplike, ak.nplikes.Jax):
                     from awkward._connect.jax import import_jax
 
                     jax = import_jax()

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -26,10 +26,10 @@ implemented = {}
 
 def _to_rectilinear(arg):
     if isinstance(arg, tuple):
-        nplike = ak.nplikes.of(*arg)
+        nplike = ak.nplikes.nplike_for(*arg)
         return tuple(nplike.to_rectilinear(x) for x in arg)
     else:
-        nplike = ak.nplikes.of(arg)
+        nplike = ak.nplikes.nplike_for(arg)
         nplike.to_rectilinear(arg)
 
 
@@ -39,7 +39,7 @@ def array_function(func, types, args, kwargs):
         args = tuple(_to_rectilinear(x) for x in args)
         kwargs = {k: _to_rectilinear(v) for k, v in kwargs.items()}
         out = func(*args, **kwargs)
-        nplike = ak.nplikes.of(out)
+        nplike = ak.nplikes.nplike_for(out)
         if isinstance(out, nplike.ndarray) and len(out.shape) != 0:
             return ak.Array(out)
         else:
@@ -149,7 +149,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
             isinstance(x, NumpyArray) or not isinstance(x, ak.contents.Content)
             for x in inputs
         ):
-            nplike = ak.nplikes.of(*inputs)
+            nplike = ak.nplikes.nplike_for(*inputs)
 
             # Broadcast parameters against one another
             parameters_factory = ak._broadcasting.intersection_parameters_factory(

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -7,7 +7,7 @@ import numpy
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 try:
     import pyarrow
@@ -491,7 +491,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
             ak.contents.NumpyArray(
                 numpy.frombuffer(pacontent, dtype=np.uint8),
                 parameters=sub_parameters,
-                nplike=ak.nplike.Numpy.instance(),
+                nplike=ak.nplikes.Numpy.instance(),
             ),
             storage_type.byte_width,
             parameters=parameters,
@@ -527,7 +527,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
             ak.contents.NumpyArray(
                 numpy.frombuffer(pacontent, dtype=np.uint8),
                 parameters=sub_parameters,
-                nplike=ak.nplike.Numpy.instance(),
+                nplike=ak.nplikes.Numpy.instance(),
             ),
             parameters=parameters,
         )
@@ -627,7 +627,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         out = ak.contents.NumpyArray(
             bytedata.view(np.bool_),
             parameters=node_parameters(awkwardarrow_type),
-            nplike=ak.nplike.Numpy.instance(),
+            nplike=ak.nplikes.Numpy.instance(),
         )
         return popbuffers_finalize(
             out, paarray, validbits, awkwardarrow_type, generate_bitmasks
@@ -647,7 +647,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         out = ak.contents.NumpyArray(
             numpy.frombuffer(data, dtype=dt),
             parameters=node_parameters(awkwardarrow_type),
-            nplike=ak.nplike.Numpy.instance(),
+            nplike=ak.nplikes.Numpy.instance(),
         )
         return popbuffers_finalize(
             out, paarray, validbits, awkwardarrow_type, generate_bitmasks

--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -29,8 +29,8 @@ cpp_type_of = {
     "timedelta64": "std::difftime",
 }
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 cppyy.add_include_path(
@@ -64,7 +64,7 @@ def from_rdataframe(data_frame, columns):
     def empty_buffers(cpp_buffers_self, names_nbytes):
         buffers = {}
         for item in names_nbytes:
-            buffers[item.first] = ak.nplike.numpy.empty(item.second)
+            buffers[item.first] = ak.nplikes.numpy.empty(item.second)
             cpp_buffers_self.append(
                 item.first,
                 buffers[item.first].ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)),

--- a/src/awkward/_lookup.py
+++ b/src/awkward/_lookup.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class Lookup:

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -6,7 +6,7 @@ import re
 
 import awkward as ak
 
-numpy = ak.nplike.Numpy.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 def half(integer):

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class Reducer:

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -61,7 +61,7 @@ def prepare_advanced_indexing(items):
         )
 
     # Then broadcast the index items
-    nplike = ak.nplikes.nplike_for(*broadcastable)
+    nplike = ak.nplikes.nplike_of(*broadcastable)
     broadcasted = nplike.broadcast_arrays(*broadcastable)
 
     # And re-assemble the index with the broadcasted items

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def headtail(oldtail):
@@ -61,7 +61,7 @@ def prepare_advanced_indexing(items):
         )
 
     # Then broadcast the index items
-    nplike = ak.nplike.of(*broadcastable)
+    nplike = ak.nplikes.of(*broadcastable)
     broadcasted = nplike.broadcast_arrays(*broadcastable)
 
     # And re-assemble the index with the broadcasted items
@@ -391,7 +391,7 @@ def normalise_item_bool_to_int(item):
         and issubclass(item.content.content.dtype.type, (bool, np.bool_))
     ):
         if item.nplike.known_data or item.nplike.known_shape:
-            if isinstance(item.nplike, ak.nplike.Jax):
+            if isinstance(item.nplike, ak.nplikes.Jax):
                 raise ak._util.error(
                     "This slice is not supported for JAX differentiation."
                 )
@@ -460,7 +460,7 @@ def normalise_item_bool_to_int(item):
             item.content.dtype.type, (bool, np.bool_)
         ):
             if item.nplike.known_data or item.nplike.known_shape:
-                if isinstance(item.nplike, ak.nplike.Jax):
+                if isinstance(item.nplike, ak.nplikes.Jax):
                     raise ak._util.error(
                         "This slice is not supported for JAX differentiation."
                     )

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -61,7 +61,7 @@ def prepare_advanced_indexing(items):
         )
 
     # Then broadcast the index items
-    nplike = ak.nplikes.of(*broadcastable)
+    nplike = ak.nplikes.nplike_for(*broadcastable)
     broadcasted = nplike.broadcast_arrays(*broadcastable)
 
     # And re-assemble the index with the broadcasted items

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -5,9 +5,9 @@ import numbers
 import numpy
 
 import awkward as ak
-import awkward.nplike
+import awkward.nplikes
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class NoError:
@@ -464,7 +464,7 @@ class TypeTracerArray:
         return self
 
 
-class TypeTracer(ak.nplike.NumpyLike):
+class TypeTracer(ak.nplikes.NumpyLike):
     known_data = False
     known_shape = False
 

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -17,10 +17,10 @@ import packaging.version
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 win = os.name == "nt"
-bits32 = ak.nplike.numpy.iinfo(np.intp).bits == 32
+bits32 = ak.nplikes.numpy.iinfo(np.intp).bits == 32
 
 # matches include/awkward/common.h
 kMaxInt8 = 127  # 2**7  - 1
@@ -32,9 +32,9 @@ kSliceNone = kMaxInt64 + 1  # for Slice::none()
 kMaxLevels = 48
 
 _backends = {
-    "cpu": ak.nplike.Numpy,
-    "cuda": ak.nplike.Cupy,
-    "jax": ak.nplike.Jax,
+    "cpu": ak.nplikes.Numpy,
+    "cuda": ak.nplikes.Cupy,
+    "jax": ak.nplikes.Jax,
 }
 
 
@@ -782,7 +782,7 @@ def extra(args, kwargs, defaults):
 
 
 def union_to_record(unionarray, anonymous):
-    nplike = ak.nplike.of(unionarray)
+    nplike = ak.nplikes.of(unionarray)
 
     contents = []
     for layout in unionarray.contents:
@@ -921,8 +921,8 @@ expand_braces.regex = re.compile(r"\{[^\{\}]*\}")
 
 
 def from_arraylib(array, regulararray, recordarray, highlevel, behavior):
-    np = ak.nplike.NumpyMetadata.instance()
-    numpy = ak.nplike.Numpy.instance()
+    np = ak.nplikes.NumpyMetadata.instance()
+    numpy = ak.nplikes.Numpy.instance()
 
     def recurse(array, mask=None):
         if regulararray and len(array.shape) > 1:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -782,7 +782,7 @@ def extra(args, kwargs, defaults):
 
 
 def union_to_record(unionarray, anonymous):
-    nplike = ak.nplikes.of(unionarray)
+    nplike = ak.nplikes.nplike_for(unionarray)
 
     contents = []
     for layout in unionarray.contents:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -782,7 +782,7 @@ def extra(args, kwargs, defaults):
 
 
 def union_to_record(unionarray, anonymous):
-    nplike = ak.nplikes.nplike_for(unionarray)
+    nplike = ak.nplikes.nplike_of(unionarray)
 
     contents = []
     for layout in unionarray.contents:

--- a/src/awkward/behaviors/categorical.py
+++ b/src/awkward/behaviors/categorical.py
@@ -4,7 +4,7 @@
 import awkward as ak
 from awkward.highlevel import Array
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class CategoricalBehavior(Array):
@@ -61,8 +61,8 @@ def _categorical_equal(one, two):
     assert one.parameter("__array__") == "categorical"
     assert two.parameter("__array__") == "categorical"
 
-    one_index = ak.nplike.numpy.asarray(one.index)
-    two_index = ak.nplike.numpy.asarray(two.index)
+    one_index = ak.nplikes.numpy.asarray(one.index)
+    two_index = ak.nplikes.numpy.asarray(two.index)
     one_content = ak._util.wrap(one.content, behavior)
     two_content = ak._util.wrap(two.content, behavior)
 
@@ -78,7 +78,7 @@ def _categorical_equal(one, two):
         two_hashable = [as_hashable(x) for x in two_list]
         two_lookup = {x: i for i, x in enumerate(two_hashable)}
 
-        one_to_two = ak.nplike.numpy.empty(len(one_hashable) + 1, dtype=np.int64)
+        one_to_two = ak.nplikes.numpy.empty(len(one_hashable) + 1, dtype=np.int64)
         for i, x in enumerate(one_hashable):
             one_to_two[i] = two_lookup.get(x, len(two_hashable))
         one_to_two[-1] = -1
@@ -105,5 +105,5 @@ def _apply_ufunc(ufunc, method, inputs, kwargs):
 
 def register(behavior):
     behavior["categorical"] = CategoricalBehavior
-    behavior[ak.nplike.numpy.equal, "categorical", "categorical"] = _categorical_equal
-    behavior[ak.nplike.numpy.ufunc, "categorical"] = _apply_ufunc
+    behavior[ak.nplikes.numpy.equal, "categorical", "categorical"] = _categorical_equal
+    behavior[ak.nplikes.numpy.ufunc, "categorical"] = _apply_ufunc

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -10,7 +10,7 @@ class ByteBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = ak.nplikes.nplike_for(self.layout).asarray(self.layout)
+        tmp = ak.nplikes.nplike_of(self.layout).asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -51,7 +51,7 @@ class CharBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = ak.nplikes.nplike_for(self.layout).asarray(self.layout)
+        tmp = ak.nplikes.nplike_of(self.layout).asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -105,7 +105,7 @@ class StringBehavior(Array):
 
 
 def _string_equal(one, two):
-    nplike = ak.nplikes.nplike_for(one, two)
+    nplike = ak.nplikes.nplike_of(one, two)
     behavior = ak._util.behavior_of(one, two)
 
     one, two = (
@@ -141,7 +141,7 @@ def _string_notequal(one, two):
 
 
 def _string_broadcast(layout, offsets):
-    nplike = ak.nplikes.nplike_for(offsets)
+    nplike = ak.nplikes.nplike_of(offsets)
     offsets = nplike.asarray(offsets)
     counts = offsets[1:] - offsets[:-1]
     if ak._util.win or ak._util.bits32:

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -3,14 +3,14 @@
 import awkward as ak
 from awkward.highlevel import Array
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class ByteBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = ak.nplike.of(self.layout).asarray(self.layout)
+        tmp = ak.nplikes.of(self.layout).asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -51,7 +51,7 @@ class CharBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = ak.nplike.of(self.layout).asarray(self.layout)
+        tmp = ak.nplikes.of(self.layout).asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -105,7 +105,7 @@ class StringBehavior(Array):
 
 
 def _string_equal(one, two):
-    nplike = ak.nplike.of(one, two)
+    nplike = ak.nplikes.of(one, two)
     behavior = ak._util.behavior_of(one, two)
 
     one, two = (
@@ -141,7 +141,7 @@ def _string_notequal(one, two):
 
 
 def _string_broadcast(layout, offsets):
-    nplike = ak.nplike.of(offsets)
+    nplike = ak.nplikes.of(offsets)
     offsets = nplike.asarray(offsets)
     counts = offsets[1:] - offsets[:-1]
     if ak._util.win or ak._util.bits32:
@@ -247,10 +247,10 @@ def register(behavior):
     behavior["string"] = StringBehavior
     behavior["__typestr__", "string"] = "string"
 
-    behavior[ak.nplike.numpy.equal, "bytestring", "bytestring"] = _string_equal
-    behavior[ak.nplike.numpy.equal, "string", "string"] = _string_equal
-    behavior[ak.nplike.numpy.not_equal, "bytestring", "bytestring"] = _string_notequal
-    behavior[ak.nplike.numpy.not_equal, "string", "string"] = _string_notequal
+    behavior[ak.nplikes.numpy.equal, "bytestring", "bytestring"] = _string_equal
+    behavior[ak.nplikes.numpy.equal, "string", "string"] = _string_equal
+    behavior[ak.nplikes.numpy.not_equal, "bytestring", "bytestring"] = _string_notequal
+    behavior[ak.nplikes.numpy.not_equal, "string", "string"] = _string_notequal
 
     behavior["__broadcast__", "bytestring"] = _string_broadcast
     behavior["__broadcast__", "string"] = _string_broadcast

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -10,7 +10,7 @@ class ByteBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = ak.nplikes.of(self.layout).asarray(self.layout)
+        tmp = ak.nplikes.nplike_for(self.layout).asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -51,7 +51,7 @@ class CharBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = ak.nplikes.of(self.layout).asarray(self.layout)
+        tmp = ak.nplikes.nplike_for(self.layout).asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -105,7 +105,7 @@ class StringBehavior(Array):
 
 
 def _string_equal(one, two):
-    nplike = ak.nplikes.of(one, two)
+    nplike = ak.nplikes.nplike_for(one, two)
     behavior = ak._util.behavior_of(one, two)
 
     one, two = (
@@ -141,7 +141,7 @@ def _string_notequal(one, two):
 
 
 def _string_broadcast(layout, offsets):
-    nplike = ak.nplikes.of(offsets)
+    nplike = ak.nplikes.nplike_for(offsets)
     offsets = nplike.asarray(offsets)
     counts = offsets[1:] - offsets[:-1]
     if ak._util.win or ak._util.bits32:

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -10,8 +10,8 @@ from awkward.contents.content import Content, unset
 from awkward.forms.bitmaskedform import BitMaskedForm
 from awkward.index import Index
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class BitMaskedArray(Content):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -9,8 +9,8 @@ from awkward.contents.content import Content, unset
 from awkward.forms.bytemaskedform import ByteMaskedForm
 from awkward.index import Index
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class ByteMaskedArray(Content):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -8,8 +8,8 @@ from collections.abc import Iterable, Sized
 import awkward as ak
 import awkward._reducers
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 # FIXME: use common Sentinel class for this
 unset = object()
@@ -45,10 +45,10 @@ class Content:
                 )
             )
 
-        if nplike is not None and not isinstance(nplike, ak.nplike.NumpyLike):
+        if nplike is not None and not isinstance(nplike, ak.nplikes.NumpyLike):
             raise ak._util.error(
                 TypeError(
-                    "{} 'nplike' must be an ak.nplike.NumpyLike or None, not {}".format(
+                    "{} 'nplike' must be an ak.nplikes.NumpyLike or None, not {}".format(
                         type(self).__name__, repr(nplike)
                     )
                 )

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -6,8 +6,8 @@ import awkward as ak
 from awkward.contents.content import Content, unset
 from awkward.forms.emptyform import EmptyForm
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class EmptyArray(Content):

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -7,8 +7,8 @@ from awkward.contents.content import Content, unset
 from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class IndexedArray(Content):

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -7,8 +7,8 @@ from awkward.contents.content import Content, unset
 from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class IndexedOptionArray(Content):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -8,7 +8,7 @@ from awkward.contents.listoffsetarray import ListOffsetArray
 from awkward.forms.listform import ListForm
 from awkward.index import Index
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class ListArray(Content):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -7,8 +7,8 @@ from awkward.contents.content import Content, unset
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class ListOffsetArray(Content):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -7,8 +7,8 @@ from awkward.contents.content import Content, unset
 from awkward.forms.numpyform import NumpyForm
 from awkward.types.numpytype import primitive_to_dtype
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class NumpyArray(Content):
@@ -40,12 +40,12 @@ class NumpyArray(Content):
 
     def __init__(self, data, identifier=None, parameters=None, nplike=None):
         if nplike is None:
-            nplike = ak.nplike.of(data)
+            nplike = ak.nplikes.of(data)
         if isinstance(data, ak.index.Index):
             data = data.data
         self._data = nplike.asarray(data)
 
-        if not isinstance(nplike, ak.nplike.Jax):
+        if not isinstance(nplike, ak.nplikes.Jax):
             ak.types.numpytype.dtype_to_primitive(self._data.dtype)
         if len(self._data.shape) == 0:
             raise ak._util.error(
@@ -80,11 +80,11 @@ class NumpyArray(Content):
 
     @property
     def ptr(self):
-        if isinstance(self.nplike, ak.nplike.Numpy):
+        if isinstance(self.nplike, ak.nplikes.Numpy):
             return self._data.ctypes.data
-        elif isinstance(self.nplike, ak.nplike.Cupy):
+        elif isinstance(self.nplike, ak.nplikes.Cupy):
             return self._data.data.ptr
-        elif isinstance(self.nplike, ak.nplike.Jax):
+        elif isinstance(self.nplike, ak.nplikes.Jax):
             return self._data.device_buffer.unsafe_buffer_pointer()
         else:
             raise ak._util.error(
@@ -521,7 +521,7 @@ class NumpyArray(Content):
         # Alternatively, self._data.flags["C_CONTIGUOUS"], but the following assumes
         # less of the nplike.
 
-        if isinstance(self.nplike, ak.nplike.Jax):
+        if isinstance(self.nplike, ak.nplikes.Jax):
             return True
 
         x = self._data.dtype.itemsize
@@ -1095,7 +1095,7 @@ class NumpyArray(Content):
                 behavior,
             )
 
-        if isinstance(self.nplike, ak.nplike.Jax):
+        if isinstance(self.nplike, ak.nplikes.Jax):
             import awkward._connect.jax._reducers  # noqa: F401
 
             if isinstance(reducer, type):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -40,7 +40,7 @@ class NumpyArray(Content):
 
     def __init__(self, data, identifier=None, parameters=None, nplike=None):
         if nplike is None:
-            nplike = ak.nplikes.of(data)
+            nplike = ak.nplikes.nplike_for(data)
         if isinstance(data, ak.index.Index):
             data = data.data
         self._data = nplike.asarray(data)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -40,7 +40,7 @@ class NumpyArray(Content):
 
     def __init__(self, data, identifier=None, parameters=None, nplike=None):
         if nplike is None:
-            nplike = ak.nplikes.nplike_for(data)
+            nplike = ak.nplikes.nplike_of(data)
         if isinstance(data, ak.index.Index):
             data = data.data
         self._data = nplike.asarray(data)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -9,8 +9,8 @@ from awkward.contents.content import Content, unset
 from awkward.forms.recordform import RecordForm
 from awkward.record import Record
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class RecordArray(Content):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -6,8 +6,8 @@ import awkward as ak
 from awkward.contents.content import Content, unset
 from awkward.forms.regularform import RegularForm
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class RegularArray(Content):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -321,7 +321,7 @@ class UnionArray(Content):
     @staticmethod
     def regular_index(tags, IndexClass=Index64, nplike=None):
         if nplike is None:
-            nplike = ak.nplikes.of(tags)
+            nplike = ak.nplikes.nplike_for(tags)
 
         lentags = tags.length
         size = ak.index.Index64.empty(1, nplike)
@@ -370,7 +370,7 @@ class UnionArray(Content):
         offsets, counts, TagsClass=Index8, IndexClass=Index64, nplike=None
     ):
         if nplike is None:
-            nplike = ak.nplikes.of(offsets, counts)
+            nplike = ak.nplikes.nplike_for(offsets, counts)
 
         f_offsets = ak.index.Index64(copy.deepcopy(offsets.data))
         contentlen = f_offsets[f_offsets.length - 1]

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -11,8 +11,8 @@ from awkward.contents.content import Content, unset
 from awkward.forms.unionform import UnionForm
 from awkward.index import Index, Index8, Index64
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class UnionArray(Content):
@@ -321,7 +321,7 @@ class UnionArray(Content):
     @staticmethod
     def regular_index(tags, IndexClass=Index64, nplike=None):
         if nplike is None:
-            nplike = ak.nplike.of(tags)
+            nplike = ak.nplikes.of(tags)
 
         lentags = tags.length
         size = ak.index.Index64.empty(1, nplike)
@@ -370,7 +370,7 @@ class UnionArray(Content):
         offsets, counts, TagsClass=Index8, IndexClass=Index64, nplike=None
     ):
         if nplike is None:
-            nplike = ak.nplike.of(offsets, counts)
+            nplike = ak.nplikes.of(offsets, counts)
 
         f_offsets = ak.index.Index64(copy.deepcopy(offsets.data))
         contentlen = f_offsets[f_offsets.length - 1]

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -321,7 +321,7 @@ class UnionArray(Content):
     @staticmethod
     def regular_index(tags, IndexClass=Index64, nplike=None):
         if nplike is None:
-            nplike = ak.nplikes.nplike_for(tags)
+            nplike = ak.nplikes.nplike_of(tags)
 
         lentags = tags.length
         size = ak.index.Index64.empty(1, nplike)
@@ -370,7 +370,7 @@ class UnionArray(Content):
         offsets, counts, TagsClass=Index8, IndexClass=Index64, nplike=None
     ):
         if nplike is None:
-            nplike = ak.nplikes.nplike_for(offsets, counts)
+            nplike = ak.nplikes.nplike_of(offsets, counts)
 
         f_offsets = ak.index.Index64(copy.deepcopy(offsets.data))
         contentlen = f_offsets[f_offsets.length - 1]

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -6,8 +6,8 @@ import awkward as ak
 from awkward.contents.content import Content, unset
 from awkward.forms.unmaskedform import UnmaskedForm
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class UnmaskedArray(Content):

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_iter(input):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_dtype(dtype, parameters=None):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -10,8 +10,8 @@ from collections.abc import Iterable, Mapping, Sized
 import awkward as ak
 from awkward._connect.numpy import NDArrayOperatorsMixin
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 _dir_pattern = re.compile(r"^[a-zA-Z_]\w*$")
 

--- a/src/awkward/identifier.py
+++ b/src/awkward/identifier.py
@@ -32,7 +32,7 @@ class Identifier:
             raise ak._util.error(
                 TypeError("Identifier fieldloc must be a dict of int -> str")
             )
-        self._nplike = ak.nplikes.nplike_for(data)
+        self._nplike = ak.nplikes.nplike_of(data)
 
         self._data = self._nplike.asarray(data, order="C")
         if len(self._data.shape) != 2:

--- a/src/awkward/identifier.py
+++ b/src/awkward/identifier.py
@@ -32,7 +32,7 @@ class Identifier:
             raise ak._util.error(
                 TypeError("Identifier fieldloc must be a dict of int -> str")
             )
-        self._nplike = ak.nplikes.of(data)
+        self._nplike = ak.nplikes.nplike_for(data)
 
         self._data = self._nplike.asarray(data, order="C")
         if len(self._data.shape) != 2:

--- a/src/awkward/identifier.py
+++ b/src/awkward/identifier.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def _identifiers_equal(one, two):
@@ -32,7 +32,7 @@ class Identifier:
             raise ak._util.error(
                 TypeError("Identifier fieldloc must be a dict of int -> str")
             )
-        self._nplike = ak.nplike.of(data)
+        self._nplike = ak.nplikes.of(data)
 
         self._data = self._nplike.asarray(data, order="C")
         if len(self._data.shape) != 2:

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -4,7 +4,7 @@ import copy
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 _dtype_to_form = {
     np.dtype(np.int8): "i8",
@@ -20,7 +20,7 @@ class Index:
 
     def __init__(self, data, metadata=None, nplike=None):
         if nplike is None:
-            nplike = ak.nplike.of(data)
+            nplike = ak.nplikes.of(data)
         self._nplike = nplike
         if metadata is not None and not isinstance(metadata, dict):
             raise ak._util.error(TypeError("Index metadata must be None or a dict"))
@@ -165,7 +165,7 @@ class Index:
 
         if hasattr(out, "shape") and len(out.shape) != 0:
             return Index(out, metadata=self.metadata, nplike=self.nplike)
-        elif (ak.nplike.is_jax_buffer(out) or ak.nplike.is_cupy_buffer(out)) and len(
+        elif (ak.nplikes.is_jax_buffer(out) or ak.nplikes.is_cupy_buffer(out)) and len(
             out.shape
         ) == 0:
             return out.item()
@@ -198,7 +198,7 @@ class Index:
             return self._to_nplike(ak._util.regularize_backend(backend))
 
     def _to_nplike(self, nplike):
-        # if isinstance(nplike, ak.nplike.Jax):
+        # if isinstance(nplike, ak.nplikes.Jax):
         #     print("YES OFFICER, this nplike right here")
         return Index(self.raw(nplike), metadata=self.metadata, nplike=nplike)
 

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -20,7 +20,7 @@ class Index:
 
     def __init__(self, data, metadata=None, nplike=None):
         if nplike is None:
-            nplike = ak.nplikes.of(data)
+            nplike = ak.nplikes.nplike_for(data)
         self._nplike = nplike
         if metadata is not None and not isinstance(metadata, dict):
             raise ak._util.error(TypeError("Index metadata must be None or a dict"))

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -20,7 +20,7 @@ class Index:
 
     def __init__(self, data, metadata=None, nplike=None):
         if nplike is None:
-            nplike = ak.nplikes.nplike_for(data)
+            nplike = ak.nplikes.nplike_of(data)
         self._nplike = nplike
         if metadata is not None and not isinstance(metadata, dict):
             raise ak._util.error(TypeError("Index metadata must be None or a dict"))

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -717,7 +717,7 @@ class Cupy(NumpyLike):
 class Jax(NumpyLike):
     @property
     def index_nplike(self):
-        return ak.nplike.Numpy.instance()
+        return ak.nplikes.Numpy.instance()
 
     def to_rectilinear(self, array, *args, **kwargs):
         if isinstance(array, self._module.DeviceArray):
@@ -796,11 +796,11 @@ class Jax(NumpyLike):
     def raw(self, array, nplike):
         if isinstance(nplike, Jax):
             return array
-        elif isinstance(nplike, ak.nplike.Cupy):
-            cupy = ak.nplike.Cupy.instance()
+        elif isinstance(nplike, ak.nplikes.Cupy):
+            cupy = ak.nplikes.Cupy.instance()
             return cupy.asarray(array)
-        elif isinstance(nplike, ak.nplike.Numpy):
-            numpy = ak.nplike.Numpy.instance()
+        elif isinstance(nplike, ak.nplikes.Numpy):
+            numpy = ak.nplikes.Numpy.instance()
             return numpy.asarray(array)
         elif isinstance(nplike, ak._typetracer.TypeTracer):
             return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
@@ -872,7 +872,7 @@ def of(*arrays, default_cls=Numpy):
         *arrays: iterable of possible array objects
         default_cls: default NumpyLike class if no array objects found
 
-    Return the #ak.nplike.NumpyLike that is best-suited to operating upon the given
+    Return the #ak.nplikes.NumpyLike that is best-suited to operating upon the given
     iterable of arrays. Return an instance of the `default_cls` if no known array types
     are found.
     """

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -866,7 +866,7 @@ def is_jax_tracer(tracer):
     return type(tracer).__module__.startswith("jax.")
 
 
-def of(*arrays, default_cls=Numpy):
+def nplike_for(*arrays, default_cls=Numpy):
     """
     Args:
         *arrays: iterable of possible array objects

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -866,7 +866,7 @@ def is_jax_tracer(tracer):
     return type(tracer).__module__.startswith("jax.")
 
 
-def nplike_for(*arrays, default_cls=Numpy):
+def nplike_of(*arrays, default_cls=Numpy):
     """
     Args:
         *arrays: iterable of possible array objects

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("all")

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("any")

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def argcartesian(

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def argcombinations(

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argmax")

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argmin")

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argsort")

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -48,13 +48,13 @@ def _impl(arrays):
             allow_other=True,
         )
         if isinstance(layout, (ak.contents.Content, ak.index.Index)):
-            if isinstance(layout.nplike, ak.nplike.Numpy):
+            if isinstance(layout.nplike, ak.nplikes.Numpy):
                 backends.add("cpu")
-            elif isinstance(layout.nplike, ak.nplike.Cupy):
+            elif isinstance(layout.nplike, ak.nplikes.Cupy):
                 backends.add("cuda")
-            elif isinstance(layout.nplike, ak.nplike.Jax):
+            elif isinstance(layout.nplike, ak.nplikes.Jax):
                 backends.add("jax")
-        elif isinstance(layout, ak.nplike.numpy.ndarray):
+        elif isinstance(layout, ak.nplikes.numpy.ndarray):
             backends.add("cpu")
         elif type(layout).__module__.startswith("cupy."):
             backends.add("cuda")

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("broadcast_arrays")
@@ -167,7 +167,7 @@ def _impl(arrays, kwargs):
     for x in arrays:
         y = ak.operations.to_layout(x, allow_record=True, allow_other=True)
         if not isinstance(y, (ak.contents.Content, ak.Record)):
-            y = ak.contents.NumpyArray(ak.nplike.of(*arrays).array([y]))
+            y = ak.contents.NumpyArray(ak.nplikes.of(*arrays).array([y]))
         inputs.append(y)
 
     def action(inputs, depth, **kwargs):

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -167,7 +167,7 @@ def _impl(arrays, kwargs):
     for x in arrays:
         y = ak.operations.to_layout(x, allow_record=True, allow_other=True)
         if not isinstance(y, (ak.contents.Content, ak.Record)):
-            y = ak.contents.NumpyArray(ak.nplikes.nplike_for(*arrays).array([y]))
+            y = ak.contents.NumpyArray(ak.nplikes.nplike_of(*arrays).array([y]))
         inputs.append(y)
 
     def action(inputs, depth, **kwargs):

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -167,7 +167,7 @@ def _impl(arrays, kwargs):
     for x in arrays:
         y = ak.operations.to_layout(x, allow_record=True, allow_other=True)
         if not isinstance(y, (ak.contents.Content, ak.Record)):
-            y = ak.contents.NumpyArray(ak.nplikes.of(*arrays).array([y]))
+            y = ak.contents.NumpyArray(ak.nplikes.nplike_for(*arrays).array([y]))
         inputs.append(y)
 
     def action(inputs, depth, **kwargs):

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def cartesian(
@@ -232,7 +232,7 @@ def cartesian(
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
-        nplike = ak.nplike.of(*arrays.values())
+        nplike = ak.nplikes.of(*arrays.values())
         new_arrays = {}
         for n, x in arrays.items():
             new_arrays[n] = ak.operations.to_layout(
@@ -242,7 +242,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     else:
         arrays = list(arrays)
         behavior = ak._util.behavior_of(*arrays, behavior=behavior)
-        nplike = ak.nplike.of(*arrays)
+        nplike = ak.nplikes.of(*arrays)
         new_arrays = []
         for x in arrays:
             new_arrays.append(

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -232,7 +232,7 @@ def cartesian(
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
-        nplike = ak.nplikes.nplike_for(*arrays.values())
+        nplike = ak.nplikes.nplike_of(*arrays.values())
         new_arrays = {}
         for n, x in arrays.items():
             new_arrays[n] = ak.operations.to_layout(
@@ -242,7 +242,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     else:
         arrays = list(arrays)
         behavior = ak._util.behavior_of(*arrays, behavior=behavior)
-        nplike = ak.nplikes.nplike_for(*arrays)
+        nplike = ak.nplikes.nplike_of(*arrays)
         new_arrays = []
         for x in arrays:
             new_arrays.append(

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -232,7 +232,7 @@ def cartesian(
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
-        nplike = ak.nplikes.of(*arrays.values())
+        nplike = ak.nplikes.nplike_for(*arrays.values())
         new_arrays = {}
         for n, x in arrays.items():
             new_arrays[n] = ak.operations.to_layout(
@@ -242,7 +242,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     else:
         arrays = list(arrays)
         behavior = ak._util.behavior_of(*arrays, behavior=behavior)
-        nplike = ak.nplikes.of(*arrays)
+        nplike = ak.nplikes.nplike_for(*arrays)
         new_arrays = []
         for x in arrays:
             new_arrays.append(

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def combinations(

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -50,7 +50,7 @@ def concatenate(
 
 def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
     # Simple single-array, axis=0 fast-path
-    single_nplike = ak.nplikes.of(arrays)
+    single_nplike = ak.nplikes.nplike_for(arrays)
     if (
         # Is an Awkward Content
         isinstance(arrays, ak.contents.Content)
@@ -132,7 +132,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                 inputs = nextinputs
 
             if depth == posaxis:
-                nplike = ak.nplikes.of(*inputs)
+                nplike = ak.nplikes.nplike_for(*inputs)
 
                 length = ak._typetracer.UnknownLength
                 for x in inputs:

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -3,7 +3,7 @@
 import awkward as ak
 from awkward.operations.ak_fill_none import fill_none
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("concatenate")
@@ -50,14 +50,14 @@ def concatenate(
 
 def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
     # Simple single-array, axis=0 fast-path
-    single_nplike = ak.nplike.of(arrays)
+    single_nplike = ak.nplikes.of(arrays)
     if (
         # Is an Awkward Content
         isinstance(arrays, ak.contents.Content)
         # Is a NumPy Array
-        or ak.nplike.is_numpy_buffer(arrays)
+        or ak.nplikes.is_numpy_buffer(arrays)
         # Is an array with a known NumpyLike
-        or single_nplike is not ak.nplike.Numpy.instance()
+        or single_nplike is not ak.nplikes.Numpy.instance()
     ):
         # Convert the array to a layout object
         content = ak.operations.to_layout(arrays, allow_record=False, allow_other=False)
@@ -132,7 +132,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                 inputs = nextinputs
 
             if depth == posaxis:
-                nplike = ak.nplike.of(*inputs)
+                nplike = ak.nplikes.of(*inputs)
 
                 length = ak._typetracer.UnknownLength
                 for x in inputs:

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -50,7 +50,7 @@ def concatenate(
 
 def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
     # Simple single-array, axis=0 fast-path
-    single_nplike = ak.nplikes.nplike_for(arrays)
+    single_nplike = ak.nplikes.nplike_of(arrays)
     if (
         # Is an Awkward Content
         isinstance(arrays, ak.contents.Content)
@@ -132,7 +132,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                 inputs = nextinputs
 
             if depth == posaxis:
-                nplike = ak.nplikes.nplike_for(*inputs)
+                nplike = ak.nplikes.nplike_of(*inputs)
 
                 length = ak._typetracer.UnknownLength
                 for x in inputs:

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -4,7 +4,7 @@ import copy as _copy
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("copy")

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def corr(
@@ -123,5 +123,5 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        nplike = ak.nplike.of(sumwxy, sumwxx, sumwyy)
+        nplike = ak.nplikes.of(sumwxy, sumwxx, sumwyy)
         return nplike.true_divide(sumwxy, nplike.sqrt(sumwxx * sumwyy))

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -123,5 +123,5 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        nplike = ak.nplikes.nplike_for(sumwxy, sumwxx, sumwyy)
+        nplike = ak.nplikes.nplike_of(sumwxy, sumwxx, sumwyy)
         return nplike.true_divide(sumwxy, nplike.sqrt(sumwxx * sumwyy))

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -123,5 +123,5 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        nplike = ak.nplikes.of(sumwxy, sumwxx, sumwyy)
+        nplike = ak.nplikes.nplike_for(sumwxy, sumwxx, sumwyy)
         return nplike.true_divide(sumwxy, nplike.sqrt(sumwxx * sumwyy))

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def count(array, axis=None, keepdims=False, mask_identity=False, flatten_records=False):

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("count_nonzero")

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -113,4 +113,4 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        return ak.nplikes.nplike_for(sumwxy, sumw).true_divide(sumwxy, sumw)
+        return ak.nplikes.nplike_of(sumwxy, sumw).true_divide(sumwxy, sumw)

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def covar(
@@ -113,4 +113,4 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        return ak.nplike.of(sumwxy, sumw).true_divide(sumwxy, sumw)
+        return ak.nplikes.of(sumwxy, sumw).true_divide(sumwxy, sumw)

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -113,4 +113,4 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        return ak.nplikes.of(sumwxy, sumw).true_divide(sumwxy, sumw)
+        return ak.nplikes.nplike_for(sumwxy, sumw).true_divide(sumwxy, sumw)

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def fields(array):

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -60,7 +60,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 
 def _impl(array, value, axis, highlevel, behavior):
     arraylayout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
-    nplike = ak.nplikes.of(arraylayout)
+    nplike = ak.nplikes.nplike_for(arraylayout)
 
     # Convert value type to appropriate layout
     if (

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -60,7 +60,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 
 def _impl(array, value, axis, highlevel, behavior):
     arraylayout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
-    nplike = ak.nplikes.nplike_for(arraylayout)
+    nplike = ak.nplikes.nplike_of(arraylayout)
 
     # Convert value type to appropriate layout
     if (

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
@@ -60,7 +60,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 
 def _impl(array, value, axis, highlevel, behavior):
     arraylayout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
-    nplike = ak.nplike.of(arraylayout)
+    nplike = ak.nplikes.of(arraylayout)
 
     # Convert value type to appropriate layout
     if (

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def firsts(array, axis=1, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def flatten(array, axis=1, highlevel=True, behavior=None):
@@ -99,7 +99,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    nplike = ak.nplike.of(layout)
+    nplike = ak.nplikes.of(layout)
 
     if axis is None:
         out = layout.completely_flatten(function_name="ak.flatten")

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -99,7 +99,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    nplike = ak.nplikes.nplike_for(layout)
+    nplike = ak.nplikes.nplike_of(layout)
 
     if axis is None:
         out = layout.completely_flatten(function_name="ak.flatten")

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -99,7 +99,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    nplike = ak.nplikes.of(layout)
+    nplike = ak.nplikes.nplike_for(layout)
 
     if axis is None:
         out = layout.completely_flatten(function_name="ak.flatten")

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_arrow(array, generate_bitmasks=False, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_arrow_schema(schema):

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -5,7 +5,7 @@ import pathlib
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_avro_file(

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -4,8 +4,8 @@ import math
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 def from_buffers(
@@ -30,8 +30,8 @@ def from_buffers(
             `"{form_key}"` and/or `"{attribute}"` or a function that takes these
             as keyword arguments and returns a string to use as a key for a buffer
             in the `container`.
-        nplike (#ak.nplike.NumpyLike): Library to use to generate values that are
-            put into the new array. The default, #ak.nplike.Numpy, makes NumPy
+        nplike (#ak.nplikes.NumpyLike): Library to use to generate values that are
+            put into the new array. The default, #ak.nplikes.Numpy, makes NumPy
             arrays, which are in main memory (e.g. not GPU). If all the values in
             `container` have the same `nplike` as this, they won't be copied.
         highlevel (bool): If True, return an #ak.Array; otherwise, return

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_iter(

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -7,8 +7,8 @@ from urllib.parse import urlparse
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 def from_json(

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -234,7 +234,7 @@ def _load(
         )
 
     if len(arrays) == 0:
-        numpy = ak.nplike.Numpy.instance()
+        numpy = ak.nplikes.Numpy.instance()
         return ak.operations.ak_from_buffers._impl(
             subform, 0, _DictOfEmptyBuffers(), "", numpy, highlevel, behavior
         )

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_regular(array, axis=1, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -3,7 +3,7 @@
 import awkward as ak
 from awkward.operations.ak_zeros_like import _ZEROS
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("full_like")
@@ -88,7 +88,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
         # In the case of strings and byte strings,
         # converting the fill avoids a ValueError.
         dtype = np.dtype(dtype)
-        nplike = ak.nplike.of(array)
+        nplike = ak.nplikes.of(array)
         fill_value = nplike.array([fill_value], dtype=dtype)[0]
         # Also, if the fill_value cannot be converted to the dtype
         # this should throw a clear, early, error.
@@ -100,7 +100,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
 
     def action(layout, **kwargs):
         if layout.parameter("__array__") == "bytestring" and fill_value is _ZEROS:
-            nplike = ak.nplike.of(layout)
+            nplike = ak.nplikes.of(layout)
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
@@ -116,7 +116,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "bytestring":
-            nplike = ak.nplike.of(layout)
+            nplike = ak.nplikes.of(layout)
             if isinstance(fill_value, bytes):
                 asbytes = fill_value
             else:
@@ -136,7 +136,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "string" and fill_value is _ZEROS:
-            nplike = ak.nplike.of(layout)
+            nplike = ak.nplikes.of(layout)
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
@@ -152,7 +152,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "string":
-            nplike = ak.nplike.of(layout)
+            nplike = ak.nplikes.of(layout)
             asstr = str(fill_value).encode("utf-8", "surrogateescape")
             asbytes = nplike.frombuffer(asstr, dtype=np.uint8)
             return ak.contents.ListArray(
@@ -168,7 +168,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif isinstance(layout, ak.contents.NumpyArray):
-            nplike = ak.nplike.of(layout)
+            nplike = ak.nplikes.of(layout)
             original = nplike.asarray(layout.data)
 
             if fill_value == 0 or fill_value is _ZEROS:

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -88,7 +88,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
         # In the case of strings and byte strings,
         # converting the fill avoids a ValueError.
         dtype = np.dtype(dtype)
-        nplike = ak.nplikes.nplike_for(array)
+        nplike = ak.nplikes.nplike_of(array)
         fill_value = nplike.array([fill_value], dtype=dtype)[0]
         # Also, if the fill_value cannot be converted to the dtype
         # this should throw a clear, early, error.
@@ -100,7 +100,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
 
     def action(layout, **kwargs):
         if layout.parameter("__array__") == "bytestring" and fill_value is _ZEROS:
-            nplike = ak.nplikes.nplike_for(layout)
+            nplike = ak.nplikes.nplike_of(layout)
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
@@ -116,7 +116,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "bytestring":
-            nplike = ak.nplikes.nplike_for(layout)
+            nplike = ak.nplikes.nplike_of(layout)
             if isinstance(fill_value, bytes):
                 asbytes = fill_value
             else:
@@ -136,7 +136,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "string" and fill_value is _ZEROS:
-            nplike = ak.nplikes.nplike_for(layout)
+            nplike = ak.nplikes.nplike_of(layout)
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
@@ -152,7 +152,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "string":
-            nplike = ak.nplikes.nplike_for(layout)
+            nplike = ak.nplikes.nplike_of(layout)
             asstr = str(fill_value).encode("utf-8", "surrogateescape")
             asbytes = nplike.frombuffer(asstr, dtype=np.uint8)
             return ak.contents.ListArray(
@@ -168,7 +168,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif isinstance(layout, ak.contents.NumpyArray):
-            nplike = ak.nplikes.nplike_for(layout)
+            nplike = ak.nplikes.nplike_of(layout)
             original = nplike.asarray(layout.data)
 
             if fill_value == 0 or fill_value is _ZEROS:

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -88,7 +88,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
         # In the case of strings and byte strings,
         # converting the fill avoids a ValueError.
         dtype = np.dtype(dtype)
-        nplike = ak.nplikes.of(array)
+        nplike = ak.nplikes.nplike_for(array)
         fill_value = nplike.array([fill_value], dtype=dtype)[0]
         # Also, if the fill_value cannot be converted to the dtype
         # this should throw a clear, early, error.
@@ -100,7 +100,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
 
     def action(layout, **kwargs):
         if layout.parameter("__array__") == "bytestring" and fill_value is _ZEROS:
-            nplike = ak.nplikes.of(layout)
+            nplike = ak.nplikes.nplike_for(layout)
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
@@ -116,7 +116,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "bytestring":
-            nplike = ak.nplikes.of(layout)
+            nplike = ak.nplikes.nplike_for(layout)
             if isinstance(fill_value, bytes):
                 asbytes = fill_value
             else:
@@ -136,7 +136,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "string" and fill_value is _ZEROS:
-            nplike = ak.nplikes.of(layout)
+            nplike = ak.nplikes.nplike_for(layout)
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
@@ -152,7 +152,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "string":
-            nplike = ak.nplikes.of(layout)
+            nplike = ak.nplikes.nplike_for(layout)
             asstr = str(fill_value).encode("utf-8", "surrogateescape")
             asbytes = nplike.frombuffer(asstr, dtype=np.uint8)
             return ak.contents.ListArray(
@@ -168,7 +168,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif isinstance(layout, ak.contents.NumpyArray):
-            nplike = ak.nplikes.of(layout)
+            nplike = ak.nplikes.nplike_for(layout)
             original = nplike.asarray(layout.data)
 
             if fill_value == 0 or fill_value is _ZEROS:

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -36,7 +36,7 @@ def _impl(array, axis, highlevel, behavior):
         if not isinstance(layout, ak.contents.Content):
             return
 
-        nplike = ak.nplikes.nplike_for(layout)
+        nplike = ak.nplikes.nplike_of(layout)
 
         if layout.is_OptionType:
             layout = layout.toIndexedOptionArray64()

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def is_none(array, axis=0, highlevel=True, behavior=None):
@@ -36,7 +36,7 @@ def _impl(array, axis, highlevel, behavior):
         if not isinstance(layout, ak.contents.Content):
             return
 
-        nplike = ak.nplike.of(layout)
+        nplike = ak.nplikes.of(layout)
 
         if layout.is_OptionType:
             layout = layout.toIndexedOptionArray64()

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -36,7 +36,7 @@ def _impl(array, axis, highlevel, behavior):
         if not isinstance(layout, ak.contents.Content):
             return
 
-        nplike = ak.nplikes.of(layout)
+        nplike = ak.nplikes.nplike_for(layout)
 
         if layout.is_OptionType:
             layout = layout.toIndexedOptionArray64()

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 ### FIXME: ak._connect.numpy.implements needs to exist!

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def linear_fit(
@@ -96,7 +96,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
         )
 
     with np.errstate(invalid="ignore"):
-        nplike = ak.nplike.of(x, y, weight)
+        nplike = ak.nplikes.of(x, y, weight)
         if weight is None:
             sumw = ak.operations.ak_count._impl(
                 x, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -96,7 +96,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
         )
 
     with np.errstate(invalid="ignore"):
-        nplike = ak.nplikes.nplike_for(x, y, weight)
+        nplike = ak.nplikes.nplike_of(x, y, weight)
         if weight is None:
             sumw = ak.operations.ak_count._impl(
                 x, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -96,7 +96,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
         )
 
     with np.errstate(invalid="ignore"):
-        nplike = ak.nplikes.of(x, y, weight)
+        nplike = ak.nplikes.nplike_for(x, y, weight)
         if weight is None:
             sumw = ak.operations.ak_count._impl(
                 x, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def local_index(array, axis=-1, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -102,7 +102,7 @@ def _impl(array, mask, valid_when, highlevel, behavior):
     def action(inputs, **kwargs):
         layoutarray, layoutmask = inputs
         if isinstance(layoutmask, ak.contents.NumpyArray):
-            m = ak.nplikes.of(layoutmask).asarray(layoutmask)
+            m = ak.nplikes.nplike_for(layoutmask).asarray(layoutmask)
             if not issubclass(m.dtype.type, (bool, np.bool_)):
                 raise ak._util.error(
                     ValueError(

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -102,7 +102,7 @@ def _impl(array, mask, valid_when, highlevel, behavior):
     def action(inputs, **kwargs):
         layoutarray, layoutmask = inputs
         if isinstance(layoutmask, ak.contents.NumpyArray):
-            m = ak.nplikes.nplike_for(layoutmask).asarray(layoutmask)
+            m = ak.nplikes.nplike_of(layoutmask).asarray(layoutmask)
             if not issubclass(m.dtype.type, (bool, np.bool_)):
                 raise ak._util.error(
                     ValueError(

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
@@ -102,7 +102,7 @@ def _impl(array, mask, valid_when, highlevel, behavior):
     def action(inputs, **kwargs):
         layoutarray, layoutmask = inputs
         if isinstance(layoutmask, ak.contents.NumpyArray):
-            m = ak.nplike.of(layoutmask).asarray(layoutmask)
+            m = ak.nplikes.of(layoutmask).asarray(layoutmask)
             if not issubclass(m.dtype.type, (bool, np.bool_)):
                 raise ak._util.error(
                     ValueError(

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("max")

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("mean")
@@ -170,4 +170,4 @@ def _impl(x, weight, axis, keepdims, mask_identity, flatten_records):
             sumwx = ak.operations.ak_sum._impl(
                 x * weight, axis, keepdims, mask_identity, flatten_records
             )
-        return ak.nplike.of(sumwx, sumw).true_divide(sumwx, sumw)
+        return ak.nplikes.of(sumwx, sumw).true_divide(sumwx, sumw)

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -170,4 +170,4 @@ def _impl(x, weight, axis, keepdims, mask_identity, flatten_records):
             sumwx = ak.operations.ak_sum._impl(
                 x * weight, axis, keepdims, mask_identity, flatten_records
             )
-        return ak.nplikes.of(sumwx, sumw).true_divide(sumwx, sumw)
+        return ak.nplikes.nplike_for(sumwx, sumw).true_divide(sumwx, sumw)

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -170,4 +170,4 @@ def _impl(x, weight, axis, keepdims, mask_identity, flatten_records):
             sumwx = ak.operations.ak_sum._impl(
                 x * weight, axis, keepdims, mask_identity, flatten_records
             )
-        return ak.nplikes.nplike_for(sumwx, sumw).true_divide(sumwx, sumw)
+        return ak.nplikes.nplike_of(sumwx, sumw).true_divide(sumwx, sumw)

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -4,7 +4,7 @@ import collections
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 ParquetMetadata = collections.namedtuple(

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("min")

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -104,4 +104,4 @@ def _impl(x, n, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        return ak.nplikes.nplike_for(sumwxn, sumw).true_divide(sumwxn, sumw)
+        return ak.nplikes.nplike_of(sumwxn, sumw).true_divide(sumwxn, sumw)

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def moment(
@@ -104,4 +104,4 @@ def _impl(x, n, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        return ak.nplike.of(sumwxn, sumw).true_divide(sumwxn, sumw)
+        return ak.nplikes.of(sumwxn, sumw).true_divide(sumwxn, sumw)

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -104,4 +104,4 @@ def _impl(x, n, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        return ak.nplikes.of(sumwxn, sumw).true_divide(sumwxn, sumw)
+        return ak.nplikes.nplike_for(sumwxn, sumw).true_divide(sumwxn, sumw)

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def nan_to_none(array, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("nan_to_num")
@@ -68,7 +68,7 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
         broadcasting_ids[id(neginf)] = len(broadcasting)
         broadcasting.append(neginf_layout)
 
-    nplike = ak.nplike.of(layout)
+    nplike = ak.nplikes.of(layout)
 
     if len(broadcasting) == 1:
 

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -68,7 +68,7 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
         broadcasting_ids[id(neginf)] = len(broadcasting)
         broadcasting.append(neginf_layout)
 
-    nplike = ak.nplikes.of(layout)
+    nplike = ak.nplikes.nplike_for(layout)
 
     if len(broadcasting) == 1:
 

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -68,7 +68,7 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
         broadcasting_ids[id(neginf)] = len(broadcasting)
         broadcasting.append(neginf_layout)
 
-    nplike = ak.nplikes.nplike_for(layout)
+    nplike = ak.nplikes.nplike_of(layout)
 
     if len(broadcasting) == 1:
 

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def num(array, axis=1, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ones_like")

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def packed(array, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def pad_none(array, target, axis=1, clip=False, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -5,7 +5,7 @@ import numbers
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def parameters(array):

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("prod")

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ptp")

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -50,7 +50,7 @@ def ravel(array, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    nplike = ak.nplikes.nplike_for(layout)
+    nplike = ak.nplikes.nplike_of(layout)
 
     out = layout.completely_flatten(function_name="ak.ravel")
     assert isinstance(out, tuple) and all(isinstance(x, nplike.ndarray) for x in out)

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ravel")
@@ -50,7 +50,7 @@ def ravel(array, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    nplike = ak.nplike.of(layout)
+    nplike = ak.nplikes.of(layout)
 
     out = layout.completely_flatten(function_name="ak.ravel")
     assert isinstance(out, tuple) and all(isinstance(x, nplike.ndarray) for x in out)

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -50,7 +50,7 @@ def ravel(array, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    nplike = ak.nplikes.of(layout)
+    nplike = ak.nplikes.nplike_for(layout)
 
     out = layout.completely_flatten(function_name="ak.ravel")
     assert isinstance(out, tuple) and all(isinstance(x, nplike.ndarray) for x in out)

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -95,7 +95,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 
 
 def _impl(array, highlevel, behavior):
-    nplike = ak.nplikes.of(array)
+    nplike = ak.nplikes.nplike_for(array)
 
     def lengths_of(data, offsets):
         if len(data) == 0:

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -95,7 +95,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 
 
 def _impl(array, highlevel, behavior):
-    nplike = ak.nplikes.nplike_for(array)
+    nplike = ak.nplikes.nplike_of(array)
 
     def lengths_of(data, offsets):
         if len(data) == 0:

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def run_lengths(array, highlevel=True, behavior=None):
@@ -95,7 +95,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 
 
 def _impl(array, highlevel, behavior):
-    nplike = ak.nplike.of(array)
+    nplike = ak.nplikes.of(array)
 
     def lengths_of(data, offsets):
         if len(data) == 0:

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -35,7 +35,7 @@ def singletons(array, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior):
     def action(layout, **kwargs):
-        nplike = ak.nplikes.of(layout)
+        nplike = ak.nplikes.nplike_for(layout)
 
         if layout.is_OptionType:
             nulls = nplike.index_nplike.asarray(

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def singletons(array, highlevel=True, behavior=None):
@@ -35,7 +35,7 @@ def singletons(array, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior):
     def action(layout, **kwargs):
-        nplike = ak.nplike.of(layout)
+        nplike = ak.nplikes.of(layout)
 
         if layout.is_OptionType:
             nulls = nplike.index_nplike.asarray(

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -35,7 +35,7 @@ def singletons(array, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior):
     def action(layout, **kwargs):
-        nplike = ak.nplikes.nplike_for(layout)
+        nplike = ak.nplikes.nplike_of(layout)
 
         if layout.is_OptionType:
             nulls = nplike.index_nplike.asarray(

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -59,7 +59,7 @@ def _impl(x, axis, keepdims, mask_identity, flatten_records):
     )
 
     with np.errstate(invalid="ignore"):
-        nplike = ak.nplikes.nplike_for(x)
+        nplike = ak.nplikes.nplike_of(x)
         expx = nplike.exp(x)
         denom = ak.operations.ak_sum._impl(
             expx, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def softmax(x, axis=None, keepdims=False, mask_identity=False, flatten_records=False):
@@ -59,7 +59,7 @@ def _impl(x, axis, keepdims, mask_identity, flatten_records):
     )
 
     with np.errstate(invalid="ignore"):
-        nplike = ak.nplike.of(x)
+        nplike = ak.nplikes.of(x)
         expx = nplike.exp(x)
         denom = ak.operations.ak_sum._impl(
             expx, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -59,7 +59,7 @@ def _impl(x, axis, keepdims, mask_identity, flatten_records):
     )
 
     with np.errstate(invalid="ignore"):
-        nplike = ak.nplikes.of(x)
+        nplike = ak.nplikes.nplike_for(x)
         expx = nplike.exp(x)
         denom = ak.operations.ak_sum._impl(
             expx, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("sort")

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -150,7 +150,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
         )
 
     with np.errstate(invalid="ignore"):
-        return ak.nplikes.nplike_for(x, weight).sqrt(
+        return ak.nplikes.nplike_of(x, weight).sqrt(
             ak.operations.ak_var._impl(
                 x,
                 weight,

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -150,7 +150,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
         )
 
     with np.errstate(invalid="ignore"):
-        return ak.nplikes.of(x, weight).sqrt(
+        return ak.nplikes.nplike_for(x, weight).sqrt(
             ak.operations.ak_var._impl(
                 x,
                 weight,

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("std")
@@ -150,7 +150,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
         )
 
     with np.errstate(invalid="ignore"):
-        return ak.nplike.of(x, weight).sqrt(
+        return ak.nplikes.of(x, weight).sqrt(
             ak.operations.ak_var._impl(
                 x,
                 weight,

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def strings_astype(array, to, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("sum")

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def to_arrow(

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -4,7 +4,7 @@ import json
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def to_arrow_table(

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def to_backend(array, backend, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -2,8 +2,8 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 def to_buffers(
@@ -36,8 +36,8 @@ def to_buffers(
         id_start (int): Starting `id` to use in `form_key` and hence `buffer_key`.
             This integer increases in a depth-first walk over the `array` nodes and
             can be used to generate unique keys for each Form.
-        nplike (#ak.nplike.NumpyLike): Library to use to generate values that are
-            put into the `container`. The default, #ak.nplike.Numpy, makes NumPy
+        nplike (#ak.nplikes.NumpyLike): Library to use to generate values that are
+            put into the `container`. The default, #ak.nplikes.Numpy, makes NumPy
             arrays, which are in main memory (e.g. not GPU) and satisfy Python's
             Buffer protocol. If all the buffers in `array` have the same `nplike`
             as this, they won't be copied.

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def to_categorical(array, highlevel=True):
@@ -100,8 +100,8 @@ def _impl(array, highlevel):
             hashable = [ak.behaviors.categorical.as_hashable(x) for x in content_list]
 
             lookup = {}
-            is_first = ak.nplike.numpy.empty(len(hashable), dtype=np.bool_)
-            mapping = ak.nplike.numpy.empty(len(hashable), dtype=np.int64)
+            is_first = ak.nplikes.numpy.empty(len(hashable), dtype=np.bool_)
+            mapping = ak.nplikes.numpy.empty(len(hashable), dtype=np.int64)
             for i, x in enumerate(hashable):
                 if x in lookup:
                     is_first[i] = False
@@ -112,17 +112,17 @@ def _impl(array, highlevel):
                     mapping[i] = j
 
             if layout.is_IndexedType and layout.is_OptionType:
-                original_index = ak.nplike.numpy.asarray(layout.index)
+                original_index = ak.nplikes.numpy.asarray(layout.index)
                 index = mapping[original_index]
                 index[original_index < 0] = -1
                 index = ak.index.Index64(index)
 
             elif layout.is_IndexedType:
-                original_index = ak.nplike.numpy.asarray(layout.index)
+                original_index = ak.nplikes.numpy.asarray(layout.index)
                 index = ak.index.Index64(mapping[original_index])
 
             elif layout.is_OptionType:
-                mask = ak.nplike.numpy.asarray(layout.mask_as_bool(valid_when=False))
+                mask = ak.nplikes.numpy.asarray(layout.mask_as_bool(valid_when=False))
                 mapping[mask.view(np.bool_)] = -1
                 index = ak.index.Index64(mapping)
 

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -2,9 +2,9 @@
 
 import awkward as ak
 
-numpy = ak.nplike.Numpy.instance()
+numpy = ak.nplikes.Numpy.instance()
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def to_dataframe(

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -7,8 +7,8 @@ from urllib.parse import urlparse
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 def to_json(

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -4,8 +4,8 @@ from collections.abc import Iterable
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
-numpy = ak.nplike.Numpy.instance()
+np = ak.nplikes.NumpyMetadata.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 def to_layout(
@@ -85,7 +85,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplike.is_cupy_buffer(array) and type(array).__name__ == "ndarray":
+    elif ak.nplikes.is_cupy_buffer(array) and type(array).__name__ == "ndarray":
         if not issubclass(array.dtype.type, numpytype):
             raise ak._util.error(ValueError(f"dtype {array.dtype!r} not allowed"))
         return _impl(
@@ -95,7 +95,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplike.is_jax_buffer(array) and type(array).__name__ == "DeviceArray":
+    elif ak.nplikes.is_jax_buffer(array) and type(array).__name__ == "DeviceArray":
         if not issubclass(array.dtype.type, numpytype):
             raise ak._util.error(ValueError(f"dtype {array.dtype!r} not allowed"))
         return _impl(

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Mapping
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def to_list(array):

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def to_regular(array, axis=1, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -441,7 +441,7 @@ def _impl(
     more_layouts = [
         ak.to_layout(x, allow_record=False, allow_other=False) for x in more_arrays
     ]
-    nplike = ak.nplikes.nplike_for(layout, *more_layouts)
+    nplike = ak.nplikes.nplike_of(layout, *more_layouts)
 
     options = {
         "allow_records": allow_records,

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -441,7 +441,7 @@ def _impl(
     more_layouts = [
         ak.to_layout(x, allow_record=False, allow_other=False) for x in more_arrays
     ]
-    nplike = ak.nplikes.of(layout, *more_layouts)
+    nplike = ak.nplikes.nplike_for(layout, *more_layouts)
 
     options = {
         "allow_records": allow_records,

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -441,7 +441,7 @@ def _impl(
     more_layouts = [
         ak.to_layout(x, allow_record=False, allow_other=False) for x in more_arrays
     ]
-    nplike = ak.nplike.of(layout, *more_layouts)
+    nplike = ak.nplikes.of(layout, *more_layouts)
 
     options = {
         "allow_records": allow_records,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -4,7 +4,7 @@ import numbers
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def type(array):

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -75,7 +75,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 
 
 def _impl(array, counts, axis, highlevel, behavior):
-    nplike = ak.nplikes.nplike_for(array)
+    nplike = ak.nplikes.nplike_of(array)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -75,7 +75,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 
 
 def _impl(array, counts, axis, highlevel, behavior):
-    nplike = ak.nplikes.of(array)
+    nplike = ak.nplikes.nplike_for(array)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -4,7 +4,7 @@ import numbers
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
@@ -75,7 +75,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 
 
 def _impl(array, counts, axis, highlevel, behavior):
-    nplike = ak.nplike.of(array)
+    nplike = ak.nplikes.of(array)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 
@@ -87,7 +87,7 @@ def _impl(array, counts, axis, highlevel, behavior):
         if counts.is_OptionType:
             mask = counts.mask_as_bool(valid_when=False)
             counts = counts.to_numpy(allow_missing=True)
-            counts = ak.nplike.numpy.ma.filled(counts, 0)
+            counts = ak.nplikes.numpy.ma.filled(counts, 0)
         elif counts.is_NumpyType or counts.is_UnknownType:
             counts = counts.to_numpy(allow_missing=False)
             mask = False

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def unzip(array, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def values_astype(array, to, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("var")
@@ -186,8 +186,8 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
                 flatten_records,
             )
         if ddof != 0:
-            return ak.nplike.of(sumwxx, sumw).true_divide(sumwxx, sumw) * ak.nplike.of(
-                sumw
-            ).true_divide(sumw, sumw - ddof)
+            return ak.nplikes.of(sumwxx, sumw).true_divide(
+                sumwxx, sumw
+            ) * ak.nplikes.of(sumw).true_divide(sumw, sumw - ddof)
         else:
-            return ak.nplike.of(sumwxx, sumw).true_divide(sumwxx, sumw)
+            return ak.nplikes.of(sumwxx, sumw).true_divide(sumwxx, sumw)

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -186,8 +186,8 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
                 flatten_records,
             )
         if ddof != 0:
-            return ak.nplikes.of(sumwxx, sumw).true_divide(
+            return ak.nplikes.nplike_for(sumwxx, sumw).true_divide(
                 sumwxx, sumw
-            ) * ak.nplikes.of(sumw).true_divide(sumw, sumw - ddof)
+            ) * ak.nplikes.nplike_for(sumw).true_divide(sumw, sumw - ddof)
         else:
-            return ak.nplikes.of(sumwxx, sumw).true_divide(sumwxx, sumw)
+            return ak.nplikes.nplike_for(sumwxx, sumw).true_divide(sumwxx, sumw)

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -186,8 +186,8 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
                 flatten_records,
             )
         if ddof != 0:
-            return ak.nplikes.nplike_for(sumwxx, sumw).true_divide(
+            return ak.nplikes.nplike_of(sumwxx, sumw).true_divide(
                 sumwxx, sumw
-            ) * ak.nplikes.nplike_for(sumw).true_divide(sumw, sumw - ddof)
+            ) * ak.nplikes.nplike_of(sumw).true_divide(sumw, sumw - ddof)
         else:
-            return ak.nplikes.nplike_for(sumwxx, sumw).true_divide(sumwxx, sumw)
+            return ak.nplikes.nplike_of(sumwxx, sumw).true_divide(sumwxx, sumw)

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("where")
@@ -77,7 +77,7 @@ def _impl1(condition, mergebool, highlevel, behavior):
     akcondition = ak.operations.to_layout(
         condition, allow_record=False, allow_other=False
     )
-    nplike = ak.nplike.of(akcondition)
+    nplike = ak.nplikes.of(akcondition)
 
     akcondition = ak.contents.NumpyArray(ak.operations.to_numpy(akcondition))
     out = nplike.nonzero(ak.operations.to_numpy(akcondition))
@@ -106,7 +106,7 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
         good_arrays.append(left)
     if isinstance(right, ak.contents.Content):
         good_arrays.append(right)
-    nplike = ak.nplike.of(*good_arrays)
+    nplike = ak.nplikes.of(*good_arrays)
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -77,7 +77,7 @@ def _impl1(condition, mergebool, highlevel, behavior):
     akcondition = ak.operations.to_layout(
         condition, allow_record=False, allow_other=False
     )
-    nplike = ak.nplikes.nplike_for(akcondition)
+    nplike = ak.nplikes.nplike_of(akcondition)
 
     akcondition = ak.contents.NumpyArray(ak.operations.to_numpy(akcondition))
     out = nplike.nonzero(ak.operations.to_numpy(akcondition))
@@ -106,7 +106,7 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
         good_arrays.append(left)
     if isinstance(right, ak.contents.Content):
         good_arrays.append(right)
-    nplike = ak.nplikes.nplike_for(*good_arrays)
+    nplike = ak.nplikes.nplike_of(*good_arrays)
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -77,7 +77,7 @@ def _impl1(condition, mergebool, highlevel, behavior):
     akcondition = ak.operations.to_layout(
         condition, allow_record=False, allow_other=False
     )
-    nplike = ak.nplikes.of(akcondition)
+    nplike = ak.nplikes.nplike_for(akcondition)
 
     akcondition = ak.contents.NumpyArray(ak.operations.to_numpy(akcondition))
     out = nplike.nonzero(ak.operations.to_numpy(akcondition))
@@ -106,7 +106,7 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
         good_arrays.append(left)
     if isinstance(right, ak.contents.Content):
         good_arrays.append(right)
-    nplike = ak.nplikes.of(*good_arrays)
+    nplike = ak.nplikes.nplike_for(*good_arrays)
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -101,7 +101,7 @@ def _impl(base, what, where, highlevel, behavior):
         else:
 
             def action(inputs, **kwargs):
-                nplike = ak.nplikes.of(*inputs)
+                nplike = ak.nplikes.nplike_for(*inputs)
                 base, what = inputs
                 if isinstance(base, ak.contents.RecordArray):
                     if what is None:

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def with_field(base, what, where=None, highlevel=True, behavior=None):
@@ -101,7 +101,7 @@ def _impl(base, what, where, highlevel, behavior):
         else:
 
             def action(inputs, **kwargs):
-                nplike = ak.nplike.of(*inputs)
+                nplike = ak.nplikes.of(*inputs)
                 base, what = inputs
                 if isinstance(base, ak.contents.RecordArray):
                     if what is None:

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -101,7 +101,7 @@ def _impl(base, what, where, highlevel, behavior):
         else:
 
             def action(inputs, **kwargs):
-                nplike = ak.nplikes.nplike_for(*inputs)
+                nplike = ak.nplikes.nplike_of(*inputs)
                 base, what = inputs
                 if isinstance(base, ak.contents.RecordArray):
                     if what is None:

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def with_name(array, name, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def with_parameter(array, parameter, value, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def without_parameters(array, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 _ZEROS = object()

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def zip(

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward.contents.content import Content
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class Record:

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -7,7 +7,7 @@ import awkward as ak
 from awkward.forms.form import _parameters_equal
 from awkward.types.type import Type
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 def is_primitive(primitive):

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -6,7 +6,7 @@ import sys
 import awkward as ak
 from awkward.types._awkward_datashape_parser import Lark_StandAlone, Transformer
 
-np = ak.nplike.NumpyMetadata.instance()
+np = ak.nplikes.NumpyMetadata.instance()
 
 
 class Type:

--- a/tests/test_0395-complex-type-arrays.py
+++ b/tests/test_0395-complex-type-arrays.py
@@ -227,7 +227,7 @@ def test_astype_complex():
         (5.5 + 0j),
     ]
     assert to_list(
-        ak.nplike.of(array_complex64).asarray(ak.highlevel.Array(array_complex64))
+        ak.nplikes.of(array_complex64).asarray(ak.highlevel.Array(array_complex64))
     ) == [
         (0.25 + 0.0j),
         (0.5 + 0.0j),

--- a/tests/test_0395-complex-type-arrays.py
+++ b/tests/test_0395-complex-type-arrays.py
@@ -227,7 +227,9 @@ def test_astype_complex():
         (5.5 + 0j),
     ]
     assert to_list(
-        ak.nplikes.of(array_complex64).asarray(ak.highlevel.Array(array_complex64))
+        ak.nplikes.nplike_for(array_complex64).asarray(
+            ak.highlevel.Array(array_complex64)
+        )
     ) == [
         (0.25 + 0.0j),
         (0.5 + 0.0j),

--- a/tests/test_0395-complex-type-arrays.py
+++ b/tests/test_0395-complex-type-arrays.py
@@ -227,7 +227,7 @@ def test_astype_complex():
         (5.5 + 0j),
     ]
     assert to_list(
-        ak.nplikes.nplike_for(array_complex64).asarray(
+        ak.nplikes.nplike_of(array_complex64).asarray(
             ak.highlevel.Array(array_complex64)
         )
     ) == [

--- a/tests/test_0884-index-and-identifier-refactoring.py
+++ b/tests/test_0884-index-and-identifier-refactoring.py
@@ -7,14 +7,14 @@ import awkward as ak  # noqa: F401
 
 
 def test_index32():
-    py_array = ak.index.Index.zeros(10, ak.nplike.Numpy.instance(), np.int32)
+    py_array = ak.index.Index.zeros(10, ak.nplikes.Numpy.instance(), np.int32)
 
     assert len(py_array) == 10
     assert "i32" == py_array.form
 
 
 def test_index64():
-    py_array = ak.index.Index.zeros(10, ak.nplike.Numpy.instance(), np.int64)
+    py_array = ak.index.Index.zeros(10, ak.nplikes.Numpy.instance(), np.int64)
 
     assert len(py_array) == 10
     assert "i64" == py_array.form

--- a/tests/test_1247-numpy-to_rectilinear-ndarray.py
+++ b/tests/test_1247-numpy-to_rectilinear-ndarray.py
@@ -8,6 +8,6 @@ import awkward as ak  # noqa: F401
 
 def test():
     array = np.array([1, 2, 9, 0])
-    nplike = ak.nplike.of(array)
+    nplike = ak.nplikes.of(array)
     ak_array = ak.operations.from_numpy(array)
     assert nplike.to_rectilinear(array).tolist() == ak_array.tolist()

--- a/tests/test_1247-numpy-to_rectilinear-ndarray.py
+++ b/tests/test_1247-numpy-to_rectilinear-ndarray.py
@@ -8,6 +8,6 @@ import awkward as ak  # noqa: F401
 
 def test():
     array = np.array([1, 2, 9, 0])
-    nplike = ak.nplikes.nplike_for(array)
+    nplike = ak.nplikes.nplike_of(array)
     ak_array = ak.operations.from_numpy(array)
     assert nplike.to_rectilinear(array).tolist() == ak_array.tolist()

--- a/tests/test_1247-numpy-to_rectilinear-ndarray.py
+++ b/tests/test_1247-numpy-to_rectilinear-ndarray.py
@@ -8,6 +8,6 @@ import awkward as ak  # noqa: F401
 
 def test():
     array = np.array([1, 2, 9, 0])
-    nplike = ak.nplikes.of(array)
+    nplike = ak.nplikes.nplike_for(array)
     ak_array = ak.operations.from_numpy(array)
     assert nplike.to_rectilinear(array).tolist() == ak_array.tolist()

--- a/tests/test_1672-broadcast-parameters.py
+++ b/tests/test_1672-broadcast-parameters.py
@@ -4,7 +4,7 @@ import pytest  # noqa: F401
 
 import awkward as ak  # noqa: F401
 
-numpy = ak.nplike.Numpy.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 @pytest.mark.skip("string broadcasting is broken")

--- a/tests/test_1688-pack-categorical.py
+++ b/tests/test_1688-pack-categorical.py
@@ -4,7 +4,7 @@ import pytest  # noqa: F401
 
 import awkward as ak  # noqa: F401
 
-numpy = ak.nplike.Numpy.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 def test():

--- a/tests/test_1707-broadcast-parameters-ufunc.py
+++ b/tests/test_1707-broadcast-parameters-ufunc.py
@@ -4,7 +4,7 @@ import pytest  # noqa: F401
 
 import awkward as ak  # noqa: F401
 
-numpy = ak.nplike.Numpy.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 def test_numpy_1d():

--- a/tests/test_1709-ak-array-constructor-behavior.py
+++ b/tests/test_1709-ak-array-constructor-behavior.py
@@ -4,7 +4,7 @@ import pytest  # noqa: F401
 
 import awkward as ak  # noqa: F401
 
-numpy = ak.nplike.Numpy.instance()
+numpy = ak.nplikes.Numpy.instance()
 
 
 class MyBehavior(ak.Array):


### PR DESCRIPTION
## Changes
1. Rename `ak.nplike` to `ak.nplikes`
2. Rename `ak.nplikes.of` to `ak.nplikes.nplike_of`

## Motivation
In type-hinting situations, it would give us more flexability to be able to import `ak.nplikes` as `nplikes`. Currently, the `nplike` module name would clash with local-scoped `nplike` variables. This is easy to work around - just use `from awkward import nplike as nplikes`, however we'll be doing that a lot, so let's just clean this up now.

Furthermore, should we wish to import `nplike.of` as a free-standing function, the same applies. `nplike_for` is a more descriptive name than `nplike.of`, even though the latter is pretty snazzy.

Closes #1741