### PR TITLE
refactor: drop unused code from Form, rename serialisation methods

### DIFF
--- a/src/awkward/forms/__init__.py
+++ b/src/awkward/forms/__init__.py
@@ -3,7 +3,7 @@
 from awkward.forms.bitmaskedform import BitMaskedForm  # noqa: F401
 from awkward.forms.bytemaskedform import ByteMaskedForm  # noqa: F401
 from awkward.forms.emptyform import EmptyForm  # noqa: F401
-from awkward.forms.form import Form, from_iter, from_json  # noqa: F401
+from awkward.forms.form import Form, from_dict, from_json  # noqa: F401
 from awkward.forms.indexedform import IndexedForm  # noqa: F401
 from awkward.forms.indexedoptionform import IndexedOptionForm  # noqa: F401
 from awkward.forms.listform import ListForm  # noqa: F401

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -85,14 +85,14 @@ class BitMaskedForm(Form):
         ] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "BitMaskedArray",
                 "mask": self._mask,
                 "valid_when": self._valid_when,
                 "lsb_order": self._lsb_order,
-                "content": self._content._tolist_part(verbose, toplevel=False),
+                "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,
         )

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward.forms.bytemaskedform import ByteMaskedForm
 from awkward.forms.form import Form, _parameters_equal
 
 
@@ -120,66 +119,6 @@ class BitMaskedForm(Form):
             )
         else:
             return False
