### PR TITLE
refactor: move `is_XXX_buffer` into respective nplikes

### DIFF
--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -893,3 +893,7 @@ class TypeTracer(ak.nplikes.NumpyLike):
 
     def datetime_as_string(self, *args, **kwargs):
         raise ak._errors.wrap_error(NotImplementedError)
+
+    @classmethod
+    def is_own_buffer(cls, obj) -> bool:
+        return isinstance(obj, TypeTracerArray)

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -167,9 +167,9 @@ class Index:
 
         if hasattr(out, "shape") and len(out.shape) != 0:
             return Index(out, metadata=self.metadata, nplike=self.nplike)
-        elif (ak.nplikes.is_jax_buffer(out) or ak.nplikes.is_cupy_buffer(out)) and len(
-            out.shape
-        ) == 0:
+        elif (
+            ak.nplikes.Jax.is_own_buffer(out) or ak.nplikes.Cupy.is_own_buffer(out)
+        ) and len(out.shape) == 0:
             return out.item()
         else:
             return out

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -358,6 +358,17 @@ class NumpyLike(Singleton):
     def datetime_as_string(self, *args, **kwargs):
         return self._module.datetime_as_string(*args, **kwargs)
 
+    @classmethod
+    def is_own_buffer(cls, obj) -> bool:
+        """
+        Args:
+            obj: object to test
+
+        Return `True` if the given object is a numpy buffer, otherwise `False`.
+
+        """
+        raise NotImplementedError
+
 
 class NumpyKernel:
     def __init__(self, kernel, name_and_types):

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -406,7 +406,7 @@ class NumpyKernel:
     def __call__(self, *args):
         assert len(args) == len(self._kernel.argtypes)
 
-        if not any(is_jax_tracer(arg) for arg in args):
+        if not any(Jax.is_tracer(arg) for arg in args):
             return self._kernel(
                 *(self._cast(x, t) for x, t in zip(args, self._kernel.argtypes))
             )
@@ -897,17 +897,17 @@ class Jax(NumpyLike):
         module, _, suffix = type(obj).__module__.partition(".")
         return module == "jaxlib"
 
+    @classmethod
+    def is_tracer(cls, obj) -> bool:
+        """
+        Args:
+            obj: object to test
 
-def is_jax_tracer(obj) -> bool:
-    """
-    Args:
-        obj: object to test
+        Return `True` if the given object is a jax tracer, otherwise `False`.
 
-    Return `True` if the given object is a jax tracer, otherwise `False`.
-
-    """
-    module, _, suffix = type(obj).__module__.partition(".")
-    return module == "jax"
+        """
+        module, _, suffix = type(obj).__module__.partition(".")
+        return module == "jax"
 
 
 def nplike_of(*arrays, default_cls=Numpy):

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -931,7 +931,7 @@ def nplike_of(*arrays, default_cls=Numpy):
             for cls in nplike_classes:
                 if cls.is_own_buffer(array):
                     nplikes.add(cls.instance())
-                    continue
+                    break
 
     if any(isinstance(x, ak._typetracer.TypeTracer) for x in nplikes):
         return ak._typetracer.TypeTracer.instance()

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -375,13 +375,13 @@ class NumpyKernel:
     def _cast(x, t):
         if issubclass(t, ctypes._Pointer):
 
-            if is_numpy_buffer(x):
+            if Numpy.is_own_buffer(x):
                 return ctypes.cast(x.ctypes.data, t)
-            elif is_cupy_buffer(x):
+            elif Cupy.is_own_buffer(x):
                 raise ak._errors.wrap_error(
                     AssertionError("CuPy buffers shouldn't be passed to Numpy Kernels.")
                 )
