### PR TITLE
fix: kernel name in `IndexedArray`

### DIFF
--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -600,7 +600,7 @@ kernels:
     automatic-tests: true
     manual-tests: []
 
-  - name: awkward_IndexedArray_local_preparenext_64
+  - name: awkward_IndexedArray_local_preparenext
     specializations:
       - name: awkward_IndexedArray_local_preparenext_64
         args:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -520,29 +520,28 @@ class IndexedArray(Content):
 
         content = other.merge(self._content)
 
+        # Fill `index` with a range starting at zero, up to `theirlength`
         assert index.nplike is self._nplike
         self._handle_error(
-            self._nplike["awkward_IndexedArray_fill_to64_count", index.dtype.type](
+            self._nplike["awkward_IndexedArray_fill_count", index.dtype.type](
                 index.data,
                 0,
                 theirlength,
                 0,
             )
         )
-        reinterpreted_index = ak.index.Index(np.asarray(index.data.view(self[0].dtype)))
 
-        assert (
-            index.nplike is self._nplike and reinterpreted_index.nplike is self._nplike
-        )
+        # Fill remaining indices
+        assert index.nplike is self._nplike
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_fill",
                 index.dtype.type,
-                reinterpreted_index.dtype.type,
+                self.index.dtype.type,
             ](
                 index.data,
                 theirlength,
-                reinterpreted_index.data,
+                self.index.data,
                 mylength,
                 theirlength,
             )
@@ -567,7 +566,6 @@ class IndexedArray(Content):
         contentlength_so_far = 0
         length_so_far = 0
         nextindex = ak.index.Index64.empty(total_length, self._nplike)
-        parameters = self._parameters
 
         parameters = self._parameters
         for array in head:
@@ -801,7 +799,7 @@ class IndexedArray(Content):
             )
             self._handle_error(
                 self._nplike[
-                    "awkward_IndexedArray_local_preparenext_64",
+                    "awkward_IndexedArray_local_preparenext",
                     nextoutindex.dtype.type,
                     starts.dtype.type,
                     parents.dtype.type,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -924,7 +924,7 @@ class IndexedOptionArray(Content):
             )
             self._handle_error(
                 self._nplike[
-                    "awkward_IndexedArray_local_preparenext_64",
+                    "awkward_IndexedArray_local_preparenext",
                     nextoutindex.dtype.type,
                     starts.dtype.type,
                     parents.dtype.type,
@@ -1219,7 +1219,7 @@ class IndexedOptionArray(Content):
         )
         self._handle_error(
             self._nplike[
-                "awkward_IndexedArray_local_preparenext_64",
+                "awkward_IndexedArray_local_preparenext",
                 nextoutindex.dtype.type,
                 starts.dtype.type,
                 parents.dtype.type,
@@ -1235,7 +1235,7 @@ class IndexedOptionArray(Content):
         )
 
         if nulls_merged:
-            # awkward_IndexedArray_local_preparenext_64 uses -1 to
+            # awkward_IndexedArray_local_preparenext uses -1 to
             # indicate `None` values. Given that this code-path runs
             # only when the `None` value indices are explicitly stored in out,
             # we need to mapping the -1 values to their corresponding indices
@@ -1302,7 +1302,7 @@ class IndexedOptionArray(Content):
 
         self._handle_error(
             self._nplike[
-                "awkward_IndexedArray_local_preparenext_64",
+                "awkward_IndexedArray_local_preparenext",
                 nextoutindex.dtype.type,
                 starts.dtype.type,
                 parents.dtype.type,

--- a/tests/test_1753-indexedarray-merge-kernel.py
+++ b/tests/test_1753-indexedarray-merge-kernel.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    x = ak.contents.IndexedArray(
+        ak.index.Index64(np.array([0, 0, 1], dtype=np.int64)),
+        ak.contents.NumpyArray(np.array([9, 6, 5], dtype=np.int16)),
+        parameters={"money": "doesn't buy happiness"},
+    )
+    y = ak.contents.IndexedArray(
+        ak.index.Index64(np.array([0, 1, 2, 4, 3], dtype=np.int64)),
+        ak.contents.NumpyArray(np.array([9, 6, 5, 8, 2], dtype=np.int16)),
+        parameters={"age": "number"},
+    )
+
+    # Test that we invoke the merge pathway
+    z = x._reverse_merge(y)
+    assert z.to_list() == [9, 6, 5, 2, 8, 9, 9, 6]
+    assert z.parameters == {"money": "doesn't buy happiness", "age": "number"}


### PR DESCRIPTION
Fixes #1753

- Corrects kernel name
- Corrects index handling logic