-
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, BitMaskedForm):
-            return (
-                self._mask == other._mask
-                and self._valid_when == other._valid_when
-                and self._lsb_order == other._lsb_order
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
-                and self._content.generated_compatibility(other._content)
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return ByteMaskedForm(
-            "i8",
-            self._content._getitem_range(),
-            self._valid_when,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return BitMaskedForm(
-            self._mask,
-            self._content._getitem_field(where, only_fields),
-            self._valid_when,
-            self._lsb_order,
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return BitMaskedForm(
-            self._mask,
-            self._content._getitem_fields(where, only_fields),
-            self._valid_when,
-            self._lsb_order,
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return ByteMaskedForm(
-            "i8",
-            self._content._carry(allow_lazy),
-            self._valid_when,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
 
     def simplify_optiontype(self):
         if isinstance(

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -103,63 +103,6 @@ class ByteMaskedForm(Form):
         else:
             return False
 
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, ByteMaskedForm):
-            return (
-                self._mask == other._mask
-                and self._valid_when == other._valid_when
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
-                and self._content.generated_compatibility(other._content)
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return ByteMaskedForm(
-            self._mask,
-            self._content._getitem_range(),
-            self._valid_when,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return ByteMaskedForm(
-            self._mask,
-            self._content._getitem_field(where, only_fields),
-            self._valid_when,
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return ByteMaskedForm(
-            self._mask,
-            self._content._getitem_fields(where, only_fields),
-            self._valid_when,
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return ByteMaskedForm(
-            self._mask,
-            self._content._carry(allow_lazy),
-            self._valid_when,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
     def simplify_optiontype(self):
         if isinstance(
             self._content,

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -70,13 +70,13 @@ class ByteMaskedForm(Form):
         ] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "ByteMaskedArray",
                 "mask": self._mask,
                 "valid_when": self._valid_when,
-                "content": self._content._tolist_part(verbose, toplevel=False),
+                "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,
         )

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form
 
 
 class EmptyForm(Form):
@@ -33,38 +33,6 @@ class EmptyForm(Form):
 
     def toNumpyForm(self, dtype):
         return ak.forms.numpyform.from_dtype(dtype, self._parameters)
-
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, EmptyForm):
-            return _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return EmptyForm(
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        raise ak._errors.index_error(self, where, "not an array of records")
-
-    def _getitem_fields(self, where, only_fields=()):
-        raise ak._errors.index_error(self, where, "not an array of records")
-
-    def _carry(self, allow_lazy):
-        return EmptyForm(
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
 
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -15,8 +15,8 @@ class EmptyForm(Form):
         args = self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra({"class": "EmptyArray"}, verbose)
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra({"class": "EmptyArray"}, verbose)
 
     def _type(self, typestrs):
         return ak.types.unknowntype.UnknownType(

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -385,9 +385,6 @@ class Form:
     def simplify_optiontype(self):
         return self
 
-    def simplify_uniontype(self, merge=True, mergebool=False):
-        return self
-
     def columns(self, list_indicator=None, column_prefix=()):
         output = []
         self._columns(column_prefix, output, list_indicator)
@@ -426,18 +423,6 @@ class Form:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def _column_types(self):
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def generated_compatibility(self, other):
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def _getitem_range(self):
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def _getitem_field(self, where, only_fields=()):
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def _getitem_fields(self, where, only_fields=()):
         raise ak._errors.wrap_error(NotImplementedError)
 
     def _tolist_part(self, verbose, toplevel):

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -9,7 +9,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def from_iter(input):
+def from_dict(input: dict) -> Form:
     if input is None:
         return None
 
@@ -33,7 +33,7 @@ def from_iter(input):
 
     elif input["class"] == "RegularArray":
         return ak.forms.regularform.RegularForm(
-            content=from_iter(input["content"]),
+            content=from_dict(input["content"]),
             size=input["size"],
             has_identifier=has_identifier,
             parameters=parameters,
@@ -44,7 +44,7 @@ def from_iter(input):
         return ak.forms.listform.ListForm(
             starts=input["starts"],
             stops=input["stops"],
-            content=from_iter(input["content"]),
+            content=from_dict(input["content"]),
             has_identifier=has_identifier,
             parameters=parameters,
             form_key=form_key,
@@ -58,7 +58,7 @@ def from_iter(input):
     ):
         return ak.forms.listoffsetform.ListOffsetForm(
             offsets=input["offsets"],
-            content=from_iter(input["content"]),
+            content=from_dict(input["content"]),
             has_identifier=has_identifier,
             parameters=parameters,
             form_key=form_key,
@@ -69,10 +69,10 @@ def from_iter(input):
             contents = []
             fields = []
             for key, content in input["contents"].items():
-                contents.append(from_iter(content))
+                contents.append(from_dict(content))
                 fields.append(key)
         else:
-            contents = [from_iter(content) for content in input["contents"]]
+            contents = [from_dict(content) for content in input["contents"]]
             fields = None
         return ak.forms.recordform.RecordForm(
             contents=contents,
@@ -90,7 +90,7 @@ def from_iter(input):
     ):
         return ak.forms.indexedform.IndexedForm(
             index=input["index"],
-            content=from_iter(input["content"]),
+            content=from_dict(input["content"]),
             has_identifier=has_identifier,
             parameters=parameters,
             form_key=form_key,
@@ -103,7 +103,7 @@ def from_iter(input):
     ):
         return ak.forms.indexedoptionform.IndexedOptionForm(
             index=input["index"],
-            content=from_iter(input["content"]),
+            content=from_dict(input["content"]),
             has_identifier=has_identifier,
             parameters=parameters,
             form_key=form_key,
@@ -112,7 +112,7 @@ def from_iter(input):
     elif input["class"] == "ByteMaskedArray":
         return ak.forms.bytemaskedform.ByteMaskedForm(
             mask=input["mask"],
-            content=from_iter(input["content"]),
+            content=from_dict(input["content"]),
             valid_when=input["valid_when"],
             has_identifier=has_identifier,
             parameters=parameters,
@@ -122,7 +122,7 @@ def from_iter(input):
     elif input["class"] == "BitMaskedArray":
         return ak.forms.bitmaskedform.BitMaskedForm(
             mask=input["mask"],
-            content=from_iter(input["content"]),
+            content=from_dict(input["content"]),
             valid_when=input["valid_when"],
             lsb_order=input["lsb_order"],
             has_identifier=has_identifier,
@@ -132,7 +132,7 @@ def from_iter(input):
 
     elif input["class"] == "UnmaskedArray":
         return ak.forms.unmaskedform.UnmaskedForm(
-            content=from_iter(input["content"]),
+            content=from_dict(input["content"]),
             has_identifier=has_identifier,
             parameters=parameters,
             form_key=form_key,
@@ -147,7 +147,7 @@ def from_iter(input):
         return ak.forms.unionform.UnionForm(
             tags=input["tags"],
             index=input["index"],
-            contents=[from_iter(content) for content in input["contents"]],
+            contents=[from_dict(content) for content in input["contents"]],
             has_identifier=has_identifier,
             parameters=parameters,
             form_key=form_key,
@@ -166,8 +166,8 @@ def from_iter(input):
         )
 
 
-def from_json(input):
-    return from_iter(json.loads(input))
+def from_json(input: str) -> Form:
+    return from_dict(json.loads(input))
 
 
 def _parameters_equal(one, two, only_array_record=False):
@@ -346,12 +346,12 @@ class Form:
         return self._form_key
 
     def __str__(self):
-        return json.dumps(self.tolist(verbose=False), indent=4)
+        return json.dumps(self.to_dict(verbose=False), indent=4)
 
-    def tolist(self, verbose=True):
-        return self._tolist_part(verbose, toplevel=True)
+    def to_dict(self, verbose=True):
+        return self._to_dict_part(verbose, toplevel=True)
 
-    def _tolist_extra(self, out, verbose):
+    def _to_dict_extra(self, out, verbose):
         if verbose or self._has_identifier:
             out["has_identifier"] = self._has_identifier
         if verbose or (self._parameters is not None and len(self._parameters) > 0):
@@ -361,7 +361,7 @@ class Form:
         return out
 
     def to_json(self):
-        return json.dumps(self.tolist(verbose=True))
+        return json.dumps(self.to_dict(verbose=True))
 
     def _repr_args(self):
         out = []
@@ -425,8 +425,8 @@ class Form:
     def _column_types(self):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _tolist_part(self, verbose, toplevel):
-        raise ak._errors.wrap_error(NotImplementedError)
+    def _to_dict_part(self, verbose, toplevel):
+        raise ak._errors._errors(NotImplementedError)
 
     def _type(self, typestrs):
         raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -48,12 +48,12 @@ class IndexedForm(Form):
         args = [repr(self._index), repr(self._content)] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "IndexedArray",
                 "index": self._index,
-                "content": self._content._tolist_part(verbose, toplevel=False),
+                "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,
         )

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -96,58 +96,6 @@ class IndexedForm(Form):
         else:
             return False
 
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, IndexedForm):
-            return (
-                self._index == other._index
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
-                and self._content.generated_compatibility(other._content)
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return IndexedForm(
-            self._index,
-            self._content,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return IndexedForm(
-            self._index,
-            self._content._getitem_field(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return IndexedForm(
-            self._index,
-            self._content._getitem_fields(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return IndexedForm(
-            self._index,
-            self._content,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:
             return self._content.purelist_parameter(key)

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -49,12 +49,12 @@ class IndexedOptionForm(Form):
         args = [repr(self._index), repr(self._content)] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "IndexedOptionArray",
                 "index": self._index,
-                "content": self._content._tolist_part(verbose, toplevel=False),
+                "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,
         )

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -87,58 +87,6 @@ class IndexedOptionForm(Form):
         else:
             return False
 
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, IndexedOptionForm):
-            return (
-                self._index == other._index
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
-                and self._content.generated_compatibility(other._content)
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return IndexedOptionForm(
-            self._index,
-            self._content,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return IndexedOptionForm(
-            self._index,
-            self._content._getitem_field(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return IndexedOptionForm(
-            self._index,
-            self._content._getitem_fields(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return IndexedOptionForm(
-            self._index,
-            self._content,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
     def simplify_optiontype(self):
         if isinstance(
             self._content,

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -66,13 +66,13 @@ class ListForm(Form):
         ] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "ListArray",
                 "starts": self._starts,
                 "stops": self._stops,
-                "content": self._content._tolist_part(verbose, toplevel=False),
+                "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,
         )

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -99,63 +99,6 @@ class ListForm(Form):
         else:
             return False
 
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, ListForm):
-            return (
-                self._starts == other._starts
-                and self._stops == other._stops
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
-                and self._content.generated_compatibility(other._content)
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return ListForm(
-            self._starts,
-            self._stops,
-            self._content,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return ListForm(
-            self._starts,
-            self._stops,
-            self._content._getitem_field(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return ListForm(
-            self._starts,
-            self._stops,
-            self._content._getitem_fields(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return ListForm(
-            self._starts,
-            self._stops,
-            self._content,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:
             return self._content.purelist_parameter(key)

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -2,7 +2,6 @@
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
-from awkward.forms.listform import ListForm
 
 
 class ListOffsetForm(Form):
@@ -69,59 +68,6 @@ class ListOffsetForm(Form):
             )
         else:
             return False
-
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, ListOffsetForm):
-            return (
-                self._offsets == other._offsets
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
-                and self._content.generated_compatibility(other._content)
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return ListOffsetForm(
-            self._offsets,
-            self._content,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return ListOffsetForm(
-            self._offsets,
-            self._content._getitem_field(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return ListOffsetForm(
-            self._offsets,
-            self._content._getitem_fields(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return ListForm(
-            self._offsets,
-            self._offsets,
-            self._content,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
 
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -38,12 +38,12 @@ class ListOffsetForm(Form):
         ] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "ListOffsetArray",
                 "offsets": self._offsets,
-                "content": self._content._tolist_part(verbose, toplevel=False),
+                "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,
         )

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -134,47 +134,6 @@ class NumpyForm(Form):
         out._parameters = self._parameters
         return out
 
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, NumpyForm):
-            return (
-                ak.types.numpytype.primitive_to_dtype(self._primitive)
-                == ak.types.numpytype.primitive_to_dtype(other._primitive)
-                and self._inner_shape == other._inner_shape
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return NumpyForm(
-            self._primitive,
-            inner_shape=self._inner_shape,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        raise ak._errors.index_error(self, where, "not an array of records")
-
-    def _getitem_fields(self, where, only_fields=()):
-        raise ak._errors.index_error(self, where, "not an array of records")
-
-    def _carry(self, allow_lazy):
-        return NumpyForm(
-            self._primitive,
-            inner_shape=self._inner_shape,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:
             return None

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -79,7 +79,7 @@ class NumpyForm(Form):
         args += self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
+    def _to_dict_part(self, verbose, toplevel):
         if (
             not verbose
             and not toplevel
@@ -97,7 +97,7 @@ class NumpyForm(Form):
             }
             if verbose or len(self._inner_shape) > 0:
                 out["inner_shape"] = list(self._inner_shape)
-            return self._tolist_extra(out, verbose)
+            return self._to_dict_extra(out, verbose)
 
     def _type(self, typestrs):
         out = ak.types.numpytype.NumpyType(

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
-from awkward.forms.indexedform import IndexedForm
 
 
 class RecordForm(Form):
@@ -175,95 +174,6 @@ class RecordForm(Form):
                 return False
         else:
             return False
-
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, RecordForm):
-            if self.is_tuple == other.is_tuple:
-                self_fields = set(self._fields)
-                other_fields = set(other._fields)
-                if self_fields == other_fields:
-                    return _parameters_equal(
-                        self._parameters, other._parameters
-                    ) and all(
-                        self.content(x).generated_compatibility(other.content(x))
-                        for x in self_fields
-                    )
-                else:
-                    return False
-            else:
-                return False
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return RecordForm(
-            self._contents,
-            self._fields,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        if len(only_fields) == 0:
-            return self.content(where)
-
-        else:
-            nexthead, nexttail = ak._slicing.headtail(only_fields)
-            if ak._util.isstr(nexthead):
-                return self.content(where)._getitem_field(nexthead, nexttail)
-            else:
-                return self.content(where)._getitem_fields(nexthead, nexttail)
-
-    def _getitem_fields(self, where, only_fields=()):
-        indexes = [self.field_to_index(field) for field in where]
-        if self._fields is None:
-            fields = None
-        else:
-            fields = [self._fields[i] for i in indexes]
-
-        if len(only_fields) == 0:
-            contents = [self.content(i) for i in indexes]
-        else:
-            nexthead, nexttail = ak._slicing.headtail(only_fields)
-            if ak._util.isstr(nexthead):
-                contents = [
-                    self.content(i)._getitem_field(nexthead, nexttail) for i in indexes
-                ]
-            else:
-                contents = [
-                    self.content(i)._getitem_fields(nexthead, nexttail) for i in indexes
-                ]
-
-        return RecordForm(
-            contents,
-            fields,
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        if allow_lazy:
-            return IndexedForm(
-                "i64",
-                self,
-                has_identifier=self._has_identifier,
-                parameters=None,
-                form_key=None,
-            )
-        else:
-            return RecordForm(
-                self._contents,
-                self._fields,
-                has_identifier=self._has_identifier,
-                parameters=self._parameters,
-                form_key=None,
-            )
 
     def purelist_parameter(self, key):
         return self.parameter(key)

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -132,18 +132,18 @@ class RecordForm(Form):
             )
         return self._contents[index]
 
-    def _tolist_part(self, verbose, toplevel):
+    def _to_dict_part(self, verbose, toplevel):
         out = {"class": "RecordArray"}
 
         contents_tolist = [
-            content._tolist_part(verbose, toplevel=False) for content in self._contents
+            content._to_dict_part(verbose, toplevel=False) for content in self._contents
         ]
         if self._fields is not None:
             out["contents"] = dict(zip(self._fields, contents_tolist))
         else:
             out["contents"] = contents_tolist
 
-        return self._tolist_extra(out, verbose)
+        return self._to_dict_extra(out, verbose)
 
     def _type(self, typestrs):
         return ak.types.recordtype.RecordType(

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -76,58 +76,6 @@ class RegularForm(Form):
         else:
             return False
 
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, RegularForm):
-            return (
-                self._size == other._size
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
-                and self._content.generated_compatibility(other._content)
-            )
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return RegularForm(
-            self._content._getitem_range(),
-            self._size,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return RegularForm(
-            self._content._getitem_field(where, only_fields),
-            self._size,
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return RegularForm(
-            self._content._getitem_fields(where, only_fields),
-            self._size,
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return RegularForm(
-            self._content._carry(allow_lazy),
-            self._size,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:
             return self._content.purelist_parameter(key)

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -44,12 +44,12 @@ class RegularForm(Form):
         args = [repr(self._content), repr(self._size)] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "RegularArray",
                 "size": self._size,
-                "content": self._content._tolist_part(verbose, toplevel=False),
+                "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,
         )

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -80,14 +80,14 @@ class UnionForm(Form):
         ] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "UnionArray",
                 "tags": self._tags,
                 "index": self._index,
                 "contents": [
-                    content._tolist_part(verbose, toplevel=False)
+                    content._to_dict_part(verbose, toplevel=False)
                     for content in self._contents
                 ],
             },

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -117,67 +117,6 @@ class UnionForm(Form):
 
         return False
 
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, UnionForm):
-            if len(self._contents) == len(other._contents):
-                return _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                ) and all(
-                    x.generated_compatibility(y)
-                    for x, y in zip(self._contents, other._contents)
-                )
-            else:
-                return False
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return UnionForm(
-            self._tags,
-            self._index,
-            self._contents,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return UnionForm(
-            self._tags,
-            self._index,
-            self._content._getitem_field(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return UnionForm(
-            self._tags,
-            self._index,
-            self._content._getitem_fields(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return UnionForm(
-            self._tags,
-            self._index,
-            self._contents,
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def simplify_uniontype(self, merge=True, mergebool=False):
-        raise ak._errors.wrap_error(NotImplementedError)
-
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:
             out = self._contents[0].purelist_parameter(key)

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -34,11 +34,11 @@ class UnmaskedForm(Form):
         args = [repr(self._content)] + self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _tolist_part(self, verbose, toplevel):
-        return self._tolist_extra(
+    def _to_dict_part(self, verbose, toplevel):
+        return self._to_dict_extra(
             {
                 "class": "UnmaskedArray",
-                "content": self._content._tolist_part(verbose, toplevel=False),
+                "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,
         )

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -63,50 +63,6 @@ class UnmaskedForm(Form):
         else:
             return False
 
-    def generated_compatibility(self, other):
-        if other is None:
-            return True
-
-        elif isinstance(other, UnmaskedForm):
-            return _parameters_equal(
-                self._parameters, other._parameters
-            ) and self._content.generated_compatibility(other._content)
-
-        else:
-            return False
-
-    def _getitem_range(self):
-        return UnmaskedForm(
-            self._content._getitem_range(),
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
-    def _getitem_field(self, where, only_fields=()):
-        return UnmaskedForm(
-            self._content._getitem_field(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _getitem_fields(self, where, only_fields=()):
-        return UnmaskedForm(
-            self._content._getitem_fields(where, only_fields),
-            has_identifier=self._has_identifier,
-            parameters=None,
-            form_key=None,
-        )
-
-    def _carry(self, allow_lazy):
-        return UnmaskedForm(
-            self._content._carry(allow_lazy),
-            has_identifier=self._has_identifier,
-            parameters=self._parameters,
-            form_key=None,
-        )
-
     def simplify_optiontype(self):
         if isinstance(
             self._content,

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -445,7 +445,7 @@ class CupyKernel(NumpyKernel):
         ak._connect.cuda.cuda_streamptr_to_contexts[cupy_stream_ptr][1].append(
             ak._connect.cuda.Invocation(
                 name=self._name_and_types[0],
-                error_context=ak._util.ErrorContext.primary(),
+                error_context=ak._errors.ErrorContext.primary(),
             )
         )
 

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -80,7 +80,7 @@ def _impl(form, length, container, buffer_key, nplike, highlevel, behavior):
         else:
             form = ak.forms.from_json(form)
     elif isinstance(form, dict):
-        form = ak.forms.from_iter(form)
+        form = ak.forms.from_dict(form)
 
     if not (ak._util.isint(length) and length >= 0):
         raise ak._errors.wrap_error(

--- a/tests/test_0914-types-and-forms.py
+++ b/tests/test_0914-types-and-forms.py
@@ -1443,10 +1443,10 @@ def test_EmptyForm():
         == "EmptyForm(has_identifier=True, parameters={'x': 123}, form_key='hello')"
     )
 
-    assert ak.forms.emptyform.EmptyForm().tolist(verbose=False) == {
+    assert ak.forms.emptyform.EmptyForm().to_dict(verbose=False) == {
         "class": "EmptyArray"
     }
-    assert ak.forms.emptyform.EmptyForm().tolist() == {
+    assert ak.forms.emptyform.EmptyForm().to_dict() == {
         "class": "EmptyArray",
         "has_identifier": False,
         "parameters": {},
@@ -1454,26 +1454,26 @@ def test_EmptyForm():
     }
     assert ak.forms.emptyform.EmptyForm(
         has_identifier=True, parameters={"x": 123}, form_key="hello"
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "EmptyArray",
         "has_identifier": True,
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter({"class": "EmptyArray"}).tolist() == {
+    assert ak.forms.from_dict({"class": "EmptyArray"}).to_dict() == {
         "class": "EmptyArray",
         "has_identifier": False,
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "EmptyArray",
             "has_identifier": True,
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "EmptyArray",
         "has_identifier": True,
         "parameters": {"x": 123},
@@ -1507,11 +1507,11 @@ def test_NumpyForm():
         == "NumpyForm('bool', inner_shape=(1, 2, 3), has_identifier=True, parameters={'x': 123}, form_key='hello')"
     )
 
-    assert ak.forms.numpyform.NumpyForm("bool").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("bool").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "bool",
     }
-    assert ak.forms.numpyform.NumpyForm("bool").tolist() == {
+    assert ak.forms.numpyform.NumpyForm("bool").to_dict() == {
         "class": "NumpyArray",
         "primitive": "bool",
         "inner_shape": [],
@@ -1525,7 +1525,7 @@ def test_NumpyForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "bool",
         "inner_shape": [1, 2, 3],
@@ -1534,220 +1534,224 @@ def test_NumpyForm():
         "form_key": "hello",
     }
 
-    assert ak.forms.numpyform.NumpyForm("bool").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("bool").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "bool",
     }
-    assert ak.forms.numpyform.NumpyForm("int8").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("int8").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int8",
     }
-    assert ak.forms.numpyform.NumpyForm("uint8").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("uint8").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint8",
     }
-    assert ak.forms.numpyform.NumpyForm("int16").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("int16").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int16",
     }
-    assert ak.forms.numpyform.NumpyForm("uint16").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("uint16").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint16",
     }
-    assert ak.forms.numpyform.NumpyForm("int32").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("int32").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int32",
     }
-    assert ak.forms.numpyform.NumpyForm("uint32").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("uint32").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint32",
     }
-    assert ak.forms.numpyform.NumpyForm("int64").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("int64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int64",
     }
-    assert ak.forms.numpyform.NumpyForm("uint64").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("uint64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint64",
     }
     if hasattr(np, "float16"):
-        assert ak.forms.numpyform.NumpyForm("float16").tolist(verbose=False) == {
+        assert ak.forms.numpyform.NumpyForm("float16").to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "float16",
         }
-    assert ak.forms.numpyform.NumpyForm("float32").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("float32").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "float32",
     }
-    assert ak.forms.numpyform.NumpyForm("float64").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("float64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "float64",
     }
     if hasattr(np, "float128"):
-        assert ak.forms.numpyform.NumpyForm("float128").tolist(verbose=False) == {
+        assert ak.forms.numpyform.NumpyForm("float128").to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "float128",
         }
-    assert ak.forms.numpyform.NumpyForm("complex64").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("complex64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "complex64",
     }
-    assert ak.forms.numpyform.NumpyForm("complex128").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("complex128").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "complex128",
     }
     if hasattr(np, "complex256"):
-        assert ak.forms.numpyform.NumpyForm("complex256").tolist(verbose=False) == {
+        assert ak.forms.numpyform.NumpyForm("complex256").to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "complex256",
         }
-    assert ak.forms.numpyform.NumpyForm("datetime64").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("datetime64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
     }
     assert ak.forms.numpyform.NumpyForm(
         "datetime64", parameters={"__unit__": "s"}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
         "parameters": {"__unit__": "s"},
     }
     assert ak.forms.numpyform.NumpyForm(
         "datetime64", parameters={"__unit__": "s", "x": 123}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
         "parameters": {"__unit__": "s", "x": 123},
     }
-    assert ak.forms.numpyform.NumpyForm("timedelta64").tolist(verbose=False) == {
+    assert ak.forms.numpyform.NumpyForm("timedelta64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
     }
     assert ak.forms.numpyform.NumpyForm(
         "timedelta64", parameters={"__unit__": "s"}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
         "parameters": {"__unit__": "s"},
     }
     assert ak.forms.numpyform.NumpyForm(
         "timedelta64", parameters={"__unit__": "s", "x": 123}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
         "parameters": {"__unit__": "s", "x": 123},
     }
 
-    assert ak.forms.numpyform.from_dtype(np.dtype("bool")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("bool")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "bool",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("int8")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("int8")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int8",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("uint8")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("uint8")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint8",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("int16")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("int16")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int16",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("uint16")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("uint16")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint16",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("int32")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("int32")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int32",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("uint32")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("uint32")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint32",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("int64")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("int64")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int64",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("uint64")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("uint64")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint64",
     }
     if hasattr(np, "float16"):
-        assert ak.forms.numpyform.from_dtype(np.dtype("float16")).tolist(
+        assert ak.forms.numpyform.from_dtype(np.dtype("float16")).to_dict(
             verbose=False
         ) == {
             "class": "NumpyArray",
             "primitive": "float16",
         }
-    assert ak.forms.numpyform.from_dtype(np.dtype("float32")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("float32")).to_dict(
+        verbose=False
+    ) == {
         "class": "NumpyArray",
         "primitive": "float32",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("float64")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("float64")).to_dict(
+        verbose=False
+    ) == {
         "class": "NumpyArray",
         "primitive": "float64",
     }
     if hasattr(np, "float128"):
-        assert ak.forms.numpyform.from_dtype(np.dtype("float128")).tolist(
+        assert ak.forms.numpyform.from_dtype(np.dtype("float128")).to_dict(
             verbose=False
         ) == {
             "class": "NumpyArray",
             "primitive": "float128",
         }
-    assert ak.forms.numpyform.from_dtype(np.dtype("complex64")).tolist(
+    assert ak.forms.numpyform.from_dtype(np.dtype("complex64")).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "complex64",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("complex128")).tolist(
+    assert ak.forms.numpyform.from_dtype(np.dtype("complex128")).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "complex128",
     }
     if hasattr(np, "complex256"):
-        assert ak.forms.numpyform.from_dtype(np.dtype("complex256")).tolist(
+        assert ak.forms.numpyform.from_dtype(np.dtype("complex256")).to_dict(
             verbose=False
         ) == {
             "class": "NumpyArray",
             "primitive": "complex256",
         }
-    assert ak.forms.numpyform.from_dtype(np.dtype("M8")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("M8")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("M8[s]")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("M8[s]")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
         "parameters": {"__unit__": "s"},
     }
     assert ak.forms.numpyform.from_dtype(
         np.dtype("M8[s]"), parameters={"x": 123}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
         "parameters": {"__unit__": "s", "x": 123},
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("m8")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("m8")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype("m8[s]")).tolist(verbose=False) == {
+    assert ak.forms.numpyform.from_dtype(np.dtype("m8[s]")).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
         "parameters": {"__unit__": "s"},
     }
     assert ak.forms.numpyform.from_dtype(
         np.dtype("m8[s]"), parameters={"x": 123}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
         "parameters": {"__unit__": "s", "x": 123},
     }
-    assert ak.forms.numpyform.from_dtype(np.dtype(("bool", (1, 2, 3)))).tolist(
+    assert ak.forms.numpyform.from_dtype(np.dtype(("bool", (1, 2, 3)))).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
@@ -1755,244 +1759,244 @@ def test_NumpyForm():
         "inner_shape": [1, 2, 3],
     }
     with pytest.raises(TypeError):
-        ak.forms.from_dtype(np.dtype("O")).tolist(verbose=False)
+        ak.forms.from_dtype(np.dtype("O")).to_dict(verbose=False)
     with pytest.raises(TypeError):
-        ak.forms.from_dtype(np.dtype([("one", np.int64), ("two", np.float64)])).tolist(
+        ak.forms.from_dtype(np.dtype([("one", np.int64), ("two", np.float64)])).to_dict(
             verbose=False
         )
-    assert ak.forms.from_iter("bool").tolist(verbose=False) == {
+    assert ak.forms.from_dict("bool").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "bool",
     }
-    assert ak.forms.from_iter("int8").tolist(verbose=False) == {
+    assert ak.forms.from_dict("int8").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int8",
     }
-    assert ak.forms.from_iter("uint8").tolist(verbose=False) == {
+    assert ak.forms.from_dict("uint8").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint8",
     }
-    assert ak.forms.from_iter("int16").tolist(verbose=False) == {
+    assert ak.forms.from_dict("int16").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int16",
     }
-    assert ak.forms.from_iter("uint16").tolist(verbose=False) == {
+    assert ak.forms.from_dict("uint16").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint16",
     }
-    assert ak.forms.from_iter("int32").tolist(verbose=False) == {
+    assert ak.forms.from_dict("int32").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int32",
     }
-    assert ak.forms.from_iter("uint32").tolist(verbose=False) == {
+    assert ak.forms.from_dict("uint32").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint32",
     }
-    assert ak.forms.from_iter("int64").tolist(verbose=False) == {
+    assert ak.forms.from_dict("int64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "int64",
     }
-    assert ak.forms.from_iter("uint64").tolist(verbose=False) == {
+    assert ak.forms.from_dict("uint64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "uint64",
     }
     if hasattr(np, "float16"):
-        assert ak.forms.from_iter("float16").tolist(verbose=False) == {
+        assert ak.forms.from_dict("float16").to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "float16",
         }
-    assert ak.forms.from_iter("float32").tolist(verbose=False) == {
+    assert ak.forms.from_dict("float32").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "float32",
     }
-    assert ak.forms.from_iter("float64").tolist(verbose=False) == {
+    assert ak.forms.from_dict("float64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "float64",
     }
     if hasattr(np, "float128"):
-        assert ak.forms.from_iter("float128").tolist(verbose=False) == {
+        assert ak.forms.from_dict("float128").to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "float128",
         }
-    assert ak.forms.from_iter("complex64").tolist(verbose=False) == {
+    assert ak.forms.from_dict("complex64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "complex64",
     }
-    assert ak.forms.from_iter("complex128").tolist(verbose=False) == {
+    assert ak.forms.from_dict("complex128").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "complex128",
     }
     if hasattr(np, "complex256"):
-        assert ak.forms.from_iter("complex256").tolist(verbose=False) == {
+        assert ak.forms.from_dict("complex256").to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "complex256",
         }
-    assert ak.forms.from_iter("datetime64").tolist(verbose=False) == {
+    assert ak.forms.from_dict("datetime64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "NumpyArray",
             "primitive": "datetime64",
             "parameters": {"__unit__": "s"},
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
         "parameters": {"__unit__": "s"},
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "NumpyArray",
             "primitive": "datetime64",
             "parameters": {"__unit__": "s", "x": 123},
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
         "parameters": {"__unit__": "s", "x": 123},
     }
-    assert ak.forms.from_iter("timedelta64").tolist(verbose=False) == {
+    assert ak.forms.from_dict("timedelta64").to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "NumpyArray",
             "primitive": "timedelta64",
             "parameters": {"__unit__": "s"},
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
         "parameters": {"__unit__": "s"},
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "NumpyArray",
             "primitive": "timedelta64",
             "parameters": {"__unit__": "s", "x": 123},
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
         "parameters": {"__unit__": "s", "x": 123},
     }
 
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "bool"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "bool"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "bool",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "int8"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "int8"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "int8",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "uint8"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "uint8"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "uint8",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "int16"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "int16"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "int16",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "uint16"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "uint16"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "uint16",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "int32"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "int32"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "int32",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "uint32"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "uint32"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "uint32",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "int64"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "int64"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "int64",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "uint64"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "uint64"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "uint64",
     }
     if hasattr(np, "float16"):
-        assert ak.forms.from_iter(
+        assert ak.forms.from_dict(
             {"class": "NumpyArray", "primitive": "float16"}
-        ).tolist(verbose=False) == {
+        ).to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "float16",
         }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "float32"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "float32"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "float32",
     }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "float64"}).tolist(
+    assert ak.forms.from_dict({"class": "NumpyArray", "primitive": "float64"}).to_dict(
         verbose=False
     ) == {
         "class": "NumpyArray",
         "primitive": "float64",
     }
     if hasattr(np, "float128"):
-        assert ak.forms.from_iter(
+        assert ak.forms.from_dict(
             {"class": "NumpyArray", "primitive": "float128"}
-        ).tolist(verbose=False) == {
+        ).to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "float128",
         }
-    assert ak.forms.from_iter({"class": "NumpyArray", "primitive": "complex64"}).tolist(
-        verbose=False
-    ) == {
+    assert ak.forms.from_dict(
+        {"class": "NumpyArray", "primitive": "complex64"}
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "complex64",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {"class": "NumpyArray", "primitive": "complex128"}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "complex128",
     }
     if hasattr(np, "complex256"):
-        assert ak.forms.from_iter(
+        assert ak.forms.from_dict(
             {"class": "NumpyArray", "primitive": "complex256"}
-        ).tolist(verbose=False) == {
+        ).to_dict(verbose=False) == {
             "class": "NumpyArray",
             "primitive": "complex256",
         }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {"class": "NumpyArray", "primitive": "datetime64"}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "datetime64",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {"class": "NumpyArray", "primitive": "timedelta64"}
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "timedelta64",
     }
 
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "NumpyArray",
             "primitive": "bool",
@@ -2001,7 +2005,7 @@ def test_NumpyForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "NumpyArray",
         "primitive": "bool",
         "inner_shape": [1, 2, 3],
@@ -2066,7 +2070,7 @@ def test_RegularForm():
         == "RegularForm(EmptyForm(), 10, has_identifier=True, parameters={'x': 123}, form_key='hello')"
     )
 
-    assert ak.forms.regularform.RegularForm(ak.forms.emptyform.EmptyForm(), 10).tolist(
+    assert ak.forms.regularform.RegularForm(ak.forms.emptyform.EmptyForm(), 10).to_dict(
         verbose=False
     ) == {
         "class": "RegularArray",
@@ -2075,7 +2079,7 @@ def test_RegularForm():
     }
     assert ak.forms.regularform.RegularForm(
         ak.forms.emptyform.EmptyForm(), 10
-    ).tolist() == {
+    ).to_dict() == {
         "class": "RegularArray",
         "size": 10,
         "content": {
@@ -2094,7 +2098,7 @@ def test_RegularForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RegularArray",
         "size": 10,
         "content": {"class": "EmptyArray"},
@@ -2102,9 +2106,9 @@ def test_RegularForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {"class": "RegularArray", "size": 10, "content": {"class": "EmptyArray"}}
-    ).tolist() == {
+    ).to_dict() == {
         "class": "RegularArray",
         "size": 10,
         "content": {
@@ -2117,7 +2121,7 @@ def test_RegularForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "RegularArray",
             "size": 10,
@@ -2126,7 +2130,7 @@ def test_RegularForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RegularArray",
         "size": 10,
         "content": {"class": "EmptyArray"},
@@ -2136,7 +2140,7 @@ def test_RegularForm():
     }
     assert ak.forms.regularform.RegularForm(
         ak.forms.numpyform.NumpyForm("bool"), 10
-    ).tolist() == {
+    ).to_dict() == {
         "class": "RegularArray",
         "content": {
             "class": "NumpyArray",
@@ -2153,7 +2157,7 @@ def test_RegularForm():
     }
     assert ak.forms.regularform.RegularForm(
         ak.forms.numpyform.NumpyForm("bool"), 10
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RegularArray",
         "content": "bool",
         "size": 10,
@@ -2243,7 +2247,7 @@ def test_ListForm():
 
     assert ak.forms.listform.ListForm(
         "i32", "i32", ak.forms.emptyform.EmptyForm()
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ListArray",
         "starts": "i32",
         "stops": "i32",
@@ -2251,7 +2255,7 @@ def test_ListForm():
     }
     assert ak.forms.listform.ListForm(
         "i32", "i32", ak.forms.emptyform.EmptyForm()
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ListArray",
         "starts": "i32",
         "stops": "i32",
@@ -2272,7 +2276,7 @@ def test_ListForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ListArray",
         "starts": "i32",
         "stops": "i32",
@@ -2281,14 +2285,14 @@ def test_ListForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ListArray",
             "starts": "i32",
             "stops": "i32",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ListArray",
         "starts": "i32",
         "stops": "i32",
@@ -2302,14 +2306,14 @@ def test_ListForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ListArray",
             "starts": "u32",
             "stops": "u32",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ListArray",
         "starts": "u32",
         "stops": "u32",
@@ -2323,14 +2327,14 @@ def test_ListForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ListArray",
             "starts": "i64",
             "stops": "i64",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ListArray",
         "starts": "i64",
         "stops": "i64",
@@ -2344,7 +2348,7 @@ def test_ListForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ListArray",
             "starts": "i32",
@@ -2354,7 +2358,7 @@ def test_ListForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ListArray",
         "starts": "i32",
         "stops": "i32",
@@ -2454,14 +2458,14 @@ def test_ListOffsetForm():
 
     assert ak.forms.listoffsetform.ListOffsetForm(
         "i32", ak.forms.emptyform.EmptyForm()
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ListOffsetArray",
         "offsets": "i32",
         "content": {"class": "EmptyArray"},
     }
     assert ak.forms.listoffsetform.ListOffsetForm(
         "i32", ak.forms.emptyform.EmptyForm()
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ListOffsetArray",
         "offsets": "i32",
         "content": {
@@ -2480,7 +2484,7 @@ def test_ListOffsetForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ListOffsetArray",
         "offsets": "i32",
         "content": {"class": "EmptyArray"},
@@ -2488,13 +2492,13 @@ def test_ListOffsetForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ListOffsetArray",
             "offsets": "i32",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ListOffsetArray",
         "offsets": "i32",
         "content": {
@@ -2507,13 +2511,13 @@ def test_ListOffsetForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ListOffsetArray",
             "offsets": "u32",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ListOffsetArray",
         "offsets": "u32",
         "content": {
@@ -2526,13 +2530,13 @@ def test_ListOffsetForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ListOffsetArray",
             "offsets": "i64",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ListOffsetArray",
         "offsets": "i64",
         "content": {
@@ -2545,7 +2549,7 @@ def test_ListOffsetForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ListOffsetArray",
             "offsets": "i32",
@@ -2554,7 +2558,7 @@ def test_ListOffsetForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ListOffsetArray",
         "offsets": "i32",
         "content": {"class": "EmptyArray"},
@@ -2720,7 +2724,7 @@ def test_RecordForm():
     assert ak.forms.recordform.RecordForm(
         [ak.forms.emptyform.EmptyForm(), ak.forms.numpyform.NumpyForm("bool")],
         None,
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RecordArray",
         "contents": [
             {"class": "EmptyArray"},
@@ -2730,7 +2734,7 @@ def test_RecordForm():
     assert ak.forms.recordform.RecordForm(
         [ak.forms.emptyform.EmptyForm(), ak.forms.numpyform.NumpyForm("bool")],
         ["x", "y"],
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RecordArray",
         "contents": {
             "x": {"class": "EmptyArray"},
@@ -2740,7 +2744,7 @@ def test_RecordForm():
     assert ak.forms.recordform.RecordForm(
         [ak.forms.emptyform.EmptyForm(), ak.forms.numpyform.NumpyForm("bool")],
         None,
-    ).tolist() == {
+    ).to_dict() == {
         "class": "RecordArray",
         "contents": [
             {
@@ -2765,7 +2769,7 @@ def test_RecordForm():
     assert ak.forms.recordform.RecordForm(
         [ak.forms.emptyform.EmptyForm(), ak.forms.numpyform.NumpyForm("bool")],
         ["x", "y"],
-    ).tolist() == {
+    ).to_dict() == {
         "class": "RecordArray",
         "contents": {
             "x": {
@@ -2796,7 +2800,7 @@ def test_RecordForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RecordArray",
         "contents": [
             {"class": "EmptyArray"},
@@ -2815,7 +2819,7 @@ def test_RecordForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RecordArray",
         "contents": {
             "x": {"class": "EmptyArray"},
@@ -2825,7 +2829,7 @@ def test_RecordForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "RecordArray",
             "contents": [
@@ -2833,7 +2837,7 @@ def test_RecordForm():
                 "bool",
             ],
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "RecordArray",
         "contents": [
             {
@@ -2855,7 +2859,7 @@ def test_RecordForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "RecordArray",
             "contents": {
@@ -2863,7 +2867,7 @@ def test_RecordForm():
                 "y": "bool",
             },
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "RecordArray",
         "contents": {
             "x": {
@@ -2885,7 +2889,7 @@ def test_RecordForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "RecordArray",
             "contents": [
@@ -2896,7 +2900,7 @@ def test_RecordForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RecordArray",
         "contents": [
             {"class": "EmptyArray"},
@@ -2906,7 +2910,7 @@ def test_RecordForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "RecordArray",
             "contents": {
@@ -2917,7 +2921,7 @@ def test_RecordForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "RecordArray",
         "contents": {
             "x": {"class": "EmptyArray"},
@@ -3006,14 +3010,14 @@ def test_IndexedForm():
 
     assert ak.forms.indexedform.IndexedForm(
         "i32", ak.forms.emptyform.EmptyForm()
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "IndexedArray",
         "index": "i32",
         "content": {"class": "EmptyArray"},
     }
     assert ak.forms.indexedform.IndexedForm(
         "i32", ak.forms.emptyform.EmptyForm()
-    ).tolist() == {
+    ).to_dict() == {
         "class": "IndexedArray",
         "index": "i32",
         "content": {
@@ -3032,7 +3036,7 @@ def test_IndexedForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "IndexedArray",
         "index": "i32",
         "content": {"class": "EmptyArray"},
@@ -3040,13 +3044,13 @@ def test_IndexedForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "IndexedArray",
             "index": "i32",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "IndexedArray",
         "index": "i32",
         "content": {
@@ -3059,13 +3063,13 @@ def test_IndexedForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "IndexedArray",
             "index": "u32",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "IndexedArray",
         "index": "u32",
         "content": {
@@ -3078,13 +3082,13 @@ def test_IndexedForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "IndexedArray",
             "index": "i64",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "IndexedArray",
         "index": "i64",
         "content": {
@@ -3097,7 +3101,7 @@ def test_IndexedForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "IndexedArray",
             "index": "i32",
@@ -3106,7 +3110,7 @@ def test_IndexedForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "IndexedArray",
         "index": "i32",
         "content": {"class": "EmptyArray"},
@@ -3191,14 +3195,14 @@ def test_IndexedOptionForm():
 
     assert ak.forms.indexedoptionform.IndexedOptionForm(
         "i32", ak.forms.emptyform.EmptyForm()
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "IndexedOptionArray",
         "index": "i32",
         "content": {"class": "EmptyArray"},
     }
     assert ak.forms.indexedoptionform.IndexedOptionForm(
         "i32", ak.forms.emptyform.EmptyForm()
-    ).tolist() == {
+    ).to_dict() == {
         "class": "IndexedOptionArray",
         "index": "i32",
         "content": {
@@ -3217,7 +3221,7 @@ def test_IndexedOptionForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "IndexedOptionArray",
         "index": "i32",
         "content": {"class": "EmptyArray"},
@@ -3225,13 +3229,13 @@ def test_IndexedOptionForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "IndexedOptionArray",
             "index": "i32",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "IndexedOptionArray",
         "index": "i32",
         "content": {
@@ -3244,13 +3248,13 @@ def test_IndexedOptionForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "IndexedOptionArray",
             "index": "i64",
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "IndexedOptionArray",
         "index": "i64",
         "content": {
@@ -3263,7 +3267,7 @@ def test_IndexedOptionForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "IndexedOptionArray",
             "index": "i32",
@@ -3272,7 +3276,7 @@ def test_IndexedOptionForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "IndexedOptionArray",
         "index": "i32",
         "content": {"class": "EmptyArray"},
@@ -3362,7 +3366,7 @@ def test_ByteMaskedForm():
 
     assert ak.forms.bytemaskedform.ByteMaskedForm(
         "i8", ak.forms.emptyform.EmptyForm(), True
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ByteMaskedArray",
         "mask": "i8",
         "valid_when": True,
@@ -3370,7 +3374,7 @@ def test_ByteMaskedForm():
     }
     assert ak.forms.bytemaskedform.ByteMaskedForm(
         "i8", ak.forms.emptyform.EmptyForm(), True
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ByteMaskedArray",
         "mask": "i8",
         "valid_when": True,
@@ -3391,7 +3395,7 @@ def test_ByteMaskedForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ByteMaskedArray",
         "mask": "i8",
         "valid_when": True,
@@ -3400,14 +3404,14 @@ def test_ByteMaskedForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ByteMaskedArray",
             "mask": "i8",
             "valid_when": True,
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ByteMaskedArray",
         "mask": "i8",
         "valid_when": True,
@@ -3421,14 +3425,14 @@ def test_ByteMaskedForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ByteMaskedArray",
             "mask": "i64",
             "valid_when": True,
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "ByteMaskedArray",
         "mask": "i64",
         "valid_when": True,
@@ -3442,7 +3446,7 @@ def test_ByteMaskedForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "ByteMaskedArray",
             "mask": "i8",
@@ -3452,7 +3456,7 @@ def test_ByteMaskedForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "ByteMaskedArray",
         "mask": "i8",
         "valid_when": True,
@@ -3583,7 +3587,7 @@ def test_BitMaskedForm():
 
     assert ak.forms.bitmaskedform.BitMaskedForm(
         "u8", ak.forms.emptyform.EmptyForm(), True, False
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "BitMaskedArray",
         "mask": "u8",
         "valid_when": True,
@@ -3592,7 +3596,7 @@ def test_BitMaskedForm():
     }
     assert ak.forms.bitmaskedform.BitMaskedForm(
         "u8", ak.forms.emptyform.EmptyForm(), True, False
-    ).tolist() == {
+    ).to_dict() == {
         "class": "BitMaskedArray",
         "mask": "u8",
         "valid_when": True,
@@ -3615,7 +3619,7 @@ def test_BitMaskedForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "BitMaskedArray",
         "mask": "u8",
         "valid_when": True,
@@ -3625,7 +3629,7 @@ def test_BitMaskedForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "BitMaskedArray",
             "mask": "u8",
@@ -3633,7 +3637,7 @@ def test_BitMaskedForm():
             "lsb_order": False,
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "BitMaskedArray",
         "mask": "u8",
         "valid_when": True,
@@ -3648,7 +3652,7 @@ def test_BitMaskedForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "BitMaskedArray",
             "mask": "i64",
@@ -3656,7 +3660,7 @@ def test_BitMaskedForm():
             "lsb_order": False,
             "content": {"class": "EmptyArray"},
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "BitMaskedArray",
         "mask": "i64",
         "valid_when": True,
@@ -3671,7 +3675,7 @@ def test_BitMaskedForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "BitMaskedArray",
             "mask": "u8",
@@ -3682,7 +3686,7 @@ def test_BitMaskedForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "BitMaskedArray",
         "mask": "u8",
         "valid_when": True,
@@ -3741,7 +3745,7 @@ def test_UnmaskedForm():
         == "UnmaskedForm(EmptyForm(), has_identifier=True, parameters={'x': 123}, form_key='hello')"
     )
 
-    assert ak.forms.unmaskedform.UnmaskedForm(ak.forms.emptyform.EmptyForm()).tolist(
+    assert ak.forms.unmaskedform.UnmaskedForm(ak.forms.emptyform.EmptyForm()).to_dict(
         verbose=False
     ) == {
         "class": "UnmaskedArray",
@@ -3749,7 +3753,7 @@ def test_UnmaskedForm():
     }
     assert ak.forms.unmaskedform.UnmaskedForm(
         ak.forms.emptyform.EmptyForm()
-    ).tolist() == {
+    ).to_dict() == {
         "class": "UnmaskedArray",
         "content": {
             "class": "EmptyArray",
@@ -3766,16 +3770,16 @@ def test_UnmaskedForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "UnmaskedArray",
         "content": {"class": "EmptyArray"},
         "has_identifier": True,
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {"class": "UnmaskedArray", "content": {"class": "EmptyArray"}}
-    ).tolist() == {
+    ).to_dict() == {
         "class": "UnmaskedArray",
         "content": {
             "class": "EmptyArray",
@@ -3787,7 +3791,7 @@ def test_UnmaskedForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "UnmaskedArray",
             "content": {"class": "EmptyArray"},
@@ -3795,7 +3799,7 @@ def test_UnmaskedForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "UnmaskedArray",
         "content": {"class": "EmptyArray"},
         "has_identifier": True,
@@ -3940,7 +3944,7 @@ def test_UnionForm():
         "i8",
         "i32",
         [ak.forms.emptyform.EmptyForm(), ak.forms.numpyform.NumpyForm("bool")],
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "UnionArray",
         "tags": "i8",
         "index": "i32",
@@ -3953,7 +3957,7 @@ def test_UnionForm():
         "i8",
         "i32",
         [ak.forms.emptyform.EmptyForm(), ak.forms.numpyform.NumpyForm("bool")],
-    ).tolist() == {
+    ).to_dict() == {
         "class": "UnionArray",
         "tags": "i8",
         "index": "i32",
@@ -3987,7 +3991,7 @@ def test_UnionForm():
         has_identifier=True,
         parameters={"x": 123},
         form_key="hello",
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "UnionArray",
         "tags": "i8",
         "index": "i32",
@@ -3999,7 +4003,7 @@ def test_UnionForm():
         "parameters": {"x": 123},
         "form_key": "hello",
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "UnionArray",
             "tags": "i8",
@@ -4009,7 +4013,7 @@ def test_UnionForm():
                 "bool",
             ],
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "UnionArray",
         "tags": "i8",
         "index": "i32",
@@ -4033,7 +4037,7 @@ def test_UnionForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "UnionArray",
             "tags": "i8",
@@ -4043,7 +4047,7 @@ def test_UnionForm():
                 "bool",
             ],
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "UnionArray",
         "tags": "i8",
         "index": "u32",
@@ -4067,7 +4071,7 @@ def test_UnionForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "UnionArray",
             "tags": "i8",
@@ -4077,7 +4081,7 @@ def test_UnionForm():
                 "bool",
             ],
         }
-    ).tolist() == {
+    ).to_dict() == {
         "class": "UnionArray",
         "tags": "i8",
         "index": "i64",
@@ -4101,7 +4105,7 @@ def test_UnionForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_iter(
+    assert ak.forms.from_dict(
         {
             "class": "UnionArray",
             "tags": "i8",
@@ -4114,7 +4118,7 @@ def test_UnionForm():
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).tolist(verbose=False) == {
+    ).to_dict(verbose=False) == {
         "class": "UnionArray",
         "tags": "i8",
         "index": "i32",

--- a/tests/test_0958-new-forms-must-accept-old-form-json.py
+++ b/tests/test_0958-new-forms-must-accept-old-form-json.py
@@ -12,7 +12,7 @@ def test_EmptyArray():
     v1 = json.loads(
         '{"class":"EmptyArray","has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "EmptyArray",
         "has_identifier": False,
@@ -25,7 +25,7 @@ def test_NumpyArray():
     v1 = json.loads(
         '{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "NumpyArray",
         "primitive": "float64",
@@ -38,7 +38,7 @@ def test_NumpyArray():
     v1 = json.loads(
         '{"class":"NumpyArray","inner_shape":[3,5],"itemsize":8,"format":"l","primitive":"int64","has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "NumpyArray",
         "primitive": "int64",
@@ -53,7 +53,7 @@ def test_RegularArray_NumpyArray():
     v1 = json.loads(
         '{"class":"RegularArray","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"size":3,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "RegularArray",
         "size": 3,
@@ -73,7 +73,7 @@ def test_RegularArray_NumpyArray():
     v1 = json.loads(
         '{"class":"RegularArray","content":{"class":"EmptyArray","has_identities":false,"parameters":{},"form_key":null},"size":0,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "RegularArray",
         "size": 0,
@@ -93,7 +93,7 @@ def test_ListArray_NumpyArray():
     v1 = json.loads(
         '{"class":"ListArray64","starts":"i64","stops":"i64","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "ListArray",
         "starts": "i64",
@@ -116,7 +116,7 @@ def test_ListOffsetArray_NumpyArray():
     v1 = json.loads(
         '{"class":"ListOffsetArray64","offsets":"i64","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "ListOffsetArray",
         "offsets": "i64",
@@ -138,7 +138,7 @@ def test_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"RecordArray","contents":{"x":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"l","primitive":"int64","has_identities":false,"parameters":{},"form_key":null},"y":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "RecordArray",
         "contents": {
@@ -167,7 +167,7 @@ def test_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"RecordArray","contents":[{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"l","primitive":"int64","has_identities":false,"parameters":{},"form_key":null},{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}],"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "RecordArray",
         "contents": [
@@ -196,7 +196,7 @@ def test_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"RecordArray","contents":{},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "RecordArray",
         "contents": {},
@@ -208,7 +208,7 @@ def test_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"RecordArray","contents":[],"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "RecordArray",
         "contents": [],
@@ -222,7 +222,7 @@ def test_IndexedArray_NumpyArray():
     v1 = json.loads(
         '{"class":"IndexedArray64","index":"i64","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "IndexedArray",
         "index": "i64",
@@ -244,7 +244,7 @@ def test_IndexedOptionArray_NumpyArray():
     v1 = json.loads(
         '{"class":"IndexedOptionArray64","index":"i64","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "IndexedOptionArray",
         "index": "i64",
@@ -266,7 +266,7 @@ def test_ByteMaskedArray_NumpyArray():
     v1 = json.loads(
         '{"class":"ByteMaskedArray","mask":"i8","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"valid_when":true,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "ByteMaskedArray",
         "mask": "i8",
@@ -287,7 +287,7 @@ def test_ByteMaskedArray_NumpyArray():
     v1 = json.loads(
         '{"class":"ByteMaskedArray","mask":"i8","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"valid_when":false,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "ByteMaskedArray",
         "mask": "i8",
@@ -310,7 +310,7 @@ def test_BitMaskedArray_NumpyArray():
     v1 = json.loads(
         '{"class":"BitMaskedArray","mask":"u8","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"valid_when":true,"lsb_order":false,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "BitMaskedArray",
         "mask": "u8",
@@ -332,7 +332,7 @@ def test_BitMaskedArray_NumpyArray():
     v1 = json.loads(
         '{"class":"BitMaskedArray","mask":"u8","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"valid_when":false,"lsb_order":false,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "BitMaskedArray",
         "mask": "u8",
@@ -354,7 +354,7 @@ def test_BitMaskedArray_NumpyArray():
     v1 = json.loads(
         '{"class":"BitMaskedArray","mask":"u8","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"valid_when":true,"lsb_order":true,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "BitMaskedArray",
         "mask": "u8",
@@ -376,7 +376,7 @@ def test_BitMaskedArray_NumpyArray():
     v1 = json.loads(
         '{"class":"BitMaskedArray","mask":"u8","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"valid_when":false,"lsb_order":true,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "BitMaskedArray",
         "mask": "u8",
@@ -400,7 +400,7 @@ def test_UnmaskedArray_NumpyArray():
     v1 = json.loads(
         '{"class":"UnmaskedArray","content":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "UnmaskedArray",
         "content": {
@@ -421,7 +421,7 @@ def test_UnionArray_NumpyArray():
     v1 = json.loads(
         '{"class":"UnionArray8_64","tags":"i8","index":"i64","contents":[{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"l","primitive":"int64","has_identities":false,"parameters":{},"form_key":null},{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}],"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "UnionArray",
         "tags": "i8",
@@ -454,7 +454,7 @@ def test_RegularArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"RegularArray","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"size":3,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "RegularArray",
         "size": 3,
@@ -482,7 +482,7 @@ def test_RegularArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"RegularArray","content":{"class":"RecordArray","contents":{"nest":{"class":"EmptyArray","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"size":0,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "RegularArray",
         "size": 0,
@@ -510,7 +510,7 @@ def test_ListArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"ListArray64","starts":"i64","stops":"i64","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "ListArray",
         "starts": "i64",
@@ -541,7 +541,7 @@ def test_ListOffsetArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"ListOffsetArray64","offsets":"i64","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "ListOffsetArray",
         "offsets": "i64",
@@ -571,7 +571,7 @@ def test_IndexedArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"IndexedArray64","index":"i64","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "IndexedArray",
         "index": "i64",
@@ -601,7 +601,7 @@ def test_IndexedOptionArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"IndexedOptionArray64","index":"i64","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "IndexedOptionArray",
         "index": "i64",
@@ -631,7 +631,7 @@ def test_ByteMaskedArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"ByteMaskedArray","mask":"i8","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"valid_when":true,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "ByteMaskedArray",
         "mask": "i8",
@@ -660,7 +660,7 @@ def test_ByteMaskedArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"ByteMaskedArray","mask":"i8","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"valid_when":false,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "ByteMaskedArray",
         "mask": "i8",
@@ -691,7 +691,7 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"BitMaskedArray","mask":"u8","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"valid_when":true,"lsb_order":false,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "BitMaskedArray",
         "mask": "u8",
@@ -721,7 +721,7 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"BitMaskedArray","mask":"u8","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"valid_when":false,"lsb_order":false,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "BitMaskedArray",
         "mask": "u8",
@@ -751,7 +751,7 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"BitMaskedArray","mask":"u8","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"valid_when":true,"lsb_order":true,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "BitMaskedArray",
         "mask": "u8",
@@ -781,7 +781,7 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"BitMaskedArray","mask":"u8","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"valid_when":false,"lsb_order":true,"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "BitMaskedArray",
         "mask": "u8",
@@ -813,7 +813,7 @@ def test_UnmaskedArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"UnmaskedArray","content":{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "UnmaskedArray",
         "content": {
@@ -842,7 +842,7 @@ def test_UnionArray_RecordArray_NumpyArray():
     v1 = json.loads(
         '{"class":"UnionArray8_64","tags":"i8","index":"i64","contents":[{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"l","primitive":"int64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null},{"class":"RecordArray","contents":{"nest":{"class":"NumpyArray","inner_shape":[],"itemsize":8,"format":"d","primitive":"float64","has_identities":false,"parameters":{},"form_key":null}},"has_identities":false,"parameters":{},"form_key":null}],"has_identities":false,"parameters":{},"form_key":null}'
     )
-    v2 = ak.forms.from_iter(v1).tolist()
+    v2 = ak.forms.from_dict(v1).to_dict()
     assert v2 == {
         "class": "UnionArray",
         "tags": "i8",


### PR DESCRIPTION
This is a preparatory PR to clean-up `ak.forms.Form`. It does two things:

- Remove dead code.
- Rename  `tolist`, `from_iter` to `to_dict`, `from_dict`

@jpivarski we still need `simplify_optiontype` as it is used in the Arrow deserialisation.