### PR TITLE
refactor: cleanup `_connect` submodule

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ exclude =
 
 [options.entry_points]
 numba_extensions =
-    init = awkward.numba:register
+    init = awkward.numba:_register
 
 [flake8]
 extend-select = C,B,B9,T,AK1

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -30,6 +30,7 @@ import awkward._lookup
 import awkward._connect.numpy
 import awkward._connect.numexpr
 import awkward.numba
+import awkward.jax
 
 # high-level interface
 from awkward.highlevel import Array

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -1,7 +1,7 @@
 import jax.numpy
 
 from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
-from awkward._connect.jax.trees import jax_flatten, jax_unflatten  # noqa: F401
+from awkward._connect.jax.trees import register_pytree_class  # noqa: F401
 
 
 def get_jax_ufunc(ufunc):

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -1,45 +1,8 @@
-# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-
-import awkward as ak
-
-
-def find_numpyarray_nodes(layout):
-
-    data_ptrs = []
-
-    def find_nparray_ptrs(node, **kwargs):
-        if isinstance(node, ak.contents.NumpyArray):
-            data_ptrs.append(node.data)
-
-    layout.recursively_apply(action=find_nparray_ptrs, return_array=False)
-
-    return data_ptrs
-
-
-def replace_numpyarray_nodes(layout, buffers):
-    def replace_numpyarray_nodes(node, **kwargs):
-        if isinstance(node, ak.contents.NumpyArray):
-            buffer = buffers[0]
-            buffers.pop(0)
-            return ak.contents.NumpyArray(
-                buffer,
-                layout.identifier,
-                layout.parameters,
-                nplike=ak.nplikes.Jax.instance(),
-            )
-
-    return layout.recursively_apply(action=replace_numpyarray_nodes)
-
-
-class AuxData:
-    def __init__(self, layout):
-        self._layout = layout
-
-    @property
-    def layout(self):
-        return self._layout
-
-    def __eq__(self, other):
-        return self.layout.layout_equal(
-            other.layout, index_dtype=False, numpyarray=False
-        )
+import awkward._connect.jax.reducers  # noqa: F401
+from awkward._connect.jax.trees import (  # noqa: F401
+    AuxData,
+    find_numpyarray_nodes,
+    jax_flatten_highlevel,
+    jax_unflatten_highlevel,
+    replace_numpyarray_nodes,
+)

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -1,13 +1,7 @@
 import jax.numpy
 
 from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
