### PR TITLE
refactor: reduce qualified names of Content, Form, Type subclasses

### DIFF
--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -23,17 +23,17 @@ pytrees_registered = False
 
 def register_pytrees():
     for cls in [
-        ak.contents.bitmaskedarray.BitMaskedArray,
-        ak.contents.bytemaskedarray.ByteMaskedArray,
-        ak.contents.emptyarray.EmptyArray,
-        ak.contents.indexedarray.IndexedArray,
-        ak.contents.indexedoptionarray.IndexedOptionArray,
-        ak.contents.numpyarray.NumpyArray,
-        ak.contents.listarray.ListArray,
-        ak.contents.listoffsetarray.ListOffsetArray,
-        ak.contents.recordarray.RecordArray,
-        ak.contents.unionarray.UnionArray,
-        ak.contents.unmaskedarray.UnmaskedArray,
+        ak.contents.BitMaskedArray,
+        ak.contents.ByteMaskedArray,
+        ak.contents.EmptyArray,
+        ak.contents.IndexedArray,
+        ak.contents.IndexedOptionArray,
+        ak.contents.NumpyArray,
+        ak.contents.ListArray,
+        ak.contents.ListOffsetArray,
+        ak.contents.RecordArray,
+        ak.contents.UnionArray,
+        ak.contents.UnmaskedArray,
         ak.record.Record,
     ]:
         jax.tree_util.register_pytree_node(
@@ -67,7 +67,7 @@ def _find_numpyarray_nodes(layout):
     data_ptrs = []
 
     def find_nparray_ptrs(node, **kwargs):
-        if isinstance(node, ak.contents.numpyarray.NumpyArray):
+        if isinstance(node, ak.contents.NumpyArray):
             data_ptrs.append(node.data)
 
     layout.recursively_apply(action=find_nparray_ptrs, return_array=False)
@@ -77,7 +77,7 @@ def _find_numpyarray_nodes(layout):
 
 def _replace_numpyarray_nodes(layout, buffers):
     def replace_numpyarray_nodes(node, **kwargs):
-        if isinstance(node, ak.contents.numpyarray.NumpyArray):
+        if isinstance(node, ak.contents.NumpyArray):
             buffer = buffers[0]
             buffers.pop(0)
             return ak.contents.NumpyArray(

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -787,7 +787,7 @@ def to_arraylib(module, array, allow_missing):
         elif isinstance(array, (ak.contents.ListArray, ak.contents.ListOffsetArray)):
             return _impl(array.toRegularArray())
 
-        elif isinstance(array, ak.contents.recordarray.RecordArray):
+        elif isinstance(array, ak.contents.RecordArray):
             raise ak._errors.wrap_error(
                 ValueError(f"{module.__name__} does not support record structures")
             )

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -243,7 +243,7 @@ class BitMaskedArray(Content):
                 self._lsb_order,
             ),
         )
