### PR TITLE
feat: make ak.from_json with schema ignore unspecified fields (instead of error).

### DIFF
--- a/tests/test_1162-ak-from_json_schema.py
+++ b/tests/test_1162-ak-from_json_schema.py
@@ -775,6 +775,7 @@ def test_ignore_before():
             },
         )
         assert array.tolist() == [{"x": 1}, {"x": 3}]
+        assert str(array.type) == "2 * {x: int64}"
 
 
 def test_ignore_after():
@@ -804,6 +805,7 @@ def test_ignore_after():
             },
         )
         assert array.tolist() == [{"x": 1}, {"x": 3}]
+        assert str(array.type) == "2 * {x: int64}"
 
 
 def test_ignore_between():
@@ -833,3 +835,94 @@ def test_ignore_between():
             },
         )
         assert array.tolist() == [{"x": 1, "z": True}, {"x": 3, "z": False}]
+        assert str(array.type) == "2 * {z: bool, x: int64}"
+
+
+def test_option_ignore_before():
+    for what in [
+        "null",
+        "true",
+        "2",
+        "2.2",
+        "[]",
+        "[2]",
+        "[2, 2.2]",
+        "{}",
+        '{"z": 2.2}',
+        '{"z": []}',
+        '{"z": [2]}',
+        '{"z": [2, 2.2]}',
+    ]:
+        array = ak.from_json(
+            '[{"y": ' + what + ', "x": 1}, {"x": 3}]',
+            schema={
+                "type": "array",
+                "items": {
+                    "type": ["object", "null"],
+                    "properties": {"x": {"type": "integer"}},
+                    "required": ["x"],
+                },
+            },
+        )
+        assert array.tolist() == [{"x": 1}, {"x": 3}]
+        assert str(array.type) == "2 * ?{x: int64}"
+
+
+def test_option_ignore_after():
+    for what in [
+        "null",
+        "true",
+        "2",
+        "2.2",
+        "[]",
+        "[2]",
+        "[2, 2.2]",
+        "{}",
+        '{"z": 2.2}',
+        '{"z": []}',
+        '{"z": [2]}',
+        '{"z": [2, 2.2]}',
+    ]:
+        array = ak.from_json(
+            '[{"x": 1, "y": ' + what + '}, {"x": 3}]',
+            schema={
+                "type": "array",
+                "items": {
+                    "type": ["object", "null"],
+                    "properties": {"x": {"type": "integer"}},
+                    "required": ["x"],
+                },
+            },
+        )
+        assert array.tolist() == [{"x": 1}, {"x": 3}]
+        assert str(array.type) == "2 * ?{x: int64}"
+
+
+def test_option_ignore_between():
+    for what in [
+        "null",
+        "true",
+        "2",
+        "2.2",
+        "[]",
+        "[2]",
+        "[2, 2.2]",
+        "{}",
+        '{"z": 2.2}',
+        '{"z": []}',
+        '{"z": [2]}',
+        '{"z": [2, 2.2]}',
+    ]:
+        array = ak.from_json(
+            '[{"x": 1, "y": ' + what + ', "z": true}, {"x": 3, "z": false}]',
+            schema={
+                "type": "array",
+                "items": {
+                    "type": ["object", "null"],
+                    "properties": {"z": {"type": "boolean"}, "x": {"type": "integer"}},
+                    "required": ["z", "x"],
+                },
+            },
+        )
+        assert array.tolist() == [{"x": 1, "z": True}, {"x": 3, "z": False}]
+        assert str(array.type) == "2 * ?{z: bool, x: int64}"

--- a/tests/test_1162-ak-from_json_schema.py
+++ b/tests/test_1162-ak-from_json_schema.py
@@ -746,3 +746,90 @@ def test_complex_substitutions():
     )
     assert result.tolist() == [1 + 1.1j, 2 + 2.2j, np.inf + 3.3j]
     assert str(result.type) == "3 * complex128"
+
+
+def test_ignore_before():
+    for what in [
+        "null",
+        "true",
+        "2",
+        "2.2",
+        "[]",
+        "[2]",
+        "[2, 2.2]",
+        "{}",
+        '{"z": 2.2}',
+        '{"z": []}',
+        '{"z": [2]}',
+        '{"z": [2, 2.2]}',
+    ]:
+        array = ak.from_json(
+            '[{"y": ' + what + ', "x": 1}, {"x": 3}]',
+            schema={
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer"}},
+                    "required": ["x"],
+                },
+            },
+        )
+        assert array.tolist() == [{"x": 1}, {"x": 3}]
+
+
+def test_ignore_after():
+    for what in [
+        "null",
+        "true",
+        "2",
+        "2.2",
+        "[]",
+        "[2]",
+        "[2, 2.2]",
+        "{}",
+        '{"z": 2.2}',
+        '{"z": []}',
+        '{"z": [2]}',
+        '{"z": [2, 2.2]}',
+    ]:
+        array = ak.from_json(
+            '[{"x": 1, "y": ' + what + '}, {"x": 3}]',
+            schema={
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer"}},
+                    "required": ["x"],
+                },
+            },
+        )
+        assert array.tolist() == [{"x": 1}, {"x": 3}]
+
+
+def test_ignore_between():
+    for what in [
+        "null",
+        "true",
+        "2",
+        "2.2",
+        "[]",
+        "[2]",
+        "[2, 2.2]",
+        "{}",
+        '{"z": 2.2}',
+        '{"z": []}',
+        '{"z": [2]}',
+        '{"z": [2, 2.2]}',
+    ]:
+        array = ak.from_json(
+            '[{"x": 1, "y": ' + what + ', "z": true}, {"x": 3, "z": false}]',
+            schema={
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"z": {"type": "boolean"}, "x": {"type": "integer"}},
+                    "required": ["z", "x"],
+                },
+            },
+        )
+        assert array.tolist() == [{"x": 1, "z": True}, {"x": 3, "z": False}]


### PR DESCRIPTION
Requested by @martindurant on Slack.

> Quick question: if you provide a schema to ak.from_json which omits some fields in the input data, are they skipped at parse time? So, is this like a columns= opportunity to improve memory use and maybe parse speed?

The parser now needs to have additional mutable state, but it's quite minor: a single integer will do it. Every JSON node queries this integer (and possibly returns early, depending on its value), but surely the computation time of checking an integer is minimal compared to parsing tokens of JSON text. I didn't even do a performance test; adding this will be fine.