### PR TITLE
fix: use raise with `ak._errors.wrap_error`

### DIFF
--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -123,10 +123,7 @@ def re_evaluate(local_dict=None):
         compiled_ex = numexpr.necompiler._numexpr_last["ex"]  # noqa: F841
     except KeyError as err:
         raise ak._errors.wrap_error(
-            RuntimeError(
-                "not a previous evaluate() execution found"
-                + ak._util.exception_suffix(__file__)
-            )
+            RuntimeError("not a previous evaluate() execution found")
         ) from err
     names = numexpr.necompiler._numexpr_last["argnames"]
     arguments = getArguments(names, local_dict)

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -125,7 +125,7 @@ def re_evaluate(local_dict=None):
         raise ak._errors.wrap_error(
             RuntimeError(
                 "not a previous evaluate() execution found"
-                + ak._errors.exception_suffix(__file__)
+                + ak._util.exception_suffix(__file__)
             )
         ) from err
     names = numexpr.necompiler._numexpr_last["argnames"]

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -125,7 +125,7 @@ def re_evaluate(local_dict=None):
         raise ak._errors.wrap_error(
             RuntimeError(
                 "not a previous evaluate() execution found"
-                + ak._util.exception_suffix(__file__)
+                + ak._errors.exception_suffix(__file__)
             )
         ) from err
     names = numexpr.necompiler._numexpr_last["argnames"]

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -1,11 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+import sys
 import threading
 import traceback
 import warnings
 from collections.abc import Mapping, Sequence
 
+import awkward as ak
 from awkward import _util, nplikes
 
 np = nplikes.NumpyMetadata.instance()
@@ -327,3 +329,25 @@ Issue: {}.""".format(
         version, date, will_be, message
     )
     warnings.warn(warning, category, stacklevel=stacklevel + 1)
+
+
+def exception_suffix(filename: str) -> str:
+    """
+    Args:
+        filename: name of file that raises the Exception
+
+    Return a parenthesised URL to the given file on GitHub, including the
+    line number of the raised Exception.
+    """
+    line = ""
+    if hasattr(sys, "_getframe"):
+        line = "#L" + str(sys._getframe(1).f_lineno)
+    filename = filename.replace("\\", "/")
+    filename = "/src/awkward/" + filename.split("awkward/")[1]
+    return (
+        "\n\n(https://github.com/scikit-hep/awkward-1.0/blob/"
+        + ak.__version__
+        + filename
+        + line
+        + ")"
+    )

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -1,13 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-import sys
 import threading
 import traceback
 import warnings
 from collections.abc import Mapping, Sequence
 
-import awkward as ak
 from awkward import _util, nplikes
 
 np = nplikes.NumpyMetadata.instance()
@@ -329,25 +327,3 @@ Issue: {}.""".format(
         version, date, will_be, message
     )
     warnings.warn(warning, category, stacklevel=stacklevel + 1)
-
-
-def exception_suffix(filename: str) -> str:
-    """
-    Args:
-        filename: name of file that raises the Exception
-
-    Return a parenthesised URL to the given file on GitHub, including the
-    line number of the raised Exception.
-    """
-    line = ""
-    if hasattr(sys, "_getframe"):
-        line = "#L" + str(sys._getframe(1).f_lineno)
-    filename = filename.replace("\\", "/")
-    filename = "/src/awkward/" + filename.split("awkward/")[1]
-    return (
-        "\n\n(https://github.com/scikit-hep/awkward-1.0/blob/"
-        + ak.__version__
-        + filename
-        + line
-        + ")"
-    )

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -545,14 +545,14 @@ class Cupy(NumpyLike):
     def ma(self):
         raise ValueError(
             "CUDA arrays cannot have missing values until CuPy implements "
-            "numpy.ma.MaskedArray" + ak._util.exception_suffix(__file__)
+            "numpy.ma.MaskedArray"
         )
 
     @property
     def char(self):
         raise ValueError(
             "CUDA arrays cannot do string manipulations until CuPy implements "
-            "numpy.char" + ak._util.exception_suffix(__file__)
+            "numpy.char"
         )
 
     @property
@@ -757,7 +757,7 @@ class Jax(NumpyLike):
         raise ak._errors.wrap_error(
             ValueError(
                 "JAX arrays cannot have missing values until JAX implements "
-                "numpy.ma.MaskedArray" + ak._util.exception_suffix(__file__)
+                "numpy.ma.MaskedArray"
             )
         )
 
