### PR TITLE
fix: use proper lengths in `ByteMaskedArray.mergemany` (backport)

### DIFF
--- a/src/awkward/_v2/contents/bytemaskedarray.py
+++ b/src/awkward/_v2/contents/bytemaskedarray.py
@@ -655,15 +655,15 @@ class ByteMaskedArray(Content):
             for x in others
         ):
             parameters = self._parameters
-            masks = [self._mask.data]
+            masks = [self._mask.data[: self.length]]
             tail_contents = []
             length = 0
             for x in others:
                 parameters = ak._v2._util.merge_parameters(
                     parameters, x._parameters, True
                 )
-                masks.append(x._mask.data)
-                tail_contents.append(x._content[: self.length])
+                masks.append(x._mask.data[: x.length])
+                tail_contents.append(x._content[: x.length])
                 length += x.length
 
             return ByteMaskedArray(

--- a/tests/v2/test_1747-bytemaskedarray-mergemany.py
+++ b/tests/v2/test_1747-bytemaskedarray-mergemany.py
@@ -1,0 +1,22 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    x = ak._v2.contents.ByteMaskedArray(
+        ak._v2.index.Index8(np.r_[0, 1, 1]),
+        ak._v2.contents.NumpyArray(np.arange(12)),
+        valid_when=True,
+    )
+    y = ak._v2.contents.ByteMaskedArray(
+        ak._v2.index.Index8(np.r_[1, 1, 1, 0, 0]),
+        ak._v2.contents.NumpyArray(np.arange(12)),
+        valid_when=True,
+    )
+    z = x.merge(y)
+
+    assert z.to_list() == [None, 1, 2, 0, 1, 2, None, None]


### PR DESCRIPTION
Fixes #1747 for v1-main