-        return ak.contents.indexedoptionarray.IndexedOptionArray(
+        return ak.contents.IndexedOptionArray(
             index[0 : self._length],
             self._content,
             self._identifier,
@@ -427,11 +427,11 @@ class BitMaskedArray(Content):
         if isinstance(
             self._content,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self.toIndexedOptionArray64().simplify_optiontype()
@@ -448,11 +448,11 @@ class BitMaskedArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self._content.mergeable(other.content, mergebool)
@@ -579,11 +579,11 @@ class BitMaskedArray(Content):
         elif isinstance(
             self._content,
             (
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
@@ -677,7 +677,7 @@ class BitMaskedArray(Content):
             if content.length > self._length:
                 content = content[: self._length]
 
-            return ak.contents.indexedoptionarray.IndexedOptionArray(
+            return ak.contents.IndexedOptionArray(
                 next._index,
                 content,
                 next._identifier,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -194,7 +194,7 @@ class ByteMaskedArray(Content):
             ),
         )
 
-        return ak.contents.indexedoptionarray.IndexedOptionArray(
+        return ak.contents.IndexedOptionArray(
             index, self._content, self._identifier, self._parameters, self._nplike
         )
 
@@ -412,7 +412,7 @@ class ByteMaskedArray(Content):
         next = self._content._carry(nextcarry, True)
         out = next._getitem_next_jagged(reducedstarts, reducedstops, slicecontent, tail)
 
-        out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+        out2 = ak.contents.IndexedOptionArray(
             outindex, out, self._identifier, self._parameters, self._nplike
         )
         return out2.simplify_optiontype()
@@ -435,7 +435,7 @@ class ByteMaskedArray(Content):
 
             next = self._content._carry(nextcarry, True)
             out = next._getitem_next(head, tail, advanced)
-            out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+            out2 = ak.contents.IndexedOptionArray(
                 outindex,
                 out,
                 self._identifier,
@@ -544,11 +544,11 @@ class ByteMaskedArray(Content):
         if isinstance(
             self._content,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self.toIndexedOptionArray64().simplify_optiontype()
@@ -570,7 +570,7 @@ class ByteMaskedArray(Content):
             next = self._content._carry(nextcarry, False)
             out = next.num(posaxis, depth)
 
-            out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+            out2 = ak.contents.IndexedOptionArray(
                 outindex, out, None, self.parameters, self._nplike
             )
             return out2.simplify_optiontype()
@@ -590,7 +590,7 @@ class ByteMaskedArray(Content):
             if offsets.length == 0:
                 return (
                     offsets,
-                    ak.contents.indexedoptionarray.IndexedOptionArray(
+                    ak.contents.IndexedOptionArray(
                         outindex, flattened, None, self._parameters, self._nplike
                     ),
                 )
@@ -625,11 +625,11 @@ class ByteMaskedArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self._content.mergeable(other.content, mergebool)
@@ -683,7 +683,7 @@ class ByteMaskedArray(Content):
 
             next = self._content._carry(nextcarry, False)
             out = next._local_index(posaxis, depth)
-            out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+            out2 = ak.contents.IndexedOptionArray(
                 outindex,
                 out,
                 self._identifier,
@@ -693,7 +693,7 @@ class ByteMaskedArray(Content):
             return out2.simplify_optiontype()
 
     def numbers_to_type(self, name):
-        return ak.contents.bytemaskedarray.ByteMaskedArray(
+        return ak.contents.ByteMaskedArray(
             self._mask,
             self._content.numbers_to_type(name),
             self._valid_when,
@@ -770,7 +770,7 @@ class ByteMaskedArray(Content):
             out = next._combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
-            out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+            out2 = ak.contents.IndexedOptionArray(
                 outindex, out, None, parameters, self._nplike
             )
             return out2.simplify_optiontype()
@@ -946,11 +946,11 @@ class ByteMaskedArray(Content):
         elif isinstance(
             self._content,
             (
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
@@ -983,7 +983,7 @@ class ByteMaskedArray(Content):
                 )
             )
             next = self.project()._pad_none(target, posaxis, depth, clip)
-            return ak.contents.indexedoptionarray.IndexedOptionArray(
+            return ak.contents.IndexedOptionArray(
                 index,
                 next,
                 None,
@@ -991,7 +991,7 @@ class ByteMaskedArray(Content):
                 self._nplike,
             ).simplify_optiontype()
         else:
-            return ak.contents.bytemaskedarray.ByteMaskedArray(
+            return ak.contents.ByteMaskedArray(
                 self._mask,
                 self._content._pad_none(target, posaxis, depth, clip),
                 self._valid_when,
@@ -1081,7 +1081,7 @@ class ByteMaskedArray(Content):
             if content.length > self._mask.length:
                 content = content[: self._mask.length]
 
-            return ak.contents.indexedoptionarray.IndexedOptionArray(
+            return ak.contents.IndexedOptionArray(
                 next._index,
                 content,
                 next._identifier,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -346,11 +346,11 @@ class Content:
             slicer=head,
         )
 
-        out = ak.contents.indexedoptionarray.IndexedOptionArray(
+        out = ak.contents.IndexedOptionArray(
             outindex, raw.content, None, self._parameters, self._nplike
         )
 
-        return ak.contents.regulararray.RegularArray(
+        return ak.contents.RegularArray(
             out.simplify_optiontype(),
             indexlength,
             1,
@@ -405,10 +405,10 @@ class Content:
         )
 
         tmp = content._getitem_next_jagged(starts, stops, jagged.content, tail)
-        out = ak.contents.indexedoptionarray.IndexedOptionArray(
+        out = ak.contents.IndexedOptionArray(
             outputmask, tmp, None, self._parameters, self._nplike
         )
-        return ak.contents.regulararray.RegularArray(
+        return ak.contents.RegularArray(
             out.simplify_optiontype(),
             index.length,
             1,
@@ -427,32 +427,32 @@ class Content:
                 "cannot mix missing values in slice with NumPy-style advanced indexing",
             )
 
-        if isinstance(head.content, ak.contents.listoffsetarray.ListOffsetArray):
+        if isinstance(head.content, ak.contents.ListOffsetArray):
             if self.nplike.known_shape and self.length != 1:
                 raise ak._errors.wrap_error(
                     NotImplementedError("reached a not-well-considered code path")
                 )
             return self._getitem_next_missing_jagged(head, tail, advanced, self)
 
-        if isinstance(head.content, ak.contents.numpyarray.NumpyArray):
+        if isinstance(head.content, ak.contents.NumpyArray):
             headcontent = ak.index.Index64(head.content.data)
             nextcontent = self._getitem_next(headcontent, tail, advanced)
         else:
             nextcontent = self._getitem_next(head.content, tail, advanced)
 
-        if isinstance(nextcontent, ak.contents.regulararray.RegularArray):
+        if isinstance(nextcontent, ak.contents.RegularArray):
             return self._getitem_next_regular_missing(
                 head, tail, advanced, nextcontent, nextcontent.length
             )
 
-        elif isinstance(nextcontent, ak.contents.recordarray.RecordArray):
+        elif isinstance(nextcontent, ak.contents.RecordArray):
             if len(nextcontent._fields) == 0:
                 return nextcontent
 
             contents = []
 
             for content in nextcontent.contents:
-                if isinstance(content, ak.contents.regulararray.RegularArray):
+                if isinstance(content, ak.contents.RegularArray):
                     contents.append(
                         self._getitem_next_regular_missing(
                             head, tail, advanced, content, content.length
@@ -467,7 +467,7 @@ class Content:
                         )
                     )
 
-            return ak.contents.recordarray.RecordArray(
+            return ak.contents.RecordArray(
                 contents,
                 nextcontent._fields,
                 None,
@@ -543,10 +543,10 @@ class Content:
         ):
             return self._getitem_fields(ak.operations.to_list(where))
 
-        elif isinstance(where, ak.contents.emptyarray.EmptyArray):
+        elif isinstance(where, ak.contents.EmptyArray):
             return where.toNumpyArray(np.int64)
 
-        elif isinstance(where, ak.contents.numpyarray.NumpyArray):
+        elif isinstance(where, ak.contents.NumpyArray):
             if issubclass(where.dtype.type, np.int64):
                 carry = ak.index.Index64(where.data.reshape(-1))
                 allow_lazy = True
@@ -760,9 +760,7 @@ class Content:
             )
         )
 
-        return ak.contents.unionarray.UnionArray(
-            tags, index, contents, None, None, self._nplike
-        )
+        return ak.contents.UnionArray(tags, index, contents, None, None, self._nplike)
 
     def _merging_strategy(self, others):
         if len(others) == 0:
@@ -781,12 +779,12 @@ class Content:
             if isinstance(
                 other,
                 (
-                    ak.contents.indexedarray.IndexedArray,
-                    ak.contents.indexedoptionarray.IndexedOptionArray,
-                    ak.contents.bytemaskedarray.ByteMaskedArray,
-                    ak.contents.bitmaskedarray.BitMaskedArray,
-                    ak.contents.unmaskedarray.UnmaskedArray,
-                    ak.contents.unionarray.UnionArray,
+                    ak.contents.IndexedArray,
+                    ak.contents.IndexedOptionArray,
+                    ak.contents.ByteMaskedArray,
+                    ak.contents.BitMaskedArray,
+                    ak.contents.UnmaskedArray,
+                    ak.contents.UnionArray,
                 ),
             ):
                 break
@@ -1053,7 +1051,7 @@ class Content:
             )
             length = contents[-1].length
         assert length is not None
-        return ak.contents.recordarray.RecordArray(
+        return ak.contents.RecordArray(
             contents, recordlookup, length, None, parameters, self._nplike
         )
 
@@ -1078,9 +1076,9 @@ class Content:
             if isinstance(
                 self,
                 (
-                    ak.contents.listarray.ListArray,
-                    ak.contents.listoffsetarray.ListOffsetArray,
-                    ak.contents.regulararray.RegularArray,
+                    ak.contents.ListArray,
+                    ak.contents.ListOffsetArray,
+                    ak.contents.RegularArray,
                 ),
             ):
                 content = self.content
@@ -1092,7 +1090,7 @@ class Content:
                 return 'at {} ("{}"): __array__ = "string" must directly contain a node with __array__ = "char"'.format(
                     path, type(self)
                 )
-            if isinstance(content, ak.contents.numpyarray.NumpyArray):
+            if isinstance(content, ak.contents.NumpyArray):
                 if content.dtype.type != np.uint8:
                     return 'at {} ("{}"): __array__ = "char" requires dtype == uint8'.format(
                         path, type(self)
@@ -1112,9 +1110,9 @@ class Content:
             if isinstance(
                 self,
                 (
-                    ak.contents.listarray.ListArray,
-                    ak.contents.listoffsetarray.ListOffsetArray,
-                    ak.contents.regulararray.RegularArray,
+                    ak.contents.ListArray,
+                    ak.contents.ListOffsetArray,
+                    ak.contents.RegularArray,
                 ),
             ):
                 content = self.content
@@ -1126,7 +1124,7 @@ class Content:
                 return 'at {} ("{}"): __array__ = "bytestring" must directly contain a node with __array__ = "byte"'.format(
                     path, type(self)
                 )
-            if isinstance(content, ak.contents.numpyarray.NumpyArray):
+            if isinstance(content, ak.contents.NumpyArray):
                 if content.dtype.type != np.uint8:
                     return 'at {} ("{}"): __array__ = "byte" requires dtype == uint8'.format(
                         path, type(self)
@@ -1156,8 +1154,8 @@ class Content:
             if isinstance(
                 self,
                 (
-                    ak.contents.indexedarray.IndexedArray,
-                    ak.contents.indexedoptionarray.IndexedOptionArray,
+                    ak.contents.IndexedArray,
+                    ak.contents.IndexedOptionArray,
                 ),
             ):
                 content = self.content
@@ -1289,7 +1287,7 @@ class Content:
                 ](index.data, target, self.length)
             )
 
-        next = ak.contents.indexedoptionarray.IndexedOptionArray(
+        next = ak.contents.IndexedOptionArray(
             index,
             self,
             None,

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -90,7 +90,7 @@ class EmptyArray(Content):
             nplike = self._nplike
         if nplike is None:
             nplike = numpy
-        return ak.contents.numpyarray.NumpyArray(
+        return ak.contents.NumpyArray(
             nplike.empty(0, dtype), self._identifier, self._parameters, nplike
         )
 
@@ -182,7 +182,7 @@ class EmptyArray(Content):
                 return out
         else:
             out = ak.index.Index64.empty(0, self._nplike)
-            return ak.contents.numpyarray.NumpyArray(out, None, None, self._nplike)
+            return ak.contents.NumpyArray(out, None, None, self._nplike)
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
@@ -212,14 +212,12 @@ class EmptyArray(Content):
         return EmptyArray(None, self._parameters, self._nplike)
 
     def _local_index(self, axis, depth):
-        return ak.contents.numpyarray.NumpyArray(
+        return ak.contents.NumpyArray(
             self._nplike.empty(0, np.int64), None, None, self._nplike
         )
 
     def numbers_to_type(self, name):
-        return ak.contents.emptyarray.EmptyArray(
-            self._identifier, self._parameters, self._nplike
-        )
+        return ak.contents.EmptyArray(self._identifier, self._parameters, self._nplike)
 
     def _is_unique(self, negaxis, starts, parents, outlength):
         return True
@@ -258,9 +256,7 @@ class EmptyArray(Content):
         return self
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        return ak.contents.emptyarray.EmptyArray(
-            self._identifier, self._parameters, self._nplike
-        )
+        return ak.contents.EmptyArray(self._identifier, self._parameters, self._nplike)
 
     def _reduce_next(
         self,
@@ -323,7 +319,7 @@ class EmptyArray(Content):
 
         else:
             dtype = np.dtype(options["emptyarray_to"])
-            next = ak.contents.numpyarray.NumpyArray(
+            next = ak.contents.NumpyArray(
                 numpy.empty(length, dtype),
                 self._identifier,
                 self._parameters,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -149,7 +149,7 @@ class IndexedArray(Content):
         )
 
     def toIndexedOptionArray64(self):
-        return ak.contents.indexedoptionarray.IndexedOptionArray(
+        return ak.contents.IndexedOptionArray(
             self._index, self._content, self._identifier, self._parameters, self._nplike
         )
 
@@ -333,7 +333,7 @@ class IndexedArray(Content):
                     self._index.length,
                 )
             )
-            next = ak.contents.indexedoptionarray.IndexedOptionArray(
+            next = ak.contents.IndexedOptionArray(
                 nextindex,
                 self._content,
                 self._identifier,
@@ -365,19 +365,19 @@ class IndexedArray(Content):
         if isinstance(
             self._content,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
 
             if isinstance(
                 self._content,
                 (
-                    ak.contents.indexedarray.IndexedArray,
-                    ak.contents.indexedoptionarray.IndexedOptionArray,
+                    ak.contents.IndexedArray,
+                    ak.contents.IndexedOptionArray,
                 ),
             ):
                 inner = self._content.index
@@ -385,9 +385,9 @@ class IndexedArray(Content):
             elif isinstance(
                 self._content,
                 (
-                    ak.contents.bytemaskedarray.ByteMaskedArray,
-                    ak.contents.bitmaskedarray.BitMaskedArray,
-                    ak.contents.unmaskedarray.UnmaskedArray,
+                    ak.contents.ByteMaskedArray,
+                    ak.contents.BitMaskedArray,
+                    ak.contents.UnmaskedArray,
                 ),
             ):
                 rawcontent = self._content.toIndexedOptionArray64()
@@ -413,7 +413,7 @@ class IndexedArray(Content):
                     inner.length,
                 )
             )
-            if isinstance(self._content, ak.contents.indexedarray.IndexedArray):
+            if isinstance(self._content, ak.contents.IndexedArray):
                 return IndexedArray(
                     result,
                     self._content.content,
@@ -425,13 +425,13 @@ class IndexedArray(Content):
             if isinstance(
                 self._content,
                 (
-                    ak.contents.indexedoptionarray.IndexedOptionArray,
-                    ak.contents.bytemaskedarray.ByteMaskedArray,
-                    ak.contents.bitmaskedarray.BitMaskedArray,
-                    ak.contents.unmaskedarray.UnmaskedArray,
+                    ak.contents.IndexedOptionArray,
+                    ak.contents.ByteMaskedArray,
+                    ak.contents.BitMaskedArray,
+                    ak.contents.UnmaskedArray,
                 ),
             ):
-                return ak.contents.indexedoptionarray.IndexedOptionArray(
+                return ak.contents.IndexedOptionArray(
                     result,
                     self._content.content,
                     self._identifier,
@@ -465,11 +465,11 @@ class IndexedArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self._content.mergeable(other.content, mergebool)
@@ -491,7 +491,7 @@ class IndexedArray(Content):
         i = 0
         while i < len(others):
             other = others[i]
-            if isinstance(other, ak.contents.unionarray.UnionArray):
+            if isinstance(other, ak.contents.UnionArray):
                 break
             else:
                 head.append(other)
@@ -548,9 +548,7 @@ class IndexedArray(Content):
         )
         parameters = ak._util.merge_parameters(self._parameters, other._parameters)
 
-        return ak.contents.indexedarray.IndexedArray(
-            index, content, None, parameters, self._nplike
-        )
+        return ak.contents.IndexedArray(index, content, None, parameters, self._nplike)
 
     def mergemany(self, others):
         if len(others) == 0:
@@ -574,14 +572,14 @@ class IndexedArray(Content):
             if isinstance(
                 array,
                 (
-                    ak.contents.bytemaskedarray.ByteMaskedArray,
-                    ak.contents.bitmaskedarray.BitMaskedArray,
-                    ak.contents.unmaskedarray.UnmaskedArray,
+                    ak.contents.ByteMaskedArray,
+                    ak.contents.BitMaskedArray,
+                    ak.contents.UnmaskedArray,
                 ),
             ):
                 array = array.toIndexedOptionArray64()
 
-            if isinstance(array, ak.contents.indexedarray.IndexedArray):
+            if isinstance(array, ak.contents.IndexedArray):
                 contents.append(array.content)
                 array_index = array.index
                 assert (
@@ -604,7 +602,7 @@ class IndexedArray(Content):
                 contentlength_so_far += array.content.length
                 length_so_far += array.length
 
-            elif isinstance(array, ak.contents.emptyarray.EmptyArray):
+            elif isinstance(array, ak.contents.EmptyArray):
                 pass
             else:
                 contents.append(array)
@@ -625,7 +623,7 @@ class IndexedArray(Content):
 
         tail_contents = contents[1:]
         nextcontent = contents[0].mergemany(tail_contents)
-        next = ak.contents.indexedarray.IndexedArray(
+        next = ak.contents.IndexedArray(
             nextindex, nextcontent, None, parameters, self._nplike
         )
 
@@ -724,7 +722,7 @@ class IndexedArray(Content):
         return next[0 : length[0]]
 
     def numbers_to_type(self, name):
-        return ak.contents.indexedarray.IndexedArray(
+        return ak.contents.IndexedArray(
             self._index,
             self._content.numbers_to_type(name),
             self._identifier,
@@ -1087,11 +1085,11 @@ class IndexedArray(Content):
         elif isinstance(
             self._content,
             (
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
@@ -1111,7 +1109,7 @@ class IndexedArray(Content):
         elif posaxis == depth + 1:
             return self.project()._pad_none(target, posaxis, depth, clip)
         else:
-            return ak.contents.indexedarray.IndexedArray(
+            return ak.contents.IndexedArray(
                 self._index,
                 self._content._pad_none(target, posaxis, depth, clip),
                 None,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -349,7 +349,7 @@ class IndexedOptionArray(Content):
         next = self._content._carry(nextcarry, True)
         out = next._getitem_next_jagged(reducedstarts, reducedstops, slicecontent, tail)
 
-        out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+        out2 = ak.contents.IndexedOptionArray(
             outindex, out, self._identifier, self._parameters, self._nplike
         )
         return out2.simplify_optiontype()
@@ -424,7 +424,7 @@ class IndexedOptionArray(Content):
                     self._index.length,
                 )
             )
-            next = ak.contents.indexedoptionarray.IndexedOptionArray(
+            next = ak.contents.IndexedOptionArray(
                 nextindex,
                 self._content,
                 self._identifier,
@@ -472,19 +472,19 @@ class IndexedOptionArray(Content):
         if isinstance(
             self._content,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
 
             if isinstance(
                 self._content,
                 (
-                    ak.contents.indexedarray.IndexedArray,
-                    ak.contents.indexedoptionarray.IndexedOptionArray,
+                    ak.contents.IndexedArray,
+                    ak.contents.IndexedOptionArray,
                 ),
             ):
                 inner = self._content.index
@@ -492,9 +492,9 @@ class IndexedOptionArray(Content):
             elif isinstance(
                 self._content,
                 (
-                    ak.contents.bytemaskedarray.ByteMaskedArray,
-                    ak.contents.bitmaskedarray.BitMaskedArray,
-                    ak.contents.unmaskedarray.UnmaskedArray,
+                    ak.contents.ByteMaskedArray,
+                    ak.contents.BitMaskedArray,
+                    ak.contents.UnmaskedArray,
                 ),
             ):
                 rawcontent = self._content.toIndexedOptionArray64()
@@ -519,7 +519,7 @@ class IndexedOptionArray(Content):
                     inner.length,
                 )
             )
-            return ak.contents.indexedoptionarray.IndexedOptionArray(
+            return ak.contents.IndexedOptionArray(
                 result,
                 self._content.content,
                 self._identifier,
@@ -541,7 +541,7 @@ class IndexedOptionArray(Content):
         _, nextcarry, outindex = self._nextcarry_outindex(self._nplike)
         next = self._content._carry(nextcarry, False)
         out = next.num(posaxis, depth)
-        out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+        out2 = ak.contents.IndexedOptionArray(
             outindex, out, None, self.parameters, self._nplike
         )
         return out2.simplify_optiontype()
@@ -559,7 +559,7 @@ class IndexedOptionArray(Content):
             if offsets.length == 0:
                 return (
                     offsets,
-                    ak.contents.indexedoptionarray.IndexedOptionArray(
+                    ak.contents.IndexedOptionArray(
                         outindex, flattened, None, self._parameters, self._nplike
                     ),
                 )
@@ -594,11 +594,11 @@ class IndexedOptionArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self._content.mergeable(other.content, mergebool)
@@ -620,7 +620,7 @@ class IndexedOptionArray(Content):
         i = 0
         while i < len(others):
             other = others[i]
-            if isinstance(other, ak.contents.unionarray.UnionArray):
+            if isinstance(other, ak.contents.UnionArray):
                 break
             else:
                 head.append(other)
@@ -680,7 +680,7 @@ class IndexedOptionArray(Content):
         )
         parameters = ak._util.merge_parameters(self._parameters, other._parameters)
 
-        return ak.contents.indexedoptionarray.IndexedOptionArray(
+        return ak.contents.IndexedOptionArray(
             index, content, None, parameters, self._nplike
         )
 
@@ -707,14 +707,14 @@ class IndexedOptionArray(Content):
             if isinstance(
                 array,
                 (
-                    ak.contents.bytemaskedarray.ByteMaskedArray,
-                    ak.contents.bitmaskedarray.BitMaskedArray,
-                    ak.contents.unmaskedarray.UnmaskedArray,
+                    ak.contents.ByteMaskedArray,
+                    ak.contents.BitMaskedArray,
+                    ak.contents.UnmaskedArray,
                 ),
             ):
                 array = array.toIndexedOptionArray64()
 
-            if isinstance(array, ak.contents.indexedoptionarray.IndexedOptionArray):
+            if isinstance(array, ak.contents.IndexedOptionArray):
                 contents.append(array.content)
                 array_index = array.index
                 assert (
@@ -737,7 +737,7 @@ class IndexedOptionArray(Content):
                 contentlength_so_far += array.content.length
                 length_so_far += array.length
 
-            elif isinstance(array, ak.contents.emptyarray.EmptyArray):
+            elif isinstance(array, ak.contents.EmptyArray):
                 pass
             else:
                 contents.append(array)
@@ -758,7 +758,7 @@ class IndexedOptionArray(Content):
 
         tail_contents = contents[1:]
         nextcontent = contents[0].mergemany(tail_contents)
-        next = ak.contents.indexedoptionarray.IndexedOptionArray(
+        next = ak.contents.IndexedOptionArray(
             nextindex, nextcontent, None, parameters, self._nplike
         )
 
@@ -793,7 +793,7 @@ class IndexedOptionArray(Content):
                 "awkward_UnionArray_fillna", index.dtype.type, self._index.dtype.type
             ](index.data, self._index.data, tags.length)
         )
-        out = ak.contents.unionarray.UnionArray(
+        out = ak.contents.UnionArray(
             tags, index, contents, None, self._parameters, self._nplike
         )
         return out.simplify_uniontype(True, True)
@@ -807,7 +807,7 @@ class IndexedOptionArray(Content):
 
             next = self._content._carry(nextcarry, False)
             out = next._local_index(posaxis, depth)
-            out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+            out2 = ak.contents.IndexedOptionArray(
                 outindex,
                 out,
                 self._identifier,
@@ -881,7 +881,7 @@ class IndexedOptionArray(Content):
             )
 
     def numbers_to_type(self, name):
-        return ak.contents.indexedoptionarray.IndexedOptionArray(
+        return ak.contents.IndexedOptionArray(
             self._index,
             self._content.numbers_to_type(name),
             self._identifier,
@@ -1457,7 +1457,7 @@ class IndexedOptionArray(Content):
             out = next._combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
-            out2 = ak.contents.indexedoptionarray.IndexedOptionArray(
+            out2 = ak.contents.IndexedOptionArray(
                 outindex, out, None, parameters, self._nplike
             )
             return out2.simplify_optiontype()
@@ -1482,11 +1482,11 @@ class IndexedOptionArray(Content):
         elif isinstance(
             self._content,
             (
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
@@ -1515,7 +1515,7 @@ class IndexedOptionArray(Content):
                 ](index.data, mask.data, mask.length)
             )
             next = self.project()._pad_none(target, posaxis, depth, clip)
-            return ak.contents.indexedoptionarray.IndexedOptionArray(
+            return ak.contents.IndexedOptionArray(
                 index,
                 next,
                 None,
@@ -1523,7 +1523,7 @@ class IndexedOptionArray(Content):
                 self._nplike,
             ).simplify_optiontype()
         else:
-            return ak.contents.indexedoptionarray.IndexedOptionArray(
+            return ak.contents.IndexedOptionArray(
                 self._index,
                 self._content._pad_none(target, posaxis, depth, clip),
                 None,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -330,7 +330,7 @@ class ListArray(Content):
                 ),
             )
 
-        if isinstance(slicecontent, ak.contents.listoffsetarray.ListOffsetArray):
+        if isinstance(slicecontent, ak.contents.ListOffsetArray):
             outoffsets = ak.index.Index64.empty(slicestarts.length + 1, self._nplike)
             assert (
                 outoffsets.nplike is self._nplike
@@ -369,11 +369,11 @@ class ListArray(Content):
                 sliceoffsets[:-1], sliceoffsets[1:], slicecontent._content, tail
             )
 
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 outoffsets, outcontent, None, self._parameters, self._nplike
             )
 
-        elif isinstance(slicecontent, ak.contents.numpyarray.NumpyArray):
+        elif isinstance(slicecontent, ak.contents.NumpyArray):
             carrylen = ak.index.Index64.empty(1, self._nplike)
             assert (
                 carrylen.nplike is self._nplike
@@ -435,13 +435,11 @@ class ListArray(Content):
             nexthead, nexttail = ak._slicing.headtail(tail)
             outcontent = nextcontent._getitem_next(nexthead, nexttail, None)
 
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 outoffsets, outcontent, None, None, self._nplike
             )
 
-        elif isinstance(
-            slicecontent, ak.contents.indexedoptionarray.IndexedOptionArray
-        ):
+        elif isinstance(slicecontent, ak.contents.IndexedOptionArray):
             if self._nplike.known_shape and self._starts.length < slicestarts.length:
                 raise ak._errors.index_error(
                     self,
@@ -513,13 +511,13 @@ class ListArray(Content):
 
             if isinstance(
                 slicecontent._content,
-                ak.contents.listoffsetarray.ListOffsetArray,
+                ak.contents.ListOffsetArray,
             ):
 
                 # Generate ranges between starts and stops
                 as_list_offset_array = self.toListOffsetArray64(True)
                 nextcontent = as_list_offset_array._content._carry(nextcarry, True)
-                next = ak.contents.listoffsetarray.ListOffsetArray(
+                next = ak.contents.ListOffsetArray(
                     smalloffsets, nextcontent, None, self._parameters, self._nplike
                 )
                 out = next._getitem_next_jagged(
@@ -531,18 +529,18 @@ class ListArray(Content):
                     smalloffsets[:-1], smalloffsets[1:], slicecontent._content, tail
                 )
 
-            if isinstance(out, ak.contents.listoffsetarray.ListOffsetArray):
+            if isinstance(out, ak.contents.ListOffsetArray):
                 content = out._content
                 if largeoffsets.nplike.known_data:
                     missing_trim = missing[0 : largeoffsets[-1]]
                 else:
                     missing_trim = missing
-                indexedoptionarray = ak.contents.indexedoptionarray.IndexedOptionArray(
+                indexedoptionarray = ak.contents.IndexedOptionArray(
                     missing_trim, content, None, self._parameters, self._nplike
                 )
                 if isinstance(self._nplike, ak._typetracer.TypeTracer):
                     indexedoptionarray = indexedoptionarray.typetracer
-                return ak.contents.listoffsetarray.ListOffsetArray(
+                return ak.contents.ListOffsetArray(
                     largeoffsets,
                     indexedoptionarray.simplify_optiontype(),
                     None,
@@ -558,7 +556,7 @@ class ListArray(Content):
                     )
                 )
 
-        elif isinstance(slicecontent, ak.contents.emptyarray.EmptyArray):
+        elif isinstance(slicecontent, ak.contents.EmptyArray):
             return self
 
         else:
@@ -679,7 +677,7 @@ class ListArray(Content):
             nextcontent = self._content._carry(nextcarry, True)
 
             if advanced is None or advanced.length == 0:
-                return ak.contents.listoffsetarray.ListOffsetArray(
+                return ak.contents.ListOffsetArray(
                     nextoffsets,
                     nextcontent._getitem_next(nexthead, nexttail, advanced),
                     self._identifier,
@@ -730,7 +728,7 @@ class ListArray(Content):
                     ),
                     slicer=head,
                 )
-                return ak.contents.listoffsetarray.ListOffsetArray(
+                return ak.contents.ListOffsetArray(
                     nextoffsets,
                     nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
                     self._identifier,
@@ -887,7 +885,7 @@ class ListArray(Content):
                 multistarts, multistops, head._content, tail
             )
 
-            return ak.contents.regulararray.RegularArray(
+            return ak.contents.RegularArray(
                 down, headlength, 1, None, self._parameters, self._nplike
             )
 
@@ -925,7 +923,7 @@ class ListArray(Content):
                     self.length,
                 )
             )
-            return ak.contents.numpyarray.NumpyArray(tonum, None, None, self._nplike)
+            return ak.contents.NumpyArray(tonum, None, None, self._nplike)
         else:
             return self.toListOffsetArray64(True).num(posaxis, depth)
 
@@ -936,11 +934,11 @@ class ListArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self.mergeable(other.content, mergebool)
@@ -948,9 +946,9 @@ class ListArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.regulararray.RegularArray,
-                ak.contents.listarray.ListArray,
-                ak.contents.listoffsetarray.ListOffsetArray,
+                ak.contents.RegularArray,
+                ak.contents.ListArray,
+                ak.contents.ListOffsetArray,
             ),
         ):
             return self._content.mergeable(other.content, mergebool)
@@ -977,14 +975,14 @@ class ListArray(Content):
             if isinstance(
                 array,
                 (
-                    ak.contents.listarray.ListArray,
-                    ak.contents.listoffsetarray.ListOffsetArray,
-                    ak.contents.regulararray.RegularArray,
+                    ak.contents.ListArray,
+                    ak.contents.ListOffsetArray,
+                    ak.contents.RegularArray,
                 ),
             ):
                 contents.append(array.content)
 
-            elif isinstance(array, ak.contents.emptyarray.EmptyArray):
+            elif isinstance(array, ak.contents.EmptyArray):
                 pass
             else:
                 raise ak._errors.wrap_error(
@@ -1010,8 +1008,8 @@ class ListArray(Content):
             if isinstance(
                 array,
                 (
-                    ak.contents.listarray.ListArray,
-                    ak.contents.listoffsetarray.ListOffsetArray,
+                    ak.contents.ListArray,
+                    ak.contents.ListOffsetArray,
                 ),
             ):
                 array_starts = ak.index.Index(array.starts)
@@ -1044,7 +1042,7 @@ class ListArray(Content):
                 contentlength_so_far += array.content.length
                 length_so_far += array.length
 
-            elif isinstance(array, ak.contents.regulararray.RegularArray):
+            elif isinstance(array, ak.contents.RegularArray):
                 listoffsetarray = array.toListOffsetArray64(True)
 
                 array_starts = ak.index.Index64(listoffsetarray.starts)
@@ -1077,10 +1075,10 @@ class ListArray(Content):
                 contentlength_so_far += array.content.length
                 length_so_far += listoffsetarray.length
 
-            elif isinstance(array, ak.contents.emptyarray.EmptyArray):
+            elif isinstance(array, ak.contents.EmptyArray):
                 pass
 
-        next = ak.contents.listarray.ListArray(
+        next = ak.contents.ListArray(
             nextstarts, nextstops, nextcontent, None, parameters, self._nplike
         )
 
@@ -1126,7 +1124,7 @@ class ListArray(Content):
                     offsets.length - 1,
                 )
             )
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 offsets,
                 ak.contents.NumpyArray(localindex),
                 self._identifier,
@@ -1134,7 +1132,7 @@ class ListArray(Content):
                 self._nplike,
             )
         else:
-            return ak.contents.listarray.ListArray(
+            return ak.contents.ListArray(
                 self._starts,
                 self._stops,
                 self._content._local_index(posaxis, depth + 1),
@@ -1144,7 +1142,7 @@ class ListArray(Content):
             )
 
     def numbers_to_type(self, name):
-        return ak.contents.listarray.ListArray(
+        return ak.contents.ListArray(
             self._starts,
             self._stops,
             self._content.numbers_to_type(name),
@@ -1358,7 +1356,7 @@ class ListArray(Content):
                             self._starts.length,
                         )
                     )
-                    next = ak.contents.indexedoptionarray.IndexedOptionArray(
+                    next = ak.contents.IndexedOptionArray(
                         index,
                         self._content,
                         None,
@@ -1366,7 +1364,7 @@ class ListArray(Content):
                         self._nplike,
                     )
 
-                    return ak.contents.listarray.ListArray(
+                    return ak.contents.ListArray(
                         starts_,
                         stops_,
                         next.simplify_optiontype(),
@@ -1375,7 +1373,7 @@ class ListArray(Content):
                         self._nplike,
                     )
             else:
-                return ak.contents.listarray.ListArray(
+                return ak.contents.ListArray(
                     self._starts,
                     self._stops,
                     self._content._pad_none(target, posaxis, depth + 1, clip),

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -272,7 +272,7 @@ class ListOffsetArray(Content):
         except IndexError as err:
             raise ak._errors.index_error(self, carry.data, str(err)) from err
 
-        return ak.contents.listarray.ListArray(
+        return ak.contents.ListArray(
             nextstarts,
             nextstops,
             self._content,
@@ -351,7 +351,7 @@ class ListOffsetArray(Content):
         )
 
     def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
-        out = ak.contents.listarray.ListArray(
+        out = ak.contents.ListArray(
             self.starts,
             self.stops,
             self._content,
@@ -466,7 +466,7 @@ class ListOffsetArray(Content):
             nextcontent = self._content._carry(nextcarry, True)
 
             if advanced is None or advanced.length == 0:
-                return ak.contents.listoffsetarray.ListOffsetArray(
+                return ak.contents.ListOffsetArray(
                     nextoffsets,
                     nextcontent._getitem_next(nexthead, nexttail, advanced),
                     self._identifier,
@@ -513,7 +513,7 @@ class ListOffsetArray(Content):
                     slicer=head,
                 )
 
-                return ak.contents.listoffsetarray.ListOffsetArray(
+                return ak.contents.ListOffsetArray(
                     nextoffsets,
                     nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
                     self._identifier,
@@ -615,7 +615,7 @@ class ListOffsetArray(Content):
                 return nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
 
         elif isinstance(head, ak.contents.ListOffsetArray):
-            listarray = ak.contents.listarray.ListArray(
+            listarray = ak.contents.ListArray(
                 self.starts,
                 self.stops,
                 self._content,
@@ -659,11 +659,11 @@ class ListOffsetArray(Content):
                     self.length,
                 )
             )
-            return ak.contents.numpyarray.NumpyArray(tonum, None, None, self._nplike)
+            return ak.contents.NumpyArray(tonum, None, None, self._nplike)
         else:
             next = self._content.num(posaxis, depth + 1)
             offsets = self._compact_offsets64(True)
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 offsets, next, None, self.parameters, self._nplike
             )
 
@@ -735,11 +735,11 @@ class ListOffsetArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self.mergeable(other.content, mergebool)
@@ -747,9 +747,9 @@ class ListOffsetArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.regulararray.RegularArray,
-                ak.contents.listarray.ListArray,
-                ak.contents.listoffsetarray.ListOffsetArray,
+                ak.contents.RegularArray,
+                ak.contents.ListArray,
+                ak.contents.ListOffsetArray,
             ),
         ):
             return self._content.mergeable(other.content, mergebool)
@@ -760,7 +760,7 @@ class ListOffsetArray(Content):
     def mergemany(self, others):
         if len(others) == 0:
             return self
-        listarray = ak.contents.listarray.ListArray(
+        listarray = ak.contents.ListArray(
             self.starts, self.stops, self._content, None, self._parameters, self._nplike
         )
         out = listarray.mergemany(others)
@@ -805,7 +805,7 @@ class ListOffsetArray(Content):
                     offsets.length - 1,
                 )
             )
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 offsets,
                 ak.contents.NumpyArray(localindex),
                 self._identifier,
@@ -813,7 +813,7 @@ class ListOffsetArray(Content):
                 self._nplike,
             )
         else:
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 self._offsets,
                 self._content._local_index(posaxis, depth + 1),
                 self._identifier,
@@ -822,7 +822,7 @@ class ListOffsetArray(Content):
             )
 
     def numbers_to_type(self, name):
-        return ak.contents.listoffsetarray.ListOffsetArray(
+        return ak.contents.ListOffsetArray(
             self._offsets,
             self._content.numbers_to_type(name),
             self._identifier,
@@ -851,7 +851,7 @@ class ListOffsetArray(Content):
 
             if isinstance(self._content, ak.contents.NumpyArray):
                 out, outoffsets = self._content._as_unique_strings(self._offsets)
-                out2 = ak.contents.listoffsetarray.ListOffsetArray(
+                out2 = ak.contents.ListOffsetArray(
                     outoffsets,
                     out,
                     None,
@@ -1436,10 +1436,10 @@ class ListOffsetArray(Content):
             for ptr in tocarry:
                 contents.append(self._content._carry(ptr, True))
 
-            recordarray = ak.contents.recordarray.RecordArray(
+            recordarray = ak.contents.RecordArray(
                 contents, recordlookup, None, None, parameters, self._nplike
             )
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 offsets, recordarray, self._identifier, self._parameters, self._nplike
             )
         else:
@@ -1447,7 +1447,7 @@ class ListOffsetArray(Content):
             next = compact._content._combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth + 1
             )
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 compact.offsets, next, self._identifier, self._parameters, self._nplike
             )
 
@@ -1839,14 +1839,14 @@ class ListOffsetArray(Content):
                         target,
                     )
                 )
-                next = ak.contents.indexedoptionarray.IndexedOptionArray(
+                next = ak.contents.IndexedOptionArray(
                     outindex,
                     self._content,
                     self._identifier,
                     self._parameters,
                     self._nplike,
                 )
-                return ak.contents.listoffsetarray.ListOffsetArray(
+                return ak.contents.ListOffsetArray(
                     offsets_,
                     next.simplify_optiontype(),
                     self._identifier,
@@ -1889,14 +1889,14 @@ class ListOffsetArray(Content):
                         target,
                     )
                 )
-                next = ak.contents.indexedoptionarray.IndexedOptionArray(
+                next = ak.contents.IndexedOptionArray(
                     outindex,
                     self._content,
                     self._identifier,
                     self._parameters,
                     self._nplike,
                 )
-                return ak.contents.regulararray.RegularArray(
+                return ak.contents.RegularArray(
                     next.simplify_optiontype(),
                     target,
                     self.length,
@@ -1905,7 +1905,7 @@ class ListOffsetArray(Content):
                     self._nplike,
                 )
         else:
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 self._offsets,
                 self._content._pad_none(target, posaxis, depth + 1, clip),
                 None,
@@ -2207,7 +2207,7 @@ class ListOffsetArray(Content):
                         nplike=self.nplike,
                     )
 
-                    return ak.contents.unionarray.UnionArray(
+                    return ak.contents.UnionArray(
                         tags=union_tags,
                         index=union_index,
                         contents=[content, self.toListOffsetArray64(True)],

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -375,7 +375,7 @@ class NumpyArray(Content):
                 tonum.data, size, reps
             )
         )
-        return ak.contents.numpyarray.NumpyArray(
+        return ak.contents.NumpyArray(
             tonum.data.reshape(shape), None, self.parameters, self._nplike
         )
 
@@ -394,11 +394,11 @@ class NumpyArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self.mergeable(other._content, mergebool)
@@ -463,9 +463,9 @@ class NumpyArray(Content):
         parameters = self._parameters
         for array in head:
             parameters = ak._util.merge_parameters(parameters, array._parameters, True)
-            if isinstance(array, ak.contents.emptyarray.EmptyArray):
+            if isinstance(array, ak.contents.EmptyArray):
                 pass
-            elif isinstance(array, ak.contents.numpyarray.NumpyArray):
+            elif isinstance(array, ak.contents.NumpyArray):
                 contiguous_arrays.append(array.data)
             else:
                 raise ak._errors.wrap_error(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -385,7 +385,7 @@ class RecordArray(Content):
                 raise ak._errors.index_error(self, where)
 
             nextindex = ak.index.Index64(where, nplike=self.nplike)
-            return ak.contents.indexedarray.IndexedArray(
+            return ak.contents.IndexedArray(
                 nextindex,
                 self,
                 self._carry_identifier(carry),
@@ -471,11 +471,9 @@ class RecordArray(Content):
         if posaxis == depth:
             npsingle = self._nplike.index_nplike.full((1,), self.length, np.int64)
             single = ak.index.Index64(npsingle, nplike=self._nplike)
-            singleton = ak.contents.numpyarray.NumpyArray(
-                single, None, None, self._nplike
-            )
+            singleton = ak.contents.NumpyArray(single, None, None, self._nplike)
             contents = [singleton] * len(self._contents)
-            record = ak.contents.recordarray.RecordArray(
+            record = ak.contents.RecordArray(
                 contents, self._fields, 1, None, self._parameters, self._nplike
             )
             return record[0]
@@ -483,7 +481,7 @@ class RecordArray(Content):
             contents = []
             for content in self._contents:
                 contents.append(content.num(posaxis, depth))
-            return ak.contents.recordarray.RecordArray(
+            return ak.contents.RecordArray(
                 contents,
                 self._fields,
                 self._length,
@@ -533,11 +531,11 @@ class RecordArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self.mergeable(other.content, mergebool)
@@ -588,7 +586,7 @@ class RecordArray(Content):
                     parameters, array._parameters, True
                 )
 
-                if isinstance(array, ak.contents.recordarray.RecordArray):
+                if isinstance(array, ak.contents.RecordArray):
                     if self.is_tuple:
                         if len(self.contents) == len(array.contents):
                             for i in range(len(self.contents)):
@@ -604,7 +602,7 @@ class RecordArray(Content):
                         raise ak._errors.wrap_error(
                             ValueError("cannot merge tuple with non-tuple record")
                         )
-                elif isinstance(array, ak.contents.emptyarray.EmptyArray):
+                elif isinstance(array, ak.contents.EmptyArray):
                     pass
                 else:
                     raise ak._errors.wrap_error(
@@ -625,7 +623,7 @@ class RecordArray(Content):
                     parameters, array._parameters, True
                 )
 
-                if isinstance(array, ak.contents.recordarray.RecordArray):
+                if isinstance(array, ak.contents.RecordArray):
                     if not array.is_tuple:
                         those_fields = array._fields.copy()
                         those_fields.sort()
@@ -647,7 +645,7 @@ class RecordArray(Content):
                             AssertionError("cannot merge non-tuple record with tuple")
                         )
 
-                elif isinstance(array, ak.contents.emptyarray.EmptyArray):
+                elif isinstance(array, ak.contents.EmptyArray):
                     pass
                 else:
                     raise ak._errors.wrap_error(
@@ -727,7 +725,7 @@ class RecordArray(Content):
         contents = []
         for x in self._contents:
             contents.append(x.numbers_to_type(name))
-        return ak.contents.recordarray.RecordArray(
+        return ak.contents.RecordArray(
             contents,
             self._fields,
             self._length,
@@ -797,7 +795,7 @@ class RecordArray(Content):
                         n, replacement, recordlookup, parameters, posaxis, depth
                     )
                 )
-            return ak.contents.recordarray.RecordArray(
+            return ak.contents.RecordArray(
                 contents,
                 recordlookup,
                 self.length,
@@ -861,7 +859,7 @@ class RecordArray(Content):
             for content in self._contents:
                 contents.append(content._pad_none(target, posaxis, depth, clip))
             if len(contents) == 0:
-                return ak.contents.recordarray.RecordArray(
+                return ak.contents.RecordArray(
                     contents,
                     self._fields,
                     self._length,
@@ -870,7 +868,7 @@ class RecordArray(Content):
                     self._nplike,
                 )
             else:
-                return ak.contents.recordarray.RecordArray(
+                return ak.contents.RecordArray(
                     contents,
                     self._fields,
                     self._length,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -338,7 +338,7 @@ class RegularArray(Content):
                 )
             )
             nextcontent = self._content._carry(nextcarry, True)
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 offsets, nextcontent, identifier, self._parameters, self._nplike
             )
 
@@ -353,7 +353,7 @@ class RegularArray(Content):
                     self._size,
                 )
             )
-            return ak.contents.listoffsetarray.ListOffsetArray(
+            return ak.contents.ListOffsetArray(
                 offsets, self._content, self._identifier, self._parameters, self._nplike
             )
 
@@ -648,10 +648,10 @@ class RegularArray(Content):
                     tonum.data, self._size, self._length
                 )
             )
-            return ak.contents.numpyarray.NumpyArray(tonum, None, None, self._nplike)
+            return ak.contents.NumpyArray(tonum, None, None, self._nplike)
         else:
             next = self._content.num(posaxis, depth + 1)
-            return ak.contents.regulararray.RegularArray(
+            return ak.contents.RegularArray(
                 next, self._size, self._length, None, self._parameters, self._nplike
             )
 
@@ -662,11 +662,11 @@ class RegularArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self.mergeable(other.content, mergebool)
@@ -674,9 +674,9 @@ class RegularArray(Content):
         elif isinstance(
             other,
             (
-                ak.contents.regulararray.RegularArray,
-                ak.contents.listarray.ListArray,
-                ak.contents.listoffsetarray.ListOffsetArray,
+                ak.contents.RegularArray,
+                ak.contents.ListArray,
+                ak.contents.ListOffsetArray,
             ),
         ):
             return self._content.mergeable(other.content, mergebool)
@@ -684,10 +684,7 @@ class RegularArray(Content):
         # For n-dimensional NumpyArrays, let's now convert them to RegularArray
         # We could add a special case that tries to first convert self to NumpyArray
         # and merge conventionally, but it's not worth it at this stage.
-        elif (
-            isinstance(other, ak.contents.numpyarray.NumpyArray)
-            and other.purelist_depth > 1
-        ):
+        elif isinstance(other, ak.contents.NumpyArray) and other.purelist_depth > 1:
             return self._content.mergeable(other.toRegularArray().content, mergebool)
         else:
             return False
@@ -701,9 +698,7 @@ class RegularArray(Content):
 
         # Regularize NumpyArray into RegularArray (or NumpyArray if 1D)
         others = [
-            o.toRegularArray()
-            if isinstance(o, ak.contents.numpyarray.NumpyArray)
-            else o
+            o.toRegularArray() if isinstance(o, ak.contents.NumpyArray) else o
             for o in others
         ]
 
@@ -751,7 +746,7 @@ class RegularArray(Content):
                 )
             )
             return ak.contents.RegularArray(
-                ak.contents.numpyarray.NumpyArray(localindex),
+                ak.contents.NumpyArray(localindex),
                 self._size,
                 self._length,
                 self._identifier,
@@ -769,7 +764,7 @@ class RegularArray(Content):
             )
 
     def numbers_to_type(self, name):
-        return ak.contents.regulararray.RegularArray(
+        return ak.contents.RegularArray(
             self._content.numbers_to_type(name),
             self._size,
             self._length,
@@ -948,10 +943,10 @@ class RegularArray(Content):
                 contents.append(self._content._carry(ptr, True))
                 length = contents[-1].length
             assert length is not None
-            recordarray = ak.contents.recordarray.RecordArray(
+            recordarray = ak.contents.RecordArray(
                 contents, recordlookup, length, None, parameters, self._nplike
             )
-            return ak.contents.regulararray.RegularArray(
+            return ak.contents.RegularArray(
                 recordarray,
                 combinationslen,
                 self._length,
@@ -965,7 +960,7 @@ class RegularArray(Content):
             )._combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth + 1
             )
-            return ak.contents.regulararray.RegularArray(
+            return ak.contents.RegularArray(
                 next,
                 self._size,
                 self._length,
@@ -1088,14 +1083,14 @@ class RegularArray(Content):
                         "awkward_RegularArray_rpad_and_clip_axis1", index.dtype.type
                     ](index.data, target, self._size, self._length)
                 )
-                next = ak.contents.indexedoptionarray.IndexedOptionArray(
+                next = ak.contents.IndexedOptionArray(
                     index,
                     self._content,
                     None,
                     self._parameters,
                     self._nplike,
                 )
-                return ak.contents.regulararray.RegularArray(
+                return ak.contents.RegularArray(
                     next.simplify_optiontype(),
                     target,
                     self._length,
@@ -1105,7 +1100,7 @@ class RegularArray(Content):
                 )
 
         else:
-            return ak.contents.regulararray.RegularArray(
+            return ak.contents.RegularArray(
                 self._content._pad_none(target, posaxis, depth + 1, clip),
                 self._size,
                 self._length,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -874,7 +874,7 @@ class UnionArray(Content):
             )
 
         parameters = ak._util.merge_parameters(self._parameters, other._parameters)
-        return ak.contents.unionarray.UnionArray(
+        return ak.contents.UnionArray(
             tags, index, contents, None, parameters, self._nplike
         )
 
@@ -898,7 +898,7 @@ class UnionArray(Content):
         parameters = self._parameters
         for array in head:
             parameters = ak._util.merge_parameters(parameters, array._parameters, True)
-            if isinstance(array, ak.contents.unionarray.UnionArray):
+            if isinstance(array, ak.contents.UnionArray):
                 union_tags = ak.index.Index(array.tags)
                 union_index = ak.index.Index(array.index)
                 union_contents = array.contents
@@ -938,7 +938,7 @@ class UnionArray(Content):
                 length_so_far += array.length
                 nextcontents.extend(union_contents)
 
-            elif isinstance(array, ak.contents.emptyarray.EmptyArray):
+            elif isinstance(array, ak.contents.EmptyArray):
                 pass
 
             else:
@@ -970,7 +970,7 @@ class UnionArray(Content):
                 ValueError("FIXME: handle UnionArray with more than 127 contents")
             )
 
-        next = ak.contents.unionarray.UnionArray(
+        next = ak.contents.UnionArray(
             nexttags, nextindex, nextcontents, None, parameters, self._nplike
         )
 
@@ -1041,7 +1041,7 @@ class UnionArray(Content):
         contents = []
         for x in self._contents:
             contents.append(x.numbers_to_type(name))
-        return ak.contents.unionarray.UnionArray(
+        return ak.contents.UnionArray(
             self._tags,
             self._index,
             contents,
@@ -1148,7 +1148,7 @@ class UnionArray(Content):
 
     def _validity_error(self, path):
         for i in range(len(self.contents)):
-            if isinstance(self.contents[i], ak.contents.unionarray.UnionArray):
+            if isinstance(self.contents[i], ak.contents.UnionArray):
                 return "{} contains {}, the operation that made it might have forgotten to call 'simplify_uniontype'".format(
                     type(self), type(self.contents[i])
                 )
@@ -1210,7 +1210,7 @@ class UnionArray(Content):
             contents = []
             for content in self._contents:
                 contents.append(content._pad_none(target, posaxis, depth, clip))
-            out = ak.contents.unionarray.UnionArray(
+            out = ak.contents.UnionArray(
                 self.tags,
                 self.index,
                 contents,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -117,7 +117,7 @@ class UnmaskedArray(Content):
 
     def toIndexedOptionArray64(self):
         arange = self._nplike.index_nplike.arange(self._content.length, dtype=np.int64)
-        return ak.contents.indexedoptionarray.IndexedOptionArray(
+        return ak.contents.IndexedOptionArray(
             ak.index.Index64(arange, nplike=self.nplike),
             self._content,
             self._identifier,
@@ -126,7 +126,7 @@ class UnmaskedArray(Content):
         )
 
     def toByteMaskedArray(self, valid_when):
-        return ak.contents.bytemaskedarray.ByteMaskedArray(
+        return ak.contents.ByteMaskedArray(
             ak.index.Index8(
                 self.mask_as_bool(valid_when).view(np.int8), nplike=self.nplike
             ),
@@ -254,7 +254,7 @@ class UnmaskedArray(Content):
 
     def project(self, mask=None):
         if mask is not None:
-            return ak.contents.bytemaskedarray.ByteMaskedArray(
+            return ak.contents.ByteMaskedArray(
                 mask,
                 self._content,
                 False,
@@ -269,11 +269,11 @@ class UnmaskedArray(Content):
         if isinstance(
             self._content,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self._content
@@ -289,7 +289,7 @@ class UnmaskedArray(Content):
             else:
                 return out
         else:
-            return ak.contents.unmaskedarray.UnmaskedArray(
+            return ak.contents.UnmaskedArray(
                 self._content.num(posaxis, depth), None, self._parameters, self._nplike
             )
 
@@ -312,11 +312,11 @@ class UnmaskedArray(Content):
         if isinstance(
             other,
             (
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return self._content.mergeable(other.content, mergebool)
@@ -364,7 +364,7 @@ class UnmaskedArray(Content):
             )
 
     def numbers_to_type(self, name):
-        return ak.contents.unmaskedarray.UnmaskedArray(
+        return ak.contents.UnmaskedArray(
             self._content.numbers_to_type(name),
             self._identifier,
             self._parameters,
@@ -464,7 +464,7 @@ class UnmaskedArray(Content):
         if posaxis == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
-            return ak.contents.unmaskedarray.UnmaskedArray(
+            return ak.contents.UnmaskedArray(
                 self._content._combinations(
                     n, replacement, recordlookup, parameters, posaxis, depth
                 ),
@@ -505,11 +505,11 @@ class UnmaskedArray(Content):
         if isinstance(
             self._content,
             (
-                ak.contents.bitmaskedarray.BitMaskedArray,
-                ak.contents.bytemaskedarray.ByteMaskedArray,
-                ak.contents.indexedarray.IndexedArray,
-                ak.contents.indexedoptionarray.IndexedOptionArray,
-                ak.contents.unmaskedarray.UnmaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.UnmaskedArray,
             ),
         ):
             return "{0} contains \"{1}\", the operation that made it might have forgotten to call 'simplify_optiontype()'"
@@ -529,7 +529,7 @@ class UnmaskedArray(Content):
         elif posaxis == depth + 1:
             return self._content._pad_none(target, posaxis, depth, clip)
         else:
-            return ak.contents.unmaskedarray.UnmaskedArray(
+            return ak.contents.UnmaskedArray(
                 self._content._pad_none(target, posaxis, depth, clip),
                 None,
                 self._parameters,

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -124,14 +124,14 @@ class BitMaskedForm(Form):
         if isinstance(
             self._content,
             (
-                ak.forms.indexedform.IndexedForm,
-                ak.forms.indexedoptionform.IndexedOptionForm,
-                ak.forms.bytemaskedform.ByteMaskedForm,
-                ak.forms.bitmaskedform.BitMaskedForm,
-                ak.forms.unmaskedform.UnmaskedForm,
+                ak.forms.IndexedForm,
+                ak.forms.IndexedOptionForm,
+                ak.forms.ByteMaskedForm,
+                ak.forms.BitMaskedForm,
+                ak.forms.UnmaskedForm,
             ),
         ):
-            return ak.forms.indexedoptionform.IndexedOptionForm(
+            return ak.forms.IndexedOptionForm(
                 "i64",
                 self._content,
                 has_identifier=self._has_identifier,

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -98,7 +98,7 @@ class BitMaskedForm(Form):
         )
 
     def _type(self, typestrs):
-        return ak.types.optiontype.OptionType(
+        return ak.types.OptionType(
             self._content._type(typestrs),
             self._parameters,
             ak._util.gettypestr(self._parameters, typestrs),

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -107,14 +107,14 @@ class ByteMaskedForm(Form):
         if isinstance(
             self._content,
             (
-                ak.forms.indexedform.IndexedForm,
-                ak.forms.indexedoptionform.IndexedOptionForm,
-                ak.forms.bytemaskedform.ByteMaskedForm,
-                ak.forms.bitmaskedform.BitMaskedForm,
-                ak.forms.unmaskedform.UnmaskedForm,
+                ak.forms.IndexedForm,
+                ak.forms.IndexedOptionForm,
+                ak.forms.ByteMaskedForm,
+                ak.forms.BitMaskedForm,
+                ak.forms.UnmaskedForm,
             ),
         ):
-            return ak.forms.indexedoptionform.IndexedOptionForm(
+            return ak.forms.IndexedOptionForm(
                 "i64",
                 self._content,
                 has_identifier=self._has_identifier,

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -82,7 +82,7 @@ class ByteMaskedForm(Form):
         )
 
     def _type(self, typestrs):
-        return ak.types.optiontype.OptionType(
+        return ak.types.OptionType(
             self._content._type(typestrs),
             self._parameters,
             ak._util.gettypestr(self._parameters, typestrs),

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -19,7 +19,7 @@ class EmptyForm(Form):
         return self._to_dict_extra({"class": "EmptyArray"}, verbose)
 
     def _type(self, typestrs):
-        return ak.types.unknowntype.UnknownType(
+        return ak.types.UnknownType(
             self._parameters,
             ak._util.gettypestr(self._parameters, typestrs),
         )

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -14,7 +14,7 @@ def from_dict(input: dict) -> Form:
         return None
 
     if ak._util.isstr(input):
-        return ak.forms.numpyform.NumpyForm(primitive=input)
+        return ak.forms.NumpyForm(primitive=input)
 
     assert isinstance(input, dict)
     has_identifier = input.get("has_identifier", input.get("has_identities", False))
@@ -24,15 +24,15 @@ def from_dict(input: dict) -> Form:
     if input["class"] == "NumpyArray":
         primitive = input["primitive"]
         inner_shape = input.get("inner_shape", [])
-        return ak.forms.numpyform.NumpyForm(
+        return ak.forms.NumpyForm(
             primitive, inner_shape, has_identifier, parameters, form_key
         )
 
     elif input["class"] == "EmptyArray":
-        return ak.forms.emptyform.EmptyForm(has_identifier, parameters, form_key)
+        return ak.forms.EmptyForm(has_identifier, parameters, form_key)
 
     elif input["class"] == "RegularArray":
-        return ak.forms.regularform.RegularForm(
+        return ak.forms.RegularForm(
             content=from_dict(input["content"]),
             size=input["size"],
             has_identifier=has_identifier,
@@ -41,7 +41,7 @@ def from_dict(input: dict) -> Form:
         )
 
     elif input["class"] in ("ListArray", "ListArray32", "ListArrayU32", "ListArray64"):
-        return ak.forms.listform.ListForm(
+        return ak.forms.ListForm(
             starts=input["starts"],
             stops=input["stops"],
             content=from_dict(input["content"]),
@@ -56,7 +56,7 @@ def from_dict(input: dict) -> Form:
         "ListOffsetArrayU32",
         "ListOffsetArray64",
     ):
-        return ak.forms.listoffsetform.ListOffsetForm(
+        return ak.forms.ListOffsetForm(
             offsets=input["offsets"],
             content=from_dict(input["content"]),
             has_identifier=has_identifier,
@@ -74,7 +74,7 @@ def from_dict(input: dict) -> Form:
         else:
             contents = [from_dict(content) for content in input["contents"]]
             fields = None
-        return ak.forms.recordform.RecordForm(
+        return ak.forms.RecordForm(
             contents=contents,
             fields=fields,
             has_identifier=has_identifier,
@@ -88,7 +88,7 @@ def from_dict(input: dict) -> Form:
         "IndexedArrayU32",
         "IndexedArray64",
     ):
-        return ak.forms.indexedform.IndexedForm(
+        return ak.forms.IndexedForm(
             index=input["index"],
             content=from_dict(input["content"]),
             has_identifier=has_identifier,
@@ -101,7 +101,7 @@ def from_dict(input: dict) -> Form:
         "IndexedOptionArray32",
         "IndexedOptionArray64",
     ):
-        return ak.forms.indexedoptionform.IndexedOptionForm(
+        return ak.forms.IndexedOptionForm(
             index=input["index"],
             content=from_dict(input["content"]),
             has_identifier=has_identifier,
@@ -110,7 +110,7 @@ def from_dict(input: dict) -> Form:
         )
 
     elif input["class"] == "ByteMaskedArray":
-        return ak.forms.bytemaskedform.ByteMaskedForm(
+        return ak.forms.ByteMaskedForm(
             mask=input["mask"],
             content=from_dict(input["content"]),
             valid_when=input["valid_when"],
@@ -120,7 +120,7 @@ def from_dict(input: dict) -> Form:
         )
 
     elif input["class"] == "BitMaskedArray":
-        return ak.forms.bitmaskedform.BitMaskedForm(
+        return ak.forms.BitMaskedForm(
             mask=input["mask"],
             content=from_dict(input["content"]),
             valid_when=input["valid_when"],
@@ -131,7 +131,7 @@ def from_dict(input: dict) -> Form:
         )
 
     elif input["class"] == "UnmaskedArray":
-        return ak.forms.unmaskedform.UnmaskedForm(
+        return ak.forms.UnmaskedForm(
             content=from_dict(input["content"]),
             has_identifier=has_identifier,
             parameters=parameters,
@@ -144,7 +144,7 @@ def from_dict(input: dict) -> Form:
         "UnionArray8_U32",
         "UnionArray8_64",
     ):
-        return ak.forms.unionform.UnionForm(
+        return ak.forms.UnionForm(
             tags=input["tags"],
             index=input["index"],
             contents=[from_dict(content) for content in input["contents"]],

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -91,14 +91,14 @@ class IndexedOptionForm(Form):
         if isinstance(
             self._content,
             (
-                ak.forms.indexedform.IndexedForm,
-                ak.forms.indexedoptionform.IndexedOptionForm,
-                ak.forms.bytemaskedform.ByteMaskedForm,
-                ak.forms.bitmaskedform.BitMaskedForm,
-                ak.forms.unmaskedform.UnmaskedForm,
+                ak.forms.IndexedForm,
+                ak.forms.IndexedOptionForm,
+                ak.forms.ByteMaskedForm,
+                ak.forms.BitMaskedForm,
+                ak.forms.UnmaskedForm,
             ),
         ):
-            return ak.forms.indexedoptionform.IndexedOptionForm(
+            return ak.forms.IndexedOptionForm(
                 "i64",
                 self._content.content,
                 has_identifier=self._has_identifier,

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -67,7 +67,7 @@ class IndexedOptionForm(Form):
         else:
             parameters = self._parameters
 
-        return ak.types.optiontype.OptionType(
+        return ak.types.OptionType(
             self._content._type(typestrs),
             parameters,
             ak._util.gettypestr(self._parameters, typestrs),

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -78,7 +78,7 @@ class ListForm(Form):
         )
 
     def _type(self, typestrs):
-        return ak.types.listtype.ListType(
+        return ak.types.ListType(
             self._content._type(typestrs),
             self._parameters,
             ak._util.gettypestr(self._parameters, typestrs),

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -49,7 +49,7 @@ class ListOffsetForm(Form):
         )
 
     def _type(self, typestrs):
-        return ak.types.listtype.ListType(
+        return ak.types.ListType(
             self._content._type(typestrs),
             self._parameters,
             ak._util.gettypestr(self._parameters, typestrs),

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -100,13 +100,13 @@ class NumpyForm(Form):
             return self._to_dict_extra(out, verbose)
 
     def _type(self, typestrs):
-        out = ak.types.numpytype.NumpyType(
+        out = ak.types.NumpyType(
             self._primitive,
             None,
             ak._util.gettypestr(self._parameters, typestrs),
         )
         for x in self._inner_shape[::-1]:
-            out = ak.types.regulartype.RegularType(out, x)
+            out = ak.types.RegularType(out, x)
 
         out._parameters = self._parameters
 

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -146,7 +146,7 @@ class RecordForm(Form):
         return self._to_dict_extra(out, verbose)
 
     def _type(self, typestrs):
-        return ak.types.recordtype.RecordType(
+        return ak.types.RecordType(
             [x._type(typestrs) for x in self._contents],
             self._fields,
             self._parameters,

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -55,7 +55,7 @@ class RegularForm(Form):
         )
 
     def _type(self, typestrs):
-        return ak.types.regulartype.RegularType(
+        return ak.types.RegularType(
             self._content._type(typestrs),
             self._size,
             self._parameters,

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -95,7 +95,7 @@ class UnionForm(Form):
         )
 
     def _type(self, typestrs):
-        return ak.types.uniontype.UnionType(
+        return ak.types.UnionType(
             [x._type(typestrs) for x in self._contents],
             self._parameters,
             ak._util.gettypestr(self._parameters, typestrs),

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -67,11 +67,11 @@ class UnmaskedForm(Form):
         if isinstance(
             self._content,
             (
-                ak.forms.indexedform.IndexedForm,
-                ak.forms.indexedoptionform.IndexedOptionForm,
-                ak.forms.bytemaskedform.ByteMaskedForm,
-                ak.forms.bitmaskedform.BitMaskedForm,
-                ak.forms.unmaskedform.UnmaskedForm,
+                ak.forms.IndexedForm,
+                ak.forms.IndexedOptionForm,
+                ak.forms.ByteMaskedForm,
+                ak.forms.BitMaskedForm,
+                ak.forms.UnmaskedForm,
             ),
         ):
             return self._content

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -44,7 +44,7 @@ class UnmaskedForm(Form):
         )
 
     def _type(self, typestrs):
-        return ak.types.optiontype.OptionType(
+        return ak.types.OptionType(
             self._content._type(typestrs),
             self._parameters,
             ak._util.gettypestr(self._parameters, typestrs),

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -116,7 +116,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                 batch = [collapsed.merge_as_union(x)]
 
         out = batch[0].mergemany(batch[1:])
-        if isinstance(out, ak.contents.unionarray.UnionArray):
+        if isinstance(out, ak.contents.UnionArray):
             out = out.simplify_uniontype(merge=merge, mergebool=mergebool)
 
     else:

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -11,7 +11,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 class Record:
     def __init__(self, array, at):
-        if not isinstance(array, ak.contents.recordarray.RecordArray):
+        if not isinstance(array, ak.contents.RecordArray):
             raise ak._errors.wrap_error(
                 TypeError(f"Record 'array' must be a RecordArray, not {array!r}")
             )

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -8,7 +8,7 @@ import awkward.types.type
 
 class ArrayType:
     def __init__(self, content, length):
-        if not isinstance(content, awkward.types.type.Type):
+        if not isinstance(content, ak.types.Type):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} all 'contents' must be Type subclasses, not {}".format(

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -203,13 +203,13 @@ class RecordType(Type):
             return False
 
     def index_to_field(self, index):
-        return ak.forms.recordform.RecordForm.index_to_field(self, index)
+        return ak.forms.RecordForm.index_to_field(self, index)
 
     def field_to_index(self, field):
-        return ak.forms.recordform.RecordForm.field_to_index(self, field)
+        return ak.forms.RecordForm.field_to_index(self, field)
 
     def has_field(self, field):
-        return ak.forms.recordform.RecordForm.has_field(self, field)
+        return ak.forms.RecordForm.has_field(self, field)
 
     def content(self, index_or_field):
-        return ak.forms.recordform.RecordForm.content(self, index_or_field)
+        return ak.forms.RecordForm.content(self, index_or_field)


### PR DESCRIPTION
Specifically,

```bash
find src/awkward -type f -name '*.py' -exec sed -i.bak 's/ak.contents.[a-z]*array.\([A-Za-z]*Array\)/ak.contents.\1/g' {} \;
rm -f **/*.py.bak
black src/awkward
```

```bash
find src/awkward -type f -name '*.py' -exec sed -i.bak 's/ak.forms.[a-z]*form.\([A-Za-z]*Form\)/ak.forms.\1/g' {} \;
rm -f **/*.py.bak
black src/awkward
```

and

```bash
find src/awkward -type f -name '*.py' -exec sed -i.bak 's/ak.types.[a-z]*type.\([A-Za-z]*Type\)/ak.types.\1/g' {} \;
rm -f **/*.py.bak
black src/awkward
```

When pip-installed, `ak.types` doesn't seem to have `listtype`, etc., but it does have `ListType`. Wait—could it be because MacOS is case-sensitive? No, if that's it, then this would have failed before.

Regardless of whether this fixes the issue I see in using Uproot with Awkward's `main`, it's a name change we've been wanting to do.