### PR TITLE
refactor: make _v2 facade a static module.

### DIFF
--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -49,13 +49,11 @@ awkward.behaviors.categorical.register(behavior)  # noqa: F405
 from awkward.operations import *
 
 # temporary shim to access v2 under _v2
-import sys
-
-_v2 = sys.modules[f"{__name__}._v2"] = sys.modules[__name__]
+import awkward._v2
 
 # version
 __version__ = awkward._ext.__version__
-__all__ = [x for x in globals() if not x.startswith("_") and x not in ("numpy",)]
+__all__ = [x for x in globals() if not x.startswith("_")]
 
 
 def __dir__():

--- a/src/awkward/_v2.py
+++ b/src/awkward/_v2.py
@@ -2,33 +2,28 @@
 
 # Following https://github.com/scikit-hep/awkward/blob/main-v1/src/awkward/_v2/__init__.py
 
+# behaviors
+# high-level interface
+# third-party connectors
+# internal
 # layout classes; functionality that used to be in C++ (in Awkward 1.x)
-from awkward import index  # noqa: F401
-from awkward import identifier  # noqa: F401
+from awkward import Array  # noqa: F401
+from awkward import ArrayBuilder  # noqa: F401
+from awkward import Record  # noqa: F401
+from awkward import _broadcasting  # noqa: F401
+from awkward import _connect  # noqa: F401
+from awkward import _lookup  # noqa: F401
+from awkward import _slicing  # noqa: F401
+from awkward import _typetracer  # noqa: F401
+from awkward import _util  # noqa: F401
+from awkward import behavior  # noqa: F401
+from awkward import behaviors  # noqa: F401
 from awkward import contents  # noqa: F401
+from awkward import forms  # noqa: F401
+from awkward import identifier  # noqa: F401
+from awkward import index  # noqa: F401
 from awkward import record  # noqa: F401
 from awkward import types  # noqa: F401
-from awkward import forms  # noqa: F401
-from awkward import _slicing  # noqa: F401
-from awkward import _broadcasting  # noqa: F401
-from awkward import _typetracer  # noqa: F401
-
-# internal
-from awkward import _util  # noqa: F401
-from awkward import _lookup  # noqa: F401
-
-# third-party connectors
-from awkward import _connect  # noqa: F401
-
-# high-level interface
-from awkward import Array  # noqa: F401
-from awkward import Record  # noqa: F401
-from awkward import ArrayBuilder  # noqa: F401
-
-# behaviors
-from awkward import behaviors  # noqa: F401
 
 # operations
 from awkward.operations import *  # noqa: F401
-
-from awkward import behavior  # noqa: F401

--- a/src/awkward/_v2.py
+++ b/src/awkward/_v2.py
@@ -1,0 +1,34 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+# Following https://github.com/scikit-hep/awkward/blob/main-v1/src/awkward/_v2/__init__.py
+
+# layout classes; functionality that used to be in C++ (in Awkward 1.x)
+from awkward import index  # noqa: F401
+from awkward import identifier  # noqa: F401
+from awkward import contents  # noqa: F401
+from awkward import record  # noqa: F401
+from awkward import types  # noqa: F401
+from awkward import forms  # noqa: F401
+from awkward import _slicing  # noqa: F401
+from awkward import _broadcasting  # noqa: F401
+from awkward import _typetracer  # noqa: F401
+
+# internal
+from awkward import _util  # noqa: F401
+from awkward import _lookup  # noqa: F401
+
+# third-party connectors
+from awkward import _connect  # noqa: F401
+
+# high-level interface
+from awkward import Array  # noqa: F401
+from awkward import Record  # noqa: F401
+from awkward import ArrayBuilder  # noqa: F401
+
+# behaviors
+from awkward import behaviors  # noqa: F401
+
+# operations
+from awkward.operations import *  # noqa: F401
+
+from awkward import behavior  # noqa: F401

--- a/src/awkward/_v2.py
+++ b/src/awkward/_v2.py
@@ -17,6 +17,8 @@ from awkward import contents  # noqa: F401
 from awkward import forms  # noqa: F401
 from awkward import identifier  # noqa: F401
 from awkward import index  # noqa: F401
+from awkward import numba  # noqa: F401
+from awkward import operations  # noqa: F401
 from awkward import record  # noqa: F401
 from awkward import types  # noqa: F401
 from awkward.operations import *  # noqa: F401,F403 pylint: disable=W0401,W0614

--- a/src/awkward/_v2.py
+++ b/src/awkward/_v2.py
@@ -2,11 +2,6 @@
 
 # Following https://github.com/scikit-hep/awkward/blob/main-v1/src/awkward/_v2/__init__.py
 
-# behaviors
-# high-level interface
-# third-party connectors
-# internal
-# layout classes; functionality that used to be in C++ (in Awkward 1.x)
 from awkward import Array  # noqa: F401
 from awkward import ArrayBuilder  # noqa: F401
 from awkward import Record  # noqa: F401
@@ -24,6 +19,4 @@ from awkward import identifier  # noqa: F401
 from awkward import index  # noqa: F401
 from awkward import record  # noqa: F401
 from awkward import types  # noqa: F401
-
-# operations
-from awkward.operations import *  # noqa: F401
+from awkward.operations import *  # noqa: F401,F403 pylint: disable=W0401,W0614


### PR DESCRIPTION
Instead of making `awkward._v2` be referentially the same as `awkward`, inserted into `sys.modules` by hand (which does strange things to the `__package__` names of all submodules, described here: https://github.com/scikit-hep/awkward/pull/1757#issuecomment-1262759917), I made a file named src/awkward/_v2.py and filled it with what the old _v2 had.

Now `awkward._v2` is a plain old boring submodule, referentially distinct from `awkward`, and submodule `__package__` names are not changed. It also has exactly the contents that the old `awkward._v2` had (not a superset of them), and it gives us a place where we could add a deprecation warning, if we ever want to. The direct imports can be replaced with a module-level `__getitem__` that warns before it returns what was requested, like the module-level `__getitem__` in Uproot ([here](https://github.com/scikit-hep/uproot5/blob/main/src/uproot/dynamic.py)).