### PR TITLE
refactor: split error-handling code from `_util`

### DIFF
--- a/dev/flake8_awkward.py
+++ b/dev/flake8_awkward.py
@@ -19,10 +19,11 @@ class Visitor(ast.NodeVisitor):
     def visit_Raise(self, node):
         if isinstance(node.exc, ast.Call):
             if isinstance(node.exc.func, ast.Attribute):
-                if node.exc.func.attr in {"error", "indexerror"}:
+                if node.exc.func.attr in {"wrap_error", "index_error"}:
                     return
-            if node.exc.func.id in {"ImportError"}:
-                return
+            if isinstance(node.exc.func, ast.Name):
+                if node.exc.func.id in {"ImportError"}:
+                    return
 
         self.errors.append(
             Flake8ASTErrorInfo(node.lineno, node.col_offset, self.msg, type(self))

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -23,6 +23,7 @@ import awkward._typetracer
 
 # internal
 import awkward._util
+import awkward._errors
 import awkward._lookup
 
 # third-party connectors

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -89,7 +89,7 @@ def checklength(inputs, options):
     length = inputs[0].length
     for x in inputs[1:]:
         if x.length != length:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "cannot broadcast {} of length {} with {} of length {}{}".format(
                         type(inputs[0]).__name__,
@@ -298,7 +298,7 @@ def one_to_one_parameters_factory(
 
     def apply(n_outputs) -> list[dict[str, Any] | None]:
         if n_outputs != len(inputs):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "cannot follow one-to-one parameter broadcasting rule for actions "
                     "which change the number of outputs."
@@ -392,7 +392,7 @@ def apply_step(
     try:
         parameters_factory_impl = BROADCAST_RULE_TO_FACTORY_IMPL[rule]
     except KeyError:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 f"`broadcast_parameters_rule` should be one of {[str(x) for x in BroadcastParameterRule]}, "
                 f"but this routine received `{rule}`"
@@ -506,7 +506,7 @@ def apply_step(
                         if length is None:
                             length = tagslist[-1].shape[0]
                         elif length != tagslist[-1].shape[0]:
-                            raise ak._util.error(
+                            raise ak._errors.wrap_error(
                                 ValueError(
                                     "cannot broadcast UnionArray of length {} "
                                     "with UnionArray of length {}{}".format(
@@ -681,7 +681,7 @@ def apply_step(
                             elif x.size == maxsize:
                                 nextinputs.append(x.content[: x.length * x.size])
                             else:
-                                raise ak._util.error(
+                                raise ak._errors.wrap_error(
                                     ValueError(
                                         "cannot broadcast RegularArray of size "
                                         "{} with RegularArray of size {} {}".format(
@@ -820,7 +820,7 @@ def apply_step(
                         for x, p in zip(outcontent, parameters)
                     )
                 else:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         AssertionError(
                             "unexpected offsets, starts: {}, {}".format(
                                 type(offsets), type(starts)
@@ -902,7 +902,7 @@ def apply_step(
         # Any RecordArrays?
         elif any(isinstance(x, RecordArray) for x in inputs):
             if not options["allow_records"]:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(f"cannot broadcast records {in_function(options)}")
                 )
 
@@ -912,7 +912,7 @@ def apply_step(
                     if fields is None:
                         fields = x.fields
                     elif set(fields) != set(x.fields):
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             ValueError(
                                 "cannot broadcast records because fields don't "
                                 "match{}:\n    {}\n    {}".format(
@@ -925,7 +925,7 @@ def apply_step(
                     if length is None:
                         length = x.length
                     elif length != x.length:
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             ValueError(
                                 "cannot broadcast RecordArray of length {} "
                                 "with RecordArray of length {}{}".format(
@@ -965,7 +965,7 @@ def apply_step(
             )
 
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "cannot broadcast: {}{}".format(
                         ", ".join(repr(type(x)) for x in inputs), in_function(options)
@@ -989,7 +989,7 @@ def apply_step(
     elif result is None:
         return continuation()
     else:
-        raise ak._util.error(AssertionError(result))
+        raise ak._errors.wrap_error(AssertionError(result))
 
 
 def broadcast_and_apply(

--- a/src/awkward/_connect/avro.py
+++ b/src/awkward/_connect/avro.py
@@ -26,7 +26,7 @@ class ReadAvroFT:
             try:
                 self.temp_header += self.data.read(numbytes)
                 if not self.check_valid():
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         TypeError("invalid Avro file: first 4 bytes are not b'Obj\x01'")
                     )
                 pos = 4
@@ -911,4 +911,4 @@ class ReadAvroFT:
             #         exec_code = exec_code+hh
             #         exec_code = exec_code+jj
             #         exec_code = exec_code+kk
-            raise ak._util.error(NotImplementedError)
+            raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/_connect/cling.py
+++ b/src/awkward/_connect/cling.py
@@ -470,7 +470,7 @@ def togenerator(form, flatlist_as_rvec):
         return UnionArrayGenerator.from_form(form, flatlist_as_rvec)
 
     else:
-        raise ak._util.error(AssertionError(f"unrecognized Form: {type(form)}"))
+        raise ak._errors.wrap_error(AssertionError(f"unrecognized Form: {type(form)}"))
 
 
 class Generator:
@@ -479,7 +479,7 @@ class Generator:
         if not form.has_identifier:
             return None
         else:
-            raise ak._util.error(NotImplementedError("TODO: identifiers in C++"))
+            raise ak._errors.wrap_error(NotImplementedError("TODO: identifiers in C++"))
 
     def IndexOf(self, arraytype):
         if arraytype == "int8_t":
@@ -495,7 +495,7 @@ class Generator:
         elif arraytype == "uint64_t":
             return ak.index.IndexU64
         else:
-            raise ak._util.error(AssertionError(arraytype))
+            raise ak._errors.wrap_error(AssertionError(arraytype))
 
     def class_type_suffix(self, key):
         return ak._util.identifier_hash(key)
@@ -797,7 +797,7 @@ class ListArrayGenerator(Generator, ak._lookup.ListLookup):
         elif index_type == "i64":
             self.index_type = "int64_t"
         else:
-            raise ak._util.error(AssertionError(index_type))
+            raise ak._errors.wrap_error(AssertionError(index_type))
         self.content = content
 
         # FIXME: satisfy the ContentLookup super-class
@@ -950,7 +950,7 @@ class IndexedArrayGenerator(Generator, ak._lookup.IndexedLookup):
         elif index_type == "i64":
             self.indextype = "int64_t"
         else:
-            raise ak._util.error(AssertionError(index_type))
+            raise ak._errors.wrap_error(AssertionError(index_type))
         self.contenttype = content
         self.identifier = identifier
         self.parameters = parameters
@@ -1029,7 +1029,7 @@ class IndexedOptionArrayGenerator(Generator, ak._lookup.IndexedOptionLookup):
         elif index_type == "i64":
             self.index_type = "int64_t"
         else:
-            raise ak._util.error(AssertionError(index_type))
+            raise ak._errors.wrap_error(AssertionError(index_type))
         self.contenttype = content
         self.identifier = identifier
         self.parameters = parameters
@@ -1543,7 +1543,7 @@ class UnionArrayGenerator(Generator, ak._lookup.UnionLookup):
         elif index_type == "i64":
             self.indextype = "int64_t"
         else:
-            raise ak._util.error(AssertionError(index_type))
+            raise ak._errors.wrap_error(AssertionError(index_type))
         self.contenttypes = tuple(contents)
         self.identifier = identifier
         self.parameters = parameters

--- a/src/awkward/_connect/cuda/__init__.py
+++ b/src/awkward/_connect/cuda/__init__.py
@@ -149,7 +149,9 @@ class Invocation:
 
 def import_cupy(name="Awkward Arrays with CUDA"):
     if cupy is None:
-        raise awkward._util.error(ModuleNotFoundError(error_message.format(name)))
+        raise awkward._errors.wrap_error(
+            ModuleNotFoundError(error_message.format(name))
+        )
     return cupy
 
 
@@ -195,7 +197,7 @@ def initialize_cuda_kernels(cupy):
 
         return kernel
     else:
-        raise awkward._util.error(
+        raise awkward._errors.wrap_error(
             ModuleNotFoundError(error_message.format("Awkward Arrays with CUDA"))
         )
 
@@ -217,7 +219,7 @@ def synchronize_cuda(stream=None):
             cupy.array(NO_ERROR),
             [],
         )
-        raise awkward._util.error(
+        raise awkward._errors.wrap_error(
             ValueError(
                 f"{kernel_errors[invoked_kernel.name][int(invocation_index % math.pow(2, ERROR_BITS))]} in compiled CUDA code ({invoked_kernel.name})"
             ),

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -52,7 +52,7 @@ def register_pytrees():
 
 def import_jax(name="Awkward Arrays with JAX"):
     if jax is None:
-        raise ak._util.error(ModuleNotFoundError(error_message.format(name)))
+        raise ak._errors.wrap_error(ModuleNotFoundError(error_message.format(name)))
 
     global pytrees_registered
 

--- a/src/awkward/_connect/jax/_reducers.py
+++ b/src/awkward/_connect/jax/_reducers.py
@@ -45,7 +45,7 @@ class ArgMin(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._util.error("Cannot differentiate through argmin")
+        raise ak._errors.wrap_error("Cannot differentiate through argmin")
 
 
 class ArgMax(Reducer):
@@ -59,7 +59,7 @@ class ArgMax(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._util.error("Cannot differentiate through argmax")
+        raise ak._errors.wrap_error("Cannot differentiate through argmax")
 
 
 class Count(Reducer):
@@ -72,7 +72,7 @@ class Count(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._util.error("Cannot differentiate through count_zero")
+        raise ak._errors.wrap_error("Cannot differentiate through count_zero")
 
 
 class CountNonzero(Reducer):
@@ -85,7 +85,7 @@ class CountNonzero(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._util.error("Cannot differentiate through count_nonzero")
+        raise ak._errors.wrap_error("Cannot differentiate through count_nonzero")
 
 
 class Sum(Reducer):
@@ -97,7 +97,7 @@ class Sum(Reducer):
 
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind == "M":
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
             )
 

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -57,7 +57,7 @@ class ContentType(numba.types.Type):
         elif arraytype.dtype.bitwidth == 64:
             return ak.index.Index64
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 AssertionError(f"no Index* type for array: {arraytype}")
             )
 

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -13,7 +13,7 @@ def import_numexpr():
     try:
         import numexpr
     except ModuleNotFoundError as err:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ModuleNotFoundError(
                 """install the 'numexpr' package with:
 
@@ -122,7 +122,7 @@ def re_evaluate(local_dict=None):
     try:
         compiled_ex = numexpr.necompiler._numexpr_last["ex"]  # noqa: F841
     except KeyError as err:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             RuntimeError(
                 "not a previous evaluate() execution found"
                 + ak._util.exception_suffix(__file__)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -213,7 +213,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                         error_message.append(type(x).__name__)
                 else:
                     error_message.append(type(x).__name__)
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "no {}.{} overloads for custom types: {}".format(
                         type(ufunc).__module__, ufunc.__name__, ", ".join(error_message)
@@ -267,7 +267,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
 #             if first == -1:
 #                 first = len(Ai)
 #             elif first != len(Ai):
-#                 raise ak._util.error(ValueError(
+#                 raise ak._errors.wrap_error(ValueError(
 #                     "one of the left matrices in np.matmul is not rectangular"
 #                 ))
 #         if first == -1:
@@ -280,7 +280,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
 #             if first == -1:
 #                 first = len(Bi)
 #             elif first != len(Bi):
-#                 raise ak._util.error(ValueError(
+#                 raise ak._errors.wrap_error(ValueError(
 #                     "one of the right matrices in np.matmul is not rectangular"
 #                 ))
 #         if first == -1:
@@ -289,7 +289,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
 #         colsB = first
 
 #         if colsA != rowsB:
-#             raise ak._util.error(ValueError(
+#             raise ak._errors.wrap_error(ValueError(
 #                 u"one of the pairs of matrices in np.matmul do not match shape: "
 #                 u"(n \u00d7 k) @ (k \u00d7 m)"
 #             ))
@@ -336,7 +336,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
 
 
 def action_for_matmul(inputs):
-    raise ak._util.error(NotImplementedError)
+    raise ak._errors.wrap_error(NotImplementedError)
 
 
 # def action_for_matmul(inputs):

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -369,7 +369,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
     ### Beginning of the big if-elif-elif chain!
 
     if isinstance(storage_type, pyarrow.lib.PyExtensionType):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
             )
@@ -464,14 +464,14 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
     elif isinstance(storage_type, pyarrow.lib.MapType):
         # FIXME: make a ListOffsetArray of 2-tuples with __array__ == "sorted_map".
         # (Make sure the keys are sorted).
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     elif isinstance(
         storage_type, (pyarrow.lib.Decimal128Type, pyarrow.lib.Decimal256Type)
     ):
         # Note: Decimal128Type and Decimal256Type are subtypes of FixedSizeBinaryType.
         # NumPy doesn't support decimal: https://github.com/numpy/numpy/issues/9789
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
             )
@@ -654,7 +654,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         )
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(f"unrecognized Arrow array type: {storage_type!r}")
         )
 
@@ -663,7 +663,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
     ### Beginning of the big if-elif-elif chain!
 
     if isinstance(storage_type, pyarrow.lib.PyExtensionType):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
             )
@@ -684,7 +684,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         elif index_type is np.int32:
             index = "i32"
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(f"unrecognized Arrow DictionaryType index type: {index_type}")
             )
 
@@ -737,14 +737,14 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         return form_popbuffers_finalize(out, awkwardarrow_type)
 
     elif isinstance(storage_type, pyarrow.lib.MapType):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     elif isinstance(
         storage_type, (pyarrow.lib.Decimal128Type, pyarrow.lib.Decimal256Type)
     ):
         # Note: Decimal128Type and Decimal256Type are subtypes of FixedSizeBinaryType.
         # NumPy doesn't support decimal: https://github.com/numpy/numpy/issues/9789
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
             )
@@ -850,7 +850,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         return form_popbuffers_finalize(out, awkwardarrow_type)
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(f"unrecognized Arrow array type: {storage_type!r}")
         )
 
@@ -999,7 +999,7 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
         batches = obj.combine_chunks().to_batches()
         if len(batches) == 0:
             # FIXME: create a zero-length array with the right type
-            raise ak._util.error(NotImplementedError)
+            raise ak._errors.wrap_error(NotImplementedError)
         elif len(batches) == 1:
             return handle_arrow(batches[0], generate_bitmasks, pass_empty_field)
         else:
@@ -1031,7 +1031,7 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
         return ak.contents.RecordArray([], [], length=0)
 
     else:
-        raise ak._util.error(TypeError(f"unrecognized Arrow type: {type(obj)}"))
+        raise ak._errors.wrap_error(TypeError(f"unrecognized Arrow type: {type(obj)}"))
 
 
 def form_handle_arrow(schema, pass_empty_field=False):

--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -208,7 +208,9 @@ def from_rdataframe(data_frame, columns):
                 )
                 fill_from_func[builder_type, col_type](builder, result_ptrs[col])
             else:
-                raise ak._util.error(AssertionError(f"unrecognized Form: {type(form)}"))
+                raise ak._errors.wrap_error(
+                    AssertionError(f"unrecognized Form: {type(form)}")
+                )
 
             names_nbytes = cpp_buffers_self.names_nbytes[builder_type](builder)
             buffers = empty_buffers(cpp_buffers_self, names_nbytes)

--- a/src/awkward/_connect/rdataframe/to_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/to_rdataframe.py
@@ -72,7 +72,7 @@ class DataSourceGenerator:
 
             self.entry_types[key] = self.generators[key].entry_type()
             if self.entry_types[key] == "bool":
-                raise ak._util.error(NotImplementedError)
+                raise ak._errors.wrap_error(NotImplementedError)
 
             if isinstance(self.generators[key], ak._connect.cling.NumpyArrayGenerator):
                 pass

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -1,0 +1,329 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+import threading
+import traceback
+import warnings
+from collections.abc import Mapping, Sequence
+
+from awkward import _util, nplikes
+
+np = nplikes.NumpyMetadata.instance()
+
+
+class ErrorContext:
+    # Any other threads should get a completely independent _slate.
+    _slate = threading.local()
+
+    _width = 80
+
+    @classmethod
+    def primary(cls):
+        return cls._slate.__dict__.get("__primary_context__")
+
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+
+    def __enter__(self):
+        # Make it strictly non-reenterant. Only one ErrorContext (per thread) is primary.
+        if self.primary() is None:
+            self._slate.__dict__.clear()
+            self._slate.__dict__.update(self._kwargs)
+            self._slate.__dict__["__primary_context__"] = self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        # Step out of the way so that another ErrorContext can become primary.
+        if self.primary() is self:
+            self._slate.__dict__.clear()
+
+    def format_argument(self, width, value):
+        from awkward import contents, highlevel, record
+
+        if isinstance(value, contents.Content):
+            return self.format_argument(width, highlevel.Array(value))
+        elif isinstance(value, record.Record):
+            return self.format_argument(width, highlevel.Record(value))
+
+        valuestr = None
+        if isinstance(
+            value,
+            (
+                highlevel.Array,
+                highlevel.Record,
+                highlevel.ArrayBuilder,
+            ),
+        ):
+            try:
+                valuestr = value._repr(width)
+            except Exception as err:
+                valuestr = f"repr-raised-{type(err).__name__}"
+
+        elif value is None or isinstance(value, (bool, int, float)):
+            try:
+                valuestr = repr(value)
+            except Exception as err:
+                valuestr = f"repr-raised-{type(err).__name__}"
+
+        elif isinstance(value, (str, bytes)):
+            try:
+                if len(value) < 60:
+                    valuestr = repr(value)
+                else:
+                    valuestr = repr(value[:57]) + "..."
+            except Exception as err:
+                valuestr = f"repr-raised-{type(err).__name__}"
+
+        elif isinstance(value, np.ndarray):
+            import numpy
+
+            if not numpy.__version__.startswith("1.13."):  # 'threshold' argument
+                prefix = f"{type(value).__module__}.{type(value).__name__}("
+                suffix = ")"
+                try:
+                    valuestr = numpy.array2string(
+                        value,
+                        max_line_width=width - len(prefix) - len(suffix),
+                        threshold=0,
+                    ).replace("\n", " ")
+                    valuestr = prefix + valuestr + suffix
+                except Exception as err:
+                    valuestr = f"array2string-raised-{type(err).__name__}"
+
+                if len(valuestr) > width and "..." in valuestr[:-1]:
+                    last = valuestr.rfind("...") + 3
+                    while last > width:
+                        last = valuestr[: last - 3].rfind("...") + 3
+                    valuestr = valuestr[:last]
+
+                if len(valuestr) > width:
+                    valuestr = valuestr[: width - 3] + "..."
+
+        elif isinstance(value, (Sequence, Mapping)) and len(value) < 10000:
+            valuestr = repr(value)
+            if len(valuestr) > width:
+                valuestr = valuestr[: width - 3] + "..."
+
+        if valuestr is None:
+            return f"{type(value).__name__}-instance"
+        else:
+            return valuestr
+
+    def format_exception(self, exception: Exception) -> str:
+        raise NotImplementedError
+
+
+class OperationErrorContext(ErrorContext):
+    def __init__(self, name, arguments):
+        string_arguments = {}
+        for key, value in arguments.items():
+            if _util.isstr(key):
+                width = self._width - 8 - len(key) - 3
+            else:
+                width = self._width - 8
+
+            string_arguments[key] = self.format_argument(width, value)
+
+        super().__init__(
+            name=name,
+            arguments=string_arguments,
+            traceback=traceback.extract_stack(limit=3)[0],
+        )
+
+    @property
+    def name(self):
+        return self._kwargs["name"]
+
+    @property
+    def arguments(self):
+        return self._kwargs["arguments"]
+
+    @property
+    def traceback(self):
+        return self._kwargs["traceback"]
+
+    def format_exception(self, exception):
+        tb = self.traceback
+        try:
+            location = f" (from {tb.filename}, line {tb.lineno})"
+        except Exception:
+            location = ""
+
+        arguments = []
+        for name, valuestr in self.arguments.items():
+            if _util.isstr(name):
+                arguments.append(f"\n        {name} = {valuestr}")
+            else:
+                arguments.append(f"\n        {valuestr}")
+
+        extra_line = "" if len(arguments) == 0 else "\n    "
+        return f"""while calling{location}
+
+    {self.name}({"".join(arguments)}{extra_line})
+
+Error details: {str(exception)}"""
+
+
+class SlicingErrorContext(ErrorContext):
+    def __init__(self, array, where):
+        super().__init__(
+            array=self.format_argument(self._width - 4, array),
+            where=self.format_slice(where),
+            traceback=traceback.extract_stack(limit=3)[0],
+        )
+
+    @property
+    def array(self):
+        return self._kwargs["array"]
+
+    @property
+    def where(self):
+        return self._kwargs["where"]
+
+    @property
+    def traceback(self):
+        return self._kwargs["traceback"]
+
+    def format_exception(self, exception):
+        tb = self.traceback
+        try:
+            location = f" (from {tb.filename}, line {tb.lineno})"
+        except Exception:
+            location = ""
+
+        if _util.isstr(exception):
+            message = exception
+        else:
+            message = f"Error details: {str(exception)}"
+
+        return f"""while attempting to slice{location}
+
+    {self.array}
+
+with
+
+    {self.where}
+
+{message}"""
+
+    @staticmethod
+    def format_slice(x):
+        from awkward import contents, highlevel, index, record
+
+        if isinstance(x, slice):
+            if x.step is None:
+                return "{}:{}".format(
+                    "" if x.start is None else x.start,
+                    "" if x.stop is None else x.stop,
+                )
+            else:
+                return "{}:{}:{}".format(
+                    "" if x.start is None else x.start,
+                    "" if x.stop is None else x.stop,
+                    x.step,
+                )
+
+        elif isinstance(x, tuple):
+            return "(" + ", ".join(SlicingErrorContext.format_slice(y) for y in x) + ")"
+
+        elif isinstance(x, index.Index64):
+            return str(x.data)
+
+        elif isinstance(x, contents.Content):
+            try:
+                return str(highlevel.Array(x))
+            except Exception:
+                return x._repr("    ", "", "")
+
+        elif isinstance(x, record.Record):
+            try:
+                return str(highlevel.Record(x))
+            except Exception:
+                return x._repr("    ", "", "")
+
+        else:
+            return repr(x)
+
+
+def wrap_error(
+    exception: Exception | type[Exception], error_context: ErrorContext = None
+) -> Exception:
+    """
+    Args:
+        exception: exception object, or exception type to instantiate
+        error_context: context in which error was raised
+
+    Wrap the given exception, instantiating it if needed, to ensure meaningful error messages.
+    """
+    if isinstance(exception, type) and issubclass(exception, Exception):
+        try:
+            exception = exception()
+        except Exception:
+            return exception
+
+    if isinstance(exception, (NotImplementedError, AssertionError)):
+        return type(exception)(
+            str(exception)
+            + "\n\nSee if this has been reported at https://github.com/scikit-hep/awkward-1.0/issues"
+        )
+
+    if error_context is None:
+        error_context = ErrorContext.primary()
+
+    if isinstance(error_context, ErrorContext):
+        # Note: returns an error for the caller to raise!
+        return type(exception)(error_context.format_exception(exception))
+    else:
+        # Note: returns an error for the caller to raise!
+        return exception
+
+
+def index_error(subarray, slicer, details: str = None) -> IndexError:
+    detailsstr = ""
+    if details is not None:
+        detailsstr = f"""
+
+Error details: {details}."""
+
+    error_context = ErrorContext.primary()
+    if not isinstance(error_context, SlicingErrorContext):
+        # Note: returns an error for the caller to raise!
+        return IndexError(
+            f"cannot slice {type(subarray).__name__} with {SlicingErrorContext.format_slice(slicer)}{detailsstr}"
+        )
+
+    else:
+        # Note: returns an error for the caller to raise!
+        return IndexError(
+            error_context.format_exception(
+                f"at inner {type(subarray).__name__} of length {subarray.length}, using sub-slice {error_context.format_slice(slicer)}.{detailsstr}"
+            )
+        )
+
+
+###############################################################################
+
+# Enable warnings for the Awkward package
+warnings.filterwarnings("default", module="awkward.*")
+
+
+def deprecate(
+    message,
+    version,
+    date=None,
+    will_be="an error",
+    category=DeprecationWarning,
+    stacklevel=2,
+):
+    if date is None:
+        date = ""
+    else:
+        date = " (target date: " + date + ")"
+    warning = """In version {}{}, this will be {}.
+To raise these warnings as errors (and get stack traces to find out where they're called), run
+    import warnings
+    warnings.filterwarnings("error", module="awkward.*")
+after the first `import awkward` or use `@pytest.mark.filterwarnings("error:::awkward.*")` in pytest.
+Issue: {}.""".format(
+        version, date, will_be, message
+    )
+    warnings.warn(warning, category, stacklevel=stacklevel + 1)

--- a/src/awkward/_lookup.py
+++ b/src/awkward/_lookup.py
@@ -65,7 +65,9 @@ def tolookup(layout, positions):
         return UnionLookup.tolookup(layout, positions)
 
     else:
-        raise ak._util.error(AssertionError(f"unrecognized Content: {type(layout)}"))
+        raise ak._errors.wrap_error(
+            AssertionError(f"unrecognized Content: {type(layout)}")
+        )
 
 
 class ContentLookup:

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -285,4 +285,4 @@ def valuestr(data, limit_rows, limit_cols):
         return "\n".join(out)
 
     else:
-        raise ak._util.error(AssertionError(type(data)))
+        raise ak._errors.wrap_error(AssertionError(type(data)))

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -216,7 +216,7 @@ class Sum(Reducer):
     def apply(cls, array, parents, outlength):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind == "M":
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
             )
         else:
@@ -261,7 +261,7 @@ class Sum(Reducer):
                     )
                 )
             else:
-                raise ak._util.error(NotImplementedError)
+                raise ak._errors.wrap_error(NotImplementedError)
         elif array.dtype.type in (np.complex128, np.complex64):
             assert parents.nplike is array.nplike
             array._handle_error(
@@ -311,7 +311,7 @@ class Prod(Reducer):
     def apply(cls, array, parents, outlength):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind.upper() == "M":
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"cannot compute the product (ak.prod) of {array.dtype!r}")
             )
         result = array.nplike.empty(

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -52,7 +52,7 @@ def prepare_advanced_indexing(items):
 
     # Now ensure that we don't have mixed Awkward-NumPy style indexing
     if n_awkward_contents > 1 or (n_awkward_contents == 1 and len(broadcastable) != 0):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "cannot mix Awkward slicing (using an array with missing or variable-length lists in the slice) with "
                 "NumPy advanced slicing (using more than one broadcastable array or integer in the slice), "
@@ -90,7 +90,7 @@ def prepare_advanced_indexing(items):
                 for w in nplike.nonzero(x):
                     prepared.append(ak.index.Index64(w))
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "array slice must be an array of integers or booleans, not\n\n    {}".format(
                         repr(x).replace("\n", "\n    ")
@@ -116,7 +116,7 @@ def prepare_advanced_indexing(items):
     # Now error if we find another array
     for item in it:
         if isinstance(item, ak.index.Index):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "NumPy advanced indexing with array indices separated by None "
                     "(np.newaxis), Ellipsis, or slice are not permitted with Awkward Arrays"
@@ -175,7 +175,7 @@ def normalise_item(item, nplike):
             return as_array
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "only integers, slices (`:`), ellipsis (`...`), np.newaxis (`None`), "
                 "integer/boolean arrays (possibly with variable-length nested "
@@ -206,7 +206,7 @@ def normalise_item_RegularArray_toListOffsetArray64(item):
         return item
 
     else:
-        raise ak._util.error(AssertionError(type(item)))
+        raise ak._errors.wrap_error(AssertionError(type(item)))
 
 
 def normalise_item_nested(item):
@@ -330,7 +330,7 @@ def normalise_item_nested(item):
     elif isinstance(item, ak.contents.UnionArray):
         attempt = item.simplify_uniontype()
         if isinstance(attempt, ak.contents.UnionArray):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "irreducible unions (different types at the same level in an array) can't be used as slices"
                 )
@@ -339,10 +339,10 @@ def normalise_item_nested(item):
         return normalise_item_nested(attempt)
 
     elif isinstance(item, ak.contents.RecordArray):
-        raise ak._util.error(TypeError("record arrays can't be used as slices"))
+        raise ak._errors.wrap_error(TypeError("record arrays can't be used as slices"))
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "only integers, slices (`:`), ellipsis (`...`), np.newaxis (`None`), "
                 "integer/boolean arrays (possibly with variable-length nested "
@@ -392,7 +392,7 @@ def normalise_item_bool_to_int(item):
     ):
         if item.nplike.known_data or item.nplike.known_shape:
             if isinstance(item.nplike, ak.nplikes.Jax):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     "This slice is not supported for JAX differentiation."
                 )
             # missing values as any integer other than -1 are extremely rare
@@ -461,7 +461,7 @@ def normalise_item_bool_to_int(item):
         ):
             if item.nplike.known_data or item.nplike.known_shape:
                 if isinstance(item.nplike, ak.nplikes.Jax):
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         "This slice is not supported for JAX differentiation."
                     )
                 # missing values as any integer other than -1 are extremely rare
@@ -513,7 +513,7 @@ def normalise_item_bool_to_int(item):
         return item
 
     else:
-        raise ak._util.error(AssertionError(type(item)))
+        raise ak._errors.wrap_error(AssertionError(type(item)))
 
 
 def getitem_next_array_wrap(outcontent, shape, outer_length=0):

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -209,7 +209,7 @@ class TypeTracerArray:
             sequence = list(array)
             array = numpy.array(sequence)
             if array.dtype == np.dtype("O"):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         f"bug in Awkward Array: attempt to construct `TypeTracerArray` "
                         f"from a sequence of non-primitive types: {sequence}"
@@ -286,14 +286,14 @@ class TypeTracerArray:
         return type(self)(self._dtype, (UnknownLength,) + self._shape[1:])
 
     def __iter__(self):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             AssertionError(
                 "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
             )
         )
 
     def __array__(self, *args, **kwargs):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             AssertionError(
                 "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
             )
@@ -311,14 +311,14 @@ class TypeTracerArray:
         return self._CTypes
 
     def __len__(self):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             AssertionError(
                 "bug in Awkward Array: attempt to get length of a TypeTracerArray"
             )
         )
 
     def __setitem__(self, where, what):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             AssertionError(
                 "bug in Awkward Array: attempt to set values of a TypeTracerArray"
             )
@@ -392,7 +392,7 @@ class TypeTracerArray:
                         )
                     )
                 else:
-                    raise ak._util.error(NotImplementedError(repr(wh)))
+                    raise ak._errors.wrap_error(NotImplementedError(repr(wh)))
 
             slicer_shape = numpy.broadcast_arrays(*shapes)[0].shape
 
@@ -417,13 +417,13 @@ class TypeTracerArray:
                 elif isinstance(wh, slice):
                     after_shape.append(_length_after_slice(wh, inner_shape[i]))
                 else:
-                    raise ak._util.error(NotImplementedError(repr(wh)))
+                    raise ak._errors.wrap_error(NotImplementedError(repr(wh)))
 
             shape = (next._shape[0],) + tuple(after_shape)
             return TypeTracerArray(self._dtype, shape)
 
         else:
-            raise ak._util.error(NotImplementedError(repr(where)))
+            raise ak._errors.wrap_error(NotImplementedError(repr(where)))
 
     def __lt__(self, other):
         if isinstance(other, numbers.Real):
@@ -473,18 +473,18 @@ class TypeTracer(ak.nplikes.NumpyLike):
         return self
 
     def to_rectilinear(self, array, *args, **kwargs):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def __getitem__(self, name_and_types):
         return NoKernel()
 
     @property
     def ma(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def char(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def ndarray(self):
@@ -498,13 +498,13 @@ class TypeTracer(ak.nplikes.NumpyLike):
         elif isinstance(array, TypeTracerArray):
             return self
         elif hasattr(nplike, "known_data") and nplike.known_data:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "Converting a TypeTracer nplike to a nplike with `known_data=True` is not possible"
                 )
             )
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, Typetracer"
                 )
@@ -531,11 +531,11 @@ class TypeTracer(ak.nplikes.NumpyLike):
         return TypeTracerArray.from_array(array, dtype=dtype)
 
     def isscalar(self, *args, **kwargs):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def frombuffer(self, *args, **kwargs):
         # array[, dtype=]
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def zeros(self, shape, dtype=np.float64, **kwargs):
         # shape/len[, dtype=]
@@ -593,13 +593,13 @@ class TypeTracer(ak.nplikes.NumpyLike):
 
     def meshgrid(self, *args, **kwargs):
         # *arrays, indexing="ij"
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ testing
 
     def shape(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def array_equal(self, *args, **kwargs):
         # array1, array2
@@ -607,11 +607,11 @@ class TypeTracer(ak.nplikes.NumpyLike):
 
     def size(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def searchsorted(self, *args, **kwargs):
         # haystack, needle, side="right"
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def argsort(self, array, *args, **kwargs):
         # array
@@ -649,7 +649,7 @@ class TypeTracer(ak.nplikes.NumpyLike):
                 if shape[i] == 1 and thisshape[i] != 1:
                     shape[i] = thisshape[i]
                 elif shape[i] != 1 and thisshape[i] != 1 and shape[i] != thisshape[i]:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         ValueError(
                             "shape mismatch: objects cannot be broadcast to a single shape"
                         )
@@ -707,11 +707,11 @@ class TypeTracer(ak.nplikes.NumpyLike):
 
     def cumsum(self, *args, **kwargs):
         # arrays[, out=]
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def cumprod(self, *args, **kwargs):
         # arrays[, out=]
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def nonzero(self, array):
         # array
@@ -719,7 +719,7 @@ class TypeTracer(ak.nplikes.NumpyLike):
 
     def unique(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def concatenate(self, arrays):
         inner_shape = None
@@ -728,7 +728,7 @@ class TypeTracer(ak.nplikes.NumpyLike):
             if inner_shape is None:
                 inner_shape = x.shape[1:]
             elif inner_shape != x.shape[1:]:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "inner dimensions don't match in concatenate: {} vs {}".format(
                             inner_shape, x.shape[1:]
@@ -738,7 +738,9 @@ class TypeTracer(ak.nplikes.NumpyLike):
             emptyarrays.append(_emptyarray(x))
 
         if inner_shape is None:
-            raise ak._util.error(ValueError("need at least one array to concatenate"))
+            raise ak._errors.wrap_error(
+                ValueError("need at least one array to concatenate")
+            )
 
         return TypeTracerArray(
             numpy.concatenate(emptyarrays).dtype, (UnknownLength,) + inner_shape
@@ -747,61 +749,61 @@ class TypeTracer(ak.nplikes.NumpyLike):
     def repeat(self, *args, **kwargs):
         # array, int
         # array1, array2
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def tile(self, *args, **kwargs):
         # array, int
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def stack(self, *args, **kwargs):
         # arrays
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def vstack(self, *args, **kwargs):
         # arrays
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def packbits(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def unpackbits(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def atleast_1d(self, *args, **kwargs):
         # *arrays
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def broadcast_to(self, *args, **kwargs):
         # array, shape
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def append(self, *args, **kwargs):
         # array, element
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def where(self, *args, **kwargs):
         # array, element
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ ufuncs
 
     def sqrt(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def exp(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def true_divide(self, *args, **kwargs):
         # array1, array2
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def bitwise_or(self, *args, **kwargs):
         # array1, array2[, out=output]
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def logical_and(self, x, y):
         # array1, array2
@@ -829,21 +831,21 @@ class TypeTracer(ak.nplikes.NumpyLike):
 
     def equal(self, *args, **kwargs):
         # array1, array2
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def ceil(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ almost-ufuncs
 
     def nan_to_num(self, *args, **kwargs):
         # array, copy=True, nan=0.0, posinf=None, neginf=None
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def isclose(self, *args, **kwargs):
         # a, b, rtol=1e-05, atol=1e-08, equal_nan=False
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ reducers
 
@@ -857,31 +859,31 @@ class TypeTracer(ak.nplikes.NumpyLike):
 
     def count_nonzero(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def sum(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def prod(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def min(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def max(self, *args, **kwargs):
         # array
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def argmin(self, *args, **kwargs):
         # array[, axis=]
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def argmax(self, *args, **kwargs):
         # array[, axis=]
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def array_str(
         self, array, max_line_width=None, precision=None, suppress_small=None
@@ -890,4 +892,4 @@ class TypeTracer(ak.nplikes.NumpyLike):
         return "[?? ... ??]"
 
     def datetime_as_string(self, *args, **kwargs):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -1,17 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-# First, transition all the _v2 code to start using implementations in this file.
-# Then build up the high-level replacements.
 import collections
 import itertools
 import numbers
 import os
 import re
-import threading
-import traceback
-import warnings
-from collections.abc import Iterable, Mapping, Sequence, Sized
+from collections.abc import Iterable, Mapping, Sized
 
 import packaging.version
 
@@ -42,7 +37,7 @@ def regularize_backend(backend):
     if backend in _backends:
         return _backends[backend].instance()
     else:
-        raise error(  # noqa: AK101
+        raise ak._errors.wrap_error(  # noqa: AK101
             ValueError("The available backends for now are `cpu` and `cuda`.")
         )
 
@@ -111,311 +106,6 @@ def identifier_hash(str):
         .replace(b"/", b"")
         .decode("ascii")
     )
-
-
-###############################################################################
-
-
-class ErrorContext:
-    # Any other threads should get a completely independent _slate.
-    _slate = threading.local()
-
-    _width = 80
-
-    @classmethod
-    def primary(cls):
-        return cls._slate.__dict__.get("__primary_context__")
-
-    def __init__(self, **kwargs):
-        self._kwargs = kwargs
-
-    def __enter__(self):
-        # Make it strictly non-reenterant. Only one ErrorContext (per thread) is primary.
-        if self.primary() is None:
-            self._slate.__dict__.clear()
-            self._slate.__dict__.update(self._kwargs)
-            self._slate.__dict__["__primary_context__"] = self
-
-    def __exit__(self, exception_type, exception_value, traceback):
-        # Step out of the way so that another ErrorContext can become primary.
-        if self.primary() is self:
-            self._slate.__dict__.clear()
-
-    def format_argument(self, width, value):
-        if isinstance(value, ak.contents.Content):
-            return self.format_argument(width, ak.highlevel.Array(value))
-        elif isinstance(value, ak.record.Record):
-            return self.format_argument(width, ak.highlevel.Record(value))
-
-        valuestr = None
-        if isinstance(
-            value,
-            (
-                ak.highlevel.Array,
-                ak.highlevel.Record,
-                ak.highlevel.ArrayBuilder,
-            ),
-        ):
-            try:
-                valuestr = value._repr(width)
-            except Exception as err:
-                valuestr = f"repr-raised-{type(err).__name__}"
-
-        elif value is None or isinstance(value, (bool, int, float)):
-            try:
-                valuestr = repr(value)
-            except Exception as err:
-                valuestr = f"repr-raised-{type(err).__name__}"
-
-        elif isinstance(value, (str, bytes)):
-            try:
-                if len(value) < 60:
-                    valuestr = repr(value)
-                else:
-                    valuestr = repr(value[:57]) + "..."
-            except Exception as err:
-                valuestr = f"repr-raised-{type(err).__name__}"
-
-        elif isinstance(value, np.ndarray):
-            import numpy
-
-            if not numpy.__version__.startswith("1.13."):  # 'threshold' argument
-                prefix = f"{type(value).__module__}.{type(value).__name__}("
-                suffix = ")"
-                try:
-                    valuestr = numpy.array2string(
-                        value,
-                        max_line_width=width - len(prefix) - len(suffix),
-                        threshold=0,
-                    ).replace("\n", " ")
-                    valuestr = prefix + valuestr + suffix
-                except Exception as err:
-                    valuestr = f"array2string-raised-{type(err).__name__}"
-
-                if len(valuestr) > width and "..." in valuestr[:-1]:
-                    last = valuestr.rfind("...") + 3
-                    while last > width:
-                        last = valuestr[: last - 3].rfind("...") + 3
-                    valuestr = valuestr[:last]
-
-                if len(valuestr) > width:
-                    valuestr = valuestr[: width - 3] + "..."
-
-        elif isinstance(value, (Sequence, Mapping)) and len(value) < 10000:
-            valuestr = repr(value)
-            if len(valuestr) > width:
-                valuestr = valuestr[: width - 3] + "..."
-
-        if valuestr is None:
-            return f"{type(value).__name__}-instance"
-        else:
-            return valuestr
-
-
-class OperationErrorContext(ErrorContext):
-    def __init__(self, name, arguments):
-        string_arguments = {}
-        for key, value in arguments.items():
-            if isstr(key):
-                width = self._width - 8 - len(key) - 3
-            else:
-                width = self._width - 8
-
-            string_arguments[key] = self.format_argument(width, value)
-
-        super().__init__(
-            name=name,
-            arguments=string_arguments,
-            traceback=traceback.extract_stack(limit=3)[0],
-        )
-
-    @property
-    def name(self):
-        return self._kwargs["name"]
-
-    @property
-    def arguments(self):
-        return self._kwargs["arguments"]
-
-    @property
-    def traceback(self):
-        return self._kwargs["traceback"]
-
-    def format_exception(self, exception):
-        tb = self.traceback
-        try:
-            location = f" (from {tb.filename}, line {tb.lineno})"
-        except Exception:
-            location = ""
-
-        arguments = []
-        for name, valuestr in self.arguments.items():
-            if isstr(name):
-                arguments.append(f"\n        {name} = {valuestr}")
-            else:
-                arguments.append(f"\n        {valuestr}")
-
-        extra_line = "" if len(arguments) == 0 else "\n    "
-        return f"""while calling{location}
-
-    {self.name}({"".join(arguments)}{extra_line})
-
-Error details: {str(exception)}"""
-
-
-class SlicingErrorContext(ErrorContext):
-    def __init__(self, array, where):
-        super().__init__(
-            array=self.format_argument(self._width - 4, array),
-            where=self.format_slice(where),
-            traceback=traceback.extract_stack(limit=3)[0],
-        )
-
-    @property
-    def array(self):
-        return self._kwargs["array"]
-
-    @property
-    def where(self):
-        return self._kwargs["where"]
-
-    @property
-    def traceback(self):
-        return self._kwargs["traceback"]
-
-    def format_exception(self, exception):
-        tb = self.traceback
-        try:
-            location = f" (from {tb.filename}, line {tb.lineno})"
-        except Exception:
-            location = ""
-
-        if isstr(exception):
-            message = exception
-        else:
-            message = f"Error details: {str(exception)}"
-
-        return f"""while attempting to slice{location}
-
-    {self.array}
-
-with
-
-    {self.where}
-
-{message}"""
-
-    @staticmethod
-    def format_slice(x):
-        if isinstance(x, slice):
-            if x.step is None:
-                return "{}:{}".format(
-                    "" if x.start is None else x.start,
-                    "" if x.stop is None else x.stop,
-                )
-            else:
-                return "{}:{}:{}".format(
-                    "" if x.start is None else x.start,
-                    "" if x.stop is None else x.stop,
-                    x.step,
-                )
-
-        elif isinstance(x, tuple):
-            return "(" + ", ".join(SlicingErrorContext.format_slice(y) for y in x) + ")"
-
-        elif isinstance(x, ak.index.Index64):
-            return str(x.data)
-
-        elif isinstance(x, ak.contents.Content):
-            try:
-                return str(ak.highlevel.Array(x))
-            except Exception:
-                return x._repr("    ", "", "")
-
-        elif isinstance(x, ak.record.Record):
-            try:
-                return str(ak.highlevel.Record(x))
-            except Exception:
-                return x._repr("    ", "", "")
-
-        else:
-            return repr(x)
-
-
-def error(exception, error_context=None):
-    if isinstance(exception, type) and issubclass(exception, Exception):
-        try:
-            exception = exception()
-        except Exception:
-            return exception
-
-    if isinstance(exception, (NotImplementedError, AssertionError)):
-        return type(exception)(
-            str(exception)
-            + "\n\nSee if this has been reported at https://github.com/scikit-hep/awkward-1.0/issues"
-        )
-
-    if error_context is None:
-        error_context = ErrorContext.primary()
-
-    if isinstance(error_context, ErrorContext):
-        # Note: returns an error for the caller to raise!
-        return type(exception)(error_context.format_exception(exception))
-    else:
-        # Note: returns an error for the caller to raise!
-        return exception
-
-
-def indexerror(subarray, slicer, details=None):
-    detailsstr = ""
-    if details is not None:
-        detailsstr = f"""
-
-Error details: {details}."""
-
-    error_context = ErrorContext.primary()
-    if not isinstance(error_context, SlicingErrorContext):
-        # Note: returns an error for the caller to raise!
-        return IndexError(
-            f"cannot slice {type(subarray).__name__} with {SlicingErrorContext.format_slice(slicer)}{detailsstr}"
-        )
-
-    else:
-        # Note: returns an error for the caller to raise!
-        return IndexError(
-            error_context.format_exception(
-                f"at inner {type(subarray).__name__} of length {subarray.length}, using sub-slice {error_context.format_slice(slicer)}.{detailsstr}"
-            )
-        )
-
-
-###############################################################################
-
-# Enable warnings for the Awkward package
-warnings.filterwarnings("default", module="awkward.*")
-
-
-def deprecate(
-    message,
-    version,
-    date=None,
-    will_be="an error",
-    category=DeprecationWarning,
-    stacklevel=2,
-):
-    if date is None:
-        date = ""
-    else:
-        date = " (target date: " + date + ")"
-    warning = """In version {}{}, this will be {}.
-To raise these warnings as errors (and get stack traces to find out where they're called), run
-    import warnings
-    warnings.filterwarnings("error", module="awkward.*")
-after the first `import awkward` or use `@pytest.mark.filterwarnings("error:::awkward.*")` in pytest.
-Issue: {}.""".format(
-        version, date, will_be, message
-    )
-    warnings.warn(warning, category, stacklevel=stacklevel + 1)
 
 
 # Sentinel object for catching pass-through values
@@ -1037,7 +727,7 @@ def to_arraylib(module, array, allow_missing):
             return _impl(array.layout)
 
         elif isinstance(array, ak.highlevel.Record):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"{module.__name__} does not support record structures")
             )
 
@@ -1051,7 +741,7 @@ def to_arraylib(module, array, allow_missing):
             "bytestring",
             "string",
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"{module.__name__} does not support arrays of strings")
             )
 
@@ -1082,7 +772,7 @@ def to_arraylib(module, array, allow_missing):
 
             mask0 = array.mask_as_bool(valid_when=False)
             if mask0.any():
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(f"{module.__name__} does not support masked arrays")
                 )
             else:
@@ -1098,7 +788,7 @@ def to_arraylib(module, array, allow_missing):
             return _impl(array.toRegularArray())
 
         elif isinstance(array, ak.contents.recordarray.RecordArray):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"{module.__name__} does not support record structures")
             )
 
@@ -1106,7 +796,7 @@ def to_arraylib(module, array, allow_missing):
             return module.asarray(array.data)
 
         elif isinstance(array, ak.contents.Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 AssertionError(f"unrecognized Content type: {type(array)}")
             )
 
@@ -1114,7 +804,7 @@ def to_arraylib(module, array, allow_missing):
             return module.asarray(array)
 
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"cannot convert {array} into {type(module.array([]))}")
             )
 
@@ -1128,6 +818,6 @@ def to_arraylib(module, array, allow_missing):
         else:
             return module.asarray(array)
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(f"{module.__name__} is not supported by to_arraylib")
         )

--- a/src/awkward/behaviors/mixins.py
+++ b/src/awkward/behaviors/mixins.py
@@ -82,7 +82,7 @@ def mixin_class_method(ufunc, rhs=None, transpose=True):
 
     def register(method):
         if not isinstance(rhs, (set, type(None))):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError("expected a set of right-hand-side argument types")
             )
         if transpose and rhs is not None:

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -38,13 +38,17 @@ class ByteBehavior(Array):
         if isinstance(other, (bytes, ByteBehavior)):
             return bytes(self) + bytes(other)
         else:
-            raise ak._util.error(TypeError("can only concatenate bytes to bytes"))
+            raise ak._errors.wrap_error(
+                TypeError("can only concatenate bytes to bytes")
+            )
 
     def __radd__(self, other):
         if isinstance(other, (bytes, ByteBehavior)):
             return bytes(other) + bytes(self)
         else:
-            raise ak._util.error(TypeError("can only concatenate bytes to bytes"))
+            raise ak._errors.wrap_error(
+                TypeError("can only concatenate bytes to bytes")
+            )
 
 
 class CharBehavior(Array):
@@ -79,13 +83,13 @@ class CharBehavior(Array):
         if isinstance(other, (str, CharBehavior)):
             return str(self) + str(other)
         else:
-            raise ak._util.error(TypeError("can only concatenate str to str"))
+            raise ak._errors.wrap_error(TypeError("can only concatenate str to str"))
 
     def __radd__(self, other):
         if isinstance(other, (str, CharBehavior)):
             return str(other) + str(self)
         else:
-            raise ak._util.error(TypeError("can only concatenate str to str"))
+            raise ak._errors.wrap_error(TypeError("can only concatenate str to str"))
 
 
 class ByteStringBehavior(Array):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -62,7 +62,7 @@ class BitMaskedArray(Content):
         nplike=None,
     ):
         if not (isinstance(mask, Index) and mask.dtype == np.dtype(np.uint8)):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'mask' must be an Index with dtype=uint8, not {}".format(
                         type(self).__name__, repr(mask)
@@ -70,7 +70,7 @@ class BitMaskedArray(Content):
                 )
             )
         if not isinstance(content, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Content subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -78,7 +78,7 @@ class BitMaskedArray(Content):
                 )
             )
         if not isinstance(valid_when, bool):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'valid_when' must be boolean, not {}".format(
                         type(self).__name__, repr(valid_when)
@@ -87,7 +87,7 @@ class BitMaskedArray(Content):
             )
         if not isinstance(length, ak._typetracer.UnknownLengthType):
             if not (ak._util.isint(length) and length >= 0):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'length' must be a non-negative integer, not {}".format(
                             type(self).__name__, length
@@ -95,7 +95,7 @@ class BitMaskedArray(Content):
                     )
                 )
         if not isinstance(lsb_order, bool):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'lsb_order' must be boolean, not {}".format(
                         type(self).__name__, repr(lsb_order)
@@ -103,7 +103,7 @@ class BitMaskedArray(Content):
                 )
             )
         if length > mask.length * 8:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'length' ({}) must be <= len(mask) * 8 ({})".format(
                         type(self).__name__, length, mask.length * 8
@@ -111,7 +111,7 @@ class BitMaskedArray(Content):
                 )
             )
         if length > content.length:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'length' ({}) must be <= len(content) ({})".format(
                         type(self).__name__, length, content.length
@@ -347,7 +347,7 @@ class BitMaskedArray(Content):
         if where < 0:
             where += self.length
         if not (0 <= where < self.length) and self._nplike.known_shape:
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
         if self._lsb_order:
             bit = bool(self._mask[where // 8] & (1 << (where % 8)))
         else:
@@ -418,7 +418,7 @@ class BitMaskedArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def project(self, mask=None):
         return self.toByteMaskedArray().project(mask)
@@ -667,7 +667,7 @@ class BitMaskedArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         if self._content.is_RecordType:

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -49,7 +49,7 @@ class ByteMaskedArray(Content):
         self, mask, content, valid_when, identifier=None, parameters=None, nplike=None
     ):
         if not (isinstance(mask, Index) and mask.dtype == np.dtype(np.int8)):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'mask' must be an Index with dtype=int8, not {}".format(
                         type(self).__name__, repr(mask)
@@ -57,7 +57,7 @@ class ByteMaskedArray(Content):
                 )
             )
         if not isinstance(content, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Content subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -65,7 +65,7 @@ class ByteMaskedArray(Content):
                 )
             )
         if not isinstance(valid_when, bool):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'valid_when' must be boolean, not {}".format(
                         type(self).__name__, repr(valid_when)
@@ -77,7 +77,7 @@ class ByteMaskedArray(Content):
             and content.nplike.known_shape
             and mask.length > content.length
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "{} len(mask) ({}) must be <= len(content) ({})".format(
                         type(self).__name__, mask.length, content.length
@@ -266,7 +266,7 @@ class ByteMaskedArray(Content):
         if where < 0:
             where += self.length
         if self._nplike.known_shape and not 0 <= where < self.length:
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
         if self._mask[where] == self._valid_when:
             return self._content._getitem_at(where)
         else:
@@ -313,7 +313,7 @@ class ByteMaskedArray(Content):
         try:
             nextmask = self._mask[carry.data]
         except IndexError as err:
-            raise ak._util.indexerror(self, carry.data, str(err)) from err
+            raise ak._errors.index_error(self, carry.data, str(err)) from err
 
         return ByteMaskedArray(
             nextmask,
@@ -367,7 +367,7 @@ class ByteMaskedArray(Content):
             and self._nplike.known_shape
             and slicestarts.length != self.length
         ):
-            raise ak._util.indexerror(
+            raise ak._errors.index_error(
                 self,
                 ak.contents.ListArray(
                     slicestarts, slicestops, slicecontent, None, None, self._nplike
@@ -460,7 +460,7 @@ class ByteMaskedArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def project(self, mask=None):
         mask_length = self._mask.length
@@ -468,7 +468,7 @@ class ByteMaskedArray(Content):
 
         if mask is not None:
             if self._nplike.known_shape and mask_length != mask.length:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "mask length ({}) is not equal to {} length ({})".format(
                             mask.length, type(self).__name__, mask_length
@@ -578,7 +578,7 @@ class ByteMaskedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            raise ak._util.error(np.AxisError("axis=0 not allowed for flatten"))
+            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             numnull = ak.index.Index64.empty(1, self._nplike)
             nextcarry, outindex = self._nextcarry_outindex(numnull)
@@ -756,7 +756,9 @@ class ByteMaskedArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         if n < 1:
-            raise ak._util.error(ValueError("in combinations, 'n' must be at least 1"))
+            raise ak._errors.wrap_error(
+                ValueError("in combinations, 'n' must be at least 1")
+            )
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
@@ -930,7 +932,7 @@ class ByteMaskedArray(Content):
                 )
 
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "reduce_next with unbranching depth > negaxis is only "
                         "expected to return RegularArray or ListOffsetArray64; "
@@ -1070,7 +1072,7 @@ class ByteMaskedArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         if self._content.is_RecordType:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -29,7 +29,7 @@ class Content:
         if identifier is not None and not isinstance(
             identifier, ak.identifier.Identifier
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'identifier' must be an Identifier or None, not {}".format(
                         type(self).__name__, repr(identifier)
@@ -37,7 +37,7 @@ class Content:
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be a dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -46,7 +46,7 @@ class Content:
             )
 
         if nplike is not None and not isinstance(nplike, ak.nplikes.NumpyLike):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'nplike' must be an ak.nplikes.NumpyLike or None, not {}".format(
                         type(self).__name__, repr(nplike)
@@ -105,7 +105,7 @@ class Content:
                 return out
 
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "form_key must be None, a string, or a callable, not {}".format(
                         type(form_key)
@@ -134,7 +134,7 @@ class Content:
         if nplike is None:
             nplike = self._nplike
         if not nplike.known_data:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError("cannot call 'to_buffers' on an array without concrete data")
             )
 
@@ -154,7 +154,7 @@ class Content:
                 )
 
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "buffer_key must be a string or a callable, not {}".format(
                         type(buffer_key)
@@ -163,7 +163,7 @@ class Content:
             )
 
         if form_key is None:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "a 'form_key' must be supplied, to match Form elements to buffers in the 'container'"
                 )
@@ -206,7 +206,7 @@ class Content:
             message = error.str.decode(errors="surrogateescape")
 
             if error.pass_through:
-                raise ak._util.error(ValueError(message + filename))
+                raise ak._errors.wrap_error(ValueError(message + filename))
 
             else:
                 if error.id != ak._util.kSliceNone and self._identifier is not None:
@@ -219,9 +219,9 @@ class Content:
                 message += filename
 
                 if slicer is None:
-                    raise ak._util.error(ValueError(message))
+                    raise ak._errors.wrap_error(ValueError(message))
                 else:
-                    raise ak._util.indexerror(self, slicer, message)
+                    raise ak._errors.index_error(self, slicer, message)
 
     @staticmethod
     def _selfless_handle_error(error):
@@ -236,7 +236,7 @@ class Content:
             message = error.str.decode(errors="surrogateescape")
 
             if error.pass_through:
-                raise ak._util.error(ValueError(message + filename))
+                raise ak._errors.wrap_error(ValueError(message + filename))
 
             else:
                 if error.attempt != ak._util.kSliceNone:
@@ -244,24 +244,24 @@ class Content:
 
                 message += filename
 
-                raise ak._util.error(ValueError(message))
+                raise ak._errors.wrap_error(ValueError(message))
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "do not apply NumPy functions to low-level layouts (Content subclasses); put them in ak.highlevel.Array"
             )
         )
 
     def __array_function__(self, func, types, args, kwargs):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "do not apply NumPy functions to low-level layouts (Content subclasses); put them in ak.highlevel.Array"
             )
         )
 
     def __array__(self, **kwargs):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "do not try to convert low-level layouts (Content subclasses) into NumPy arrays; put them in ak.highlevel.Array"
             )
@@ -269,7 +269,7 @@ class Content:
 
     def __iter__(self):
         if not self._nplike.known_data:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError("cannot iterate on an array without concrete data")
             )
 
@@ -315,7 +315,7 @@ class Content:
             return self._getitem_next(nexthead, nexttail, advanced)
 
         elif dimlength in {mindepth - 1, maxdepth - 1}:
-            raise ak._util.indexerror(
+            raise ak._errors.index_error(
                 self,
                 Ellipsis,
                 "ellipsis (`...`) can't be used on data with different numbers of dimensions",
@@ -366,7 +366,7 @@ class Content:
         index = ak.index.Index64(head._index, nplike=self.nplike)
         content = that._getitem_at(0)
         if self._nplike.known_shape and content.length < index.length:
-            raise ak._util.indexerror(
+            raise ak._errors.index_error(
                 self,
                 head,
                 "cannot fit masked jagged slice with length {} into {} of size {}".format(
@@ -421,7 +421,7 @@ class Content:
         assert isinstance(head, ak.contents.IndexedOptionArray)
 
         if advanced is not None:
-            raise ak._util.indexerror(
+            raise ak._errors.index_error(
                 self,
                 head,
                 "cannot mix missing values in slice with NumPy-style advanced indexing",
@@ -429,7 +429,7 @@ class Content:
 
         if isinstance(head.content, ak.contents.listoffsetarray.ListOffsetArray):
             if self.nplike.known_shape and self.length != 1:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     NotImplementedError("reached a not-well-considered code path")
                 )
             return self._getitem_next_missing_jagged(head, tail, advanced, self)
@@ -459,7 +459,7 @@ class Content:
                         )
                     )
                 else:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         NotImplementedError(
                             "FIXME: unhandled case of SliceMissing with RecordArray containing {}".format(
                                 content
@@ -477,7 +477,7 @@ class Content:
             )
 
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 NotImplementedError(
                     f"FIXME: unhandled case of SliceMissing with {nextcontent}"
                 )
@@ -564,7 +564,7 @@ class Content:
                     wheres = self._nplike.nonzero(where.data)
                     return self._getitem(wheres)
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "array slice must be an array of integers or booleans, not\n\n    {}".format(
                             repr(where.data).replace("\n", "\n    ")
@@ -602,7 +602,7 @@ class Content:
                 )
 
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "only integers, slices (`:`), ellipsis (`...`), np.newaxis (`None`), "
                     "integer/boolean arrays (possibly with variable-length nested "
@@ -635,7 +635,7 @@ class Content:
             elif carry.length < self.length:
                 return self._getitem_range(slice(0, carry.length))
             else:
-                raise ak._util.error(IndexError)
+                raise ak._errors.wrap_error(IndexError)
         else:
             return None
 
@@ -643,31 +643,31 @@ class Content:
         if self._identifier is None:
             return None
         else:
-            raise ak._util.error(NotImplementedError)
+            raise ak._errors.wrap_error(NotImplementedError)
 
     def _range_identifier(self, start, stop):
         if self._identifier is None:
             return None
         else:
-            raise ak._util.error(NotImplementedError)
+            raise ak._errors.wrap_error(NotImplementedError)
 
     def _field_identifier(self, field):
         if self._identifier is None:
             return None
         else:
-            raise ak._util.error(NotImplementedError)
+            raise ak._errors.wrap_error(NotImplementedError)
 
     def _fields_identifier(self, fields):
         if self._identifier is None:
             return None
         else:
-            raise ak._util.error(NotImplementedError)
+            raise ak._errors.wrap_error(NotImplementedError)
 
     def _carry_identifier(self, carry):
         if self._identifier is None:
             return None
         else:
-            raise ak._util.error(NotImplementedError)
+            raise ak._errors.wrap_error(NotImplementedError)
 
     def axis_wrap_if_negative(self, axis):
         if axis is None or axis >= 0:
@@ -678,7 +678,7 @@ class Content:
         if mindepth == depth and maxdepth == depth:
             posaxis = depth + axis
             if posaxis < 0:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError(
                         f"axis={axis} exceeds the depth ({depth}) of this array"
                     )
@@ -686,7 +686,7 @@ class Content:
             return posaxis
 
         elif mindepth + axis == 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 np.AxisError(
                     "axis={} exceeds the depth ({}) of at least one record field (or union possibility) of this array".format(
                         axis, depth
@@ -726,10 +726,10 @@ class Content:
             return self._mergeable(other, mergebool)
 
     def _mergeable(self, other: "Content", mergebool: bool) -> bool:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def mergemany(self, others):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def merge_as_union(self, other):
         mylength = self.length
@@ -766,7 +766,7 @@ class Content:
 
     def _merging_strategy(self, others):
         if len(others) == 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "to merge this array with 'others', at least one other must be provided"
                 )
@@ -811,7 +811,7 @@ class Content:
         return (head, tail)
 
     def dummy(self):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             NotImplementedError(
                 "FIXME: need to implement 'dummy', which makes an array of length 1 and an arbitrary value (0?) for this array type"
             )
@@ -822,14 +822,14 @@ class Content:
 
     def _reduce(self, reducer, axis=-1, mask=True, keepdims=False, behavior=None):
         if axis is None:
-            raise ak._util.error(NotImplementedError)
+            raise ak._errors.wrap_error(NotImplementedError)
 
         negaxis = -axis
         branch, depth = self.branch_depth
 
         if branch:
             if negaxis <= 0:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "cannot use non-negative axis on a nested list structure "
                         "of variable depth (negative axis counts from the leaves of "
@@ -837,7 +837,7 @@ class Content:
                     )
                 )
             if negaxis > depth:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "cannot use axis={} on a nested list structure that splits into "
                         "different depths, the minimum of which is depth={} "
@@ -848,7 +848,7 @@ class Content:
             if negaxis <= 0:
                 negaxis += depth
             if not (0 < negaxis and negaxis <= depth):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "axis={} exceeds the depth of the nested list structure "
                         "(which is {})".format(axis, depth)
@@ -913,7 +913,7 @@ class Content:
         branch, depth = self.branch_depth
         if branch:
             if negaxis <= 0:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "cannot use non-negative axis on a nested list structure "
                         "of variable depth (negative axis counts from the leaves "
@@ -921,7 +921,7 @@ class Content:
                     )
                 )
             if negaxis > depth:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "cannot use axis={} on a nested list structure that splits into "
                         "different depths, the minimum of which is depth={} from the leaves".format(
@@ -933,7 +933,7 @@ class Content:
             if negaxis <= 0:
                 negaxis = negaxis + depth
             if not (0 < negaxis and negaxis <= depth):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "axis={} exceeds the depth of the nested list structure "
                         "(which is {})".format(axis, depth)
@@ -959,7 +959,7 @@ class Content:
         branch, depth = self.branch_depth
         if branch:
             if negaxis <= 0:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "cannot use non-negative axis on a nested list structure "
                         "of variable depth (negative axis counts from the leaves "
@@ -967,7 +967,7 @@ class Content:
                     )
                 )
             if negaxis > depth:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "cannot use axis={} on a nested list structure that splits into "
                         "different depths, the minimum of which is depth={} from the leaves".format(
@@ -979,7 +979,7 @@ class Content:
             if negaxis <= 0:
                 negaxis = negaxis + depth
             if not (0 < negaxis and negaxis <= depth):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "axis={} exceeds the depth of the nested list structure "
                         "(which is {})".format(axis, depth)
@@ -1059,13 +1059,15 @@ class Content:
 
     def combinations(self, n, replacement=False, axis=1, fields=None, parameters=None):
         if n < 1:
-            raise ak._util.error(ValueError("in combinations, 'n' must be at least 1"))
+            raise ak._errors.wrap_error(
+                ValueError("in combinations, 'n' must be at least 1")
+            )
 
         recordlookup = None
         if fields is not None:
             recordlookup = fields
             if len(recordlookup) != n:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError("if provided, the length of 'fields' must be 'n'")
                 )
         return self._combinations(n, replacement, recordlookup, parameters, axis, 0)
@@ -1196,7 +1198,7 @@ class Content:
                 branch, depth = self.branch_depth
                 if branch:
                     if negaxis <= 0:
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             np.AxisError(
                                 "cannot use non-negative axis on a nested list structure "
                                 "of variable depth (negative axis counts from the leaves "
@@ -1204,7 +1206,7 @@ class Content:
                             )
                         )
                     if negaxis > depth:
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             np.AxisError(
                                 "cannot use axis={} on a nested list structure that splits into "
                                 "different depths, the minimum of which is depth={} from the leaves".format(
@@ -1216,7 +1218,7 @@ class Content:
                     if negaxis <= 0:
                         negaxis = negaxis + depth
                     if not (0 < negaxis and negaxis <= depth):
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             np.AxisError(
                                 "axis={} exceeds the depth of this array ({})".format(
                                     axis, depth
@@ -1229,7 +1231,7 @@ class Content:
 
             return self._unique(negaxis, starts, parents, 1)
 
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             np.AxisError(
                 "unique expects axis 'None' or '-1', got axis={} that is not supported yet".format(
                     axis
@@ -1536,10 +1538,10 @@ class Content:
         return out
 
     def __copy__(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def __deepcopy__(self, memo):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _jax_flatten(self):
         from awkward._connect.jax import AuxData, _find_numpyarray_nodes

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -104,18 +104,18 @@ class EmptyArray(Content):
         return self
 
     def _getitem_at(self, where):
-        raise ak._util.indexerror(self, where, "array is empty")
+        raise ak._errors.index_error(self, where, "array is empty")
 
     def _getitem_range(self, where):
         return self
 
     def _getitem_field(self, where, only_fields=()):
-        raise ak._util.indexerror(self, where, "not an array of records")
+        raise ak._errors.index_error(self, where, "not an array of records")
 
     def _getitem_fields(self, where, only_fields=()):
         if len(where) == 0:
             return self._getitem_range(slice(0, 0))
-        raise ak._util.indexerror(self, where, "not an array of records")
+        raise ak._errors.index_error(self, where, "not an array of records")
 
     def _carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
@@ -123,10 +123,10 @@ class EmptyArray(Content):
         if not carry.nplike.known_shape or carry.length == 0:
             return self
         else:
-            raise ak._util.indexerror(self, carry.data, "array is empty")
+            raise ak._errors.index_error(self, carry.data, "array is empty")
 
     def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
-        raise ak._util.indexerror(
+        raise ak._errors.index_error(
             self,
             ak.contents.ListArray(
                 slicestarts, slicestops, slicecontent, None, None, self._nplike
@@ -139,10 +139,10 @@ class EmptyArray(Content):
             return self
 
         elif isinstance(head, int):
-            raise ak._util.indexerror(self, head, "array is empty")
+            raise ak._errors.index_error(self, head, "array is empty")
 
         elif isinstance(head, slice):
-            raise ak._util.indexerror(self, head, "array is empty")
+            raise ak._errors.index_error(self, head, "array is empty")
 
         elif ak._util.isstr(head):
             return self._getitem_next_field(head, tail, advanced)
@@ -160,16 +160,16 @@ class EmptyArray(Content):
             if not head.nplike.known_shape or head.length == 0:
                 return self
             else:
-                raise ak._util.indexerror(self, head.data, "array is empty")
+                raise ak._errors.index_error(self, head.data, "array is empty")
 
         elif isinstance(head, ak.contents.ListOffsetArray):
-            raise ak._util.indexerror(self, head, "array is empty")
+            raise ak._errors.index_error(self, head, "array is empty")
 
         elif isinstance(head, ak.contents.IndexedOptionArray):
-            raise ak._util.indexerror(self, head, "array is empty")
+            raise ak._errors.index_error(self, head, "array is empty")
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
@@ -187,7 +187,9 @@ class EmptyArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            raise ak._util.error(np.AxisError(self, "axis=0 not allowed for flatten"))
+            raise ak._errors.wrap_error(
+                np.AxisError(self, "axis=0 not allowed for flatten")
+            )
         else:
             offsets = ak.index.Index64.zeros(1, self._nplike)
             return (offsets, EmptyArray(None, self._parameters, self._nplike))
@@ -296,7 +298,7 @@ class EmptyArray(Content):
     def _pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis != depth:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array({depth})")
             )
         else:
@@ -367,7 +369,7 @@ class EmptyArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         return self

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -51,14 +51,14 @@ class IndexedArray(Content):
                 np.dtype(np.int64),
             )
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'index' must be an Index with dtype in (int32, uint32, int64), "
                     "not {}".format(type(self).__name__, repr(index))
                 )
             )
         if not isinstance(content, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Content subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -169,7 +169,7 @@ class IndexedArray(Content):
         if where < 0:
             where += self.length
         if self._nplike.known_shape and not 0 <= where < self.length:
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
         return self._content._getitem_at(self._index[where])
 
     def _getitem_range(self, where):
@@ -210,7 +210,7 @@ class IndexedArray(Content):
         try:
             nextindex = self._index[carry.data]
         except IndexError as err:
-            raise ak._util.indexerror(self, carry.data, str(err)) from err
+            raise ak._errors.index_error(self, carry.data, str(err)) from err
 
         return IndexedArray(
             nextindex,
@@ -222,7 +222,7 @@ class IndexedArray(Content):
 
     def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
         if self._nplike.known_shape and slicestarts.length != self.length:
-            raise ak._util.indexerror(
+            raise ak._errors.index_error(
                 self,
                 ak.contents.ListArray(
                     slicestarts, slicestops, slicecontent, None, None, self._nplike
@@ -302,12 +302,12 @@ class IndexedArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def project(self, mask=None):
         if mask is not None:
             if self._nplike.known_shape and self._index.length != mask.length:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "mask length ({}) is not equal to {} length ({})".format(
                             mask.length(), type(self).__name__, self._index.length
@@ -456,7 +456,7 @@ class IndexedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            raise ak._util.error(np.AxisError("axis=0 not allowed for flatten"))
+            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         else:
             return self.project()._offsets_and_flattened(posaxis, depth)
@@ -479,7 +479,7 @@ class IndexedArray(Content):
 
     def _merging_strategy(self, others):
         if len(others) == 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "to merge this array with 'others', at least one other must be provided"
                 )
@@ -640,7 +640,7 @@ class IndexedArray(Content):
         else:
             return reversed.mergemany(tail[1:])
 
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             NotImplementedError(
                 "not implemented: " + type(self).__name__ + " ::mergemany"
             )
@@ -648,7 +648,7 @@ class IndexedArray(Content):
 
     def fill_none(self, value):
         if value.nplike.known_shape and value.length != 1:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"fill_none value length ({value.length}) is not equal to 1")
             )
         return IndexedArray(
@@ -832,7 +832,7 @@ class IndexedArray(Content):
 
             if isinstance(unique, ak.contents.ListOffsetArray):
                 if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         AssertionError(
                             "reduce_next with unbranching depth > negaxis expects a "
                             "ListOffsetArray64 whose offsets start at zero ({})".format(
@@ -889,7 +889,7 @@ class IndexedArray(Content):
 
                 return out
 
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _argsort_next(
         self,
@@ -1019,7 +1019,7 @@ class IndexedArray(Content):
             # belongs to add the new index
             if isinstance(out, ak.contents.ListOffsetArray):
                 if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         AssertionError(
                             "reduce_next with unbranching depth > negaxis expects a "
                             "ListOffsetArray64 whose offsets start at zero ({})".format(
@@ -1062,7 +1062,7 @@ class IndexedArray(Content):
                 )
 
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     AssertionError(
                         "reduce_next with unbranching depth > negaxis is only "
                         "expected to return RegularArray or ListOffsetArray64; "
@@ -1242,7 +1242,7 @@ class IndexedArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         if self.parameter("__array__") == "categorical":

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -51,14 +51,14 @@ class IndexedOptionArray(Content):
                 np.dtype(np.int64),
             )
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'index' must be an Index with dtype in (int32, uint32, int64), "
                     "not {}".format(type(self).__name__, repr(index))
                 )
             )
         if not isinstance(content, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Content subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -208,7 +208,7 @@ class IndexedOptionArray(Content):
         if where < 0:
             where += self.length
         if self._nplike.known_shape and not 0 <= where < self.length:
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
         if self._index[where] < 0:
             return None
         else:
@@ -252,7 +252,7 @@ class IndexedOptionArray(Content):
         try:
             nextindex = self._index[carry.data]
         except IndexError as err:
-            raise ak._util.indexerror(self, carry.data, str(err)) from err
+            raise ak._errors.index_error(self, carry.data, str(err)) from err
 
         return IndexedOptionArray(
             nextindex,
@@ -307,7 +307,7 @@ class IndexedOptionArray(Content):
         slicestops = slicestops._to_nplike(self.nplike)
 
         if self._nplike.known_shape and slicestarts.length != self.length:
-            raise ak._util.indexerror(
+            raise ak._errors.index_error(
                 self,
                 ak.contents.ListArray(
                     slicestarts, slicestops, slicecontent, None, None, self._nplike
@@ -393,12 +393,12 @@ class IndexedOptionArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def project(self, mask=None):
         if mask is not None:
             if self._nplike.known_shape and self._index.length != mask.length:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "mask length ({}) is not equal to {} length ({})".format(
                             mask.length(), type(self).__name__, self._index.length
@@ -549,7 +549,7 @@ class IndexedOptionArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            raise ak._util.error(np.AxisError("axis=0 not allowed for flatten"))
+            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._nplike)
             next = self._content._carry(nextcarry, False)
@@ -608,7 +608,7 @@ class IndexedOptionArray(Content):
 
     def _merging_strategy(self, others):
         if len(others) == 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "to merge this array with 'others', at least one other must be provided"
                 )
@@ -771,7 +771,7 @@ class IndexedOptionArray(Content):
         else:
             return reversed.mergemany(tail[1:])
 
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             NotImplementedError(
                 "not implemented: " + type(self).__name__ + " ::mergemany"
             )
@@ -779,7 +779,7 @@ class IndexedOptionArray(Content):
 
     def fill_none(self, value):
         if value.nplike.known_shape and value.length != 1:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"fill_none value length ({value.length}) is not equal to 1")
             )
 
@@ -1394,7 +1394,7 @@ class IndexedOptionArray(Content):
             # belongs to add the option type
             if isinstance(out, ak.contents.ListOffsetArray):
                 if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         AssertionError(
                             "reduce_next with unbranching depth > negaxis expects a "
                             "ListOffsetArray whose offsets start at zero ({})".format(
@@ -1438,7 +1438,7 @@ class IndexedOptionArray(Content):
                 )
 
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     AssertionError(
                         "reduce_next with unbranching depth > negaxis is only "
                         "expected to return RegularArray or ListOffsetArray or "
@@ -1590,13 +1590,13 @@ class IndexedOptionArray(Content):
                         0
                     ]
                 else:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         AssertionError(f"unrecognized dtype: {content.dtype}")
                     )
 
                 return numpy.ma.MaskedArray(data, mask)
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "ak.to_numpy cannot convert 'None' values to "
                         "np.ma.MaskedArray unless the "
@@ -1677,7 +1677,7 @@ class IndexedOptionArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         original_index = self._index.raw(self._nplike)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -52,14 +52,14 @@ class ListArray(Content):
             np.dtype(np.uint32),
             np.dtype(np.int64),
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'starts' must be an Index with dtype in (int32, uint32, int64), "
                     "not {}".format(type(self).__name__, repr(starts))
                 )
             )
         if not (isinstance(stops, Index) and starts.dtype == stops.dtype):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'stops' must be an Index with the same dtype as 'starts' ({}), "
                     "not {}".format(
@@ -68,7 +68,7 @@ class ListArray(Content):
                 )
             )
         if not isinstance(content, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Content subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -80,7 +80,7 @@ class ListArray(Content):
             and stops.nplike.known_shape
             and starts.length > stops.length
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "{} len(starts) ({}) must be <= len(stops) ({})".format(
                         type(self).__name__, starts.length, stops.length
@@ -233,7 +233,7 @@ class ListArray(Content):
         if where < 0:
             where += self.length
         if not (0 <= where < self.length) and self._nplike.known_shape:
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
         start, stop = self._starts[where], self._stops[where]
         return self._content._getitem_range(slice(start, stop))
 
@@ -279,7 +279,7 @@ class ListArray(Content):
             nextstarts = self._starts[carry.data]
             nextstops = self._stops[: self._starts.length][carry.data]
         except IndexError as err:
-            raise ak._util.indexerror(self, carry.data, str(err)) from err
+            raise ak._errors.index_error(self, carry.data, str(err)) from err
 
         return ListArray(
             nextstarts,
@@ -320,7 +320,7 @@ class ListArray(Content):
         slicestarts = slicestarts._to_nplike(self.nplike)
         slicestops = slicestops._to_nplike(self.nplike)
         if self._nplike.known_shape and slicestarts.length != self.length:
-            raise ak._util.indexerror(
+            raise ak._errors.index_error(
                 self,
                 ak.contents.ListArray(
                     slicestarts, slicestops, slicecontent, None, None, self._nplike
@@ -443,7 +443,7 @@ class ListArray(Content):
             slicecontent, ak.contents.indexedoptionarray.IndexedOptionArray
         ):
             if self._nplike.known_shape and self._starts.length < slicestarts.length:
-                raise ak._util.indexerror(
+                raise ak._errors.index_error(
                     self,
                     ak.contents.ListArray(
                         slicestarts, slicestops, slicecontent, None, None, self._nplike
@@ -550,7 +550,7 @@ class ListArray(Content):
                     self._nplike,
                 )
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     AssertionError(
                         "expected ListOffsetArray from ListArray._getitem_next_jagged, got {}".format(
                             type(out).__name__
@@ -562,7 +562,7 @@ class ListArray(Content):
             return self
 
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 AssertionError(
                     "expected Index/IndexedOptionArray/ListOffsetArray in ListArray._getitem_next_jagged, got {}".format(
                         type(slicecontent).__name__
@@ -842,7 +842,7 @@ class ListArray(Content):
             headlength = head.length
             head = head._to_nplike(self.nplike)
             if advanced is not None:
-                raise ak._util.indexerror(
+                raise ak._errors.index_error(
                     self,
                     head,
                     "cannot mix jagged slice with NumPy-style advanced indexing",
@@ -895,7 +895,7 @@ class ListArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
@@ -987,7 +987,7 @@ class ListArray(Content):
             elif isinstance(array, ak.contents.emptyarray.EmptyArray):
                 pass
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "cannot merge "
                         + type(self).__name__
@@ -1469,7 +1469,7 @@ class ListArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         return self.toListOffsetArray64(True).packed()

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -47,14 +47,14 @@ class ListOffsetArray(Content):
             np.dtype(np.uint32),
             np.dtype(np.int64),
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'offsets' must be an Index with dtype in (int32, uint32, int64), "
                     "not {}".format(type(self).__name__, repr(offsets))
                 )
             )
         if not isinstance(content, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Content subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -62,7 +62,7 @@ class ListOffsetArray(Content):
                 )
             )
         if offsets.nplike.known_shape and not offsets.length >= 1:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "{} len(offsets) ({}) must be >= 1".format(
                         type(self).__name__, offsets.length
@@ -222,7 +222,7 @@ class ListOffsetArray(Content):
         if where < 0:
             where += self.length
         if not (0 <= where < self.length) and self._nplike.known_shape:
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
         start, stop = self._offsets[where], self._offsets[where + 1]
         return self._content._getitem_range(slice(start, stop))
 
@@ -270,7 +270,7 @@ class ListOffsetArray(Content):
             nextstarts = self.starts[carry.data]
             nextstops = self.stops[carry.data]
         except IndexError as err:
-            raise ak._util.indexerror(self, carry.data, str(err)) from err
+            raise ak._errors.index_error(self, carry.data, str(err)) from err
 
         return ak.contents.listarray.ListArray(
             nextstarts,
@@ -296,7 +296,7 @@ class ListOffsetArray(Content):
 
     def _broadcast_tooffsets64(self, offsets):
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 AssertionError(
                     "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(
                         "(empty)" if offsets.length == 0 else str(offsets[0])
@@ -305,7 +305,7 @@ class ListOffsetArray(Content):
             )
 
         if offsets.nplike.known_shape and offsets.length - 1 != self.length:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 AssertionError(
                     "cannot broadcast {} of length {} to length {}".format(
                         type(self).__name__, self.length, offsets.length - 1
@@ -629,7 +629,7 @@ class ListOffsetArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
@@ -670,7 +670,7 @@ class ListOffsetArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            raise ak._util.error(np.AxisError("axis=0 not allowed for flatten"))
+            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         elif posaxis == depth + 1:
             listoffsetarray = self.toListOffsetArray64(True)
@@ -841,7 +841,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis is not None and negaxis != depth):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "array with strings can only be checked on uniqueness with axis=-1"
                     )
@@ -900,7 +900,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
@@ -921,7 +921,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
@@ -1027,7 +1027,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
@@ -1073,7 +1073,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
@@ -1214,7 +1214,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
@@ -1260,7 +1260,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
@@ -1359,7 +1359,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "ak.combinations does not compute combinations of the characters of a string; please split it into lists"
                     )
@@ -2100,7 +2100,7 @@ class ListOffsetArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         next = self.toListOffsetArray64(True)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -55,7 +55,7 @@ class RecordArray(Content):
         nplike=None,
     ):
         if not isinstance(contents, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'contents' must be iterable, not {}".format(
                         type(self).__name__, repr(contents)
@@ -66,7 +66,7 @@ class RecordArray(Content):
             contents = list(contents)
 
         if len(contents) == 0 and length is None:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} if len(contents) == 0, a 'length' must be specified".format(
                         type(self).__name__
@@ -82,7 +82,7 @@ class RecordArray(Content):
         if not isinstance(length, ak._typetracer.UnknownLengthType) and not (
             ak._util.isint(length) and length >= 0
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'length' must be a non-negative integer or None, not {}".format(
                         type(self).__name__, repr(length)
@@ -91,7 +91,7 @@ class RecordArray(Content):
             )
         for content in contents:
             if not isinstance(content, Content):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} all 'contents' must be Content subclasses, not {}".format(
                             type(self).__name__, repr(content)
@@ -99,7 +99,7 @@ class RecordArray(Content):
                     )
                 )
             if content.length < length:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "{} len(content) ({}) must be >= length ({}) for all 'contents'".format(
                             type(self).__name__, content.length, length
@@ -111,7 +111,7 @@ class RecordArray(Content):
             if not isinstance(fields, list):
                 fields = list(fields)
             if not all(ak._util.isstr(x) for x in fields):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'fields' must all be strings, not {}".format(
                             type(self).__name__, repr(fields)
@@ -119,7 +119,7 @@ class RecordArray(Content):
                     )
                 )
             if not len(contents) == len(fields):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "{} len(contents) ({}) must be equal to len(fields) ({})".format(
                             type(self).__name__, len(contents), len(fields)
@@ -127,7 +127,7 @@ class RecordArray(Content):
                     )
                 )
         elif fields is not None:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'fields' must be iterable or None, not {}".format(
                         type(self).__name__, repr(fields)
@@ -140,7 +140,7 @@ class RecordArray(Content):
                     nplike = content.nplike
                     break
                 elif nplike is not content.nplike:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         TypeError(
                             "{} 'contents' must use the same array library (nplike): {} vs {}".format(
                                 type(self).__name__,
@@ -295,7 +295,7 @@ class RecordArray(Content):
             where += self.length
 
         if where < 0 or where >= self.length:
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
         return Record(self, where)
 
     def _getitem_range(self, where):
@@ -382,7 +382,7 @@ class RecordArray(Content):
                 where[negative] += self._length
 
             if self._nplike.index_nplike.any(where >= self._length, prefer=False):
-                raise ak._util.indexerror(self, where)
+                raise ak._errors.index_error(self, where)
 
             nextindex = ak.index.Index64(where, nplike=self.nplike)
             return ak.contents.indexedarray.IndexedArray(
@@ -495,10 +495,10 @@ class RecordArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            raise ak._util.error(np.AxisError("axis=0 not allowed for flatten"))
+            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         elif posaxis == depth + 1:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "arrays of records cannot be flattened (but their contents can be; try a different 'axis')"
                 )
@@ -510,7 +510,7 @@ class RecordArray(Content):
                 trimmed = content._getitem_range(slice(0, self.length))
                 offsets, flattened = trimmed._offsets_and_flattened(posaxis, depth)
                 if self._nplike.known_shape and offsets.length != 0:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         AssertionError(
                             "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
                         )
@@ -595,19 +595,19 @@ class RecordArray(Content):
                                 field = array[self.index_to_field(i)]
                                 for_each_field[i].append(field[0 : array.length])
                         else:
-                            raise ak._util.error(
+                            raise ak._errors.wrap_error(
                                 ValueError(
                                     "cannot merge tuples with different numbers of fields"
                                 )
                             )
                     else:
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             ValueError("cannot merge tuple with non-tuple record")
                         )
                 elif isinstance(array, ak.contents.emptyarray.EmptyArray):
                     pass
                 else:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         AssertionError(
                             "cannot merge "
                             + type(self).__name__
@@ -637,20 +637,20 @@ class RecordArray(Content):
                                 trimmed = field[0 : array.length]
                                 for_each_field[i].append(trimmed)
                         else:
-                            raise ak._util.error(
+                            raise ak._errors.wrap_error(
                                 AssertionError(
                                     "cannot merge records with different sets of field names"
                                 )
                             )
                     else:
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             AssertionError("cannot merge non-tuple record with tuple")
                         )
 
                 elif isinstance(array, ak.contents.emptyarray.EmptyArray):
                     pass
                 else:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         AssertionError(
                             "cannot merge "
                             + type(self).__name__
@@ -687,7 +687,7 @@ class RecordArray(Content):
         else:
             return reversed.mergemany(tail[1:])
 
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             NotImplementedError(
                 "not implemented: " + type(self).__name__ + " ::mergemany"
             )
@@ -743,7 +743,7 @@ class RecordArray(Content):
         return True
 
     def _unique(self, negaxis, starts, parents, outlength):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _argsort_next(
         self,
@@ -757,7 +757,7 @@ class RecordArray(Content):
         kind,
         order,
     ):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
@@ -820,7 +820,7 @@ class RecordArray(Content):
     ):
         reducer_recordclass = ak._util.reducer_recordclass(reducer, self, behavior)
         if reducer_recordclass is None:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "no ak.{} overloads for custom types: {}".format(
                         reducer.name, ", ".join(self._fields)
@@ -828,7 +828,7 @@ class RecordArray(Content):
                 )
             )
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 NotImplementedError(
                     "overloading reducers for RecordArrays has not been implemented yet"
                 )
@@ -914,7 +914,9 @@ class RecordArray(Content):
             return self._nplike.empty(self.length, dtype=[])
         contents = [x._to_numpy(allow_missing) for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
-            raise ak._util.error(ValueError(f"cannot convert {self} into np.ndarray"))
+            raise ak._errors.wrap_error(
+                ValueError(f"cannot convert {self} into np.ndarray")
+            )
         out = self._nplike.empty(
             contents[0].shape[0],
             dtype=[(str(n), x.dtype) for n, x in zip(self.fields, contents)],
@@ -945,7 +947,7 @@ class RecordArray(Content):
             in_function = ""
             if options["function_name"] is not None:
                 in_function = " in " + options["function_name"]
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "cannot combine record fields{} unless flatten_records=True".format(
                         in_function
@@ -965,7 +967,7 @@ class RecordArray(Content):
 
             def continuation():
                 if not options["allow_records"]:
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         ValueError(
                             f"cannot broadcast records in {options['function_name']}"
                         )
@@ -1018,7 +1020,7 @@ class RecordArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         return RecordArray(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -52,7 +52,7 @@ class RegularArray(Content):
         nplike=None,
     ):
         if not isinstance(content, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Content subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -61,7 +61,7 @@ class RegularArray(Content):
             )
         if not isinstance(size, ak._typetracer.UnknownLengthType):
             if not (ak._util.isint(size) and size >= 0):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'size' must be a non-negative integer, not {}".format(
                             type(self).__name__, size
@@ -72,7 +72,7 @@ class RegularArray(Content):
                 size = int(size)
         if not isinstance(zeros_length, ak._typetracer.UnknownLengthType):
             if not (ak._util.isint(zeros_length) and zeros_length >= 0):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'zeros_length' must be a non-negative integer, not {}".format(
                             type(self).__name__, zeros_length
@@ -199,7 +199,7 @@ class RegularArray(Content):
             where += self._length
 
         if where < 0 or where >= self._length:
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
         start, stop = (where) * self._size, (where + 1) * self._size
         return self._content._getitem_range(slice(start, stop))
 
@@ -258,7 +258,7 @@ class RegularArray(Content):
             where[negative] += self._length
 
         if self._nplike.index_nplike.any(where >= self._length, prefer=False):
-            raise ak._util.indexerror(self, where)
+            raise ak._errors.index_error(self, where)
 
         nextcarry = ak.index.Index64.empty(where.shape[0] * self._size, self._nplike)
 
@@ -300,7 +300,7 @@ class RegularArray(Content):
 
     def _broadcast_tooffsets64(self, offsets):
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 AssertionError(
                     "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(
                         "(empty)" if offsets.length == 0 else str(offsets[0])
@@ -309,7 +309,7 @@ class RegularArray(Content):
             )
 
         if offsets.nplike.known_shape and offsets.length - 1 != self._length:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 AssertionError(
                     "cannot broadcast RegularArray of length {} to length {}".format(
                         self._length, offsets.length - 1
@@ -578,14 +578,14 @@ class RegularArray(Content):
             head = head._to_nplike(self._nplike)
 
             if advanced is not None:
-                raise ak._util.indexerror(
+                raise ak._errors.index_error(
                     self,
                     head,
                     "cannot mix jagged slice with NumPy-style advanced indexing",
                 )
 
             if self._nplike.known_shape and head.length != self._size:
-                raise ak._util.indexerror(
+                raise ak._errors.index_error(
                     self,
                     head,
                     "cannot fit jagged slice with length {} into {} of size {}".format(
@@ -630,7 +630,7 @@ class RegularArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
@@ -887,7 +887,7 @@ class RegularArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "ak.combinations does not compute combinations of the characters of a string; please split it into lists"
                     )
@@ -1243,7 +1243,7 @@ class RegularArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         length = self._length * self._size

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -39,7 +39,7 @@ class UnmaskedArray(Content):
 
     def __init__(self, content, identifier=None, parameters=None, nplike=None):
         if not isinstance(content, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Content subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -250,7 +250,7 @@ class UnmaskedArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._util.error(AssertionError(repr(head)))
+            raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def project(self, mask=None):
         if mask is not None:
@@ -296,7 +296,7 @@ class UnmaskedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            raise ak._util.error(np.AxisError("axis=0 not allowed for flatten"))
+            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             offsets, flattened = self._content._offsets_and_flattened(posaxis, depth)
             if offsets.length == 0:
@@ -597,7 +597,7 @@ class UnmaskedArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._util.error(AssertionError(result))
+            raise ak._errors.wrap_error(AssertionError(result))
 
     def packed(self):
         return UnmaskedArray(

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -19,7 +19,7 @@ class BitMaskedForm(Form):
         form_key=None,
     ):
         if not ak._util.isstr(mask):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'mask' must be of type str, not {}".format(
                         type(self).__name__, repr(mask)
@@ -27,7 +27,7 @@ class BitMaskedForm(Form):
                 )
             )
         if not isinstance(content, Form):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Form subclasses, not {}".format(
                         type(self).__name__, repr(content)
@@ -35,7 +35,7 @@ class BitMaskedForm(Form):
                 )
             )
         if not isinstance(valid_when, bool):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'valid_when' must be bool, not {}".format(
                         type(self).__name__, repr(valid_when)
@@ -43,7 +43,7 @@ class BitMaskedForm(Form):
                 )
             )
         if not isinstance(lsb_order, bool):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'lsb_order' must be bool, not {}".format(
                         type(self).__name__, repr(lsb_order)

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -17,7 +17,7 @@ class ByteMaskedForm(Form):
         form_key=None,
     ):
         if not ak._util.isstr(mask):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'mask' must be of type str, not {}".format(
                         type(self).__name__, repr(mask)
@@ -25,7 +25,7 @@ class ByteMaskedForm(Form):
                 )
             )
         if not isinstance(content, Form):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Form subclasses, not {}".format(
                         type(self).__name__, repr(content)
@@ -33,7 +33,7 @@ class ByteMaskedForm(Form):
                 )
             )
         if not isinstance(valid_when, bool):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'valid_when' must be bool, not {}".format(
                         type(self).__name__, repr(valid_when)

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -54,10 +54,10 @@ class EmptyForm(Form):
         )
 
     def _getitem_field(self, where, only_fields=()):
-        raise ak._util.indexerror(self, where, "not an array of records")
+        raise ak._errors.index_error(self, where, "not an array of records")
 
     def _getitem_fields(self, where, only_fields=()):
-        raise ak._util.indexerror(self, where, "not an array of records")
+        raise ak._errors.index_error(self, where, "not an array of records")
 
     def _carry(self, allow_lazy):
         return EmptyForm(

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -154,10 +154,12 @@ def from_iter(input):
         )
 
     elif input["class"] == "VirtualArray":
-        raise ak._util.error(ValueError("Awkward 1.x VirtualArrays are not supported"))
+        raise ak._errors.wrap_error(
+            ValueError("Awkward 1.x VirtualArrays are not supported")
+        )
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "Input class: {} was not recognised".format(repr(input["class"]))
             )
@@ -263,7 +265,7 @@ class Form:
 
     def _init(self, has_identifier, parameters, form_key):
         if not isinstance(has_identifier, bool):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'has_identifier' must be of type bool, not {}".format(
                         type(self).__name__, repr(has_identifier)
@@ -271,7 +273,7 @@ class Form:
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be of type dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -279,7 +281,7 @@ class Form:
                 )
             )
         if form_key is not None and not ak._util.isstr(form_key):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'form_key' must be of type string or None, not {}".format(
                         type(self).__name__, repr(form_key)
@@ -304,7 +306,7 @@ class Form:
     @property
     def is_identity_like(self):
         """Return True if the content or its non-list descendents are an identity"""
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def parameter(self, key):
         if self._parameters is None:
@@ -313,31 +315,31 @@ class Form:
             return self._parameters.get(key)
 
     def purelist_parameter(self, key):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def purelist_isregular(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def purelist_depth(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def minmax_depth(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def branch_depth(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def fields(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def is_tuple(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def form_key(self):
@@ -397,7 +399,7 @@ class Form:
 
         for item in specifier:
             if not ak._util.isstr(item):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError("a column-selection specifier must be a list of strings")
                 )
 
@@ -418,28 +420,28 @@ class Form:
         return self._column_types()
 
     def _columns(self, path, output, list_indicator):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _select_columns(self, index, specifier, matches, output):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _column_types(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def generated_compatibility(self, other):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _getitem_range(self):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _getitem_field(self, where, only_fields=()):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _getitem_fields(self, where, only_fields=()):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _tolist_part(self, verbose, toplevel):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _type(self, typestrs):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -16,7 +16,7 @@ class IndexedForm(Form):
         form_key=None,
     ):
         if not ak._util.isstr(index):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'index' must be of type str, not {}".format(
                         type(self).__name__, repr(index)
@@ -24,7 +24,7 @@ class IndexedForm(Form):
                 )
             )
         if not isinstance(content, Form):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Form subclasses, not {}".format(
                         type(self).__name__, repr(content)

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -17,7 +17,7 @@ class IndexedOptionForm(Form):
         form_key=None,
     ):
         if not ak._util.isstr(index):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'index' must be of type str, not {}".format(
                         type(self).__name__, repr(index)
@@ -25,7 +25,7 @@ class IndexedOptionForm(Form):
                 )
             )
         if not isinstance(content, Form):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Form subclasses, not {}".format(
                         type(self).__name__, repr(content)

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -17,7 +17,7 @@ class ListForm(Form):
         form_key=None,
     ):
         if not ak._util.isstr(starts):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'starts' must be of type str, not {}".format(
                         type(self).__name__, repr(starts)
@@ -25,7 +25,7 @@ class ListForm(Form):
                 )
             )
         if not ak._util.isstr(stops):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'starts' must be of type str, not {}".format(
                         type(self).__name__, repr(starts)
@@ -33,7 +33,7 @@ class ListForm(Form):
                 )
             )
         if not isinstance(content, Form):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Form subclasses, not {}".format(
                         type(self).__name__, repr(content)

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -12,7 +12,7 @@ class ListOffsetForm(Form):
         self, offsets, content, has_identifier=False, parameters=None, form_key=None
     ):
         if not ak._util.isstr(offsets):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'offsets' must be of type str, not {}".format(
                         type(self).__name__, repr(offsets)

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -48,7 +48,7 @@ class NumpyForm(Form):
             ak.types.numpytype.primitive_to_dtype(primitive)
         )
         if not isinstance(inner_shape, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'inner_shape' must be iterable, not {}".format(
                         type(self).__name__, repr(inner_shape)
@@ -161,10 +161,10 @@ class NumpyForm(Form):
         )
 
     def _getitem_field(self, where, only_fields=()):
-        raise ak._util.indexerror(self, where, "not an array of records")
+        raise ak._errors.index_error(self, where, "not an array of records")
 
     def _getitem_fields(self, where, only_fields=()):
-        raise ak._util.indexerror(self, where, "not an array of records")
+        raise ak._errors.index_error(self, where, "not an array of records")
 
     def _carry(self, allow_lazy):
         return NumpyForm(

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -20,7 +20,7 @@ class RecordForm(Form):
         form_key=None,
     ):
         if not isinstance(contents, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'contents' must be iterable, not {}".format(
                         type(self).__name__, repr(contents)
@@ -29,7 +29,7 @@ class RecordForm(Form):
             )
         for content in contents:
             if not isinstance(content, Form):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} all 'contents' must be Form subclasses, not {}".format(
                             type(self).__name__, repr(content)
@@ -37,7 +37,7 @@ class RecordForm(Form):
                     )
                 )
         if fields is not None and not isinstance(fields, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'fields' must be iterable, not {}".format(
                         type(self).__name__, repr(contents)
@@ -75,7 +75,7 @@ class RecordForm(Form):
             else:
                 return self._fields[index]
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError(
                     "no index {} in record with {} fields".format(
                         index, len(self._contents)
@@ -99,7 +99,7 @@ class RecordForm(Form):
                 pass
             else:
                 return i
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             IndexError(
                 "no field {} in record with {} fields".format(
                     repr(field), len(self._contents)
@@ -124,7 +124,7 @@ class RecordForm(Form):
         elif ak._util.isstr(index_or_field):
             index = self.field_to_index(index_or_field)
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "index_or_field must be an integer (index) or string (field), not {}".format(
                         repr(index_or_field)

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -12,7 +12,7 @@ class RegularForm(Form):
         self, content, size, has_identifier=False, parameters=None, form_key=None
     ):
         if not isinstance(content, Form):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Form subclasses, not {}".format(
                         type(self).__name__, repr(content)
@@ -20,7 +20,7 @@ class RegularForm(Form):
                 )
             )
         if not ak._util.isint(size):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'size' must be of type int, not {}".format(
                         type(self).__name__, repr(size)

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -19,7 +19,7 @@ class UnionForm(Form):
         form_key=None,
     ):
         if not ak._util.isstr(tags):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'tags' must be of type str, not {}".format(
                         type(self).__name__, repr(tags)
@@ -27,7 +27,7 @@ class UnionForm(Form):
                 )
             )
         if not ak._util.isstr(index):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'index' must be of type str, not {}".format(
                         type(self).__name__, repr(index)
@@ -35,7 +35,7 @@ class UnionForm(Form):
                 )
             )
         if not isinstance(contents, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'contents' must be iterable, not {}".format(
                         type(self).__name__, repr(contents)
@@ -44,7 +44,7 @@ class UnionForm(Form):
             )
         for content in contents:
             if not isinstance(content, Form):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} all 'contents' must be Form subclasses, not {}".format(
                             type(self).__name__, repr(content)
@@ -176,7 +176,7 @@ class UnionForm(Form):
         )
 
     def simplify_uniontype(self, merge=True, mergebool=False):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -15,7 +15,7 @@ class UnmaskedForm(Form):
         form_key=None,
     ):
         if not isinstance(content, Form):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Form subclasses, not {}".format(
                         type(self).__name__, repr(content)

--- a/src/awkward/identifier.py
+++ b/src/awkward/identifier.py
@@ -29,16 +29,20 @@ class Identifier:
         if not isinstance(fieldloc, dict) or not all(
             ak._util.isint(k) and ak._util.isstr(v) for k, v in fieldloc.items()
         ):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError("Identifier fieldloc must be a dict of int -> str")
             )
         self._nplike = ak.nplikes.nplike_of(data)
 
         self._data = self._nplike.asarray(data, order="C")
         if len(self._data.shape) != 2:
-            raise ak._util.error(TypeError("Identifier data must be 2-dimensional"))
+            raise ak._errors.wrap_error(
+                TypeError("Identifier data must be 2-dimensional")
+            )
         if self._data.dtype not in (np.dtype(np.int32), np.dtype(np.int64)):
-            raise ak._util.error(TypeError("Identifier data must be int32, int64"))
+            raise ak._errors.wrap_error(
+                TypeError("Identifier data must be int32, int64")
+            )
 
     @classmethod
     def zeros(cls, ref, fieldloc, length, width, nplike, dtype):

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -23,13 +23,15 @@ class Index:
             nplike = ak.nplikes.nplike_of(data)
         self._nplike = nplike
         if metadata is not None and not isinstance(metadata, dict):
-            raise ak._util.error(TypeError("Index metadata must be None or a dict"))
+            raise ak._errors.wrap_error(
+                TypeError("Index metadata must be None or a dict")
+            )
         self._metadata = metadata
         self._data = self._nplike.index_nplike.asarray(
             data, dtype=self._expected_dtype, order="C"
         )
         if len(self._data.shape) != 1:
-            raise ak._util.error(TypeError("Index data must be one-dimensional"))
+            raise ak._errors.wrap_error(TypeError("Index data must be one-dimensional"))
 
         if issubclass(self._data.dtype.type, np.longlong):
             assert (
@@ -50,7 +52,7 @@ class Index:
             elif self._data.dtype == np.dtype(np.int64):
                 self.__class__ = Index64
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "Index data must be int8, uint8, int32, uint32, int64, not "
                         + repr(self._data.dtype)
@@ -59,7 +61,7 @@ class Index:
         else:
             if self._data.dtype != self._expected_dtype:
                 # self._data = self._data.astype(self._expected_dtype)   # copy/convert
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     NotImplementedError(
                         "while developing, we want to catch these errors"
                     )

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -378,11 +378,11 @@ class NumpyKernel:
             if is_numpy_buffer(x):
                 return ctypes.cast(x.ctypes.data, t)
             elif is_cupy_buffer(x):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     AssertionError("CuPy buffers shouldn't be passed to Numpy Kernels.")
                 )
             elif is_jax_buffer(x):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "JAX Buffers can't be passed as function args for the C Kernels"
                     )
@@ -740,7 +740,9 @@ class Jax(NumpyLike):
             return [self.to_rectilinear(x, *args, **kwargs) for x in array]
 
         else:
-            raise ak._util.error(ValueError("to_rectilinear argument must be iterable"))
+            raise ak._errors.wrap_error(
+                ValueError("to_rectilinear argument must be iterable")
+            )
 
     def __getitem__(self, name_and_types):
         return NumpyKernel(ak._cpu_kernels.kernel[name_and_types], name_and_types)
@@ -752,7 +754,7 @@ class Jax(NumpyLike):
 
     @property
     def ma(self):
-        ak._util.error(
+        ak._errors.wrap_error(
             ValueError(
                 "JAX arrays cannot have missing values until JAX implements "
                 "numpy.ma.MaskedArray" + ak._util.exception_suffix(__file__)
@@ -761,7 +763,7 @@ class Jax(NumpyLike):
 
     @property
     def char(self):
-        ak._util.error(
+        ak._errors.wrap_error(
             ValueError(
                 "JAX arrays cannot do string manipulations until JAX implements "
                 "numpy.char"
@@ -805,7 +807,7 @@ class Jax(NumpyLike):
         elif isinstance(nplike, ak._typetracer.TypeTracer):
             return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
         else:
-            ak._util.error(
+            ak._errors.wrap_error(
                 TypeError(
                     "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, Typetracer or Jax",
                 )

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -37,7 +37,7 @@ def all(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.all",
         dict(
             array=array,

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -37,7 +37,7 @@ def any(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.any",
         dict(
             array=array,

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -70,7 +70,7 @@ def argcartesian(
     All of the parameters for #ak.cartesian apply equally to #ak.argcartesian,
     so see the #ak.cartesian documentation for a more complete description.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.argcartesian",
         dict(
             arrays=arrays,

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -48,7 +48,7 @@ def argcombinations(
     #ak.argcartesian. See #ak.combinations and #ak.argcartesian for a more
     complete description.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.argcombinations",
         dict(
             array=array,
@@ -86,7 +86,7 @@ def _impl(
         parameters["__record__"] = with_name
 
     if axis < 0:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError("the 'axis' for argcombinations must be non-negative")
         )
     else:

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -44,7 +44,7 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True, flatten_records
 
     See also #ak.nanargmax.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.argmax",
         dict(
             array=array,
@@ -89,7 +89,7 @@ def nanargmax(
 
     See also #ak.argmax.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nanargmax",
         dict(
             array=array,

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -44,7 +44,7 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True, flatten_records
 
     See also #ak.nanargmin.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.argmin",
         dict(
             array=array,
@@ -89,7 +89,7 @@ def nanargmin(
 
     See also #ak.argmin.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nanargmin",
         dict(
             array=array,

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -42,7 +42,7 @@ def argsort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavio
         >>> data[index]
         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.argsort",
         dict(
             array=array,

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -32,7 +32,7 @@ def backend(*arrays):
 
     See #ak.to_backend.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.backend",
         {"*arrays": arrays},
     ):

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -132,7 +132,7 @@ def broadcast_arrays(*arrays, **kwargs):
         >>> ak.to_list(that)
         [[[1.1, 2.2], [3.3], [4.4], [5.5]], [], [[6.6]]]
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.broadcast_arrays",
         dict(arrays=arrays, kwargs=kwargs),
     ):

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -214,7 +214,7 @@ def cartesian(
     #ak.argcartesian form can be particularly useful as nested indexing in
     #ak.Array.__getitem__.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.cartesian",
         dict(
             arrays=arrays,
@@ -263,10 +263,10 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
 
     posaxis = new_arrays_values[0].axis_wrap_if_negative(axis)
     if posaxis < 0:
-        raise ak._util.error(ValueError("negative axis depth is ambiguous"))
+        raise ak._errors.wrap_error(ValueError("negative axis depth is ambiguous"))
     for x in new_arrays_values[1:]:
         if x.axis_wrap_if_negative(axis) != posaxis:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "arrays to cartesian-product do not have the same depth for negative axis"
                 )
@@ -280,7 +280,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
             if nested is True:
                 nested = list(new_arrays.keys())  # last key is ignored below
             if any(not (isinstance(n, str) and n in new_arrays) for x in nested):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "the 'nested' parameter of cartesian must be dict keys "
                         "for a dict of arrays"
@@ -303,7 +303,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
                 not (isinstance(x, int) and 0 <= x < len(new_arrays) - 1)
                 for x in nested
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "the 'nested' prarmeter of cartesian must be integers in "
                         "[0, len(arrays) - 1) for an iterable of arrays"
@@ -359,7 +359,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
                         layout.parameter("__array__") == "string"
                         or layout.parameter("__array__") == "bytestring"
                     ):
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             ValueError(
                                 "ak.cartesian does not compute combinations of the "
                                 "characters of a string; please split it into lists"
@@ -386,7 +386,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
             if nested is True:
                 nested = list(new_arrays.keys())  # last key is ignored below
             if any(not (isinstance(n, str) and n in new_arrays) for x in nested):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "the 'nested' parameter of cartesian must be dict keys "
                         "for a dict of arrays"
@@ -407,7 +407,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
                 not (isinstance(x, int) and 0 <= x < len(new_arrays) - 1)
                 for x in nested
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "the 'nested' parameter of cartesian must be integers in "
                         "[0, len(arrays) - 1) for an iterable of arrays"

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -16,7 +16,7 @@ def categories(array, highlevel=True):
 
     See also #ak.is_categorical, #ak.to_categorical, #ak.from_categorical.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.categories",
         dict(array=array, highlevel=highlevel),
     ):

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -154,7 +154,7 @@ def combinations(
     The #ak.argcombinations form can be particularly useful as nested indexing
     in #ak.Array.__getitem__.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.combinations",
         dict(
             array=array,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -34,7 +34,7 @@ def concatenate(
     must have the same lengths and nested lists are each concatenated,
     element for element, and similarly for deeper levels.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.concatenate",
         dict(
             arrays=arrays,
@@ -75,7 +75,9 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
 
     contents = [x for x in content_or_others if isinstance(x, ak.contents.Content)]
     if len(contents) == 0:
-        raise ak._util.error(ValueError("need at least one array to concatenate"))
+        raise ak._errors.wrap_error(
+            ValueError("need at least one array to concatenate")
+        )
 
     posaxis = contents[0].axis_wrap_if_negative(axis)
     maxdepth = max(
@@ -84,7 +86,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
         if isinstance(x, ak.contents.Content)
     )
     if not 0 <= posaxis < maxdepth:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "axis={} is beyond the depth of this array or the depth of this array "
                 "is ambiguous".format(axis)
@@ -93,7 +95,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
     for x in content_or_others:
         if isinstance(x, ak.contents.Content):
             if x.axis_wrap_if_negative(axis) != posaxis:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "arrays to concatenate do not have the same depth for negative "
                         "axis={}".format(axis)
@@ -140,7 +142,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                         if not ak._util.isint(length):
                             length = x.length
                         elif length != x.length and ak._util.isint(x.length):
-                            raise ak._util.error(
+                            raise ak._errors.wrap_error(
                                 ValueError(
                                     "all arrays must have the same length for "
                                     "axis={}".format(axis)
@@ -261,7 +263,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                 for x in inputs
                 if isinstance(x, ak.contents.Content)
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "at least one array is not deep enough to concatenate at "
                         "axis={}".format(axis)

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -52,7 +52,7 @@ def copy(array):
     changes, so we don't support it. However, an #ak.Array's data might come from
     a mutable third-party library, so this function allows you to make a true copy.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.fill_none",
         dict(array=array),
     ):

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -55,7 +55,7 @@ def corr(
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.corr",
         dict(
             x=x,

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -79,7 +79,7 @@ def count(array, axis=None, keepdims=False, mask_identity=False, flatten_records
     If it is desirable to exclude NaN ("not a number") values from #ak.count,
     use #ak.nan_to_none to turn them into None, which are not counted.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.count",
         dict(
             array=array,

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -41,7 +41,7 @@ def count_nonzero(
     count None values. If it is desirable to count them, use #ak.fill_none
     to turn them into something that would be counted.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.count_nonzero",
         dict(
             array=array,

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -53,7 +53,7 @@ def covar(
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.covar",
         dict(
             x=x,

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -18,7 +18,7 @@ def fields(array):
     If the array contains neither tuples nor records, this returns an empty
     list.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.fields",
         dict(array=array),
     ):

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -49,7 +49,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 
     The values could be floating-point numbers or strings.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.fill_none",
         dict(
             array=array, value=value, axis=axis, highlevel=highlevel, behavior=behavior

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -29,7 +29,7 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
 
     See #ak.singletons to invert this function.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.firsts",
         dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
     ):
@@ -47,7 +47,7 @@ def _impl(array, axis, highlevel, behavior):
             out = layout[0]
     else:
         if posaxis < 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 NotImplementedError("ak.firsts with ambiguous negative axis")
             )
         toslice = (slice(None, None, None),) * posaxis + (0,)

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -90,7 +90,7 @@ def flatten(array, axis=1, highlevel=True, behavior=None):
     However, it is important to keep in mind that this is a special case:
     #ak.flatten and `content` are not interchangeable!
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.flatten",
         dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -31,7 +31,7 @@ def from_arrow(array, generate_bitmasks=False, highlevel=True, behavior=None):
 
     See also #ak.to_arrow, #ak.to_arrow_table, #ak.from_parquet, #ak.from_arrow_schema.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_arrow",
         dict(
             array=array,

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -14,7 +14,7 @@ def from_arrow_schema(schema):
 
     See also #ak.to_arrow, #ak.to_arrow_table, #ak.from_arrow, #ak.to_parquet, #ak.from_parquet.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_arrow_schema",
         dict(schema=schema),
     ):

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -27,7 +27,7 @@ def from_avro_file(
     """
     import awkward._connect.avro
 
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_avro_file",
         dict(
             file=file,
@@ -49,13 +49,13 @@ def from_avro_file(
                     ).outcontents
                     return _impl(form, length, container, highlevel, behavior)
             except ImportError as err:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     "the filename is incorrect or the file does not exist"
                 ) from err
 
         else:
             if not hasattr(file, "read"):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError("the fileobject provided is not of the correct type.")
                 )
             else:

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -58,7 +58,7 @@ def from_buffers(
 
     See #ak.to_buffers for examples.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_buffers",
         dict(
             form=form,
@@ -83,12 +83,12 @@ def _impl(form, length, container, buffer_key, nplike, highlevel, behavior):
         form = ak.forms.from_iter(form)
 
     if not (ak._util.isint(length) and length >= 0):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError("'length' argument must be a non-negative integer")
         )
 
     if not isinstance(form, ak.forms.Form):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "'form' argument must be a Form or its Python dict/JSON string representation"
             )
@@ -105,7 +105,7 @@ def _impl(form, length, container, buffer_key, nplike, highlevel, behavior):
             return buffer_key(form_key=form.form_key, attribute=attribute, form=form)
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 f"buffer_key must be a string or a callable, not {type(buffer_key)}"
             )
@@ -126,7 +126,7 @@ _index_to_dtype = {
 
 def reconstitute(form, length, container, getkey, nplike):
     if form.has_identifier:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             NotImplementedError("ak.from_buffers for an array with an Identifier")
         )
     else:
@@ -134,7 +134,7 @@ def reconstitute(form, length, container, getkey, nplike):
 
     if isinstance(form, ak.forms.EmptyForm):
         if length != 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(f"EmptyForm node, but the expected length is {length}")
             )
         return ak.contents.EmptyArray(identifier, form.parameters)
@@ -296,6 +296,6 @@ def reconstitute(form, length, container, getkey, nplike):
         )
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             AssertionError("unexpected form node type: " + str(type(form)))
         )

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -20,7 +20,7 @@ def from_categorical(array, highlevel=True):
     See also #ak.is_categorical, #ak.categories, #ak.to_categorical,
     #ak.from_categorical.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_categorical",
         dict(array=array, highlevel=highlevel),
     ):

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -27,7 +27,7 @@ def from_cupy(array, regulararray=False, highlevel=True, behavior=None):
 
     See also #ak.to_cupy, #ak.from_numpy and #ak.from_jax.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_cupy",
         dict(
             array=array,

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -50,7 +50,7 @@ def from_iter(
 
     See also #ak.to_list.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_iter",
         dict(
             iterable=iterable,
@@ -76,7 +76,7 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
                 resize,
             )[0]
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "cannot produce an array from a single dict (that would be a record)"
                 )

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -27,7 +27,7 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
 
     See also #ak.to_jax, #ak.from_numpy and #ak.from_jax.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_jax",
         dict(
             array=array,

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -312,7 +312,7 @@ def from_json(
 
     See also #ak.to_json.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_json",
         dict(
             source=source,
@@ -442,7 +442,7 @@ def _record_to_complex(layout, complex_record_fields):
                                 + node._nplike.asarray(imag) * 1j
                             )
                     else:
-                        raise ak._util.error(
+                        raise ak._errors.wrap_error(
                             ValueError(
                                 f"expected record with fields {complex_record_fields[0]!r} and {complex_record_fields[1]!r} to have integer or floating point types, not {str(real.form.type)!r} and {str(imag.form.type)!r}"
                             )
@@ -451,7 +451,7 @@ def _record_to_complex(layout, complex_record_fields):
         return layout.recursively_apply(action)
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError("complex_record_fields must be None or a pair of strings")
         )
 
@@ -485,7 +485,7 @@ def _no_schema(
                 neginf_string,
             )
         except Exception as err:
-            raise ak._util.error(ValueError(str(err))) from None
+            raise ak._errors.wrap_error(ValueError(str(err))) from None
 
     formstr, length, buffers = builder.to_buffers()
     form = ak.forms.from_json(formstr)
@@ -520,7 +520,7 @@ def _yes_schema(
         schema = json.loads(schema)
 
     if not isinstance(schema, dict):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
         )
 
@@ -529,7 +529,7 @@ def _yes_schema(
 
     if schema.get("type") == "array":
         if "items" not in schema:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError("JSONSchema type is not concrete: array without items")
             )
 
@@ -542,7 +542,7 @@ def _yes_schema(
         is_record = True
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "only 'array' and 'object' types supported at the JSONSchema root"
             )
@@ -565,7 +565,7 @@ def _yes_schema(
                 resize,
             )
         except Exception as err:
-            raise ak._util.error(ValueError(str(err))) from None
+            raise ak._errors.wrap_error(ValueError(str(err))) from None
 
     layout = ak.operations.from_buffers(form, length, container, highlevel=False)
     layout = _record_to_complex(layout, complex_record_fields)
@@ -581,12 +581,12 @@ def _yes_schema(
 
 def build_assembly(schema, container, instructions):
     if not isinstance(schema, dict):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
         )
 
     if "type" not in schema is None:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(f"unrecognized JSONSchema: no 'type' in {schema!r}")
         )
 
@@ -713,7 +713,7 @@ def build_assembly(schema, container, instructions):
         # https://json-schema.org/understanding-json-schema/reference/array.html
 
         if "items" not in schema:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError("JSONSchema type is not concrete: array without 'items'")
             )
 
@@ -761,7 +761,7 @@ def build_assembly(schema, container, instructions):
         # https://json-schema.org/understanding-json-schema/reference/object.html
 
         if "properties" not in schema:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "JSONSchema type is not concrete: object without 'properties'"
                 )
@@ -797,9 +797,9 @@ def build_assembly(schema, container, instructions):
             return out
 
     elif isinstance(tpe, list):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             NotImplementedError("arbitrary unions of types are not yet supported")
         )
 
     else:
-        raise ak._util.error(TypeError(f"unrecognized JSONSchema: {tpe!r}"))
+        raise ak._errors.wrap_error(TypeError(f"unrecognized JSONSchema: {tpe!r}"))

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -37,7 +37,7 @@ def from_numpy(
 
     See also #ak.to_numpy and #ak.from_cupy.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_numpy",
         dict(
             array=array,

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -48,7 +48,7 @@ def from_parquet(
 
     See also #ak.to_parquet, #ak.metadata_from_parquet.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_parquet",
         dict(
             path=path,
@@ -102,11 +102,11 @@ def metadata(
 
     if row_groups is not None:
         if not all(ak._util.isint(x) and x >= 0 for x in row_groups):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError("row_groups must be a set of non-negative integers")
             )
         if len(set(row_groups)) < len(row_groups):
-            raise ak._util.error(ValueError("row group indices must not repeat"))
+            raise ak._errors.wrap_error(ValueError("row group indices must not repeat"))
 
     fs, _, paths = fsspec.get_fs_token_paths(
         path, mode="rb", storage_options=storage_options
@@ -157,13 +157,13 @@ def metadata(
                 metadata.append_row_groups(md)
     if row_groups is not None:
         if any(_ >= metadata.num_row_groups for _ in row_groups):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     f"Row group selection out of bounds 0..{metadata.num_row_groups - 1}"
                 )
             )
         if not can_sub:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "Requested selection of row-groups, but not scanning metadata"
                 )
@@ -357,7 +357,7 @@ def _all_and_metadata_paths(path, fs, paths, ignore_metadata=False, scan_files=T
     all_paths = [x for x, is_meta, is_comm in all_paths if not is_meta and not is_comm]
 
     if len(all_paths) == 0:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(f"no *.parquet or *.parq matches for path {path!r}")
         )
 

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -14,7 +14,7 @@ def from_rdataframe(data_frame, columns):
 
      See also #ak.to_rdataframe.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_rdataframe",
         dict(
             data_frame=data_frame,

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -33,7 +33,7 @@ def from_regular(array, axis=1, highlevel=True, behavior=None):
 
     See also #ak.to_regular.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.from_regular",
         dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
     ):
@@ -64,7 +64,7 @@ def _impl(array, axis, highlevel, behavior):
             elif posaxis == depth and layout.is_ListType:
                 return layout
             elif posaxis == 0:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError(
                         f"axis={axis} exceeds the depth of this array ({depth})"
                     )

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -70,7 +70,7 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.full_like",
         dict(
             array=array,

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -15,7 +15,7 @@ def is_categorical(array):
 
     See also #ak.categories, #ak.to_categorical, #ak.from_categorical.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.is_categorical",
         dict(array=array),
     ):

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -21,7 +21,7 @@ def is_none(array, axis=0, highlevel=True, behavior=None):
     Returns an array whose value is True where an element of `array` is None;
     False otherwise (at a given `axis` depth).
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.is_none",
         dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
     ):
@@ -74,7 +74,7 @@ def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array)
     max_axis = layout.branch_depth[1] - 1
     if axis > max_axis:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             np.AxisError(f"axis={axis} exceeds the depth ({max_axis}) of this array")
         )
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -12,7 +12,7 @@ def is_tuple(array):
     If `array` is a record, this returns True if the record is a tuple.
     If `array` is an array, this returns True if the outermost record is a tuple.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.is_tuple",
         dict(array=array),
     ):

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -18,7 +18,7 @@ def is_valid(array, exception=False):
 
     See also #ak.validity_error.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.is_valid",
         dict(array=array, exception=exception),
     ):

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -28,7 +28,7 @@ def isclose(
     Implements [np.isclose](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html)
     for Awkward Arrays.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.isclose",
         dict(
             a=a,

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -68,7 +68,7 @@ def linear_fit(
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.linear_fit",
         dict(
             x=x,

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -71,7 +71,7 @@ def local_index(array, axis=-1, highlevel=True, behavior=None):
                        2               8.8
                        3               9.9
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.local_index",
         dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -85,7 +85,7 @@ def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
 
     (which is 5 characters away from simply filtering the `array`).
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.mask",
         dict(
             array=array,
@@ -104,7 +104,7 @@ def _impl(array, mask, valid_when, highlevel, behavior):
         if isinstance(layoutmask, ak.contents.NumpyArray):
             m = ak.nplikes.nplike_of(layoutmask).asarray(layoutmask)
             if not issubclass(m.dtype.type, (bool, np.bool_)):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "mask must have boolean type, not " "{}".format(repr(m.dtype))
                     )

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -51,7 +51,7 @@ def max(
 
     See also #ak.nanmax.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.max",
         dict(
             array=array,
@@ -106,7 +106,7 @@ def nanmax(
 
     See also #ak.max.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nanmax",
         dict(
             array=array,

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -73,7 +73,7 @@ def mean(
 
     See also #ak.nanmean.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.mean",
         dict(
             x=x,
@@ -124,7 +124,7 @@ def nanmean(
 
     See also #ak.mean.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nanmean",
         dict(
             x=x,

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -45,7 +45,7 @@ def metadata_from_parquet(
     """
     import awkward._connect.pyarrow  # noqa: F401
 
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.metadata_from_parquet",
         dict(
             path=path,

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -51,7 +51,7 @@ def min(
 
     See also #ak.nanmin.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.min",
         dict(
             array=array,
@@ -106,7 +106,7 @@ def nanmin(
 
     See also #ak.min.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nanmin",
         dict(
             array=array,

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -57,7 +57,7 @@ def moment(
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.moment",
         dict(
             x=x,

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -19,7 +19,7 @@ def nan_to_none(array, highlevel=True, behavior=None):
 
     See also #ak.nan_to_num to convert NaN or infinity to specified values.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nan_to_none",
         dict(
             array=array,

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -29,7 +29,7 @@ def nan_to_num(
 
     See also #ak.nan_to_none to convert NaN to None, i.e. missing values with option-type.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nan_to_num",
         dict(
             array=array,

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -66,7 +66,7 @@ def num(array, axis=1, highlevel=True, behavior=None):
         >>> ak.mask(array, ak.num(array) > 0)[:, 0]
         <Array [[1.1, 2.2, 3.3], None, [7.7]] type='3 * option[var * float64]'>
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.num",
         dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -23,7 +23,7 @@ def ones_like(array, highlevel=True, behavior=None, dtype=None):
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.ones_like",
         dict(array=array, highlevel=highlevel, behavior=behavior, dtype=dtype),
     ):

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -55,7 +55,7 @@ def packed(array, highlevel=True, behavior=None):
 
     See also #ak.to_buffers.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.packed",
         dict(array=array, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -121,7 +121,7 @@ def pad_none(array, target, axis=1, clip=False, highlevel=True, behavior=None):
         >>> ak.type(ak.pad_none(array, 2, axis=2, clip=True))
         3 * var *   2 * ?float64
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.pad_none",
         dict(
             array=array,

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -21,7 +21,7 @@ def parameters(array):
     See #ak.Array and #ak.behavior for a more complete description of
     behaviors.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.parameters",
         dict(array=array),
     ):

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -37,7 +37,7 @@ def prod(array, axis=None, keepdims=False, mask_identity=False, flatten_records=
 
     See also #ak.nanprod.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.prod",
         dict(
             array=array,
@@ -82,7 +82,7 @@ def nanprod(
 
     See also #ak.prod.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nanprod",
         dict(
             array=array,

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -55,7 +55,7 @@ def ptp(array, axis=None, keepdims=False, mask_identity=True, flatten_records=Fa
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.ptp",
         dict(
             array=array,

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -41,7 +41,7 @@ def ravel(array, highlevel=True, behavior=None):
     Missing values are eliminated by flattening: there is no distinction
     between an empty list and a value of None at the level of flattening.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.ravel",
         dict(array=array, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -83,7 +83,7 @@ def run_lengths(array, highlevel=True, behavior=None):
 
     See also #ak.num, #ak.argsort, #ak.unflatten.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.run_lengths",
         dict(
             array=array,
@@ -135,7 +135,7 @@ def _impl(array, highlevel, behavior):
                 return ak.contents.NumpyArray(nextcontent)
 
             if not isinstance(layout, (ak.contents.NumpyArray, ak.contents.EmptyArray)):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     NotImplementedError("run_lengths on " + type(layout).__name__)
                 )
 
@@ -147,7 +147,7 @@ def _impl(array, highlevel, behavior):
                 layout = layout.project()
 
             if not layout.is_ListType:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     NotImplementedError("run_lengths on " + type(layout).__name__)
                 )
 
@@ -180,7 +180,7 @@ def _impl(array, highlevel, behavior):
             if not isinstance(
                 content, (ak.contents.NumpyArray, ak.contents.EmptyArray)
             ):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     NotImplementedError(
                         "run_lengths on "
                         + type(layout).__name__

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -26,7 +26,7 @@ def singletons(array, highlevel=True, behavior=None):
 
     See #ak.firsts to invert this function.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.singletons",
         dict(array=array, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -40,7 +40,7 @@ def softmax(x, axis=None, keepdims=False, mask_identity=False, flatten_records=F
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.softmax",
         dict(
             x=x,

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -31,7 +31,7 @@ def sort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=N
         >>> ak.sort(ak.Array([[7, 5, 7], [], [2], [8, 2]]))
         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.sort",
         dict(
             array=array,

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -60,7 +60,7 @@ def std(
 
     See also #ak.nanstd.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.std",
         dict(
             x=x,
@@ -121,7 +121,7 @@ def nanstd(
 
     See also #ak.std.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nanstd",
         dict(
             x=x,

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -38,7 +38,7 @@ def strings_astype(array, to, highlevel=True, behavior=None):
 
     See also #ak.numbers_astype.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.strings_astype",
         dict(array=array, to=to, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -181,7 +181,7 @@ def sum(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
 
     See also #ak.nansum.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.sum",
         dict(
             array=array,
@@ -226,7 +226,7 @@ def nansum(
 
     See also #ak.sum.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nansum",
         dict(
             array=array,

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -61,7 +61,7 @@ def to_arrow(
 
     See also #ak.from_arrow, #ak.to_arrow_table, #ak.to_parquet, #ak.from_arrow_schema.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_arrow",
         dict(
             array=array,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -62,7 +62,7 @@ def to_arrow_table(
 
     See also #ak.from_arrow, #ak.to_arrow, #ak.to_parquet.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_arrow_table",
         dict(
             array=array,

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -46,7 +46,7 @@ def to_backend(array, backend, highlevel=True, behavior=None):
 
     See #ak.kernels.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_backend",
         dict(array=array, backend=backend, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -111,7 +111,7 @@ def to_buffers(
 
     See also #ak.from_buffers and #ak.packed.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_buffers",
         dict(
             array=array,

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -71,7 +71,7 @@ def to_categorical(array, highlevel=True):
 
     See also #ak.is_categorical, #ak.categories, #ak.from_categorical.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_categorical",
         dict(array=array, highlevel=highlevel),
     ):

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -17,7 +17,7 @@ def to_cupy(array):
 
     See also #ak.from_cupy and #ak.to_numpy.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_cupy",
         dict(array=array),
     ):

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -120,7 +120,7 @@ def to_dataframe(
               2         3.0  NaN
               3         4.0  NaN
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_layout",
         dict(
             array=array,
@@ -136,7 +136,7 @@ def _impl(array, how, levelname, anonymous):
     try:
         import pandas
     except ImportError as err:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ImportError(
                 """install the 'pandas' package with:
 

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -17,7 +17,7 @@ def to_jax(array):
 
     See also #ak.from_jax and #ak.to_numpy.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_jax",
         dict(array=array),
     ):

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -106,7 +106,7 @@ def to_json(
 
     See also #ak.from_json.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_json",
         dict(
             array=array,
@@ -178,7 +178,9 @@ def _impl(
         out = ak.contents.NumpyArray(array)
 
     else:
-        raise ak._util.error(TypeError(f"unrecognized array type: {repr(array)}"))
+        raise ak._errors.wrap_error(
+            TypeError(f"unrecognized array type: {repr(array)}")
+        )
 
     jsondata = out.to_json(
         nan_string=nan_string,
@@ -286,7 +288,7 @@ def _impl(
                     )
 
     except Exception as err:
-        raise ak._util.error(err) from err
+        raise ak._errors.wrap_error(err) from err
 
 
 class _NoContextManager:

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -32,7 +32,7 @@ def to_layout(
     would rarely be used in a data analysis because #ak.contents.Content and
     #ak.record.Record are lower-level than #ak.Array.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_layout",
         dict(
             array=array,
@@ -50,7 +50,7 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif isinstance(array, ak.record.Record):
         if not allow_record:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError("ak.Record objects are not allowed in this function")
             )
         else:
@@ -61,7 +61,7 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif isinstance(array, ak.highlevel.Record):
         if not allow_record:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError("ak.Record objects are not allowed in this function")
             )
         else:
@@ -75,7 +75,9 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif isinstance(array, (np.ndarray, numpy.ma.MaskedArray)):
         if not issubclass(array.dtype.type, numpytype):
-            raise ak._util.error(ValueError(f"dtype {array.dtype!r} not allowed"))
+            raise ak._errors.wrap_error(
+                ValueError(f"dtype {array.dtype!r} not allowed")
+            )
         return _impl(
             ak.operations.from_numpy(
                 array, regulararray=True, recordarray=True, highlevel=False
@@ -87,7 +89,9 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif ak.nplikes.is_cupy_buffer(array) and type(array).__name__ == "ndarray":
         if not issubclass(array.dtype.type, numpytype):
-            raise ak._util.error(ValueError(f"dtype {array.dtype!r} not allowed"))
+            raise ak._errors.wrap_error(
+                ValueError(f"dtype {array.dtype!r} not allowed")
+            )
         return _impl(
             ak.operations.from_cupy(array, regulararray=True, highlevel=False),
             allow_record,
@@ -97,7 +101,9 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif ak.nplikes.is_jax_buffer(array) and type(array).__name__ == "DeviceArray":
         if not issubclass(array.dtype.type, numpytype):
-            raise ak._util.error(ValueError(f"dtype {array.dtype!r} not allowed"))
+            raise ak._errors.wrap_error(
+                ValueError(f"dtype {array.dtype!r} not allowed")
+            )
         return _impl(
             ak.operations.from_jax(array, regulararray=True, highlevel=False),
             allow_record,
@@ -122,7 +128,7 @@ def _impl(array, allow_record, allow_other, numpytype):
         )
 
     elif not allow_other:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(f"{array} cannot be converted into an Awkward Array")
         )
 

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -31,7 +31,7 @@ def to_list(array):
 
     See also #ak.from_iter and #ak.Array.tolist.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_list",
         dict(array=array),
     ):

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -32,7 +32,7 @@ def to_numpy(array, allow_missing=True):
 
     See also #ak.from_numpy and #ak.to_cupy.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_numpy",
         dict(array=array, allow_missing=allow_missing),
     ):

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -37,7 +37,7 @@ def to_rdataframe(arrays, flatlist_as_rvec=True):
 
     See also #ak.from_rdataframe.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_rdataframe",
         dict(arrays=arrays),
     ):
@@ -54,17 +54,19 @@ def _impl(
     import awkward._connect.rdataframe.to_rdataframe  # noqa: F401
 
     if not isinstance(arrays, Mapping):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError("'arrays' must be a dict (to provide C++ names for the arrays)")
         )
     elif not all(ak._util.isstr(name) for name in arrays):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "keys of 'arrays' dict must be strings (to provide C++ names for the arrays)"
             )
         )
     elif len(arrays) == 0:
-        raise ak._util.error(TypeError("'arrays' must contain at least one array"))
+        raise ak._errors.wrap_error(
+            TypeError("'arrays' must contain at least one array")
+        )
 
     layouts = {}
     length = None
@@ -75,7 +77,9 @@ def _impl(
         if length is None:
             length = layouts[name].length
         elif length != layouts[name].length:
-            raise ak._util.error(ValueError("lengths of 'arrays' must all be the same"))
+            raise ak._errors.wrap_error(
+                ValueError("lengths of 'arrays' must all be the same")
+            )
 
     return ak._connect.rdataframe.to_rdataframe.to_rdataframe(
         layouts,

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -40,7 +40,7 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 
     See also #ak.from_regular.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_regular",
         dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
     ):
@@ -69,7 +69,7 @@ def _impl(array, axis, highlevel, behavior):
             if posaxis == depth and layout.is_ListType:
                 return layout.toRegularArray()
             elif posaxis == 0:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     np.AxisError(
                         f"axis={axis} exceeds the depth of this array ({depth})"
                     )

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -382,7 +382,7 @@ def transform(
     See also: #ak.is_valid and #ak.valid_when to check the validity of transformed
     outputs.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.transform",
         dict(
             transformation=transformation,
@@ -473,7 +473,7 @@ def _impl(
                 return ak.contents.NumpyArray(out)
 
             else:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         f"transformation must return an Awkward array, not {type(out)}\n\n{out!r}"
                     )
@@ -527,7 +527,7 @@ def _impl(
 
             for x in out:
                 if not isinstance(x, ak.contents.Content):
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         TypeError(
                             f"transformation must return an Awkward array or tuple of arrays, not {type(x)}\n\n{x!r}"
                         )

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -53,7 +53,7 @@ def type(array):
     similar to existing type-constructors, so it's a plausible addition
     to the language.)
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.type",
         dict(array=array),
     ):
@@ -98,7 +98,7 @@ def _impl(array):
             try:
                 out = ak.types.numpytype._dtype_to_primitive_dict[array.dtype.type]
             except KeyError as err:
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "numpy array type is unrecognized by awkward: %r"
                         % array.dtype.type
@@ -120,4 +120,4 @@ def _impl(array):
         return array.form.type
 
     else:
-        raise ak._util.error(TypeError(f"unrecognized array type: {array!r}"))
+        raise ak._errors.wrap_error(TypeError(f"unrecognized array type: {array!r}"))

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -61,7 +61,7 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
 
     See also #ak.num and #ak.flatten.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.unflatten",
         dict(
             array=array,
@@ -93,9 +93,9 @@ def _impl(array, counts, axis, highlevel, behavior):
             mask = False
 
         if counts.ndim != 1:
-            raise ak._util.error(ValueError("counts must be one-dimensional"))
+            raise ak._errors.wrap_error(ValueError("counts must be one-dimensional"))
         if not issubclass(counts.dtype.type, np.integer):
-            raise ak._util.error(ValueError("counts must be integers"))
+            raise ak._errors.wrap_error(ValueError("counts must be integers"))
 
         current_offsets = [nplike.index_nplike.empty(len(counts) + 1, np.int64)]
         current_offsets[0][0] = 0
@@ -104,7 +104,7 @@ def _impl(array, counts, axis, highlevel, behavior):
     def doit(layout):
         if isinstance(counts, (numbers.Integral, np.integer)):
             if counts < 0 or counts > len(layout):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError("too large counts for array or negative counts")
                 )
             out = ak.contents.RegularArray(layout, counts)
@@ -121,7 +121,7 @@ def _impl(array, counts, axis, highlevel, behavior):
             if position >= len(current_offsets[0]) or current_offsets[0][
                 position
             ] != len(layout):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     ValueError(
                         "structure imposed by 'counts' does not fit in the array or partition "
                         "at axis={}".format(axis)
@@ -176,7 +176,7 @@ def _impl(array, counts, axis, highlevel, behavior):
                 if not nplike.index_nplike.array_equal(
                     inneroffsets[positions], outeroffsets
                 ):
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         ValueError(
                             "structure imposed by 'counts' does not fit in the array or partition "
                             "at axis={}".format(axis)
@@ -194,7 +194,7 @@ def _impl(array, counts, axis, highlevel, behavior):
     if current_offsets is not None and not (
         len(current_offsets[0]) == 1 and current_offsets[0][0] == 0
     ):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "structure imposed by 'counts' does not fit in the array or partition "
                 "at axis={}".format(axis)

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -31,7 +31,7 @@ def unzip(array, highlevel=True, behavior=None):
         >>> y
         <Array [[1], [2, 2], [3, 3, 3]] type='3 * var * int64'>
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.unzip",
         dict(array=array, highlevel=highlevel, behavior=behavior),
     ):
@@ -50,7 +50,7 @@ def _impl(array, highlevel, behavior):
         elif isinstance(layout, ak.contents.UnionArray):
             for content in layout.contents:
                 if set(ak.operations.fields(content)) != set(fields):
-                    raise ak._util.error(
+                    raise ak._errors.wrap_error(
                         ValueError("union of different sets of fields, cannot ak.unzip")
                     )
 

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -19,7 +19,7 @@ def validity_error(array, exception=False):
 
     See also #ak.is_valid.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.validity_error",
         dict(array=array, exception=exception),
     ):
@@ -31,6 +31,6 @@ def _impl(array, exception):
     out = layout.validity_error(path="highlevel")
 
     if out not in (None, "") and exception:
-        raise ak._util.error(ValueError(out))
+        raise ak._errors.wrap_error(ValueError(out))
     else:
         return out

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -47,7 +47,7 @@ def values_astype(array, to, highlevel=True, behavior=None):
 
     See also #ak.strings_astype.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.values_astype",
         dict(array=array, to=to, highlevel=highlevel, behavior=behavior),
     ):
@@ -62,7 +62,7 @@ def _impl(array, to, highlevel, behavior):
         if to_dtype.name.startswith("datetime64"):
             to_str = to_dtype.name
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     f"cannot use {to_dtype} to cast the numeric type of an array"
                 )

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -66,7 +66,7 @@ def var(
 
     See also #ak.nanvar.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.var",
         dict(
             x=x,
@@ -127,7 +127,7 @@ def nanvar(
 
     See also #ak.var.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.nanvar",
         dict(
             x=x,

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -43,20 +43,20 @@ def where(condition, *args, **kwargs):
     )
 
     if len(args) == 0:
-        with ak._util.OperationErrorContext(
+        with ak._errors.OperationErrorContext(
             "ak.where",
             dict(condition=condition, mergebool=mergebool, highlevel=highlevel),
         ):
             return _impl1(condition, mergebool, highlevel, behavior)
 
     elif len(args) == 1:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError("either both or neither of x and y should be given")
         )
 
     elif len(args) == 2:
         x, y = args
-        with ak._util.OperationErrorContext(
+        with ak._errors.OperationErrorContext(
             "ak.where",
             dict(
                 condition=condition, x=x, y=y, mergebool=mergebool, highlevel=highlevel
@@ -65,7 +65,7 @@ def where(condition, *args, **kwargs):
             return _impl3(condition, x, y, mergebool, highlevel, behavior)
 
     else:
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "where() takes from 1 to 3 positional arguments but {} were "
                 "given".format(len(args) + 1)

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -31,7 +31,7 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
     #ak.with_field, so performance is not a factor in choosing one over the
     other.)
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.with_field",
         dict(base=base, what=what, where=where, highlevel=highlevel, behavior=behavior),
     ):
@@ -44,7 +44,7 @@ def _impl(base, what, where, highlevel, behavior):
         or ak._util.isstr(where)
         or (isinstance(where, Iterable) and all(ak._util.isstr(x) for x in where))
     ):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             TypeError(
                 "New fields may only be assigned by field name(s) "
                 "or as a new integer slot by passing None for 'where'"
@@ -82,7 +82,7 @@ def _impl(base, what, where, highlevel, behavior):
         base = ak.operations.to_layout(base, allow_record=True, allow_other=False)
 
         if len(base.fields) == 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError("no tuples or records in array; cannot add a new field")
             )
 

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -27,7 +27,7 @@ def with_name(array, name, highlevel=True, behavior=None):
     to the data; see #ak.Array and #ak.behavior for a more complete
     description.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.with_name",
         dict(array=array, name=name, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -25,7 +25,7 @@ def with_parameter(array, parameter, value, highlevel=True, behavior=None):
     You can also remove a single parameter with this function, since setting
     a parameter to None is equivalent to removing it.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.with_parameter",
         dict(
             array=array,

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -20,7 +20,7 @@ def without_parameters(array, highlevel=True, behavior=None):
     Note that a "new array" is a lightweight shallow copy, not a duplication
     of large data buffers.
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.without_parameters",
         dict(array=array, highlevel=highlevel, behavior=behavior),
     ):

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -26,7 +26,7 @@ def zeros_like(array, highlevel=True, behavior=None, dtype=None):
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.zeros_like",
         dict(array=array, highlevel=highlevel, behavior=behavior, dtype=dtype),
     ):

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -123,7 +123,7 @@ def zip(
         >>> ak.zip([one, two], optiontype_outside_record=True)
         <Array [None, (2, 5), None] type='3 * ?(int64, int64)'>
     """
-    with ak._util.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.zip",
         dict(
             arrays=arrays,
@@ -159,7 +159,9 @@ def _impl(
     optiontype_outside_record,
 ):
     if depth_limit is not None and depth_limit <= 0:
-        raise ak._util.error(ValueError("depth_limit must be None or at least 1"))
+        raise ak._errors.wrap_error(
+            ValueError("depth_limit must be None or at least 1")
+        )
 
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -12,15 +12,15 @@ np = ak.nplikes.NumpyMetadata.instance()
 class Record:
     def __init__(self, array, at):
         if not isinstance(array, ak.contents.recordarray.RecordArray):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(f"Record 'array' must be a RecordArray, not {array!r}")
             )
         if not ak._util.isint(at):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(f"Record 'at' must be an integer, not {array!r}")
             )
         if at < 0 or at >= array.length:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     f"Record 'at' must be >= 0 and < len(array) == {array.length}, not {at}"
                 )
@@ -105,23 +105,23 @@ class Record:
 
     def axis_wrap_if_negative(self, axis):
         if axis == 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 np.AxisError("Record type at axis=0 is a scalar, not an array")
             )
         return self._array.axis_wrap_if_negative(axis)
 
     def __getitem__(self, where):
-        with ak._util.SlicingErrorContext(self, where):
+        with ak._errors.SlicingErrorContext(self, where):
             return self._getitem(where)
 
     def _getitem(self, where):
         if ak._util.isint(where):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by an integer")
             )
 
         elif isinstance(where, slice):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by a range slice (`:`)")
             )
 
@@ -129,12 +129,12 @@ class Record:
             return self._getitem_field(where)
 
         elif where is np.newaxis:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by np.newaxis (`None`)")
             )
 
         elif where is Ellipsis:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by an ellipsis (`...`)")
             )
 
@@ -148,17 +148,17 @@ class Record:
             return self._getitem_field(where[0])._getitem(where[1:])
 
         elif isinstance(where, ak.highlevel.Array):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by an array")
             )
 
         elif isinstance(where, ak.contents.Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by an array")
             )
 
         elif isinstance(where, Content):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by an array")
             )
 
@@ -166,12 +166,12 @@ class Record:
             return self._getitem_fields(where)
 
         elif isinstance(where, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by an array")
             )
 
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "only field name (str) or names (non-tuple iterable of str) "
                     "are valid indices for slicing a scalar record, not\n\n    "

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -9,7 +9,7 @@ import awkward.types.type
 class ArrayType:
     def __init__(self, content, length):
         if not isinstance(content, awkward.types.type.Type):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Type subclasses, not {}".format(
                         type(self).__name__, repr(content)
@@ -17,7 +17,7 @@ class ArrayType:
                 )
             )
         if not ak._util.isint(length) or length < 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'length' must be of a positive integer, not {}".format(
                         type(self).__name__, repr(length)

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -8,7 +8,7 @@ from awkward.types.type import Type
 class ListType(Type):
     def __init__(self, content, parameters=None, typestr=None):
         if not isinstance(content, Type):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Type subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -16,7 +16,7 @@ class ListType(Type):
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be of type dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -24,7 +24,7 @@ class ListType(Type):
                 )
             )
         if typestr is not None and not ak._util.isstr(typestr):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(
                         type(self).__name__, repr(typestr)

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -27,7 +27,7 @@ def primitive_to_dtype(primitive):
     else:
         out = _primitive_to_dtype_dict.get(primitive)
         if out is None:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "unrecognized primitive: {}. Must be one of\n\n    {}\n\nor a "
                     "datetime64/timedelta64 with units (e.g. 'datetime64[15us]')".format(
@@ -44,7 +44,7 @@ def dtype_to_primitive(dtype):
     else:
         out = _dtype_to_primitive_dict.get(dtype)
         if out is None:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "unsupported dtype: {}. Must be one of\n\n    {}\n\nor a "
                     "datetime64/timedelta64 with units (e.g. 'datetime64[15us]')".format(
@@ -96,7 +96,7 @@ class NumpyType(Type):
     def __init__(self, primitive, parameters=None, typestr=None):
         primitive = dtype_to_primitive(primitive_to_dtype(primitive))
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be of type dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -104,7 +104,7 @@ class NumpyType(Type):
                 )
             )
         if typestr is not None and not ak._util.isstr(typestr):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(
                         type(self).__name__, repr(typestr)

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -11,7 +11,7 @@ from awkward.types.uniontype import UnionType
 class OptionType(Type):
     def __init__(self, content, parameters=None, typestr=None):
         if not isinstance(content, Type):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Type subclass, not {}".format(
                         type(self).__name__, repr(content)
@@ -19,7 +19,7 @@ class OptionType(Type):
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be of type dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -27,7 +27,7 @@ class OptionType(Type):
                 )
             )
         if typestr is not None and not ak._util.isstr(typestr):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(
                         type(self).__name__, repr(typestr)

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -12,7 +12,7 @@ from awkward.types.type import Type
 class RecordType(Type):
     def __init__(self, contents, fields, parameters=None, typestr=None):
         if not isinstance(contents, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'contents' must be iterable, not {}".format(
                         type(self).__name__, repr(contents)
@@ -23,7 +23,7 @@ class RecordType(Type):
             contents = list(contents)
         for content in contents:
             if not isinstance(content, Type):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} all 'contents' must be Type subclasses, not {}".format(
                             type(self).__name__, repr(content)
@@ -31,7 +31,7 @@ class RecordType(Type):
                     )
                 )
         if fields is not None and not isinstance(fields, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'fields' must be iterable, not {}".format(
                         type(self).__name__, repr(contents)
@@ -39,7 +39,7 @@ class RecordType(Type):
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be of type dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -47,7 +47,7 @@ class RecordType(Type):
                 )
             )
         if typestr is not None and not ak._util.isstr(typestr):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(
                         type(self).__name__, repr(typestr)

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -8,7 +8,7 @@ from awkward.types.type import Type
 class RegularType(Type):
     def __init__(self, content, size, parameters=None, typestr=None):
         if not isinstance(content, Type):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'content' must be a Type subtype, not {}".format(
                         type(self).__name__, repr(content)
@@ -16,7 +16,7 @@ class RegularType(Type):
                 )
             )
         if not ak._util.isint(size) or size < 0:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'size' must be of a positive integer, not {}".format(
                         type(self).__name__, repr(size)
@@ -24,7 +24,7 @@ class RegularType(Type):
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be of type dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -32,7 +32,7 @@ class RegularType(Type):
                 )
             )
         if typestr is not None and not ak._util.isstr(typestr):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(
                         type(self).__name__, repr(typestr)

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -317,7 +317,7 @@ def from_datashape(datashape, highlevel=True):
         elif isinstance(out, RecordType):
             return out
         else:
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 ValueError(
                     f"type '{type(out).__name__}' is not compatible with highlevel=True"
                 )

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -10,7 +10,7 @@ from awkward.types.type import Type
 class UnionType(Type):
     def __init__(self, contents, parameters=None, typestr=None):
         if not isinstance(contents, Iterable):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'contents' must be iterable, not {}".format(
                         type(self).__name__, repr(contents)
@@ -21,7 +21,7 @@ class UnionType(Type):
             contents = list(contents)
         for content in contents:
             if not isinstance(content, Type):
-                raise ak._util.error(
+                raise ak._errors.wrap_error(
                     TypeError(
                         "{} all 'contents' must be Type subclasses, not {}".format(
                             type(self).__name__, repr(content)
@@ -29,7 +29,7 @@ class UnionType(Type):
                     )
                 )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be of type dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -37,7 +37,7 @@ class UnionType(Type):
                 )
             )
         if typestr is not None and not ak._util.isstr(typestr):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(
                         type(self).__name__, repr(typestr)

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -8,7 +8,7 @@ from awkward.types.type import Type
 class UnknownType(Type):
     def __init__(self, parameters=None, typestr=None):
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'parameters' must be of type dict or None, not {}".format(
                         type(self).__name__, repr(parameters)
@@ -16,7 +16,7 @@ class UnknownType(Type):
                 )
             )
         if typestr is not None and not ak._util.isstr(typestr):
-            raise ak._util.error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(
                         type(self).__name__, repr(typestr)

--- a/studies/scalar.py
+++ b/studies/scalar.py
@@ -70,7 +70,7 @@ class JaxScalar:
     __slots__ = ["_value"]
 
     def __len__(self):
-        raise ak._util.error(TypeError("len() of unsized object"))
+        raise ak._errors.wrap_error(TypeError("len() of unsized object"))
 
     def _binop(self, op, other):
         if isinstance(other, JaxScalar):
@@ -99,7 +99,7 @@ class JaxScalar:
         return self._binop(self._value.__mul__, other)
 
     def __matmul__(self, other):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError("Input operand 0 does not have enough dimensions ")
         )
 
@@ -155,7 +155,7 @@ class JaxScalar:
         return self._binop(self._value.__rmul__, other)
 
     def __rmatmul__(self, other):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError("Input operand 0 does not have enough dimensions ")
         )
 
@@ -199,7 +199,7 @@ class JaxScalar:
         return self._binop(self._value.__imul__, other)
 
     def __imatmul__(self, other):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError("Input operand 0 does not have enough dimensions ")
         )
 
@@ -344,7 +344,7 @@ class CupyScalar:
     __slots__ = ["_value"]
 
     def __len__(self):
-        raise ak._util.error(TypeError("len() of unsized object"))
+        raise ak._errors.wrap_error(TypeError("len() of unsized object"))
 
     def _binop(self, op, other):
         if isinstance(other, CupyScalar):
@@ -373,7 +373,7 @@ class CupyScalar:
         return self._binop(self._value.__mul__, other)
 
     def __matmul__(self, other):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError("Input operand 0 does not have enough dimensions ")
         )
 
@@ -429,7 +429,7 @@ class CupyScalar:
         return self._binop(self._value.__rmul__, other)
 
     def __rmatmul__(self, other):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError("Input operand 0 does not have enough dimensions ")
         )
 
@@ -473,7 +473,7 @@ class CupyScalar:
         return self._binop(self._value.__imul__, other)
 
     def __imatmul__(self, other):
-        raise ak._util.error(
+        raise ak._errors.wrap_error(
             ValueError("Input operand 0 does not have enough dimensions ")
         )
 


### PR DESCRIPTION
`ak._util` has become something of a catch-all module. Besides making `_util` quite large, this also means that `_util` depends on many Awkward modules, which in turn depend upon `_util`. Currently, we resolve this by using the module object, which can break import cycles. However, this can be improved.

This PR splits out the error-handling code into an `_errors` private module. 

There is more work that can be done here, but to keep this PR small and mergeable, we can do that in another PR.