### PR TITLE
refactor: clean up `_connect`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ exclude =
 
 [options.entry_points]
 numba_extensions =
-    init = awkward.numba:register
+    init = awkward.numba:_register
 
 [flake8]
 extend-select = C,B,B9,T,AK1

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -30,6 +30,7 @@ import awkward._lookup
 import awkward._connect.numpy
 import awkward._connect.numexpr
 import awkward.numba
+import awkward.jax
 
 # high-level interface
 from awkward.highlevel import Array

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -1,45 +1,8 @@
-# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-
-import awkward as ak
-
-
-def find_numpyarray_nodes(layout):
-
-    data_ptrs = []
-
-    def find_nparray_ptrs(node, **kwargs):
-        if isinstance(node, ak.contents.NumpyArray):
-            data_ptrs.append(node.data)
-
-    layout.recursively_apply(action=find_nparray_ptrs, return_array=False)
-
-    return data_ptrs
-
-
-def replace_numpyarray_nodes(layout, buffers):
-    def replace_numpyarray_nodes(node, **kwargs):
-        if isinstance(node, ak.contents.NumpyArray):
-            buffer = buffers[0]
-            buffers.pop(0)
-            return ak.contents.NumpyArray(
-                buffer,
-                layout.identifier,
-                layout.parameters,
-                nplike=ak.nplikes.Jax.instance(),
-            )
-
-    return layout.recursively_apply(action=replace_numpyarray_nodes)
-
-
-class AuxData:
-    def __init__(self, layout):
-        self._layout = layout
-
-    @property
-    def layout(self):
-        return self._layout
-
-    def __eq__(self, other):
-        return self.layout.layout_equal(
-            other.layout, index_dtype=False, numpyarray=False
-        )
+import awkward._connect.jax.reducers  # noqa: F401
+from awkward._connect.jax.trees import (  # noqa: F401
+    AuxData,
+    find_numpyarray_nodes,
+    jax_flatten_highlevel,
+    jax_unflatten_highlevel,
+    replace_numpyarray_nodes,
+)

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -1,4 +1,6 @@
-import awkward._connect.jax.reducers  # noqa: F401
+import jax.numpy
+
+from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
 from awkward._connect.jax.trees import (  # noqa: F401
     AuxData,
     find_numpyarray_nodes,
@@ -6,3 +8,7 @@ from awkward._connect.jax.trees import (  # noqa: F401
     jax_unflatten_highlevel,
     replace_numpyarray_nodes,
 )
+
+
+def get_jax_ufunc(ufunc):
+    return getattr(jax.numpy, ufunc.__name__)

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -2,65 +2,6 @@
 
 import awkward as ak
 
-try:
-    import jax
-
-    error_message = None
-
-except ModuleNotFoundError:
-    jax = None
-    error_message = """to use {0}, you must install jax:
-
-    pip install jax jaxlib
-
-or
-
-    conda install -c conda-forge jax jaxlib
-"""
-
-pytrees_registered = False
-
-
-def register_pytrees():
-    for cls in [
-        ak.contents.BitMaskedArray,
-        ak.contents.ByteMaskedArray,
-        ak.contents.EmptyArray,
-        ak.contents.IndexedArray,
-        ak.contents.IndexedOptionArray,
-        ak.contents.NumpyArray,
-        ak.contents.ListArray,
-        ak.contents.ListOffsetArray,
-        ak.contents.RecordArray,
-        ak.contents.UnionArray,
-        ak.contents.UnmaskedArray,
-        ak.record.Record,
-    ]:
-        jax.tree_util.register_pytree_node(
-            cls,
-            cls.jax_flatten,
-            cls.jax_unflatten,
-        )
-
-    for cls in [ak.highlevel.Array, ak.highlevel.Record]:
-        jax.tree_util.register_pytree_node(
-            cls,
-            cls._jax_flatten,
-            cls._jax_unflatten,
-        )
-
-
-def import_jax(name="Awkward Arrays with JAX"):
-    if jax is None:
-        raise ak._errors.wrap_error(ModuleNotFoundError(error_message.format(name)))
-
-    global pytrees_registered
-
-    if not pytrees_registered:
-        register_pytrees()
-        pytrees_registered = True
-    return jax
-
 
 def _find_numpyarray_nodes(layout):
 

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -3,10 +3,10 @@ import jax.numpy
 from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
 from awkward._connect.jax.trees import (  # noqa: F401
     AuxData,
-    find_numpyarray_nodes,
+    find_all_buffers,
     jax_flatten_highlevel,
     jax_unflatten_highlevel,
-    replace_numpyarray_nodes,
+    replace_all_buffers,
 )
 
 

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -3,7 +3,7 @@
 import awkward as ak
 
 
-def _find_numpyarray_nodes(layout):
+def find_numpyarray_nodes(layout):
 
     data_ptrs = []
 
@@ -16,7 +16,7 @@ def _find_numpyarray_nodes(layout):
     return data_ptrs
 
 
-def _replace_numpyarray_nodes(layout, buffers):
+def replace_numpyarray_nodes(layout, buffers):
     def replace_numpyarray_nodes(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
             buffer = buffers[0]

--- a/src/awkward/_connect/jax/_reducers.py
+++ b/src/awkward/_connect/jax/_reducers.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._connect.jax import import_jax
+from awkward.jax import import_jax
 
 np = ak.nplikes.NumpyMetadata.instance()
 

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -25,7 +25,7 @@ def find_numpyarray_nodes(
 def replace_numpyarray_nodes(
     layout: contents.Content | record.Record, buffers: list[numpy.ndarray]
 ):
-    def replace_numpyarray_nodes(node, **kwargs):
+    def action(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
             buffer = buffers[0]
             buffers.pop(0)
@@ -36,7 +36,7 @@ def replace_numpyarray_nodes(
                 nplike=ak.nplikes.Jax.instance(),
             )
 
-    return layout.recursively_apply(action=replace_numpyarray_nodes)
+    return layout.recursively_apply(action=action, trim=False)
 
 
 class AuxData:

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -13,11 +13,11 @@ def find_numpyarray_nodes(
 
     data_ptrs = []
 
-    def find_nparray_ptrs(node, **kwargs):
+    def action(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
             data_ptrs.append(node.data)
 
-    layout.recursively_apply(action=find_nparray_ptrs, return_array=False)
+    layout.recursively_apply(action=action, return_array=False, trim=False)
 
     return data_ptrs
 
@@ -27,10 +27,8 @@ def replace_numpyarray_nodes(
 ):
     def action(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
-            buffer = buffers[0]
-            buffers.pop(0)
             return ak.contents.NumpyArray(
-                buffer,
+                buffers.pop(0),
                 layout.identifier,
                 layout.parameters,
                 nplike=ak.nplikes.Jax.instance(),

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -1,0 +1,65 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+import awkward as ak
+from awkward import contents, highlevel, nplikes, record
+
+numpy = nplikes.Numpy.instance()
+
+
+def find_numpyarray_nodes(
+    layout: contents.Content | record.Record,
+) -> list[numpy.ndarray]:
+
+    data_ptrs = []
+
+    def find_nparray_ptrs(node, **kwargs):
+        if isinstance(node, ak.contents.NumpyArray):
+            data_ptrs.append(node.data)
+
+    layout.recursively_apply(action=find_nparray_ptrs, return_array=False)
+
+    return data_ptrs
+
+
+def replace_numpyarray_nodes(
+    layout: contents.Content | record.Record, buffers: list[numpy.ndarray]
+):
+    def replace_numpyarray_nodes(node, **kwargs):
+        if isinstance(node, ak.contents.NumpyArray):
+            buffer = buffers[0]
+            buffers.pop(0)
+            return ak.contents.NumpyArray(
+                buffer,
+                layout.identifier,
+                layout.parameters,
+                nplike=ak.nplikes.Jax.instance(),
+            )
+
+    return layout.recursively_apply(action=replace_numpyarray_nodes)
+
+
+class AuxData:
+    def __init__(self, layout: contents.Content | record.Record, behavior=None):
+        self._layout = layout
+
+    @property
+    def layout(self) -> contents.Content | record.Record:
+        return self._layout
+
+    def __eq__(self, other: AuxData) -> bool:
+        return self.layout.layout_equal(
+            other.layout, index_dtype=False, numpyarray=False
+        )
+
+
+def jax_flatten_highlevel(
+    array: highlevel.Array | highlevel.Record,
+) -> tuple[list[numpy.ndarray], AuxData]:
+    return array._layout._jax_flatten()
+
+
+def jax_unflatten_highlevel(
+    aux_data: AuxData, children: list[numpy.ndarray]
+) -> highlevel.Array | highlevel.Record:
+    return ak._util.wrap(aux_data.layout.jax_unflatten(aux_data, children))

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -40,12 +40,19 @@ def replace_numpyarray_nodes(
 
 
 class AuxData:
-    def __init__(self, layout: contents.Content | record.Record, behavior=None):
+    def __init__(
+        self, layout: contents.Content | record.Record, behavior: dict | None = None
+    ):
         self._layout = layout
+        self._behavior = behavior
 
     @property
     def layout(self) -> contents.Content | record.Record:
         return self._layout
+
+    @property
+    def behavior(self) -> dict | None:
+        return self._behavior
 
     def __eq__(self, other: AuxData) -> bool:
         return self.layout.layout_equal(
@@ -62,4 +69,6 @@ def jax_flatten_highlevel(
 def jax_unflatten_highlevel(
     aux_data: AuxData, children: list[numpy.ndarray]
 ) -> highlevel.Array | highlevel.Record:
-    return ak._util.wrap(aux_data.layout.jax_unflatten(aux_data, children))
+    return ak._util.wrap(
+        aux_data.layout.jax_unflatten(aux_data, children), behavior=aux_data.behavior
+    )

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -61,7 +61,7 @@ class AuxData:
 def jax_flatten_highlevel(
     array: highlevel.Array | highlevel.Record,
 ) -> tuple[list[numpy.ndarray], AuxData]:
-    return array._layout._jax_flatten()
+    return array._layout.jax_flatten()
 
 
 def jax_unflatten_highlevel(

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -7,7 +7,7 @@ from awkward import contents, highlevel, nplikes, record
 numpy = nplikes.Numpy.instance()
 
 
-def find_numpyarray_nodes(
+def find_all_buffers(
     layout: contents.Content | record.Record,
 ) -> list[numpy.ndarray]:
 
@@ -22,7 +22,7 @@ def find_numpyarray_nodes(
     return data_ptrs
 
 
-def replace_numpyarray_nodes(
+def replace_all_buffers(
     layout: contents.Content | record.Record, buffers: list[numpy.ndarray]
 ):
     def action(node, **kwargs):

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -5,11 +5,11 @@ import warnings
 
 import awkward as ak
 
-checked_version = False
+_has_checked_version = False
 
 
 def import_numexpr():
-    global checked_version
+    global _has_checked_version
     try:
         import numexpr
     except ModuleNotFoundError as err:
@@ -25,15 +25,16 @@ or
             )
         ) from err
     else:
-        if not checked_version and ak._util.parse_version(
-            numexpr.__version__
-        ) < ak._util.parse_version("2.7.1"):
-            warnings.warn(
-                "Awkward Array is only known to work with numexpr 2.7.1 or later"
-                "(you have version {})".format(numexpr.__version__),
-                RuntimeWarning,
-            )
-        checked_version = True
+        if not _has_checked_version:
+            if ak._util.parse_version(numexpr.__version__) < ak._util.parse_version(
+                "2.7.1"
+            ):
+                warnings.warn(
+                    "Awkward Array is only known to work with numexpr 2.7.1 or later"
+                    "(you have version {})".format(numexpr.__version__),
+                    RuntimeWarning,
+                )
+            _has_checked_version = True
         return numexpr
 
 

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -8,7 +8,7 @@ import awkward as ak
 _has_checked_version = False
 
 
-def import_numexpr():
+def _import_numexpr():
     global _has_checked_version
     try:
         import numexpr
@@ -69,7 +69,7 @@ def getArguments(names, local_dict=None, global_dict=None):
 def evaluate(
     expression, local_dict=None, global_dict=None, order="K", casting="safe", **kwargs
 ):
-    numexpr = import_numexpr()
+    numexpr = _import_numexpr()
 
     context = numexpr.necompiler.getContext(kwargs, frame_depth=1)
     expr_key = (expression, tuple(sorted(context.items())))
@@ -118,7 +118,7 @@ evaluate.evaluate = evaluate
 
 
 def re_evaluate(local_dict=None):
-    numexpr = import_numexpr()
+    numexpr = _import_numexpr()
 
     try:
         compiled_ex = numexpr.necompiler._numexpr_last["ex"]  # noqa: F841

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -165,7 +165,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                         args.append(x)
 
                 if isinstance(nplike, ak.nplikes.Jax):
-                    from awkward._connect.jax import import_jax
+                    from awkward.jax import import_jax
 
                     jax = import_jax()
                     result = getattr(jax.numpy, ufunc.__name__)(*args, **kwargs)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -165,10 +165,10 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                         args.append(x)
 
                 if isinstance(nplike, ak.nplikes.Jax):
-                    from awkward.jax import import_jax
+                    from awkward._connect.jax import get_jax_ufunc
 
-                    jax = import_jax()
-                    result = getattr(jax.numpy, ufunc.__name__)(*args, **kwargs)
+                    jax_ufunc = get_jax_ufunc(ufunc)
+                    result = jax_ufunc(*args, **kwargs)
                 else:
                     result = getattr(ufunc, method)(*args, **kwargs)
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -613,7 +613,7 @@ class BitMaskedArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._nplike.known_shape:
+        if self._nplike.known_shape and options["trim"]:
             content = self._content[0 : self._length]
         else:
             content = self._content

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1020,7 +1020,7 @@ class ByteMaskedArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._nplike.known_shape:
+        if self._nplike.known_shape and options["trim"]:
             content = self._content[0 : self._mask.length]
         else:
             content = self._content

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1550,6 +1550,9 @@ class Content:
         jax = Jax.instance()
 
         buffers = find_all_buffers(self)
+        # Drop the references to the existing buffers by replacing them with empty buffers
+        # This works-around the fact that AuxData should probably contain only a form and length,
+        # rather than the actual layout (which holds references to the buffers that we're returning)
         empty_buffers = [jax.empty(len(n), n.dtype) for n in buffers]
         this = replace_all_buffers(self, empty_buffers)
         return buffers, AuxData(this)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1356,6 +1356,7 @@ class Content:
         numpy_to_regular=True,
         return_array=True,
         function_name=None,
+        trim=True,
     ):
         return self._recursively_apply(
             action,
@@ -1369,6 +1370,7 @@ class Content:
                 "numpy_to_regular": numpy_to_regular,
                 "return_array": return_array,
                 "function_name": function_name,
+                "trim": trim,
             },
         )
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1543,18 +1543,13 @@ class Content:
     def __deepcopy__(self, memo):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _jax_flatten(self):
+    def jax_flatten(self):
         from awkward._connect.jax import AuxData, find_numpyarray_nodes
 
         layout = ak.operations.to_layout(self, allow_record=True, allow_other=False)
 
         numpyarray_nodes = find_numpyarray_nodes(layout)
         return (numpyarray_nodes, AuxData(layout))
-
-    @classmethod
-    def jax_flatten(cls, array):
-        assert type(array) is cls
-        return array._jax_flatten()
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1542,11 +1542,11 @@ class Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def _jax_flatten(self):
-        from awkward._connect.jax import AuxData, _find_numpyarray_nodes
+        from awkward._connect.jax import AuxData, find_numpyarray_nodes
 
         layout = ak.operations.to_layout(self, allow_record=True, allow_other=False)
 
-        numpyarray_nodes = _find_numpyarray_nodes(layout)
+        numpyarray_nodes = find_numpyarray_nodes(layout)
         return (numpyarray_nodes, AuxData(layout))
 
     @classmethod
@@ -1556,9 +1556,9 @@ class Content:
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):
-        from awkward._connect.jax import _replace_numpyarray_nodes
+        from awkward._connect.jax import replace_numpyarray_nodes
 
-        return _replace_numpyarray_nodes(aux_data.layout, list(children))
+        return replace_numpyarray_nodes(aux_data.layout, list(children))
 
     def layout_equal(self, other, index_dtype=True, numpyarray=True):
         return (

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1545,9 +1545,12 @@ class Content:
 
     def jax_flatten(self):
         from awkward._connect.jax import AuxData, find_all_buffers, replace_all_buffers
+        from awkward.nplikes import Jax
+
+        jax = Jax.instance()
 
         buffers = find_all_buffers(self)
-        empty_buffers = [numpy.empty(len(n), n.dtype) for n in buffers]
+        empty_buffers = [jax.empty(len(n), n.dtype) for n in buffers]
         this = replace_all_buffers(self, empty_buffers)
         return buffers, AuxData(this)
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1544,18 +1544,18 @@ class Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def jax_flatten(self):
-        from awkward._connect.jax import AuxData, find_numpyarray_nodes
+        from awkward._connect.jax import AuxData, find_all_buffers, replace_all_buffers
 
-        layout = ak.operations.to_layout(self, allow_record=True, allow_other=False)
-
-        numpyarray_nodes = find_numpyarray_nodes(layout)
-        return (numpyarray_nodes, AuxData(layout))
+        buffers = find_all_buffers(self)
+        empty_buffers = [numpy.empty(len(n), n.dtype) for n in buffers]
+        this = replace_all_buffers(self, empty_buffers)
+        return buffers, AuxData(this)
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):
-        from awkward._connect.jax import replace_numpyarray_nodes
+        from awkward._connect.jax import replace_all_buffers
 
-        return replace_numpyarray_nodes(aux_data.layout, list(children))
+        return replace_all_buffers(aux_data.layout, list(children))
 
     def layout_equal(self, other, index_dtype=True, numpyarray=True):
         return (

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1184,6 +1184,7 @@ class IndexedArray(Content):
             self._nplike.known_shape
             and self._nplike.known_data
             and self._index.length != 0
+            and options["trim"]
         ):
             npindex = self._index.data
             indexmin = npindex.min()

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1619,6 +1619,7 @@ class IndexedOptionArray(Content):
             self._nplike.known_shape
             and self._nplike.known_data
             and self._index.length != 0
+            and options["trim"]
         ):
             npindex = self._index.data
             npselect = npindex >= 0

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1412,6 +1412,7 @@ class ListArray(Content):
             self._nplike.known_shape
             and self._nplike.known_data
             and self._starts.length != 0
+            and options["trim"]
         ):
             startsmin = self._starts.data.min()
             starts = ak.index.Index(self._starts.data - startsmin, nplike=self._nplike)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2045,7 +2045,7 @@ class ListOffsetArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._nplike.known_shape and self._nplike.known_data:
+        if self._nplike.known_shape and self._nplike.known_data and options["trim"]:
             offsetsmin = self._offsets[0]
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._nplike

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1100,12 +1100,9 @@ class NumpyArray(Content):
             )
 
         if isinstance(self.nplike, ak.nplikes.Jax):
-            import awkward._connect.jax._reducers  # noqa: F401
+            from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
 
-            if isinstance(reducer, type):
-                reducer = getattr(ak._connect.jax._reducers, reducer.__name__)
-            else:
-                reducer = getattr(ak._connect.jax._reducers, type(reducer).__name__)
+            reducer = get_jax_reducer(reducer)
         out = reducer.apply(self, parents, outlength)
 
         if reducer.needs_position:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -233,6 +233,9 @@ class NumpyArray(Content):
         start, stop, step = where.indices(self.length)
         assert step == 1
 
+        # if start == 0 and stop == self.length and step == 1:
+        #     return self
+
         try:
             out = self._data[where]
         except IndexError as err:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -956,7 +956,7 @@ class RecordArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._nplike.known_shape:
+        if self._nplike.known_shape and options["trim"]:
             contents = [x[: self._length] for x in self._contents]
         else:
             contents = self._contents

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1186,7 +1186,7 @@ class RegularArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._nplike.known_shape:
+        if self._nplike.known_shape and options["trim"]:
             content = self._content[: self._length * self._size]
         else:
             content = self._content

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1436,19 +1436,6 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 return True
         return False
 
-    def _jax_flatten_layout(self):
-        return self._layout._jax_flatten()
-
-    @classmethod
-    def _jax_flatten(cls, array):
-        assert type(array) is cls
-        return array._jax_flatten_layout()
-
-    @classmethod
-    def _jax_unflatten(cls, aux_data, children):
-        layout_cls = aux_data.layout.__class__
-        return ak._util.wrap(layout_cls.jax_unflatten(aux_data, children))
-
 
 class Record(NDArrayOperatorsMixin):
     """

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -255,6 +255,11 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         if check_valid:
             ak.operations.validity_error(self, exception=True)
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        ak.jax.maybe_register_behavior_class(cls)
+
     @property
     def layout(self):
         """
@@ -1519,6 +1524,11 @@ class Record(NDArrayOperatorsMixin):
 
         if check_valid:
             ak.operations.validity_error(self, exception=True)
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        ak.jax.maybe_register_behavior_class(cls)
 
     @property
     def layout(self):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2055,19 +2055,6 @@ class Record(NDArrayOperatorsMixin):
                 return True
         return False
 
-    def _jax_flatten_layout(self):
-        return self._layout._jax_flatten()
-
-    @classmethod
-    def _jax_flatten(cls, array):
-        assert type(array) is cls
-        return array._jax_flatten_layout()
-
-    @classmethod
-    def _jax_unflatten(cls, aux_data, children):
-        layout_cls = aux_data.layout.__class__
-        return ak._util.wrap(layout_cls.jax_unflatten(aux_data, children))
-
 
 class ArrayBuilder(Sized):
     """

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -1,28 +1,12 @@
 from __future__ import annotations
 
 import types
-from typing import Any
+from typing import TypeVar
 
 import awkward as ak
-from awkward import _errors, highlevel, nplikes
+from awkward import _errors, nplikes
 
 numpy = nplikes.Numpy()
-
-
-def jax_flatten_highlevel(
-    array: highlevel.Array | highlevel.Record,
-) -> tuple[list[numpy.ndarray], Any]:
-    import awkward._connect.jax as jax_connect
-
-    return jax_connect.jax_flatten_highlevel(array)
-
-
-def jax_unflatten_highlevel(
-    aux_data: Any, children: list[numpy.ndarray]
-) -> highlevel.Array | highlevel.Record:
-    import awkward._connect.jax as jax_connect
-
-    return jax_connect.jax_unflatten_highlevel(aux_data, children)
 
 
 _is_registered = False
@@ -50,6 +34,28 @@ def register_and_check():
         ) from None
 
     _register(jax)
+
+
+T = TypeVar("T", bound="type[ak.Array | ak.Record]")
+
+
+def register_behavior_class(cls: T) -> T:
+    """
+    Args:
+        cls: behavior class to register with Jax
+
+    Return the behavior class, after registering it with Jax.
+
+    """
+    jax = assert_registered()
+    import awkward._connect.jax as jax_connect
+
+    jax.tree_util.register_pytree_node(
+        cls,
+        jax_connect.jax_flatten_highlevel,
+        jax_connect.jax_unflatten_highlevel,
+    )
+    return cls
 
 
 def _register(jax: types.ModuleType):

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import types
+
+import awkward as ak
+
+_is_registered = False
+
+
+def register():
+    """
+    Register Awkward Array node types with Jax's tree mechanism.
+    """
+    # Let's only do this once
+    global _is_registered
+    if _is_registered:
+        return
+
+    import jax
+
+    for cls in [
+        ak.contents.BitMaskedArray,
+        ak.contents.ByteMaskedArray,
+        ak.contents.EmptyArray,
+        ak.contents.IndexedArray,
+        ak.contents.IndexedOptionArray,
+        ak.contents.NumpyArray,
+        ak.contents.ListArray,
+        ak.contents.ListOffsetArray,
+        ak.contents.RecordArray,
+        ak.contents.UnionArray,
+        ak.contents.UnmaskedArray,
+        ak.record.Record,
+    ]:
+        jax.tree_util.register_pytree_node(
+            cls,
+            cls.jax_flatten,
+            cls.jax_unflatten,
+        )
+
+    for cls in [ak.highlevel.Array, ak.highlevel.Record]:
+        jax.tree_util.register_pytree_node(
+            cls,
+            cls._jax_flatten,
+            cls._jax_unflatten,
+        )
+    _is_registered = True
+
+
+def import_jax() -> types.ModuleType:
+    """
+    Import jax and return the module, or raise a helpful error message if it is not available.
+    """
+    try:
+        import jax
+
+    except ModuleNotFoundError:
+        raise ak._errors.wrap_error(
+            ModuleNotFoundError(
+                """install the 'numba' package with:
+
+        python3 -m pip install jax jaxlib
+
+    or
+
+        conda install -c conda-forge jax jaxlib
+    """
+            )
+        ) from None
+
+    register()
+    return jax

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -6,8 +6,6 @@ from typing import Any
 import awkward as ak
 from awkward import highlevel, nplikes
 
-_is_registered = False
-
 numpy = nplikes.Numpy()
 
 
@@ -25,6 +23,9 @@ def jax_unflatten_highlevel(
     import awkward._connect.jax as jax_connect
 
     return jax_connect.jax_unflatten_highlevel(aux_data, children)
+
+
+_is_registered = False
 
 
 def register():
@@ -79,7 +80,7 @@ def import_jax() -> types.ModuleType:
     except ModuleNotFoundError:
         raise ak._errors.wrap_error(
             ModuleNotFoundError(
-                """install the 'numba' package with:
+                """install the 'jax' package with:
 
         python3 -m pip install jax jaxlib
 

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -4,7 +4,7 @@ import types
 from typing import TypeVar
 
 import awkward as ak
-from awkward import _errors, nplikes
+from awkward import _errors, highlevel, nplikes
 
 numpy = nplikes.Numpy()
 
@@ -36,7 +36,7 @@ def register_and_check():
     _register(jax)
 
 
-T = TypeVar("T", bound="type[ak.Array | ak.Record]")
+T = TypeVar("T", bound="type[highlevel.Array | highlevel.Record]")
 
 
 def register_behavior_class(cls: T) -> T:

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -39,7 +39,7 @@ def register_and_check():
 T = TypeVar("T", bound="type[highlevel.Array | highlevel.Record]")
 
 
-def register_behavior_class(cls: T) -> T:
+def behavior_class(cls: T) -> T:
     """
     Args:
         cls: behavior class to register with Jax

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -36,10 +36,12 @@ def register_and_check():
     _register(jax)
 
 
-T = TypeVar("T", bound="type[highlevel.Array | highlevel.Record]")
+HighLevelType = TypeVar(
+    "HighLevelType", bound="type[highlevel.Array | highlevel.Record]"
+)
 
 
-def behavior_class(cls: T) -> T:
+def register_behavior_class(cls: HighLevelType) -> HighLevelType:
     """
     Args:
         cls: behavior class to register with Jax
@@ -47,7 +49,7 @@ def behavior_class(cls: T) -> T:
     Return the behavior class, after registering it with Jax.
 
     """
-    jax = assert_registered()
+    jax = import_jax()
     import awkward._connect.jax as jax_connect
 
     jax.tree_util.register_pytree_node(

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -782,8 +782,7 @@ class Jax(NumpyLike):
         return NumpyKernel(ak._cpu_kernels.kernel[name_and_types], name_and_types)
 
     def __init__(self):
-        import jax.numpy
-
+        jax = ak.jax.import_jax()
         self._module = jax.numpy
 
     @property

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -782,7 +782,9 @@ class Jax(NumpyLike):
         return NumpyKernel(ak._cpu_kernels.kernel[name_and_types], name_and_types)
 
     def __init__(self):
-        self._module = ak.jax.import_jax().numpy
+        import jax.numpy
+
+        self._module = jax.numpy
 
     @property
     def ma(self):

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -782,9 +782,7 @@ class Jax(NumpyLike):
         return NumpyKernel(ak._cpu_kernels.kernel[name_and_types], name_and_types)
 
     def __init__(self):
-        from awkward._connect.jax import import_jax  # noqa: F401
-
-        self._module = import_jax().numpy
+        self._module = ak.jax.import_jax().numpy
 
     @property
     def ma(self):

--- a/src/awkward/numba.py
+++ b/src/awkward/numba.py
@@ -8,26 +8,26 @@ _has_checked_version = False
 def register_and_check():
     global _has_checked_version
 
-    if not _has_checked_version:
-        try:
-            import numba
-        except ImportError as err:
-            raise ImportError(
-                """install the 'numba' package with:
+    try:
+        import numba
+    except ImportError as err:
+        raise ImportError(
+            """install the 'numba' package with:
 
-    pip install numba --upgrade
+pip install numba --upgrade
 
 or
 
-    conda install numba"""
-            ) from err
+conda install numba"""
+        ) from err
 
-        _has_checked_version = True
+    if not _has_checked_version:
         if ak._util.parse_version(numba.__version__) < ak._util.parse_version("0.50"):
             raise ImportError(
                 "Awkward Array can only work with numba 0.50 or later "
                 "(you have version {})".format(numba.__version__)
             )
+        _has_checked_version = True
 
     _register(numba)
 

--- a/src/awkward/numba.py
+++ b/src/awkward/numba.py
@@ -29,12 +29,14 @@ conda install numba"""
             )
         _has_checked_version = True
 
-    _register(numba)
+    _register()
 
 
-def _register(numba):
+def _register():
     if hasattr(ak.numba, "ArrayViewType"):
         return
+
+    import numba
 
     import awkward._connect.numba.arrayview
     import awkward._connect.numba.builder

--- a/src/awkward/numba.py
+++ b/src/awkward/numba.py
@@ -2,13 +2,13 @@
 
 import awkward as ak
 
-checked_version = False
+_has_checked_version = False
 
 
 def register_and_check():
-    global checked_version
+    global _has_checked_version
 
-    if not checked_version:
+    if not _has_checked_version:
         try:
             import numba
         except ImportError as err:
@@ -22,21 +22,19 @@ or
     conda install numba"""
             ) from err
 
-        checked_version = True
+        _has_checked_version = True
         if ak._util.parse_version(numba.__version__) < ak._util.parse_version("0.50"):
             raise ImportError(
                 "Awkward Array can only work with numba 0.50 or later "
                 "(you have version {})".format(numba.__version__)
             )
 
-    register()
+    _register(numba)
 
 
-def register():
+def _register(numba):
     if hasattr(ak.numba, "ArrayViewType"):
         return
-
-    import numba
 
     import awkward._connect.numba.arrayview
     import awkward._connect.numba.builder

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -36,5 +36,5 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
             behavior=behavior,
         ),
     ):
-        jax.register()
+        jax.assert_registered()
         return _util.from_arraylib(array, regulararray, False, highlevel, behavior)

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -1,6 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward as ak
+from awkward import _errors, _util, jax
 
 
 def from_jax(array, regulararray=False, highlevel=True, behavior=None):
@@ -27,7 +27,7 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
 
     See also #ak.to_jax, #ak.from_numpy and #ak.from_jax.
     """
-    with ak._errors.OperationErrorContext(
+    with _errors.OperationErrorContext(
         "ak.from_jax",
         dict(
             array=array,
@@ -36,4 +36,5 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
             behavior=behavior,
         ),
     ):
-        return ak._util.from_arraylib(array, regulararray, False, highlevel, behavior)
+        jax.register()
+        return _util.from_arraylib(array, regulararray, False, highlevel, behavior)

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward.jax import import_jax
 
 
 def to_jax(array):
@@ -21,7 +22,5 @@ def to_jax(array):
         "ak.to_jax",
         dict(array=array),
     ):
-        from awkward._connect.jax import import_jax
-
         jax = import_jax().numpy
         return ak._util.to_arraylib(jax, array, True)

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -21,5 +21,4 @@ def to_jax(array):
         "ak.to_jax",
         dict(array=array),
     ):
-        jax_numpy = jax.import_jax().numpy
-        return _util.to_arraylib(jax_numpy, array, True)
+        return _util.to_arraylib(jax.import_jax().numpy, array, True)

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward as ak
-from awkward.jax import import_jax
+from awkward import _errors, _util, jax
 
 
 def to_jax(array):
@@ -18,9 +17,9 @@ def to_jax(array):
 
     See also #ak.from_jax and #ak.to_numpy.
     """
-    with ak._errors.OperationErrorContext(
+    with _errors.OperationErrorContext(
         "ak.to_jax",
         dict(array=array),
     ):
-        jax = import_jax().numpy
-        return ak._util.to_arraylib(jax, array, True)
+        jax_numpy = jax.import_jax().numpy
+        return _util.to_arraylib(jax_numpy, array, True)

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -400,6 +400,7 @@ def transform(
             numpy_to_regular=numpy_to_regular,
             regular_to_jagged=regular_to_jagged,
             return_array=return_array,
+            trim=trim,
             behavior=behavior,
             highlevel=highlevel,
         ),
@@ -417,6 +418,7 @@ def transform(
             numpy_to_regular,
             regular_to_jagged,
             return_array,
+            trim,
             behavior,
             highlevel,
         )
@@ -435,6 +437,7 @@ def _impl(
     numpy_to_regular,
     regular_to_jagged,
     return_array,
+    trim,
     behavior,
     highlevel,
 ):
@@ -454,6 +457,7 @@ def _impl(
         "regular_to_jagged": regular_to_jagged,
         "keep_parameters": True,
         "return_array": return_array,
+        "trim": trim,
         "function_name": "ak.transform",
         "broadcast_parameters_rule": broadcast_parameters_rule,
     }

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -19,6 +19,7 @@ def transform(
     numpy_to_regular=False,
     regular_to_jagged=False,
     return_array=True,
+    trim=True,
     highlevel=True,
     behavior=None,
 ):
@@ -59,6 +60,8 @@ def transform(
             calling `transformation`.
         regular_to_jagged (bool): If True, regular-type lists are converted into
             variable-length lists before calling `transformation`.
+        trim (bool): If True, trim content nodes to the length of their parents.
+            Otherwise, operate upon the raw #ak.contents.Content objects.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -260,13 +260,13 @@ class Record:
             return None
 
     def jax_flatten(self):
-        from awkward._connect.jax import AuxData, find_numpyarray_nodes
+        from awkward._connect.jax import AuxData, find_all_buffers
 
-        numpyarray_nodes = find_numpyarray_nodes(self)
+        numpyarray_nodes = find_all_buffers(self)
         return (numpyarray_nodes, AuxData(self))
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):
-        from awkward._connect.jax import replace_numpyarray_nodes
+        from awkward._connect.jax import replace_all_buffers
 
-        return ak._util.wrap(replace_numpyarray_nodes(aux_data.layout, list(children)))
+        return ak._util.wrap(replace_all_buffers(aux_data.layout, list(children)))

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -259,16 +259,11 @@ class Record:
         else:
             return None
 
-    def _jax_flatten(self):
+    def jax_flatten(self):
         from awkward._connect.jax import AuxData, find_numpyarray_nodes
 
         numpyarray_nodes = find_numpyarray_nodes(self)
         return (numpyarray_nodes, AuxData(self))
-
-    @classmethod
-    def jax_flatten(cls, array):
-        assert type(array) is cls
-        return array._jax_flatten()
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -260,9 +260,9 @@ class Record:
             return None
 
     def _jax_flatten(self):
-        from awkward._connect.jax import AuxData, _find_numpyarray_nodes
+        from awkward._connect.jax import AuxData, find_numpyarray_nodes
 
-        numpyarray_nodes = _find_numpyarray_nodes(self)
+        numpyarray_nodes = find_numpyarray_nodes(self)
         return (numpyarray_nodes, AuxData(self))
 
     @classmethod
@@ -272,6 +272,6 @@ class Record:
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):
-        from awkward._connect.jax import _replace_numpyarray_nodes
+        from awkward._connect.jax import replace_numpyarray_nodes
 
-        return ak._util.wrap(_replace_numpyarray_nodes(aux_data.layout, list(children)))
+        return ak._util.wrap(replace_numpyarray_nodes(aux_data.layout, list(children)))

--- a/tests/test_1399-from-jax.py
+++ b/tests/test_1399-from-jax.py
@@ -6,8 +6,9 @@ import pytest  # noqa: F401
 import awkward as ak  # noqa: F401
 
 jax = pytest.importorskip("jax")
-
 jax.config.update("jax_enable_x64", True)
+
+ak.jax.register_and_check()
 
 
 def test_from_jax():

--- a/tests/test_1399-to-jax.py
+++ b/tests/test_1399-to-jax.py
@@ -8,6 +8,8 @@ import awkward as ak  # noqa: F401
 jax = pytest.importorskip("jax")
 jax.config.update("jax_enable_x64", True)
 
+ak.jax.register_and_check()
+
 
 def test_from_jax_1():
     ak_array_1d = ak.Array(np.arange(10))

--- a/tests/test_1447-jax-autodiff-slices-ufuncs.py
+++ b/tests/test_1447-jax-autodiff-slices-ufuncs.py
@@ -9,6 +9,8 @@ jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
 jax.config.update("jax_enable_x64", True)
 
+ak.jax.register()
+
 # #### ak.contents.NumpyArray ####
 
 test_numpyarray = ak.Array(np.arange(10, dtype=np.float64), backend="jax")

--- a/tests/test_1447-jax-autodiff-slices-ufuncs.py
+++ b/tests/test_1447-jax-autodiff-slices-ufuncs.py
@@ -9,7 +9,7 @@ jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
 jax.config.update("jax_enable_x64", True)
 
-ak.jax.register()
+ak.jax.register_and_check()
 
 # #### ak.contents.NumpyArray ####
 

--- a/tests/test_1490-jax-reducers-combinations.py
+++ b/tests/test_1490-jax-reducers-combinations.py
@@ -9,6 +9,8 @@ jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
 jax.config.update("jax_enable_x64", True)
 
+ak.jax.register_and_check()
+
 # #### ak.contents.NumpyArray ####
 
 test_numpyarray = ak.Array(np.arange(10, dtype=np.float64), backend="jax")

--- a/tests/test_1762-jax-behavior-support.py
+++ b/tests/test_1762-jax-behavior-support.py
@@ -41,9 +41,10 @@ def test_jvp_nested_list():
     def func(x):
         return x[::-1] ** 2
 
-    value_jvp, jvp_grad = jax.jvp(func, (array,), (tangent,))
-    assert value_jvp.to_list() == [[1.0, 4.0, 9.0, 16.0, 25.0]]
-    assert jvp_grad.to_list() == [[0.0, 0.0, 0.0, 0.0, 10.0]]
+    with jax.checking_leaks():
+        value_jvp, jvp_grad = jax.jvp(func, (array,), (tangent,))
+        assert value_jvp.to_list() == [[1.0, 4.0, 9.0, 16.0, 25.0]]
+        assert jvp_grad.to_list() == [[0.0, 0.0, 0.0, 0.0, 10.0]]
 
 
 def test_recursively_apply_trim():

--- a/tests/test_1762-jax-behavior-support.py
+++ b/tests/test_1762-jax-behavior-support.py
@@ -1,0 +1,34 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_platform_name", "cpu")
+jax.config.update("jax_enable_x64", True)
+
+ak.jax.register_and_check()
+
+
+class GradBehavior(ak.Array):
+    ...
+
+
+def test():
+    def square_fifth_entry(x):
+        return x[4] ** 2
+
+    primal = ak.Array(np.arange(10, dtype=np.float64), backend="jax")
+    tangent = ak.Array(np.arange(10, dtype=np.float64), backend="jax")
+
+    behavior = {"grad": GradBehavior}
+    primal_grad = ak.with_parameter(primal, "__array__", "grad", behavior=behavior)
+    tangent_grad = ak.with_parameter(tangent, "__array__", "grad", behavior=behavior)
+    value_jvp_grad, jvp_grad_grad = jax.jvp(
+        square_fifth_entry, (primal_grad,), (tangent_grad,)
+    )
+
+    assert value_jvp_grad == pytest.approx(16.0)
+    assert jvp_grad_grad == pytest.approx(32.0)

--- a/tests/test_1762-jax-behavior-support.py
+++ b/tests/test_1762-jax-behavior-support.py
@@ -33,6 +33,19 @@ def test_behavior():
     assert jvp_grad_grad == pytest.approx(32.0)
 
 
+def test_jvp_nested_list():
+    # with jax.checking_leaks():
+    array = ak.Array(np.array([[1.0, 2.0, 3.0, 4.0, 5.0]]), backend="jax")
+    tangent = ak.Array(np.array([[0.0, 0.0, 0.0, 0.0, 1.0]]), backend="jax")
+
+    def func(x):
+        return x[::-1] ** 2
+
+    value_jvp, jvp_grad = jax.jvp(func, (array,), (tangent,))
+    assert value_jvp.to_list() == [[1.0, 4.0, 9.0, 16.0, 25.0]]
+    assert jvp_grad.to_list() == [[0.0, 0.0, 0.0, 0.0, 10.0]]
+
+
 def test_recursively_apply_trim():
     numpy = ak.nplikes.Numpy.instance()
 

--- a/tests/test_1762-jax-behavior-support.py
+++ b/tests/test_1762-jax-behavior-support.py
@@ -53,7 +53,7 @@ def test_recursively_apply_trim():
         elif depth == 2:
             assert len(layout) == 6
 
-    layout.recursively_apply(visitor)
+    layout.recursively_apply(visitor, trim=True)
     assert visitor_was_called
 
 
@@ -78,6 +78,30 @@ def test_recursively_apply_no_trim():
             assert len(layout) == 24
 
     layout.recursively_apply(visitor, trim=False)
+    assert visitor_was_called
+
+
+def test_ak_transform_trim():
+    numpy = ak.nplikes.Numpy.instance()
+
+    layout = ak.contents.ListOffsetArray(
+        ak.index.Index(numpy.array([0, 3, 6], dtype=np.int64)),
+        ak.contents.NumpyArray(numpy.arange(24)),
+    )
+
+    # Test trimmed
+    visitor_was_called = False
+
+    def visitor(layout, depth, **kwargs):
+        nonlocal visitor_was_called
+        visitor_was_called = True
+
+        if depth == 1:
+            assert len(layout) == 2
+        elif depth == 2:
+            assert len(layout) == 6
+
+    ak.transform(visitor, layout, trim=True)
     assert visitor_was_called
 
 


### PR DESCRIPTION
The _motivation_ for this PR is that we need an `ak.jax` public interface to our Jax integration, namely explicit registration.

During the process of implementing this feature, I found other parts of `_connect` that I felt could benefit from some reworking as Awkward v2 has matured. Not all of these changes are necessary, so if people don't like them, we can revert them. Hopefully I can make a good case for the changes that I did make.

## New Features
- [x] expose a (new) `ak.jax` module (which we had in v1) to provide public access to register Jax
- [x] add `ak.jax.assert_registered` to ensure Jax is registered
- [x] implement support for restoring behaviours 
- [x] add `ak.jax.register_behavior_class` to register behavior classes with Jax
- [x] add `__subclass_hook__` to highlevel types in order to automatically invoke `ak.jax.register_behavior_class()`

## Refactoring
- [x] make `_connect.numexpr.import_numexpr` private
- [x] change `ak.jax.import_jax()` to assert that it is registered, instead of registering it
- [x] move the `_jax_flatten` Array/Record classmethods to high-level functions in `ak._connect.jax`
 - We don't need these to be classmethods on the Array, so let's keep the namespace empty
- [x] refactor `ak._connect.jax` to separate `_connect.jax.trees`
- [x] ensure Jax reducers inherits from `Reducer`
- [x] add `ak._connect.jax.get_jax_reducer` to find the Jax reducer for a given NumPy reducer

## Breaking Changes
- `ak.jax.register` needs to be called by external code before using Jax with Awkward. 

I think that this is a _good_ change, because this was already partly true; previously, calling `jax.XXX` functions on Awkward Arrays would only succeed if the registration step had been performed manually, or `to_jax()` had been invoked. 

This change makes it harder to forget to register Jax integration, because now the Jax integration in either direction won't work until it is enabled. Internal modules call `assert_registered()`, which encourages users to call `register_and_check()`. There is also `jax.import_jax()` which imports Jax after ensuring that it is registered.

Although this is _slightly_ less convenient; it ensures that users don't have to think about whether to call `ak.jax.register_and_check()` - one always must. It takes a stateful API `ak.to_jax` and makes it stateless.

## High Level Changes
I think our `_connect` modules should assume that the importer knows what they're doing, and _wants_ these modules because they are known to be available on the host system. This makes it easier to reason about state, and lets us avoid silently invoking the `register()` functions by accident.  

So, for our main connect modules:
- `jax` - needs to be registered, as it uses global state for integration. Internal APIs can directly use the Jax APIs, but must ensure that `assert_registered` is called. i.e. we should explicitly call `ak.jax.import_jax()`, `ak.jax.register_and_check()`, or `ak.jax.ensure_registered()` when we need these guarantees at the high-level, e.g. `ak.to_jax()`. Import checks can be done at registration, and internal functions therefore just need to check that things are currently registered.
- `numba` - see Jax[^numba] 
- `cupy` - does not need to be registered, so internal functions need to / can perform import-checks dynamically.
- `numexpr` - see CuPy
Instead of registering Jax when needed, we should explicitly call `ak.jax.import_jax()`, `ak.jax.register_and_check()`, or `jax.ensure_registered()` when we need these guarantees at the high-level, e.g. `ak.to_jax()`.

[^numba]: Perhaps not in the case of numba: it should always be registered due to the entry point. Checking this anyway would be more robust, however.`