### PR TITLE
chore: remove sre_parse dependency from Lark-generated parser.

### DIFF
--- a/src/awkward/types/_awkward_datashape_parser.py
+++ b/src/awkward/types/_awkward_datashape_parser.py
@@ -400,8 +400,11 @@ try:
 except ImportError:
     regex = None
 
-import sre_constants
-import sre_parse
+if sys.version_info >= (3, 11):
+    import re._constants as sre_constants
+    import re._parser as sre_parse
+else:
+    import sre_parse
 
 categ_pattern = re.compile(r'\\p{[A-Za-z_]+}')
 

--- a/src/awkward/types/_awkward_datashape_parser.py
+++ b/src/awkward/types/_awkward_datashape_parser.py
@@ -404,6 +404,7 @@ if sys.version_info >= (3, 11):
     import re._constants as sre_constants
     import re._parser as sre_parse
 else:
+    import sre_constants
     import sre_parse
 
 categ_pattern = re.compile(r'\\p{[A-Za-z_]+}')


### PR DESCRIPTION
Lark will be making this change as well: https://github.com/lark-parser/lark/commit/1b62465068fe95436d1e83839b522b18f84124f5.

When that gets into a stable release, we should _re-generate_ this file (and we should, from time to time, because it's decoupled from the original library and doesn't see updates). But in the meantime, it won't cause warnings in Python 3.11, which deprecates `sre_parse`.