@@ -937,5 +937,4 @@ def nplike_of(*arrays, default_cls=Numpy):
     ak.to_backend(array, 'cuda')
 
 to move one or the other to main memory or the GPU(s)."""
-            + ak._util.exception_suffix(__file__)
         )

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -545,14 +545,14 @@ class Cupy(NumpyLike):
     def ma(self):
         raise ValueError(
             "CUDA arrays cannot have missing values until CuPy implements "
-            "numpy.ma.MaskedArray" + ak._errors.exception_suffix(__file__)
+            "numpy.ma.MaskedArray" + ak._util.exception_suffix(__file__)
         )
 
     @property
     def char(self):
         raise ValueError(
             "CUDA arrays cannot do string manipulations until CuPy implements "
-            "numpy.char" + ak._errors.exception_suffix(__file__)
+            "numpy.char" + ak._util.exception_suffix(__file__)
         )
 
     @property
@@ -757,7 +757,7 @@ class Jax(NumpyLike):
         raise ak._errors.wrap_error(
             ValueError(
                 "JAX arrays cannot have missing values until JAX implements "
-                "numpy.ma.MaskedArray" + ak._errors.exception_suffix(__file__)
+                "numpy.ma.MaskedArray" + ak._util.exception_suffix(__file__)
             )
         )
 
@@ -807,7 +807,7 @@ class Jax(NumpyLike):
         elif isinstance(nplike, ak._typetracer.TypeTracer):
             return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
         else:
-            raise ak._errors.wrap_error(
+            ak._errors.wrap_error(
                 TypeError(
                     "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, Typetracer or Jax",
                 )
@@ -937,5 +937,5 @@ def nplike_of(*arrays, default_cls=Numpy):
     ak.to_backend(array, 'cuda')
 
 to move one or the other to main memory or the GPU(s)."""
-            + ak._errors.exception_suffix(__file__)
+            + ak._util.exception_suffix(__file__)
         )

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -545,14 +545,14 @@ class Cupy(NumpyLike):
     def ma(self):
         raise ValueError(
             "CUDA arrays cannot have missing values until CuPy implements "
-            "numpy.ma.MaskedArray" + ak._util.exception_suffix(__file__)
+            "numpy.ma.MaskedArray" + ak._errors.exception_suffix(__file__)
         )
 
     @property
     def char(self):
         raise ValueError(
             "CUDA arrays cannot do string manipulations until CuPy implements "
-            "numpy.char" + ak._util.exception_suffix(__file__)
+            "numpy.char" + ak._errors.exception_suffix(__file__)
         )
 
     @property
@@ -757,7 +757,7 @@ class Jax(NumpyLike):
         raise ak._errors.wrap_error(
             ValueError(
                 "JAX arrays cannot have missing values until JAX implements "
-                "numpy.ma.MaskedArray" + ak._util.exception_suffix(__file__)
+                "numpy.ma.MaskedArray" + ak._errors.exception_suffix(__file__)
             )
         )
 
@@ -807,7 +807,7 @@ class Jax(NumpyLike):
         elif isinstance(nplike, ak._typetracer.TypeTracer):
             return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
         else:
-            ak._errors.wrap_error(
+            raise ak._errors.wrap_error(
                 TypeError(
                     "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, Typetracer or Jax",
                 )
@@ -937,5 +937,5 @@ def nplike_of(*arrays, default_cls=Numpy):
     ak.to_backend(array, 'cuda')
 
 to move one or the other to main memory or the GPU(s)."""
-            + ak._util.exception_suffix(__file__)
+            + ak._errors.exception_suffix(__file__)
         )

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -754,7 +754,7 @@ class Jax(NumpyLike):
 
     @property
     def ma(self):
-        ak._errors.wrap_error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "JAX arrays cannot have missing values until JAX implements "
                 "numpy.ma.MaskedArray" + ak._util.exception_suffix(__file__)
@@ -763,7 +763,7 @@ class Jax(NumpyLike):
 
     @property
     def char(self):
-        ak._errors.wrap_error(
+        raise ak._errors.wrap_error(
             ValueError(
                 "JAX arrays cannot do string manipulations until JAX implements "
                 "numpy.char"


### PR DESCRIPTION
This PR fixes two unrelated bugs:
- Use `raise` with `ak._errors.wrap_error` - a couple of lines were never raising exceptions
- Remove uses of `exception_suffix` in `ak._errors` - the v1 → v2 transition removed this