-            elif is_jax_buffer(x):
+            elif Jax.is_own_buffer(x):
                 raise ak._errors.wrap_error(
                     ValueError(
                         "JAX Buffers can't be passed as function args for the C Kernels"
@@ -513,6 +513,17 @@ class Numpy(NumpyLike):
             raise TypeError(
                 "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, Typetracer or Jax"
             )
+
+    @classmethod
+    def is_own_buffer(cls, obj) -> bool:
+        """
+        Args:
+            obj: object to test
+
+        Return `True` if the given object is a numpy buffer, otherwise `False`.
+
+        """
+        return isinstance(obj, numpy.ndarray)
 
 
 class Cupy(NumpyLike):
@@ -713,6 +724,18 @@ class Cupy(NumpyLike):
         # array, max_line_width, precision=None, suppress_small=None
         return self._module.array_str(array, max_line_width, precision, suppress_small)
 
+    @classmethod
+    def is_own_buffer(cls, obj) -> bool:
+        """
+        Args:
+            obj: object to test
+
+        Return `True` if the given object is a cupy buffer, otherwise `False`.
+
+        """
+        module, _, suffix = type(obj).__module__.partition(".")
+        return module == "cupy"
+
 
 class Jax(NumpyLike):
     @property
@@ -851,40 +874,17 @@ class Jax(NumpyLike):
         out = self._module.argmax(*args, **kwargs)
         return out
 
+    @classmethod
+    def is_own_buffer(cls, obj) -> bool:
+        """
+        Args:
+            obj: object to test
 
-def is_numpy_buffer(obj) -> bool:
-    """
-    Args:
-        obj: object to test
+        Return `True` if the given object is a jax buffer, otherwise `False`.
 
-    Return `True` if the given object is a numpy buffer, otherwise `False`.
-
-    """
-    return isinstance(obj, numpy.ndarray)
-
-
-def is_cupy_buffer(obj) -> bool:
-    """
-    Args:
-        obj: object to test
-
-    Return `True` if the given object is a cupy buffer, otherwise `False`.
-
-    """
-    module, _, suffix = type(obj).__module__.partition(".")
-    return module == "cupy"
-
-
-def is_jax_buffer(obj) -> bool:
-    """
-    Args:
-        obj: object to test
-
-    Return `True` if the given object is a jax buffer, otherwise `False`.
-
-    """
-    module, _, suffix = type(obj).__module__.partition(".")
-    return module == "jaxlib"
+        """
+        module, _, suffix = type(obj).__module__.partition(".")
+        return module == "jaxlib"
 
 
 def is_jax_tracer(obj) -> bool:
@@ -910,16 +910,17 @@ def nplike_of(*arrays, default_cls=Numpy):
     are found.
     """
     nplikes = set()
+    nplike_classes = (Numpy, Cupy, Jax)
+
     for array in arrays:
         nplike = getattr(array, "nplike", None)
         if nplike is not None:
             nplikes.add(nplike)
-        elif is_numpy_buffer(array):
-            nplikes.add(Numpy.instance())
-        elif is_cupy_buffer(array):
-            nplikes.add(Cupy.instance())
-        elif is_jax_buffer(array):
-            nplikes.add(Jax.instance())
+        else:
+            for cls in nplike_classes:
+                if cls.is_own_buffer(array):
+                    nplikes.add(cls.instance())
+                    continue
 
     if any(isinstance(x, ak._typetracer.TypeTracer) for x in nplikes):
         return ak._typetracer.TypeTracer.instance()

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -921,7 +921,7 @@ def nplike_of(*arrays, default_cls=Numpy):
     are found.
     """
     nplikes = set()
-    nplike_classes = (Numpy, Cupy, Jax)
+    nplike_classes = (Numpy, Cupy, Jax, ak._typetracer.TypeTracer)
 
     for array in arrays:
         nplike = getattr(array, "nplike", None)

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -51,13 +51,15 @@ def concatenate(
 def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
     # Simple single-array, axis=0 fast-path
     single_nplike = ak.nplikes.nplike_of(arrays)
+    numpy = ak.nplikes.Numpy.instance()
+
     if (
         # Is an Awkward Content
         isinstance(arrays, ak.contents.Content)
         # Is a NumPy Array
-        or ak.nplikes.is_numpy_buffer(arrays)
+        or numpy.is_own_buffer(arrays)
         # Is an array with a known NumpyLike
-        or single_nplike is not ak.nplikes.Numpy.instance()
+        or single_nplike is not numpy
     ):
         # Convert the array to a layout object
         content = ak.operations.to_layout(arrays, allow_record=False, allow_other=False)

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -87,7 +87,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplikes.is_cupy_buffer(array) and type(array).__name__ == "ndarray":
+    elif ak.nplikes.Cupy.is_own_buffer(array) and type(array).__name__ == "ndarray":
         if not issubclass(array.dtype.type, numpytype):
             raise ak._errors.wrap_error(
                 ValueError(f"dtype {array.dtype!r} not allowed")
@@ -99,7 +99,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplikes.is_jax_buffer(array) and type(array).__name__ == "DeviceArray":
+    elif ak.nplikes.Jax.is_own_buffer(array) and type(array).__name__ == "DeviceArray":
         if not issubclass(array.dtype.type, numpytype):
             raise ak._errors.wrap_error(
                 ValueError(f"dtype {array.dtype!r} not allowed")


### PR DESCRIPTION
Now that we have four `NumpyLike` implementations, I think it's reasonable to move the external `is_XXX_buffer` functions into their respective NumpyLike classes.

This PR adds an `is_own_buffer` classmethod to each `NumpyLike`, including `TypeTracer`