### PR TITLE
feat: extend parameter coalescence to ignore transparent layouts

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -719,7 +719,9 @@ class Content:
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not (
             ak.forms.form._parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
+                self.dimension_parameters,
+                other.dimension_parameters,
+                only_array_record=True,
             )
         ):
             return False
@@ -1572,7 +1574,9 @@ class Content:
             and len(self) == len(other)
             and ak.identifier._identifiers_equal(self.identifier, other.identifier)
             and ak.forms.form._parameters_equal(
-                self.parameters, other.parameters, only_array_record=False
+                self.dimension_parameters,
+                other.dimension_parameters,
+                only_array_record=False,
             )
             and self._layout_equal(other, index_dtype, numpyarray)
         )

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1,9 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import copy
 import math
 import numbers
 from collections.abc import Iterable, Sized
+from typing import Any
 
 import awkward as ak
 import awkward._reducers
@@ -725,7 +727,7 @@ class Content:
         else:
             return self._mergeable(other, mergebool)
 
-    def _mergeable(self, other: "Content", mergebool: bool) -> bool:
+    def _mergeable(self, other: Content, mergebool: bool) -> bool:
         raise ak._util.error(NotImplementedError)
 
     def mergemany(self, others):
@@ -1268,6 +1270,10 @@ class Content:
     @property
     def dimension_optiontype(self):
         return self.Form.dimension_optiontype.__get__(self)
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return self.Form.dimension_parameters.__get__(self)
 
     def pad_none_axis0(self, target, clip):
         if not clip and target < self.length:

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.bytemaskedform import ByteMaskedForm
@@ -234,6 +237,12 @@ class BitMaskedForm(Form):
     @property
     def dimension_optiontype(self):
         return True
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return ak._util.merge_parameters(
+            self._parameters, self._content.dimension_parameters
+        )
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -213,6 +216,12 @@ class ByteMaskedForm(Form):
     @property
     def dimension_optiontype(self):
         return True
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return ak._util.merge_parameters(
+            self._parameters, self._content.dimension_parameters
+        )
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -103,6 +106,10 @@ class EmptyForm(Form):
     @property
     def dimension_optiontype(self):
         return False
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return self._parameters
 
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -302,6 +302,10 @@ class Form:
         return self._parameters
 
     @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        raise ak._util.error(NotImplementedError)
+
+    @property
     def is_identity_like(self):
         """Return True if the content or its non-list descendents are an identity"""
         raise ak._util.error(NotImplementedError)

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal, _parameters_update
@@ -185,6 +188,12 @@ class IndexedForm(Form):
     @property
     def dimension_optiontype(self):
         return False
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return ak._util.merge_parameters(
+            self._parameters, self._content.dimension_parameters
+        )
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -196,6 +199,12 @@ class IndexedOptionForm(Form):
     @property
     def dimension_optiontype(self):
         return True
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return ak._util.merge_parameters(
+            self._parameters, self._content.dimension_parameters
+        )
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -204,6 +207,10 @@ class ListForm(Form):
     @property
     def dimension_optiontype(self):
         return False
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return self._parameters
 
     def _columns(self, path, output, list_indicator):
         if (

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -171,6 +174,10 @@ class ListOffsetForm(Form):
     @property
     def dimension_optiontype(self):
         return False
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return self._parameters
 
     def _columns(self, path, output, list_indicator):
         if (

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -213,6 +215,10 @@ class NumpyForm(Form):
     @property
     def dimension_optiontype(self):
         return False
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return self._parameters
 
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -1,7 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import glob
 from collections.abc import Iterable
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -310,6 +312,10 @@ class RecordForm(Form):
     @property
     def dimension_optiontype(self):
         return False
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return self._parameters
 
     def _columns(self, path, output, list_indicator):
         for content, field in zip(self._contents, self.fields):

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -176,6 +179,10 @@ class RegularForm(Form):
     @property
     def dimension_optiontype(self):
         return False
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return self._parameters
 
     def _columns(self, path, output, list_indicator):
         if (

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -252,6 +254,17 @@ class UnionForm(Form):
             if content.dimension_optiontype:
                 return True
         return False
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        parameters = self._contents[0].dimension_parameters
+        for content in self._contents[1:]:
+            # Merge parameters that are equal between contents
+            parameters = ak._util.merge_parameters(
+                content.dimension_parameters, parameters, merge_equal=True
+            )
+        # Merge any additional parameters from this layout
+        return ak._util.merge_parameters(parameters, self._parameters)
 
     def _columns(self, path, output, list_indicator):
         for content, field in zip(self._contents, self.fields):

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -1,4 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from typing import Any
 
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
@@ -159,6 +162,12 @@ class UnmaskedForm(Form):
     @property
     def dimension_optiontype(self):
         return True
+
+    @property
+    def dimension_parameters(self) -> dict[str, Any] | None:
+        return ak._util.merge_parameters(
+            self._parameters, self._content.dimension_parameters
+        )
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)


### PR DESCRIPTION
This PR goes towards fixing #1041, but requires some policy decisions about parameters. Originally, it added `dimension_parameters`; a tree-visiting mechanism for merging parameter dictionaries between layouts of the same dimension. @jpivarski then pointed out that we really care more about the _type_ in most cases, as that is the user-visible aspect of layouts.

This PR should do the following:
- [ ] Add a mechanism for retrieiving attribute(s) that coalesces the intra-dimension parameter(s) according to a policy 
- [ ] Change `Content.mergeable`, `Content.layout_equal`, `arrayclass()` etc. to use this API instead of inspecting single-layout parameter dictionaries, or special cased `purelist_XXX`
- [ ] Document the policy types so that we can refer to them in future.

## Policies
| Node Type | Pure List                 | Same Type                 |
|-----------|---------------------------|---------------------------|
| Option    | Merge with content        | Only ours                 |
| Indexed   | Merge with content        | Merge with content        |
| List      | Merge with content        | Only ours                 |
| Union     | Merge contents*, and ours | Merge contents*, and ours |
| Record    | Only ours                 | Only ours                 |
| Leaf      | Only ours                 | Only ours                 |

Practically speaking, we'll likely implement this as members of the `Form` types. Therefore, the word "policy" could mean a family of methods `_parameters_same_type, _parameters_pure_list`, or an enum that is switched upon. In fact, it could also be both, e.g a high-level enum that dispatches the correct family of methods. This is an aside for now.

Related issues:
- https://github.com/scikit-hep/awkward/issues/1685
- https://github.com/scikit-hep/awkward/issues/1686
