### PR TITLE
feat: support scalars in `TypeTracer` operations

### DIFF
--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -556,19 +556,14 @@ class TypeTracer(ak.nplikes.NumpyLike):
         return TypeTracerArray(dtype, shape)
 
     def full(self, shape, value, dtype=None, **kwargs):
-        # shape/len, value[, dtype=]
-        if dtype is None:
-            dtype = numpy.array(value).dtype
-        return TypeTracerArray(dtype, shape)
+        array = TypeTracerArray.from_array(value, dtype=dtype)
+        return array.reshape(shape)
 
     def zeros_like(self, a, dtype=None, **kwargs):
-        if dtype is None:
-            dtype = a.dtype
-
         if isinstance(a, UnknownScalar):
             return UnknownScalar(dtype)
 
-        return TypeTracerArray(dtype, a.shape)
+        return TypeTracerArray.from_array(a, dtype=dtype)
 
     def ones_like(self, a, dtype=None, **kwargs):
         return self.zeros_like(a, dtype)

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -1,13 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numbers
+from typing import TypeVar
 
 import numpy
 
 import awkward as ak
-import awkward.nplikes
+from awkward import index, nplikes
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = nplikes.NumpyMetadata.instance()
 
 
 class NoError:
@@ -198,23 +199,34 @@ def _length_after_slice(slice, original_length):
         return 0
 
 
+TTypeTracerArray = TypeVar("TTypeTracerArray", bound="TypeTracerArray")
+
+
 class TypeTracerArray:
     @classmethod
-    def from_array(cls, array, dtype=None):
-        if isinstance(array, ak.index.Index):
+    def from_array(cls: TTypeTracerArray, array, dtype=None) -> TTypeTracerArray:
+        """
+        Args:
+            array: array-like object, e.g. np.ndarray, #ak.index.Index
+            dtype: dtype of returned #ak._typetracer.TypeTracerArray
+
+        Returns an #ak._typetracer.TypeTracerArray that describes the type information
+        of the given array.
+        """
+        if isinstance(array, index.Index):
             array = array.data
 
-        # not array-like
-        if not hasattr(array, "shape"):
-            sequence = list(array)
-            array = numpy.array(sequence)
-            if array.dtype == np.dtype("O"):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        f"bug in Awkward Array: attempt to construct `TypeTracerArray` "
-                        f"from a sequence of non-primitive types: {sequence}"
-                    )
+        # not array-like, try and cast to a NumPy array
+        elif not hasattr(array, "shape"):
+            array = numpy.array(array)
+
+        if array.dtype == np.dtype("O"):
+            raise ak._errors.wrap_error(
+                ValueError(
+                    f"bug in Awkward Array: attempt to construct `TypeTracerArray` "
+                    f"from a sequence of non-primitive types: {array}"
                 )
+            )
 
         if dtype is None:
             dtype = array.dtype
@@ -514,20 +526,14 @@ class TypeTracer(ak.nplikes.NumpyLike):
 
     def array(self, data, dtype=None, **kwargs):
         # data[, dtype=[, copy=]]
-        if dtype is None:
-            dtype = data.dtype
         return TypeTracerArray.from_array(data, dtype=dtype)
 
     def asarray(self, array, dtype=None, **kwargs):
         # array[, dtype=][, order=]
-        if dtype is None:
-            dtype = array.dtype
         return TypeTracerArray.from_array(array, dtype=dtype)
 
     def ascontiguousarray(self, array, dtype=None, **kwargs):
         # array[, dtype=]
