### PR TITLE
docs: point all references of CI/CD to GH Actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,9 +122,7 @@ rm -rf docs-shinx/_auto docs_sphinx/_build docs-sphinx/_static
 
 ### Continuous testing
 
-Pull requests must pass all [continuous integration](https://dev.azure.com/jpivarski/Scikit-HEP/_build?definitionId=3&_a=summary) tests before they are merged. I will sometimes cancel non-essential builds to give priority to pull requests that are almost ready to be merged. If you needed the result of the build as a diagnostic, you can ask me to restart your job or make a trivial change to trigger a new build.
-
-Currently, we only run merge builds (the state of your branch if merged with `main`), not regular branch builds (the state of your branch as-is), because only merge builds can be made to run for pull requests from external forks and it makes better use of our limited execution time on Azure. If you want to enable regular branch builds, you can turn it on for your branch by editing `trigger/branches/exclude` in [.ci/azure-buildtest-awkwrad.yml](https://github.com/scikit-hep/awkward-1.0/blob/9b6fca3f6e6456860ae40979171f762e0045ce7c/.ci/azure-buildtest-awkward.yml#L1-L5). The merge build trigger is not controlled by the YAML file. It is better, however, to keep up-to-date with `git merge main`.
+Pull requests must pass all [continuous integration](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml) tests before they are merged. I will sometimes cancel non-essential builds to give priority to pull requests that are almost ready to be merged. If you needed the result of the build as a diagnostic, you can ask me to restart your job or make a trivial change to trigger a new build.
 
 ### The main branch
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -4,7 +4,7 @@
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
 [![Python 3.7‒3.11](https://img.shields.io/badge/python-3.7%E2%80%923.11-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Continuous integration tests](https://img.shields.io/azure-devops/build/jpivarski/Scikit-HEP/3/main?label=tests)](https://dev.azure.com/jpivarski/Scikit-HEP/_build)
+[![Build Test](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml)
 
 [![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)
 [![NSF-1836650](https://img.shields.io/badge/NSF-1836650-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ python -m pytest -vv -rs tests-spec
 python -m pytest -vv -rs tests-cpu-kernels
 ```
 
-   * [Continuous integration](https://dev.azure.com/jpivarski/Scikit-HEP/_build?definitionId=3&_a=summary) and [continuous deployment](https://dev.azure.com/jpivarski/Scikit-HEP/_build?definitionId=4&_a=summary) are hosted by [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/).
+   * [Continuous integration](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml) and [continuous deployment](https://github.com/scikit-hep/awkward/actions/workflows/wheels.yml) are hosted by [GitHub Actions](https://github.com/features/actions/).
    * [Release history](https://awkward-array.readthedocs.io/en/latest/_auto/changelog.html) (changelog) is hosted by [ReadTheDocs](https://readthedocs.org).
    * [CONTRIBUTING.md](CONTRIBUTING.md) for technical information on how to contribute.
    * [Code of conduct](https://scikit-hep.org/code-of-conduct) for how we work together.

--- a/dev/download-github-artefact.py
+++ b/dev/download-github-artefact.py
@@ -5,9 +5,10 @@ import argparse
 import io
 import os
 import re
-import requests
 import subprocess
 import zipfile
+
+import requests
 
 
 def get_sha_head():

--- a/docs-sphinx/api-reference.rst
+++ b/docs-sphinx/api-reference.rst
@@ -28,9 +28,9 @@
    :alt: BSD-3 Clause License
    :target: https://opensource.org/licenses/BSD-3-Clause
 
-.. image:: https://img.shields.io/azure-devops/build/jpivarski/Scikit-HEP/3/main?label=tests
+.. image:: https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml/badge.svg?branch=main
    :alt: Continuous integration tests
-   :target: https://dev.azure.com/jpivarski/Scikit-HEP/_build
+   :target: https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml
 
 :raw-html:`</p><p>`
 


### PR DESCRIPTION
Spotted some outdated CI/CD badges and links while going through the docs. I am not sure which branch should I compare this with - `docs`, `agoose77/docs-update-for-v2`, `agoose77/docs-expand-content`, or `main` (also probably `main-v1`) 😬 