-from awkward._connect.jax.trees import (  # noqa: F401
-    AuxData,
-    find_all_buffers,
-    jax_flatten_highlevel,
-    jax_unflatten_highlevel,
-    replace_all_buffers,
-)
+from awkward._connect.jax.trees import jax_flatten, jax_unflatten  # noqa: F401
 
 
 def get_jax_ufunc(ufunc):

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -1,4 +1,6 @@
-import awkward._connect.jax.reducers  # noqa: F401
+import jax.numpy
+
+from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
 from awkward._connect.jax.trees import (  # noqa: F401
     AuxData,
     find_numpyarray_nodes,
@@ -6,3 +8,7 @@ from awkward._connect.jax.trees import (  # noqa: F401
     jax_unflatten_highlevel,
     replace_numpyarray_nodes,
 )
+
+
+def get_jax_ufunc(ufunc):
+    return getattr(jax.numpy, ufunc.__name__)

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -2,65 +2,6 @@
 
 import awkward as ak
 
-try:
-    import jax
-
-    error_message = None
-
-except ModuleNotFoundError:
-    jax = None
-    error_message = """to use {0}, you must install jax:
-
-    pip install jax jaxlib
-
-or
-
-    conda install -c conda-forge jax jaxlib
-"""
-
-pytrees_registered = False
-
-
-def register_pytrees():
-    for cls in [
-        ak.contents.BitMaskedArray,
-        ak.contents.ByteMaskedArray,
-        ak.contents.EmptyArray,
-        ak.contents.IndexedArray,
-        ak.contents.IndexedOptionArray,
-        ak.contents.NumpyArray,
-        ak.contents.ListArray,
-        ak.contents.ListOffsetArray,
-        ak.contents.RecordArray,
-        ak.contents.UnionArray,
-        ak.contents.UnmaskedArray,
-        ak.record.Record,
-    ]:
-        jax.tree_util.register_pytree_node(
-            cls,
-            cls.jax_flatten,
-            cls.jax_unflatten,
-        )
-
-    for cls in [ak.highlevel.Array, ak.highlevel.Record]:
-        jax.tree_util.register_pytree_node(
-            cls,
-            cls._jax_flatten,
-            cls._jax_unflatten,
-        )
-
-
-def import_jax(name="Awkward Arrays with JAX"):
-    if jax is None:
-        raise ak._errors.wrap_error(ModuleNotFoundError(error_message.format(name)))
-
-    global pytrees_registered
-
-    if not pytrees_registered:
-        register_pytrees()
-        pytrees_registered = True
-    return jax
-
 
 def _find_numpyarray_nodes(layout):
 

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -3,10 +3,10 @@ import jax.numpy
 from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
 from awkward._connect.jax.trees import (  # noqa: F401
     AuxData,
-    find_numpyarray_nodes,
+    find_all_buffers,
     jax_flatten_highlevel,
     jax_unflatten_highlevel,
-    replace_numpyarray_nodes,
+    replace_all_buffers,
 )
 
 

--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -3,7 +3,7 @@
 import awkward as ak
 
 
-def _find_numpyarray_nodes(layout):
+def find_numpyarray_nodes(layout):
 
     data_ptrs = []
 
@@ -16,7 +16,7 @@ def _find_numpyarray_nodes(layout):
     return data_ptrs
 
 
-def _replace_numpyarray_nodes(layout, buffers):
+def replace_numpyarray_nodes(layout, buffers):
     def replace_numpyarray_nodes(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
             buffer = buffers[0]

--- a/src/awkward/_connect/jax/_reducers.py
+++ b/src/awkward/_connect/jax/_reducers.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._connect.jax import import_jax
+from awkward.jax import import_jax
 
 np = ak.nplikes.NumpyMetadata.instance()
 

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -19,7 +19,7 @@ class ArgMin(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._errors.wrap_error("Cannot differentiate through argmin")
+        raise ak._errors.wrap_error(RuntimeError("Cannot differentiate through argmin"))
 
 
 class ArgMax(Reducer):
@@ -33,7 +33,7 @@ class ArgMax(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._errors.wrap_error("Cannot differentiate through argmax")
+        raise ak._errors.wrap_error(RuntimeError("Cannot differentiate through argmax"))
 
 
 class Count(Reducer):
@@ -46,7 +46,9 @@ class Count(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._errors.wrap_error("Cannot differentiate through count_zero")
+        raise ak._errors.wrap_error(
+            RuntimeError("Cannot differentiate through count_zero")
+        )
 
 
 class CountNonzero(Reducer):
@@ -59,7 +61,9 @@ class CountNonzero(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._errors.wrap_error("Cannot differentiate through count_nonzero")
+        raise ak._errors.wrap_error(
+            RuntimeError("Cannot differentiate through count_nonzero")
+        )
 
 
 class Sum(Reducer):
@@ -72,7 +76,7 @@ class Sum(Reducer):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind == "M":
             raise ak._errors.wrap_error(
-                ValueError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
+                TypeError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
             )
 
         result = jax.ops.segment_sum(array.data, parents.data)

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -13,11 +13,11 @@ def find_numpyarray_nodes(
 
     data_ptrs = []
 
-    def find_nparray_ptrs(node, **kwargs):
+    def action(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
             data_ptrs.append(node.data)
 
-    layout.recursively_apply(action=find_nparray_ptrs, return_array=False)
+    layout.recursively_apply(action=action, return_array=False)
 
     return data_ptrs
 
@@ -27,10 +27,8 @@ def replace_numpyarray_nodes(
 ):
     def replace_numpyarray_nodes(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
-            buffer = buffers[0]
-            buffers.pop(0)
             return ak.contents.NumpyArray(
-                buffer,
+                buffers.pop(0),
                 layout.identifier,
                 layout.parameters,
                 nplike=ak.nplikes.Jax.instance(),

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -7,7 +7,7 @@ from awkward import contents, highlevel, nplikes, record
 numpy = nplikes.Numpy.instance()
 
 
-def find_numpyarray_nodes(
+def find_all_buffers(
     layout: contents.Content | record.Record,
 ) -> list[numpy.ndarray]:
 
@@ -22,7 +22,7 @@ def find_numpyarray_nodes(
     return data_ptrs
 
 
-def replace_numpyarray_nodes(
+def replace_all_buffers(
     layout: contents.Content | record.Record, buffers: list[numpy.ndarray]
 ):
     def replace_numpyarray_nodes(node, **kwargs):

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -1,0 +1,65 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+import awkward as ak
+from awkward import contents, highlevel, nplikes, record
+
+numpy = nplikes.Numpy.instance()
+
+
+def find_numpyarray_nodes(
+    layout: contents.Content | record.Record,
+) -> list[numpy.ndarray]:
+
+    data_ptrs = []
+
+    def find_nparray_ptrs(node, **kwargs):
+        if isinstance(node, ak.contents.NumpyArray):
+            data_ptrs.append(node.data)
+
+    layout.recursively_apply(action=find_nparray_ptrs, return_array=False)
+
+    return data_ptrs
+
+
+def replace_numpyarray_nodes(
+    layout: contents.Content | record.Record, buffers: list[numpy.ndarray]
+):
+    def replace_numpyarray_nodes(node, **kwargs):
+        if isinstance(node, ak.contents.NumpyArray):
+            buffer = buffers[0]
+            buffers.pop(0)
+            return ak.contents.NumpyArray(
+                buffer,
+                layout.identifier,
+                layout.parameters,
+                nplike=ak.nplikes.Jax.instance(),
+            )
+
+    return layout.recursively_apply(action=replace_numpyarray_nodes)
+
+
+class AuxData:
+    def __init__(self, layout: contents.Content | record.Record, behavior=None):
+        self._layout = layout
+
+    @property
+    def layout(self) -> contents.Content | record.Record:
+        return self._layout
+
+    def __eq__(self, other: AuxData) -> bool:
+        return self.layout.layout_equal(
+            other.layout, index_dtype=False, numpyarray=False
+        )
+
+
+def jax_flatten_highlevel(
+    array: highlevel.Array | highlevel.Record,
+) -> tuple[list[numpy.ndarray], AuxData]:
+    return array._layout._jax_flatten()
+
+
+def jax_unflatten_highlevel(
+    aux_data: AuxData, children: list[numpy.ndarray]
+) -> highlevel.Array | highlevel.Record:
+    return ak._util.wrap(aux_data.layout.jax_unflatten(aux_data, children))

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -75,7 +75,7 @@ class AuxData(Generic[T]):
 
         def create_placeholder_like(array) -> numpy.ndarray:
             data = numpy.empty(1, dtype=array.dtype)
-            strides = tuple([0 for _ in array.shape])
+            strides = tuple(0 for _ in array.shape)
             return numpy.lib.stride_tricks.as_strided(
                 data, array.shape, strides=strides, writeable=False
             )

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from typing import Generic, TypeVar
+
 import awkward as ak
 from awkward import contents, highlevel, nplikes, record
 
@@ -25,24 +27,53 @@ def find_all_buffers(
 def replace_all_buffers(
     layout: contents.Content | record.Record, buffers: list[numpy.ndarray]
 ):
+    if any(nplikes.Jax.is_tracer(b) or nplikes.Jax.is_own_buffer(b) for b in buffers):
+        nplike = nplikes.Jax.instance()
+    else:
+        nplike = nplikes.nplike_of(buffers)
+
     def replace_numpyarray_nodes(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
             return ak.contents.NumpyArray(
-                buffers.pop(0),
-                layout.identifier,
-                layout.parameters,
-                nplike=ak.nplikes.Jax.instance(),
+                buffers.pop(0), layout.identifier, layout.parameters, nplike=nplike
             )
 
     return layout.recursively_apply(action=replace_numpyarray_nodes)
 
 
-class AuxData:
+T = TypeVar(
+    "T", bound=highlevel.Array | highlevel.Record | contents.Content | record.Record
+)
+
+
+class AuxData(Generic[T]):
     def __init__(
-        self, layout: contents.Content | record.Record, behavior: dict | None = None
+        self,
+        layout: contents.Content | record.Record,
+        is_highlevel: bool,
+        behavior: dict | None = None,
     ):
         self._layout = layout
         self._behavior = behavior
+        self._is_highlevel = is_highlevel
+
+    @classmethod
+    def from_array_or_layout(cls, obj: T):
+        from awkward.nplikes import Numpy
+
+        layout = ak.to_layout(obj)
+        buffers = find_all_buffers(layout)
+        # Drop the references to the existing buffers by replacing them with empty buffers
+        # This works-around the fact that AuxData should probably contain only a form and length,
+        # rather than the actual layout (which holds references to the buffers that we're returning)
+        # Use NumPy buffers here to ensure that we don't create any new tracers (they're just placeholders)
+        numpy = Numpy.instance()
+        placeholder_buffers = [numpy.empty(len(n), n.dtype) for n in buffers]
+        return buffers, AuxData(
+            layout=replace_all_buffers(layout, placeholder_buffers),
+            is_highlevel=isinstance(obj, (ak.Array, ak.Record)),
+            behavior=ak._util.behavior_of(obj),
+        )
 
     @property
     def layout(self) -> contents.Content | record.Record:
@@ -52,21 +83,27 @@ class AuxData:
     def behavior(self) -> dict | None:
         return self._behavior
 
+    @property
+    def is_highlevel(self) -> bool:
+        return self._is_highlevel
+
+    def unflatten(self, buffers) -> T:
+        layout = replace_all_buffers(self._layout, list(buffers))
+        return ak._util.wrap(
+            layout, behavior=self._behavior, highlevel=self._is_highlevel
+        )
+
     def __eq__(self, other: AuxData) -> bool:
         return self.layout.layout_equal(
             other.layout, index_dtype=False, numpyarray=False
         )
 
 
-def jax_flatten_highlevel(
-    array: highlevel.Array | highlevel.Record,
+def jax_flatten(
+    array: T,
 ) -> tuple[list[numpy.ndarray], AuxData]:
-    return array._layout.jax_flatten()
+    return AuxData.from_array_or_layout(array)
 
 
-def jax_unflatten_highlevel(
-    aux_data: AuxData, children: list[numpy.ndarray]
-) -> highlevel.Array | highlevel.Record:
-    return ak._util.wrap(
-        aux_data.layout.jax_unflatten(aux_data, children), behavior=aux_data.behavior
-    )
+def jax_unflatten(aux_data: AuxData, children: list[numpy.ndarray]) -> T:
+    return aux_data.unflatten(children)

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Union
 
 import awkward as ak
 from awkward import _errors, contents, highlevel, nplikes, record
@@ -42,7 +42,7 @@ def replace_all_buffers(
 
 
 T = TypeVar(
-    "T", bound=highlevel.Array | highlevel.Record | contents.Content | record.Record
+    "T", bound=Union[highlevel.Array, highlevel.Record, contents.Content, record.Record]
 )
 
 

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -32,13 +32,13 @@ def replace_all_buffers(
     else:
         nplike = nplikes.nplike_of(buffers)
 
-    def replace_numpyarray_nodes(node, **kwargs):
+    def action(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):
             return ak.contents.NumpyArray(
                 buffers.pop(0), layout.identifier, layout.parameters, nplike=nplike
             )
 
-    return layout.recursively_apply(action=replace_numpyarray_nodes)
+    return layout.recursively_apply(action=action)
 
 
 T = TypeVar(

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -27,10 +27,7 @@ def find_all_buffers(
 def replace_all_buffers(
     layout: contents.Content | record.Record, buffers: list[numpy.ndarray]
 ):
-    if any(nplikes.Jax.is_own_buffer(b) for b in buffers):
-        nplike = nplikes.Jax.instance()
-    else:
-        nplike = nplikes.nplike_of(buffers)
+    nplike = nplikes.nplike_of(*buffers)
 
     def action(node, **kwargs):
         if isinstance(node, ak.contents.NumpyArray):

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -75,6 +75,7 @@ class AuxData(Generic[T]):
         # rather than the actual layout (which holds references to the buffers that we're returning)
         # Use NumPy buffers here to ensure that we don't create any new tracers (they're just placeholders)
         numpy = Numpy.instance()
+        # FIXME: this is wasteful - we allocate unused memory.
         placeholder_buffers = [numpy.empty(len(n), n.dtype) for n in buffers]
         return buffers, AuxData(
             layout=replace_all_buffers(layout, placeholder_buffers),

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -40,12 +40,19 @@ def replace_numpyarray_nodes(
 
 
 class AuxData:
-    def __init__(self, layout: contents.Content | record.Record, behavior=None):
+    def __init__(
+        self, layout: contents.Content | record.Record, behavior: dict | None = None
+    ):
         self._layout = layout
+        self._behavior = behavior
 
     @property
     def layout(self) -> contents.Content | record.Record:
         return self._layout
+
+    @property
+    def behavior(self) -> dict | None:
+        return self._behavior
 
     def __eq__(self, other: AuxData) -> bool:
         return self.layout.layout_equal(
@@ -62,4 +69,6 @@ def jax_flatten_highlevel(
 def jax_unflatten_highlevel(
     aux_data: AuxData, children: list[numpy.ndarray]
 ) -> highlevel.Array | highlevel.Record:
-    return ak._util.wrap(aux_data.layout.jax_unflatten(aux_data, children))
+    return ak._util.wrap(
+        aux_data.layout.jax_unflatten(aux_data, children), behavior=aux_data.behavior
+    )

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Generic, NoReturn, TypeVar, Union
 
+import jax
+
 import awkward as ak
 from awkward import _errors, contents, highlevel, nplikes, record
 
@@ -136,3 +138,24 @@ def jax_flatten(
 
 def jax_unflatten(aux_data: AuxData, children: list[numpy.ndarray]) -> T:
     return aux_data.unflatten(children)
+
+
+HighLevelType = TypeVar(
+    "HighLevelType", bound="type[highlevel.Array | highlevel.Record]"
+)
+
+
+def register_pytree_class(cls: T) -> T:
+    """
+    Args:
+        cls: class to register with JAX
+
+    Return the class, after registering it with JAX.
+
+    """
+    jax.tree_util.register_pytree_node(
+        cls,
+        jax_flatten,
+        jax_unflatten,
+    )
+    return cls

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -61,7 +61,7 @@ class AuxData:
 def jax_flatten_highlevel(
     array: highlevel.Array | highlevel.Record,
 ) -> tuple[list[numpy.ndarray], AuxData]:
-    return array._layout._jax_flatten()
+    return array._layout.jax_flatten()
 
 
 def jax_unflatten_highlevel(

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -27,7 +27,7 @@ def find_all_buffers(
 def replace_all_buffers(
     layout: contents.Content | record.Record, buffers: list[numpy.ndarray]
 ):
-    if any(nplikes.Jax.is_tracer(b) or nplikes.Jax.is_own_buffer(b) for b in buffers):
+    if any(nplikes.Jax.is_own_buffer(b) for b in buffers):
         nplike = nplikes.Jax.instance()
     else:
         nplike = nplikes.nplike_of(buffers)

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -5,11 +5,11 @@ import warnings
 
 import awkward as ak
 
-checked_version = False
+_has_checked_version = False
 
 
-def import_numexpr():
-    global checked_version
+def _import_numexpr():
+    global _has_checked_version
     try:
         import numexpr
     except ModuleNotFoundError as err:
@@ -25,15 +25,16 @@ or
             )
         ) from err
     else:
-        if not checked_version and ak._util.parse_version(
-            numexpr.__version__
-        ) < ak._util.parse_version("2.7.1"):
-            warnings.warn(
-                "Awkward Array is only known to work with numexpr 2.7.1 or later"
-                "(you have version {})".format(numexpr.__version__),
-                RuntimeWarning,
-            )
-        checked_version = True
+        if not _has_checked_version:
+            if ak._util.parse_version(numexpr.__version__) < ak._util.parse_version(
+                "2.7.1"
+            ):
+                warnings.warn(
+                    "Awkward Array is only known to work with numexpr 2.7.1 or later"
+                    "(you have version {})".format(numexpr.__version__),
+                    RuntimeWarning,
+                )
+            _has_checked_version = True
         return numexpr
 
 
@@ -68,7 +69,7 @@ def getArguments(names, local_dict=None, global_dict=None):
 def evaluate(
     expression, local_dict=None, global_dict=None, order="K", casting="safe", **kwargs
 ):
-    numexpr = import_numexpr()
+    numexpr = _import_numexpr()
 
     context = numexpr.necompiler.getContext(kwargs, frame_depth=1)
     expr_key = (expression, tuple(sorted(context.items())))
@@ -117,7 +118,7 @@ evaluate.evaluate = evaluate
 
 
 def re_evaluate(local_dict=None):
-    numexpr = import_numexpr()
+    numexpr = _import_numexpr()
 
     try:
         compiled_ex = numexpr.necompiler._numexpr_last["ex"]  # noqa: F841

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -165,7 +165,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                         args.append(x)
 
                 if isinstance(nplike, ak.nplikes.Jax):
-                    from awkward._connect.jax import import_jax
+                    from awkward.jax import import_jax
 
                     jax = import_jax()
                     result = getattr(jax.numpy, ufunc.__name__)(*args, **kwargs)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -165,10 +165,10 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                         args.append(x)
 
                 if isinstance(nplike, ak.nplikes.Jax):
-                    from awkward.jax import import_jax
+                    from awkward._connect.jax import get_jax_ufunc
 
-                    jax = import_jax()
-                    result = getattr(jax.numpy, ufunc.__name__)(*args, **kwargs)
+                    jax_ufunc = get_jax_ufunc(ufunc)
+                    result = jax_ufunc(*args, **kwargs)
                 else:
                     result = getattr(ufunc, method)(*args, **kwargs)
 

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -895,5 +895,5 @@ class TypeTracer(ak.nplikes.NumpyLike):
         raise ak._errors.wrap_error(NotImplementedError)
 
     @classmethod
-    def is_own_buffer(cls, obj) -> bool:
+    def is_own_array(cls, obj) -> bool:
         return isinstance(obj, TypeTracerArray)

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -615,6 +615,11 @@ def from_arraylib(array, regulararray, recordarray, highlevel, behavior):
     numpy = ak.nplikes.Numpy.instance()
 
     def recurse(array, mask=None):
+        if ak.nplikes.Jax.is_tracer(array):
+            raise ak._errors.wrap_error(
+                TypeError("Jax tracers cannot be used with `ak.from_arraylib`")
+            )
+
         if regulararray and len(array.shape) > 1:
             return ak.contents.RegularArray(
                 recurse(array.reshape((-1,) + array.shape[2:])),

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -758,7 +758,7 @@ def to_arraylib(module, array, allow_missing):
             tags = module.asarray(array.tags)
             for tag, content in enumerate(contents):
                 mask = tags == tag
-                if type(out).__module__.startswith("jaxlib."):
+                if ak.nplikes.Jax.is_own_buffer(out):
                     out = out.at[mask].set(content)
                 else:
                     out[mask] = content

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -763,7 +763,7 @@ def to_arraylib(module, array, allow_missing):
             tags = module.asarray(array.tags)
             for tag, content in enumerate(contents):
                 mask = tags == tag
-                if ak.nplikes.Jax.is_own_buffer(out):
+                if ak.nplikes.Jax.is_own_array(out):
                     out = out.at[mask].set(content)
                 else:
                     out[mask] = content

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1542,11 +1542,11 @@ class Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def _jax_flatten(self):
-        from awkward._connect.jax import AuxData, _find_numpyarray_nodes
+        from awkward._connect.jax import AuxData, find_numpyarray_nodes
 
         layout = ak.operations.to_layout(self, allow_record=True, allow_other=False)
 
-        numpyarray_nodes = _find_numpyarray_nodes(layout)
+        numpyarray_nodes = find_numpyarray_nodes(layout)
         return (numpyarray_nodes, AuxData(layout))
 
     @classmethod
@@ -1556,9 +1556,9 @@ class Content:
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):
-        from awkward._connect.jax import _replace_numpyarray_nodes
+        from awkward._connect.jax import replace_numpyarray_nodes
 
-        return _replace_numpyarray_nodes(aux_data.layout, list(children))
+        return replace_numpyarray_nodes(aux_data.layout, list(children))
 
     def layout_equal(self, other, index_dtype=True, numpyarray=True):
         return (

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1541,18 +1541,13 @@ class Content:
     def __deepcopy__(self, memo):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _jax_flatten(self):
+    def jax_flatten(self):
         from awkward._connect.jax import AuxData, find_numpyarray_nodes
 
         layout = ak.operations.to_layout(self, allow_record=True, allow_other=False)
 
         numpyarray_nodes = find_numpyarray_nodes(layout)
         return (numpyarray_nodes, AuxData(layout))
-
-    @classmethod
-    def jax_flatten(cls, array):
-        assert type(array) is cls
-        return array._jax_flatten()
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1541,26 +1541,6 @@ class Content:
     def __deepcopy__(self, memo):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def jax_flatten(self):
-        from awkward._connect.jax import AuxData, find_all_buffers, replace_all_buffers
-        from awkward.nplikes import Jax
-
-        jax = Jax.instance()
-
-        buffers = find_all_buffers(self)
-        # Drop the references to the existing buffers by replacing them with empty buffers
-        # This works-around the fact that AuxData should probably contain only a form and length,
-        # rather than the actual layout (which holds references to the buffers that we're returning)
-        empty_buffers = [jax.empty(len(n), n.dtype) for n in buffers]
-        this = replace_all_buffers(self, empty_buffers)
-        return buffers, AuxData(this)
-
-    @classmethod
-    def jax_unflatten(cls, aux_data, children):
-        from awkward._connect.jax import replace_all_buffers
-
-        return replace_all_buffers(aux_data.layout, list(children))
-
     def layout_equal(self, other, index_dtype=True, numpyarray=True):
         return (
             self.__class__ is other.__class__

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1100,12 +1100,9 @@ class NumpyArray(Content):
             )
 
         if isinstance(self.nplike, ak.nplikes.Jax):
-            import awkward._connect.jax._reducers  # noqa: F401
+            from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
 
-            if isinstance(reducer, type):
-                reducer = getattr(ak._connect.jax._reducers, reducer.__name__)
-            else:
-                reducer = getattr(ak._connect.jax._reducers, type(reducer).__name__)
+            reducer = get_jax_reducer(reducer)
         out = reducer.apply(self, parents, outlength)
 
         if reducer.needs_position:

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1528,7 +1528,7 @@ class Record(NDArrayOperatorsMixin):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
-        ak.jax.maybe_register_behavior_class(cls)
+        ak.jax.register_behavior_class(cls)
 
     @property
     def layout(self):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -255,6 +255,11 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         if check_valid:
             ak.operations.validity_error(self, exception=True)
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        ak.jax.maybe_register_behavior_class(cls)
+
     @property
     def layout(self):
         """
@@ -1519,6 +1524,11 @@ class Record(NDArrayOperatorsMixin):
 
         if check_valid:
             ak.operations.validity_error(self, exception=True)
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        ak.jax.maybe_register_behavior_class(cls)
 
     @property
     def layout(self):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1436,19 +1436,6 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 return True
         return False
 
-    def _jax_flatten_layout(self):
-        return self._layout._jax_flatten()
-
-    @classmethod
-    def _jax_flatten(cls, array):
-        assert type(array) is cls
-        return array._jax_flatten_layout()
-
-    @classmethod
-    def _jax_unflatten(cls, aux_data, children):
-        layout_cls = aux_data.layout.__class__
-        return ak._util.wrap(layout_cls.jax_unflatten(aux_data, children))
-
 
 class Record(NDArrayOperatorsMixin):
     """
@@ -2057,19 +2044,6 @@ class Record(NDArrayOperatorsMixin):
             if element in test:
                 return True
         return False
-
-    def _jax_flatten_layout(self):
-        return self._layout._jax_flatten()
-
-    @classmethod
-    def _jax_flatten(cls, array):
-        assert type(array) is cls
-        return array._jax_flatten_layout()
-
-    @classmethod
-    def _jax_unflatten(cls, aux_data, children):
-        layout_cls = aux_data.layout.__class__
-        return ak._util.wrap(layout_cls.jax_unflatten(aux_data, children))
 
 
 class ArrayBuilder(Sized):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -258,7 +258,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
-        ak.jax.maybe_register_behavior_class(cls)
+        ak.jax.register_behavior_class(cls)
 
     @property
     def layout(self):

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -168,7 +168,7 @@ class Index:
         if hasattr(out, "shape") and len(out.shape) != 0:
             return Index(out, metadata=self.metadata, nplike=self.nplike)
         elif (
-            ak.nplikes.Jax.is_own_buffer(out) or ak.nplikes.Cupy.is_own_buffer(out)
+            ak.nplikes.Jax.is_own_array(out) or ak.nplikes.Cupy.is_own_array(out)
         ) and len(out.shape) == 0:
             return out.item()
         else:

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -22,7 +22,7 @@ class _RegistrationState(enum.Enum):
     FAILED = enum.auto()
 
 
-_registration_lock = threading.Lock()
+_registration_lock = threading.RLock()
 _registration_state = _RegistrationState.INIT
 
 

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -125,7 +125,7 @@ def assert_registered():
     """Ensure that Jax integration is registered. Raise a RuntimeError if not."""
     if not _is_registered:
         raise _errors.wrap_error(
-            RuntimeError("Jax features require `ak.jax.register()`")
+            RuntimeError("Jax features require `ak.jax.register_and_check()`")
         )
 
 

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import types
+
+import awkward as ak
+
+_is_registered = False
+
+
+def register():
+    """
+    Register Awkward Array node types with Jax's tree mechanism.
+    """
+    # Let's only do this once
+    global _is_registered
+    if _is_registered:
+        return
+
+    import jax
+
+    for cls in [
+        ak.contents.BitMaskedArray,
+        ak.contents.ByteMaskedArray,
+        ak.contents.EmptyArray,
+        ak.contents.IndexedArray,
+        ak.contents.IndexedOptionArray,
+        ak.contents.NumpyArray,
+        ak.contents.ListArray,
+        ak.contents.ListOffsetArray,
+        ak.contents.RecordArray,
+        ak.contents.UnionArray,
+        ak.contents.UnmaskedArray,
+        ak.record.Record,
+    ]:
+        jax.tree_util.register_pytree_node(
+            cls,
+            cls.jax_flatten,
+            cls.jax_unflatten,
+        )
+
+    for cls in [ak.highlevel.Array, ak.highlevel.Record]:
+        jax.tree_util.register_pytree_node(
+            cls,
+            cls._jax_flatten,
+            cls._jax_unflatten,
+        )
+    _is_registered = True
+
+
+def import_jax() -> types.ModuleType:
+    """
+    Import jax and return the module, or raise a helpful error message if it is not available.
+    """
+    try:
+        import jax
+
+    except ModuleNotFoundError:
+        raise ak._errors.wrap_error(
+            ModuleNotFoundError(
+                """install the 'numba' package with:
+
+        python3 -m pip install jax jaxlib
+
+    or
+
+        conda install -c conda-forge jax jaxlib
+    """
+            )
+        ) from None
+
+    register()
+    return jax

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -6,8 +6,6 @@ from typing import Any
 import awkward as ak
 from awkward import highlevel, nplikes
 
-_is_registered = False
-
 numpy = nplikes.Numpy()
 
 
@@ -25,6 +23,9 @@ def jax_unflatten_highlevel(
     import awkward._connect.jax as jax_connect
 
     return jax_connect.jax_unflatten_highlevel(aux_data, children)
+
+
+_is_registered = False
 
 
 def register():
@@ -79,7 +80,7 @@ def import_jax() -> types.ModuleType:
     except ModuleNotFoundError:
         raise ak._errors.wrap_error(
             ModuleNotFoundError(
-                """install the 'numba' package with:
+                """install the 'jax' package with:
 
         python3 -m pip install jax jaxlib
 

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import enum
 import threading
-import types
 import weakref
 from typing import TypeVar
 
@@ -31,7 +30,7 @@ def register_and_check():
     Register Awkward Array node types with JAX's tree mechanism.
     """
     try:
-        import jax
+        import jax  # noqa: F401
 
     except ModuleNotFoundError:
         raise ak._errors.wrap_error(
@@ -47,7 +46,7 @@ def register_and_check():
             )
         ) from None
 
-    _register(jax)
+    _register()
 
 
 HighLevelType = TypeVar(
@@ -77,7 +76,7 @@ def register_behavior_class(cls: HighLevelType):
             _known_highlevel_classes.add(cls)
 
 
-def _register(jax: types.ModuleType):
+def _register():
     """
     Register Awkward Array node types with JAX's tree mechanism.
     """

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -107,9 +107,9 @@ def _register():
 
             for cls in _known_highlevel_classes:
                 jax_connect.register_pytree_class(cls)
-
         except Exception:
             _registration_state = _RegistrationState.FAILED
+            raise
         else:
             _registration_state = _RegistrationState.SUCCESS
 

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -28,7 +28,7 @@ _registration_state = _RegistrationState.INIT
 
 def register_and_check():
     """
-    Register Awkward Array node types with Jax's tree mechanism.
+    Register Awkward Array node types with JAX's tree mechanism.
     """
     try:
         import jax
@@ -58,9 +58,9 @@ HighLevelType = TypeVar(
 def _register_behavior_class(cls: HighLevelType) -> HighLevelType:
     """
     Args:
-        cls: behavior class to register with Jax
+        cls: behavior class to register with JAX
 
-    Return the behavior class, after registering it with Jax.
+    Return the behavior class, after registering it with JAX.
 
     """
     jax = import_jax()
@@ -80,10 +80,10 @@ _known_highlevel_classes = weakref.WeakSet([highlevel.Array, highlevel.Record])
 def register_behavior_class(cls: HighLevelType):
     """
     Args:
-        cls: behavior class to register with Jax
+        cls: behavior class to register with JAX
 
-    Register the behavior class with Jax, if Jax integration is enabled. Otherwise,
-    queue the type for subsequent registration when/if Jax is registered.
+    Register the behavior class with JAX, if JAX integration is enabled. Otherwise,
+    queue the type for subsequent registration when/if JAX is registered.
     """
     with _registration_lock:
         if _registration_state == _RegistrationState.SUCCESS:
@@ -94,7 +94,7 @@ def register_behavior_class(cls: HighLevelType):
 
 def _register(jax: types.ModuleType):
     """
-    Register Awkward Array node types with Jax's tree mechanism.
+    Register Awkward Array node types with JAX's tree mechanism.
     """
     global _registration_state
     # Require that no threads are trying to register before checking this flag
@@ -138,15 +138,15 @@ def _register(jax: types.ModuleType):
 
 
 def assert_registered():
-    """Ensure that Jax integration is registered. Raise a RuntimeError if not."""
+    """Ensure that JAX integration is registered. Raise a RuntimeError if not."""
     with _registration_lock:
         if _registration_state == _RegistrationState.INIT:
             raise _errors.wrap_error(
-                RuntimeError("Jax features require `ak.jax.register_and_check()`")
+                RuntimeError("JAX features require `ak.jax.register_and_check()`")
             )
         elif _registration_state == _RegistrationState.FAILED:
             raise _errors.wrap_error(
-                RuntimeError("Jax features require `ak.jax.register_and_check()`")
+                RuntimeError("JAX features require `ak.jax.register_and_check()`")
             )
         elif _registration_state == _RegistrationState.SUCCESS:
             return
@@ -155,7 +155,7 @@ def assert_registered():
 
 
 def import_jax():
-    """Ensure that Jax integration is registered, and return the Jax module. Raise a RuntimeError if not."""
+    """Ensure that JAX integration is registered, and return the JAX module. Raise a RuntimeError if not."""
     assert_registered()
     import jax
 

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -55,8 +55,8 @@ def register_behavior_class(cls: HighLevelType) -> HighLevelType:
 
     jax.tree_util.register_pytree_node(
         cls,
-        jax_connect.jax_flatten_highlevel,
-        jax_connect.jax_unflatten_highlevel,
+        jax_connect.jax_flatten,
+        jax_connect.jax_unflatten,
     )
     return cls
 
@@ -107,15 +107,15 @@ def _register(jax: types.ModuleType):
         ]:
             jax.tree_util.register_pytree_node(
                 cls,
-                cls.jax_flatten,
-                cls.jax_unflatten,
+                jax_connect.jax_flatten,
+                jax_connect.jax_unflatten,
             )
 
         for cls in _known_highlevel_classes:
             jax.tree_util.register_pytree_node(
                 cls,
-                jax_connect.jax_flatten_highlevel,
-                jax_connect.jax_unflatten_highlevel,
+                jax_connect.jax_flatten,
+                jax_connect.jax_unflatten,
             )
     finally:
         _is_registered = True

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -359,7 +359,7 @@ class NumpyLike(Singleton):
         return self._module.datetime_as_string(*args, **kwargs)
 
     @classmethod
-    def is_own_buffer(cls, obj) -> bool:
+    def is_own_array(cls, obj) -> bool:
         """
         Args:
             obj: object to test
@@ -386,13 +386,13 @@ class NumpyKernel:
     def _cast(x, t):
         if issubclass(t, ctypes._Pointer):
 
-            if Numpy.is_own_buffer(x):
+            if Numpy.is_own_array(x):
                 return ctypes.cast(x.ctypes.data, t)
-            elif Cupy.is_own_buffer(x):
+            elif Cupy.is_own_array(x):
                 raise ak._errors.wrap_error(
                     AssertionError("CuPy buffers shouldn't be passed to Numpy Kernels.")
                 )
-            elif Jax.is_own_buffer(x):
+            elif Jax.is_own_array(x):
                 raise ak._errors.wrap_error(
                     ValueError(
                         "JAX Buffers can't be passed as function args for the C Kernels"
@@ -526,7 +526,7 @@ class Numpy(NumpyLike):
             )
 
     @classmethod
-    def is_own_buffer(cls, obj) -> bool:
+    def is_own_array(cls, obj) -> bool:
         """
         Args:
             obj: object to test
@@ -736,7 +736,7 @@ class Cupy(NumpyLike):
         return self._module.array_str(array, max_line_width, precision, suppress_small)
 
     @classmethod
-    def is_own_buffer(cls, obj) -> bool:
+    def is_own_array(cls, obj) -> bool:
         """
         Args:
             obj: object to test
@@ -885,7 +885,7 @@ class Jax(NumpyLike):
         return out
 
     @classmethod
-    def is_own_buffer(cls, obj) -> bool:
+    def is_own_array(cls, obj) -> bool:
         """
         Args:
             obj: object to test
@@ -943,7 +943,7 @@ def nplike_of(*arrays, default=_UNSET):
             nplikes.add(nplike)
         else:
             for cls in nplike_classes:
-                if cls.is_own_buffer(array):
+                if cls.is_own_array(array):
                     nplikes.add(cls.instance())
                     break
 

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -893,6 +893,17 @@ class Jax(NumpyLike):
         Return `True` if the given object is a jax buffer, otherwise `False`.
 
         """
+        return cls.is_array(obj) or cls.is_tracer(obj)
+
+    @classmethod
+    def is_array(cls, obj) -> bool:
+        """
+        Args:
+            obj: object to test
+
+        Return `True` if the given object is a jax buffer, otherwise `False`.
+
+        """
         module, _, suffix = type(obj).__module__.partition(".")
         return module == "jaxlib"
 
@@ -909,11 +920,15 @@ class Jax(NumpyLike):
         return module == "jax"
 
 
-def nplike_of(*arrays, default_cls=Numpy):
+# Temporary sentinel marking "argument not given"
+_UNSET = object()
+
+
+def nplike_of(*arrays, default=_UNSET):
     """
     Args:
         *arrays: iterable of possible array objects
-        default_cls: default NumpyLike class if no array objects found
+        default: default NumpyLike instance if no array objects found
 
     Return the #ak.nplikes.NumpyLike that is best-suited to operating upon the given
     iterable of arrays. Return an instance of the `default_cls` if no known array types
@@ -936,7 +951,10 @@ def nplike_of(*arrays, default_cls=Numpy):
         return ak._typetracer.TypeTracer.instance()
 
     if nplikes == set():
-        return default_cls.instance()
+        if default is _UNSET:
+            return Numpy.instance()
+        else:
+            return default
     elif len(nplikes) == 1:
         return next(iter(nplikes))
     else:

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -782,8 +782,7 @@ class Jax(NumpyLike):
         return NumpyKernel(ak._cpu_kernels.kernel[name_and_types], name_and_types)
 
     def __init__(self):
-        import jax.numpy
-
+        jax = ak.jax.import_jax()
         self._module = jax.numpy
 
     @property

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -782,7 +782,9 @@ class Jax(NumpyLike):
         return NumpyKernel(ak._cpu_kernels.kernel[name_and_types], name_and_types)
 
     def __init__(self):
-        self._module = ak.jax.import_jax().numpy
+        import jax.numpy
+
+        self._module = jax.numpy
 
     @property
     def ma(self):

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -782,9 +782,7 @@ class Jax(NumpyLike):
         return NumpyKernel(ak._cpu_kernels.kernel[name_and_types], name_and_types)
 
     def __init__(self):
-        from awkward._connect.jax import import_jax  # noqa: F401
-
-        self._module = import_jax().numpy
+        self._module = ak.jax.import_jax().numpy
 
     @property
     def ma(self):

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -909,11 +909,15 @@ class Jax(NumpyLike):
         return module == "jax"
 
 
-def nplike_of(*arrays, default_cls=Numpy):
+# Temporary sentinel marking "argument not given"
+_UNSET = object()
+
+
+def nplike_of(*arrays, default=_UNSET):
     """
     Args:
         *arrays: iterable of possible array objects
-        default_cls: default NumpyLike class if no array objects found
+        default: default NumpyLike instance if no array objects found
 
     Return the #ak.nplikes.NumpyLike that is best-suited to operating upon the given
     iterable of arrays. Return an instance of the `default_cls` if no known array types
@@ -936,7 +940,10 @@ def nplike_of(*arrays, default_cls=Numpy):
         return ak._typetracer.TypeTracer.instance()
 
     if nplikes == set():
-        return default_cls.instance()
+        if default is _UNSET:
+            return Numpy.instance()
+        else:
+            return default
     elif len(nplikes) == 1:
         return next(iter(nplikes))
     else:

--- a/src/awkward/numba.py
+++ b/src/awkward/numba.py
@@ -2,37 +2,37 @@
 
 import awkward as ak
 
-checked_version = False
+_has_checked_version = False
 
 
 def register_and_check():
-    global checked_version
+    global _has_checked_version
 
-    if not checked_version:
-        try:
-            import numba
-        except ImportError as err:
-            raise ImportError(
-                """install the 'numba' package with:
+    try:
+        import numba
+    except ImportError as err:
+        raise ImportError(
+            """install the 'numba' package with:
 
-    pip install numba --upgrade
+pip install numba --upgrade
 
 or
 
-    conda install numba"""
-            ) from err
+conda install numba"""
+        ) from err
 
-        checked_version = True
+    if not _has_checked_version:
         if ak._util.parse_version(numba.__version__) < ak._util.parse_version("0.50"):
             raise ImportError(
                 "Awkward Array can only work with numba 0.50 or later "
                 "(you have version {})".format(numba.__version__)
             )
+        _has_checked_version = True
 
-    register()
+    _register()
 
 
-def register():
+def _register():
     if hasattr(ak.numba, "ArrayViewType"):
         return
 

--- a/src/awkward/numba.py
+++ b/src/awkward/numba.py
@@ -3,6 +3,7 @@
 import awkward as ak
 
 _has_checked_version = False
+_is_registered = False
 
 
 def register_and_check():

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -47,19 +47,16 @@ def _impl(arrays):
             allow_record=True,
             allow_other=True,
         )
-        if isinstance(layout, (ak.contents.Content, ak.index.Index)):
-            if isinstance(layout.nplike, ak.nplikes.Numpy):
-                backends.add("cpu")
-            elif isinstance(layout.nplike, ak.nplikes.Cupy):
-                backends.add("cuda")
-            elif isinstance(layout.nplike, ak.nplikes.Jax):
-                backends.add("jax")
-        elif isinstance(layout, ak.nplikes.numpy.ndarray):
-            backends.add("cpu")
-        elif type(layout).__module__.startswith("cupy."):
-            backends.add("cuda")
-        elif type(layout).__module__.startswith("jaxlib."):
+        # Find the nplike, if it is explicitly associated with this object
+        nplike = ak.nplikes.nplike_of(layout, default=None)
+        if nplike is None:
+            continue
+        if isinstance(nplike, ak.nplikes.Jax):
             backends.add("jax")
+        elif isinstance(nplike, ak.nplikes.Cupy):
+            backends.add("cuda")
+        elif isinstance(nplike, ak.nplikes.Numpy):
+            backends.add("cpu")
 
     if backends == set():
         return None

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -57,7 +57,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
         # Is an Awkward Content
         isinstance(arrays, ak.contents.Content)
         # Is a NumPy Array
-        or numpy.is_own_buffer(arrays)
+        or numpy.is_own_array(arrays)
         # Is an array with a known NumpyLike
         or single_nplike is not numpy
     ):

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -1,6 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward as ak
+from awkward import _errors, _util, jax
 
 
 def from_jax(array, regulararray=False, highlevel=True, behavior=None):
@@ -27,7 +27,7 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
 
     See also #ak.to_jax, #ak.from_numpy and #ak.from_jax.
     """
-    with ak._errors.OperationErrorContext(
+    with _errors.OperationErrorContext(
         "ak.from_jax",
         dict(
             array=array,
@@ -36,4 +36,5 @@ def from_jax(array, regulararray=False, highlevel=True, behavior=None):
             behavior=behavior,
         ),
     ):
-        return ak._util.from_arraylib(array, regulararray, False, highlevel, behavior)
+        jax.assert_registered()
+        return _util.from_arraylib(array, regulararray, False, highlevel, behavior)

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -132,5 +132,5 @@ def _impl(array, container, buffer_key, form_key, id_start, nplike):
         buffer_key=buffer_key,
         form_key=form_key,
         id_start=id_start,
-        nplike=numpy,
+        nplike=nplike,
     )

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward.jax import import_jax
 
 
 def to_jax(array):
@@ -21,7 +22,5 @@ def to_jax(array):
         "ak.to_jax",
         dict(array=array),
     ):
-        from awkward._connect.jax import import_jax
-
         jax = import_jax().numpy
         return ak._util.to_arraylib(jax, array, True)

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward as ak
-from awkward.jax import import_jax
+from awkward import _errors, _util, jax
 
 
 def to_jax(array):
@@ -18,9 +17,8 @@ def to_jax(array):
 
     See also #ak.from_jax and #ak.to_numpy.
     """
-    with ak._errors.OperationErrorContext(
+    with _errors.OperationErrorContext(
         "ak.to_jax",
         dict(array=array),
     ):
-        jax = import_jax().numpy
-        return ak._util.to_arraylib(jax, array, True)
+        return _util.to_arraylib(jax.import_jax().numpy, array, True)

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -87,7 +87,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplikes.Cupy.is_own_buffer(array) and type(array).__name__ == "ndarray":
+    elif ak.nplikes.Cupy.is_own_buffer(array):
         if not issubclass(array.dtype.type, numpytype):
             raise ak._errors.wrap_error(
                 ValueError(f"dtype {array.dtype!r} not allowed")
@@ -99,7 +99,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplikes.Jax.is_own_buffer(array) and type(array).__name__ == "DeviceArray":
+    elif ak.nplikes.Jax.is_own_buffer(array):
         if not issubclass(array.dtype.type, numpytype):
             raise ak._errors.wrap_error(
                 ValueError(f"dtype {array.dtype!r} not allowed")

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -87,7 +87,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplikes.Cupy.is_own_buffer(array):
+    elif ak.nplikes.Cupy.is_own_array(array):
         if not issubclass(array.dtype.type, numpytype):
             raise ak._errors.wrap_error(
                 ValueError(f"dtype {array.dtype!r} not allowed")
@@ -99,7 +99,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplikes.Jax.is_own_buffer(array):
+    elif ak.nplikes.Jax.is_own_array(array):
         if not issubclass(array.dtype.type, numpytype):
             raise ak._errors.wrap_error(
                 ValueError(f"dtype {array.dtype!r} not allowed")

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -260,13 +260,13 @@ class Record:
             return None
 
     def jax_flatten(self):
-        from awkward._connect.jax import AuxData, find_numpyarray_nodes
+        from awkward._connect.jax import AuxData, find_all_buffers
 
-        numpyarray_nodes = find_numpyarray_nodes(self)
+        numpyarray_nodes = find_all_buffers(self)
         return (numpyarray_nodes, AuxData(self))
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):
-        from awkward._connect.jax import replace_numpyarray_nodes
+        from awkward._connect.jax import replace_all_buffers
 
-        return ak._util.wrap(replace_numpyarray_nodes(aux_data.layout, list(children)))
+        return ak._util.wrap(replace_all_buffers(aux_data.layout, list(children)))

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -259,16 +259,11 @@ class Record:
         else:
             return None
 
-    def _jax_flatten(self):
+    def jax_flatten(self):
         from awkward._connect.jax import AuxData, find_numpyarray_nodes
 
         numpyarray_nodes = find_numpyarray_nodes(self)
         return (numpyarray_nodes, AuxData(self))
-
-    @classmethod
-    def jax_flatten(cls, array):
-        assert type(array) is cls
-        return array._jax_flatten()
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -260,9 +260,9 @@ class Record:
             return None
 
     def _jax_flatten(self):
-        from awkward._connect.jax import AuxData, _find_numpyarray_nodes
+        from awkward._connect.jax import AuxData, find_numpyarray_nodes
 
-        numpyarray_nodes = _find_numpyarray_nodes(self)
+        numpyarray_nodes = find_numpyarray_nodes(self)
         return (numpyarray_nodes, AuxData(self))
 
     @classmethod
@@ -272,6 +272,6 @@ class Record:
 
     @classmethod
     def jax_unflatten(cls, aux_data, children):
-        from awkward._connect.jax import _replace_numpyarray_nodes
+        from awkward._connect.jax import replace_numpyarray_nodes
 
-        return ak._util.wrap(_replace_numpyarray_nodes(aux_data.layout, list(children)))
+        return ak._util.wrap(replace_numpyarray_nodes(aux_data.layout, list(children)))

--- a/tests/test_1049-concatenate-single-array.py
+++ b/tests/test_1049-concatenate-single-array.py
@@ -5,6 +5,8 @@ import pytest  # noqa: F401
 
 import awkward as ak  # noqa: F401
 
+ak.jax.register_and_check()
+
 
 def test_single_numpy_array():
     array = np.arange(4 * 3 * 2).reshape(4, 3, 2)

--- a/tests/test_1049-concatenate-single-array.py
+++ b/tests/test_1049-concatenate-single-array.py
@@ -5,8 +5,6 @@ import pytest  # noqa: F401
 
 import awkward as ak  # noqa: F401
 
-ak.jax.register_and_check()
-
 
 def test_single_numpy_array():
     array = np.arange(4 * 3 * 2).reshape(4, 3, 2)
@@ -35,6 +33,8 @@ def test_single_awkward_array():
 
 def test_single_jax_array():
     jnp = pytest.importorskip("jax.numpy")
+    ak.jax.register_and_check()
+
     array = jnp.arange(4 * 3 * 2).reshape(4, 3, 2)
     result = ak.concatenate(array)
     assert result.tolist() == [

--- a/tests/test_1399-from-jax.py
+++ b/tests/test_1399-from-jax.py
@@ -6,8 +6,9 @@ import pytest  # noqa: F401
 import awkward as ak  # noqa: F401
 
 jax = pytest.importorskip("jax")
-
 jax.config.update("jax_enable_x64", True)
+
+ak.jax.register_and_check()
 
 
 def test_from_jax():

--- a/tests/test_1399-to-jax.py
+++ b/tests/test_1399-to-jax.py
@@ -8,6 +8,8 @@ import awkward as ak  # noqa: F401
 jax = pytest.importorskip("jax")
 jax.config.update("jax_enable_x64", True)
 
+ak.jax.register_and_check()
+
 
 def test_from_jax_1():
     ak_array_1d = ak.Array(np.arange(10))

--- a/tests/test_1447-jax-autodiff-slices-ufuncs.py
+++ b/tests/test_1447-jax-autodiff-slices-ufuncs.py
@@ -9,6 +9,8 @@ jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
 jax.config.update("jax_enable_x64", True)
 
+ak.jax.register()
+
 # #### ak.contents.NumpyArray ####
 
 test_numpyarray = ak.Array(np.arange(10, dtype=np.float64), backend="jax")

--- a/tests/test_1447-jax-autodiff-slices-ufuncs.py
+++ b/tests/test_1447-jax-autodiff-slices-ufuncs.py
@@ -9,7 +9,7 @@ jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
 jax.config.update("jax_enable_x64", True)
 
-ak.jax.register()
+ak.jax.register_and_check()
 
 # #### ak.contents.NumpyArray ####
 

--- a/tests/test_1490-jax-reducers-combinations.py
+++ b/tests/test_1490-jax-reducers-combinations.py
@@ -9,6 +9,8 @@ jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
 jax.config.update("jax_enable_x64", True)
 
+ak.jax.register_and_check()
+
 # #### ak.contents.NumpyArray ####
 
 test_numpyarray = ak.Array(np.arange(10, dtype=np.float64), backend="jax")

--- a/tests/test_1490-jax-reducers-combinations.py
+++ b/tests/test_1490-jax-reducers-combinations.py
@@ -149,25 +149,10 @@ def test_numpyarray_grad_any_1():
     def func_numpyarray_1(x):
         return ak.any(x)
 
-    def func_nummpyarray_1_jax(x):
-        return jax.numpy.any(x)
-
     value_jvp, jvp_grad = jax.jvp(
         func_numpyarray_1, (test_numpyarray,), (test_numpyarray_tangent,)
     )
-    value_jvp_jax, jvp_grad_jax = jax.jvp(
-        func_nummpyarray_1_jax, (test_numpyarray_jax,), (test_numpyarray_tangent_jax,)
-    )
-
-    value_vjp, vjp_func = jax.vjp(func_numpyarray_1, test_numpyarray)
-    value_vjp_jax, vjp_func_jax = jax.vjp(func_nummpyarray_1_jax, test_numpyarray_jax)
-
-    assert value_jvp == value_jvp_jax
-    assert value_vjp == value_vjp_jax
-    assert jvp_grad == jvp_grad_jax
-    assert (
-        ak.to_list(vjp_func(value_vjp)[0]) == (vjp_func_jax(value_vjp_jax)[0]).tolist()
-    )
+    assert jvp_grad.dtype == np.dtype([("float0", "V")])
 
 
 test_regulararray = ak.Array(
@@ -537,58 +522,24 @@ def test_regular_array_all_0():
     def func_regulararray_all_0(x):
         return ak.all(x, 0)
 
-    def func_regulararray_all_0_jax(x):
-        return jax.numpy.all(x, 0)
-
-    value_jvp, jvp_grad = jax.jvp(
-        func_regulararray_all_0, (test_regulararray,), (test_regulararray_tangent,)
-    )
-    value_jvp_jax, jvp_grad_jax = jax.jvp(
-        func_regulararray_all_0_jax,
-        (test_regulararray_jax,),
-        (test_regulararray_tangent_jax,),
-    )
-
-    value_vjp, vjp_func = jax.vjp(func_regulararray_all_0, test_regulararray)
-    value_vjp_jax, vjp_func_jax = jax.vjp(
-        func_regulararray_all_0_jax, test_regulararray_jax
-    )
-
-    assert ak.to_list(value_jvp) == value_jvp_jax.tolist()
-    assert ak.to_list(value_vjp) == value_vjp_jax.tolist()
-    assert ak.to_list(jvp_grad) == jvp_grad_jax.tolist()
-    assert (
-        ak.to_list(vjp_func(value_vjp)[0]) == (vjp_func_jax(value_vjp_jax)[0]).tolist()
-    )
+    with pytest.raises(
+        TypeError, match=".*Make sure that you are not computing the derivative.*"
+    ):
+        jax.jvp(
+            func_regulararray_all_0, (test_regulararray,), (test_regulararray_tangent,)
+        )
 
 
 def test_regular_array_all_1():
     def func_regulararray_all_1(x):
         return ak.all(x, 1)
 
-    def func_regulararray_all_1_jax(x):
-        return jax.numpy.all(x, 1)
-
-    value_jvp, jvp_grad = jax.jvp(
-        func_regulararray_all_1, (test_regulararray,), (test_regulararray_tangent,)
-    )
-    value_jvp_jax, jvp_grad_jax = jax.jvp(
-        func_regulararray_all_1_jax,
-        (test_regulararray_jax,),
-        (test_regulararray_tangent_jax,),
-    )
-
-    value_vjp, vjp_func = jax.vjp(func_regulararray_all_1, test_regulararray)
-    value_vjp_jax, vjp_func_jax = jax.vjp(
-        func_regulararray_all_1_jax, test_regulararray_jax
-    )
-
-    assert ak.to_list(value_jvp) == value_jvp_jax.tolist()
-    assert ak.to_list(value_vjp) == value_vjp_jax.tolist()
-    assert ak.to_list(jvp_grad) == jvp_grad_jax.tolist()
-    assert (
-        ak.to_list(vjp_func(value_vjp)[0]) == (vjp_func_jax(value_vjp_jax)[0]).tolist()
-    )
+    with pytest.raises(
+        TypeError, match=".*Make sure that you are not computing the derivative.*"
+    ):
+        jax.jvp(
+            func_regulararray_all_1, (test_regulararray,), (test_regulararray_tangent,)
+        )
 
 
 def test_regular_array_all_none():
@@ -624,58 +575,24 @@ def test_regular_array_any_0():
     def func_regulararray_any_0(x):
         return ak.any(x, 0)
 
-    def func_regulararray_any_0_jax(x):
-        return jax.numpy.any(x, 0)
-
-    value_jvp, jvp_grad = jax.jvp(
-        func_regulararray_any_0, (test_regulararray,), (test_regulararray_tangent,)
-    )
-    value_jvp_jax, jvp_grad_jax = jax.jvp(
-        func_regulararray_any_0_jax,
-        (test_regulararray_jax,),
-        (test_regulararray_tangent_jax,),
-    )
-
-    value_vjp, vjp_func = jax.vjp(func_regulararray_any_0, test_regulararray)
-    value_vjp_jax, vjp_func_jax = jax.vjp(
-        func_regulararray_any_0_jax, test_regulararray_jax
-    )
-
-    assert ak.to_list(value_jvp) == value_jvp_jax.tolist()
-    assert ak.to_list(value_vjp) == value_vjp_jax.tolist()
-    assert ak.to_list(jvp_grad) == jvp_grad_jax.tolist()
-    assert (
-        ak.to_list(vjp_func(value_vjp)[0]) == (vjp_func_jax(value_vjp_jax)[0]).tolist()
-    )
+    with pytest.raises(
+        TypeError, match=".*Make sure that you are not computing the derivative.*"
+    ):
+        jax.jvp(
+            func_regulararray_any_0, (test_regulararray,), (test_regulararray_tangent,)
+        )
 
 
 def test_regular_array_any_1():
     def func_regulararray_any_1(x):
         return ak.any(x, 1)
 
-    def func_regulararray_any_1_jax(x):
-        return jax.numpy.any(x, 1)
-
-    value_jvp, jvp_grad = jax.jvp(
-        func_regulararray_any_1, (test_regulararray,), (test_regulararray_tangent,)
-    )
-    value_jvp_jax, jvp_grad_jax = jax.jvp(
-        func_regulararray_any_1_jax,
-        (test_regulararray_jax,),
-        (test_regulararray_tangent_jax,),
-    )
-
-    value_vjp, vjp_func = jax.vjp(func_regulararray_any_1, test_regulararray)
-    value_vjp_jax, vjp_func_jax = jax.vjp(
-        func_regulararray_any_1_jax, test_regulararray_jax
-    )
-
-    assert ak.to_list(value_jvp) == value_jvp_jax.tolist()
-    assert ak.to_list(value_vjp) == value_vjp_jax.tolist()
-    assert ak.to_list(jvp_grad) == jvp_grad_jax.tolist()
-    assert (
-        ak.to_list(vjp_func(value_vjp)[0]) == (vjp_func_jax(value_vjp_jax)[0]).tolist()
-    )
+    with pytest.raises(
+        TypeError, match=".*Make sure that you are not computing the derivative.*"
+    ):
+        jax.jvp(
+            func_regulararray_any_1, (test_regulararray,), (test_regulararray_tangent,)
+        )
 
 
 def test_regular_array_any_none():

--- a/tests/test_1762-jax-behavior-support.py
+++ b/tests/test_1762-jax-behavior-support.py
@@ -1,0 +1,34 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_platform_name", "cpu")
+jax.config.update("jax_enable_x64", True)
+
+ak.jax.register_and_check()
+
+
+class GradBehavior(ak.Array):
+    ...
+
+
+def test():
+    def square_fifth_entry(x):
+        return x[4] ** 2
+
+    primal = ak.Array(np.arange(10, dtype=np.float64), backend="jax")
+    tangent = ak.Array(np.arange(10, dtype=np.float64), backend="jax")
+
+    behavior = {"grad": GradBehavior}
+    primal_grad = ak.with_parameter(primal, "__array__", "grad", behavior=behavior)
+    tangent_grad = ak.with_parameter(tangent, "__array__", "grad", behavior=behavior)
+    value_jvp_grad, jvp_grad_grad = jax.jvp(
+        square_fifth_entry, (primal_grad,), (tangent_grad,)
+    )
+
+    assert value_jvp_grad == pytest.approx(16.0)
+    assert jvp_grad_grad == pytest.approx(32.0)

--- a/tests/test_1762-jax-behavior-support.py
+++ b/tests/test_1762-jax-behavior-support.py
@@ -32,3 +32,17 @@ def test():
 
     assert value_jvp_grad == pytest.approx(16.0)
     assert jvp_grad_grad == pytest.approx(32.0)
+
+
+def test_jvp_nested_list():
+    # with jax.checking_leaks():
+    array = ak.Array(np.array([[1.0, 2.0, 3.0, 4.0, 5.0]]), backend="jax")
+    tangent = ak.Array(np.array([[0.0, 0.0, 0.0, 0.0, 1.0]]), backend="jax")
+
+    def func(x):
+        return x[::-1] ** 2
+
+    with jax.checking_leaks():
+        value_jvp, jvp_grad = jax.jvp(func, (array,), (tangent,))
+        assert value_jvp.to_list() == [[1.0, 4.0, 9.0, 16.0, 25.0]]
+        assert jvp_grad.to_list() == [[0.0, 0.0, 0.0, 0.0, 10.0]]


### PR DESCRIPTION
This PR is a re-write of #1762, so I'll copy the information here:

The _motivation_ for this PR is that we need an `ak.jax` public interface to our Jax integration, namely explicit registration.

During the process of implementing this feature, I found other parts of `_connect` that I felt could benefit from some reworking as Awkward v2 has matured. Not all of these changes are necessary, so if people don't like them, we can revert them. Hopefully I can make a good case for the changes that I did make.

## New Features
- [x] expose a (new) `ak.jax` module (which we had in v1) to provide public access to register Jax
- [x] add `ak.jax.assert_registered` to ensure Jax is registered
- [x] implement support for restoring behaviours 
- [x] add `ak.jax.register_behavior_class` to register behavior classes with Jax
- [x] add `__subclass_hook__` to highlevel types in order to automatically invoke `ak.jax.register_behavior_class()`

## Refactoring
- [x] make `_connect.numexpr.import_numexpr` private
- [x] change `ak.jax.import_jax()` to assert that it is registered, instead of registering it
- [x] move the `_jax_flatten` Array/Record classmethods to high-level functions in `ak._connect.jax`
 - We don't need these to be classmethods on the Array, so let's keep the namespace empty
- [x] refactor `ak._connect.jax` to separate `_connect.jax.trees`
- [x] ensure Jax reducers inherits from `Reducer`
- [x] add `ak._connect.jax.get_jax_reducer` to find the Jax reducer for a given NumPy reducer
- [x] use `NumpyLike` mechanism in `from_backend`.

## Bug Fixes
- [x] fixed tracer leaks in Jax flattening
- [x] use `nplike` parameter in `ak.to_buffers`

## Breaking Changes
- `ak.jax.register_and_check()` needs to be called by external code before using Jax with Awkward. 

I think that this is a _good_ change, because this was already partly true; previously, calling `jax.XXX` functions on Awkward Arrays would only succeed if the registration step had been performed manually, or `to_jax()` had been invoked. 

This change makes it harder to forget to register Jax integration, because now the Jax integration in either direction won't work until it is enabled. Internal modules call `assert_registered()`, which encourages users to call `register_and_check()`. There is also `jax.import_jax()` which imports Jax after ensuring that it is registered.

Although this is _slightly_ less convenient; it ensures that users don't have to think about whether to call `ak.jax.register_and_check()` - one always must. It takes a stateful API `ak.to_jax()` and makes it stateless.

## High Level Changes
I think our `_connect` modules should assume that the importer knows what they're doing, and _wants_ these modules because they are known to be available on the host system. This makes it easier to reason about state, and lets us avoid silently invoking the `register()` functions by accident.  

So, for our main connect modules:
- `jax` - needs to be registered, as it uses global state for integration. Internal APIs can directly use the Jax APIs, but must ensure that `assert_registered` is called. i.e. we should explicitly call `ak.jax.import_jax()`, `ak.jax.register_and_check()`, or `ak.jax.assert_registered()` when we need these guarantees at the high-level, e.g. `ak.to_jax()`. Import checks can be done at registration, and internal functions therefore just need to check that things are currently registered.
- `numba` - see Jax[^numba] 
- `cupy` - does not need to be registered, so internal functions need to / can perform import-checks dynamically.
- `numexpr` - see CuPy
Instead of registering Jax when needed, we should explicitly call `ak.jax.import_jax()`, `ak.jax.register_and_check()`, or `jax.ensure_registered()` when we need these guarantees at the high-level, e.g. `ak.to_jax()`.

[^numba]: Perhaps not in the case of numba: it should always be registered due to the entry point. Checking this anyway would be more robust, however.`