-        if dtype is None:
-            dtype = array.dtype
         return TypeTracerArray.from_array(array, dtype=dtype)
 
     def isscalar(self, *args, **kwargs):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -50,7 +50,7 @@ class NumpyArray(Content):
         if len(self._data.shape) == 0:
             raise ak._errors.wrap_error(
                 TypeError(
-                    "{} 'data' must be an array, not {}".format(
+                    "{} 'data' must be an array, not a scalar: {}".format(
                         type(self).__name__, repr(data)
                     )
                 )

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -197,11 +197,14 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             layout = data._layout
             behavior = ak._util.behavior_of(data, behavior=behavior)
 
-        elif isinstance(data, np.ndarray) and data.dtype != np.dtype("O"):
+        elif numpy.is_own_array(data):
             layout = ak.operations.from_numpy(data, highlevel=False)
 
-        elif ak._util.in_module(data, "cupy"):
+        elif ak.nplikes.Cupy.is_own_array(data):
             layout = ak.operations.from_cupy(data, highlevel=False)
+
+        elif ak.nplikes.Jax.is_own_array(data):
+            layout = ak.operations.from_jax(data, highlevel=False)
 
         elif ak._util.in_module(data, "pyarrow"):
             layout = ak.operations.from_arrow(data, highlevel=False)

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numbers
-from collections.abc import Iterable
 
 import awkward as ak
 
@@ -79,7 +78,7 @@ def _impl(array, value, axis, highlevel, behavior):
             nplike.asarray(value), allow_record=False, allow_other=False
         )
     elif (
-        isinstance(value, Iterable)
+        ak._util.is_sized_iterable(value)
         and not (isinstance(value, (str, bytes)))
         or isinstance(value, (ak.highlevel.Record, ak.record.Record))
     ):

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -73,7 +73,7 @@ def _impl(array, allow_record, allow_other, numpytype):
     elif isinstance(array, ak._ext.ArrayBuilder):
         return array.snapshot()
 
-    elif isinstance(array, (np.ndarray, numpy.ma.MaskedArray)):
+    elif numpy.is_own_array(array):
         if not issubclass(array.dtype.type, numpytype):
             raise ak._errors.wrap_error(
                 ValueError(f"dtype {array.dtype!r} not allowed")

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable
 
 import awkward as ak
+from awkward import _errors
 
 np = ak.nplikes.NumpyMetadata.instance()
 numpy = ak.nplikes.Numpy.instance()
@@ -32,7 +33,7 @@ def to_layout(
     would rarely be used in a data analysis because #ak.contents.Content and
     #ak.record.Record are lower-level than #ak.Array.
     """
-    with ak._errors.OperationErrorContext(
+    with _errors.OperationErrorContext(
         "ak.to_layout",
         dict(
             array=array,
@@ -50,7 +51,7 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif isinstance(array, ak.record.Record):
         if not allow_record:
-            raise ak._errors.wrap_error(
+            raise _errors.wrap_error(
                 TypeError("ak.Record objects are not allowed in this function")
             )
         else:
@@ -61,7 +62,7 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif isinstance(array, ak.highlevel.Record):
         if not allow_record:
-            raise ak._errors.wrap_error(
+            raise _errors.wrap_error(
                 TypeError("ak.Record objects are not allowed in this function")
             )
         else:
@@ -75,9 +76,7 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif numpy.is_own_array(array):
         if not issubclass(array.dtype.type, numpytype):
-            raise ak._errors.wrap_error(
-                ValueError(f"dtype {array.dtype!r} not allowed")
-            )
+            raise _errors.wrap_error(ValueError(f"dtype {array.dtype!r} not allowed"))
         return _impl(
             ak.operations.from_numpy(
                 array, regulararray=True, recordarray=True, highlevel=False
@@ -89,9 +88,7 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif ak.nplikes.Cupy.is_own_array(array):
         if not issubclass(array.dtype.type, numpytype):
-            raise ak._errors.wrap_error(
-                ValueError(f"dtype {array.dtype!r} not allowed")
-            )
+            raise _errors.wrap_error(ValueError(f"dtype {array.dtype!r} not allowed"))
         return _impl(
             ak.operations.from_cupy(array, regulararray=True, highlevel=False),
             allow_record,
@@ -101,9 +98,7 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif ak.nplikes.Jax.is_own_array(array):
         if not issubclass(array.dtype.type, numpytype):
-            raise ak._errors.wrap_error(
-                ValueError(f"dtype {array.dtype!r} not allowed")
-            )
+            raise _errors.wrap_error(ValueError(f"dtype {array.dtype!r} not allowed"))
         return _impl(
             ak.operations.from_jax(array, regulararray=True, highlevel=False),
             allow_record,
@@ -113,6 +108,16 @@ def _impl(array, allow_record, allow_other, numpytype):
 
     elif ak._typetracer.TypeTracer.is_own_array(array):
         typetracer = ak._typetracer.TypeTracer.instance()
+
+        if len(array.shape) == 0:
+            array = array.reshape(1)
+
+        if array.dtype.kind in {"S", "U"}:
+            raise _errors.wrap_error(
+                NotImplementedError(
+                    "strings are currently not supported for typetracer arrays"
+                )
+            )
 
         return ak.contents.NumpyArray(
             array,
@@ -138,7 +143,7 @@ def _impl(array, allow_record, allow_other, numpytype):
         )
 
     elif not allow_other:
-        raise ak._errors.wrap_error(
+        raise _errors.wrap_error(
             TypeError(f"{array} cannot be converted into an Awkward Array")
         )
 

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -111,6 +111,16 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
+    elif ak._typetracer.TypeTracer.is_own_array(array):
+        typetracer = ak._typetracer.TypeTracer.instance()
+
+        return ak.contents.NumpyArray(
+            array,
+            parameters=None,
+            identifier=None,
+            nplike=typetracer,
+        )
+
     elif isinstance(array, (str, bytes)):
         return _impl(
             ak.operations.from_iter([array], highlevel=False),

--- a/tests/test_1703-fill-none-typetracer.py
+++ b/tests/test_1703-fill-none-typetracer.py
@@ -1,0 +1,16 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array([1, 2, None])
+    result = ak.fill_none(array, 0)
+    assert result.tolist() == [1, 2, 0]
+
+    array_tt = ak.Array(array.layout.typetracer.forget_length())
+    result_tt = ak.fill_none(array_tt, 0)
+    assert result_tt.layout.length is ak._typetracer.UnknownLength


### PR DESCRIPTION
Fixes #1703

This PR:
- adds support for JAX arrays in `ak.Array`
- adds support for `TypeTracerArray` in `ak.to_layout`
- tightens `isinstance` to `ak._util.is_sized_iterable` in `ak.fill_none`
- removes iterator support from `TypeTracerArray.from_array` and refactors its usage