### PR TITLE
fix: don't assume trailing `.` for module name in `is_XXX_buffer` (backport)

### DIFF
--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -870,15 +870,18 @@ def is_numpy_buffer(array):
 
 
 def is_cupy_buffer(array):
-    return type(array).__module__.startswith("cupy.")
+    module, _, suffix = type(array).__module__.partition(".")
+    return module == "cupy"
 
 
 def is_jax_buffer(array):
-    return type(array).__module__.startswith("jaxlib.")
+    module, _, suffix = type(array).__module__.partition(".")
+    return module == "jaxlib"
 
 
 def is_jax_tracer(tracer):
-    return type(tracer).__module__.startswith("jax.")
+    module, _, suffix = type(tracer).__module__.partition(".")
+    return module == "jax"
 
 
 def of(*arrays, default_cls=Numpy):

--- a/src/awkward/nplike.py
+++ b/src/awkward/nplike.py
@@ -865,22 +865,50 @@ class Jax(NumpyLike):
         return out
 
 
-def is_numpy_buffer(array):
-    return isinstance(array, numpy.ndarray)
+def is_numpy_buffer(obj) -> bool:
+    """
+    Args:
+        obj: object to test
+
+    Return `True` if the given object is a numpy buffer, otherwise `False`.
+
+    """
+    return isinstance(obj, numpy.ndarray)
 
 
-def is_cupy_buffer(array):
-    module, _, suffix = type(array).__module__.partition(".")
+def is_cupy_buffer(obj) -> bool:
+    """
+    Args:
+        obj: object to test
+
+    Return `True` if the given object is a cupy buffer, otherwise `False`.
+
+    """
+    module, _, suffix = type(obj).__module__.partition(".")
     return module == "cupy"
 
 
-def is_jax_buffer(array):
-    module, _, suffix = type(array).__module__.partition(".")
+def is_jax_buffer(obj) -> bool:
+    """
+    Args:
+        obj: object to test
+
+    Return `True` if the given object is a jax buffer, otherwise `False`.
+
+    """
+    module, _, suffix = type(obj).__module__.partition(".")
     return module == "jaxlib"
 
 
-def is_jax_tracer(tracer):
-    module, _, suffix = type(tracer).__module__.partition(".")
+def is_jax_tracer(obj) -> bool:
+    """
+    Args:
+        obj: object to test
+
+    Return `True` if the given object is a jax tracer, otherwise `False`.
+
+    """
+    module, _, suffix = type(obj).__module__.partition(".")
     return module == "jax"
 
 


### PR DESCRIPTION
Backport of #1743 for main-v1