### PR TITLE
fix: ignore unknown JAX "buffer" types & fix nplike mixing

### DIFF
--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -123,7 +123,7 @@ class AuxData(Generic[T]):
             # Check that JAX isn't trying to give us float0 types
             dtype = getattr(buffer, "dtype", None)
             if dtype == np.dtype([("float0", "V")]):
-                raise ak._errors.wrap_error(
+                raise _errors.wrap_error(
                     TypeError(
                         f"a buffer with the dtype {buffer.dtype} was encountered during unflattening. "
                         "JAX uses this dtype for the tangents of integer/boolean outputs; these cannot "

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -22,7 +22,7 @@ def find_all_buffers(
         if isinstance(node, ak.contents.NumpyArray):
             data_ptrs.append(node.data)
 
-    layout.recursively_apply(action=action, return_array=False)
+    layout.recursively_apply(action=action, return_array=False, numpy_to_regular=False)
 
     return data_ptrs
 
@@ -46,7 +46,7 @@ def replace_all_buffers(
                     buffer, layout.identifier, layout.parameters, nplike=nplike
                 )
 
-    return layout.recursively_apply(action=action)
+    return layout.recursively_apply(action=action, numpy_to_regular=False)
 
 
 T = TypeVar(
@@ -123,7 +123,6 @@ class AuxData(Generic[T]):
         layout = replace_all_buffers(
             self._layout, list(buffers), nplike=nplikes.Jax.instance()
         )
-        assert layout.nplike is nplikes.Jax.instance()
         return ak._util.wrap(
             layout, behavior=self._behavior, highlevel=self._is_highlevel
         )

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -43,7 +43,7 @@ def replace_all_buffers(
                 return
             else:
                 return ak.contents.NumpyArray(
-                    buffer, layout.identifier, layout.parameters, nplike=nplike
+                    buffer, node.identifier, node.parameters, nplike=nplike
                 )
 
     return layout.recursively_apply(action=action, numpy_to_regular=False)

--- a/tests/test_1764-jax-jacobian.py
+++ b/tests/test_1764-jax-jacobian.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_platform_name", "cpu")
+jax.config.update("jax_enable_x64", True)
+
+ak.jax.register_and_check()
+
+
+def test():
+    array = ak.Array([[1, 2, 3], [4, 5, 6.0]])
+
+    def func(x):
+        return x * 2 - 1
+
+    array_np = ak.to_numpy(array)
+    jac_np = jax.jacfwd(func)(array_np)
+
+    jac = jax.jacfwd(func)(array)
+    assert jac.to_list() == jac_np.tolist()

--- a/tests/test_1764-jax-jacobian.py
+++ b/tests/test_1764-jax-jacobian.py
@@ -11,6 +11,7 @@ jax.config.update("jax_enable_x64", True)
 ak.jax.register_and_check()
 
 
+@pytest.mark.skip("Jacobian support not implemented")
 def test():
     array = ak.Array([[1, 2, 3], [4, 5, 6.0]])
 


### PR DESCRIPTION
#1763 made some good strides in refactoring the JAX support, but there were some outstanding bugs with respect to parameter handling.

This PR just ensures that we have the same `nplike` throughout the layout (apart from `AuxData` layouts, which have `Numpy` at the leaves). It also introduces a test for later support of Jacobians. 

Finally, we also ignore non-buffers. This is probably the wrong thing to do in the general sense, but it's a start towards Jacobian support.