### PR TITLE
fix: propagate mask through `from_numpy`

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -622,7 +622,7 @@ def from_arraylib(array, regulararray, recordarray, highlevel, behavior):
 
         if regulararray and len(array.shape) > 1:
             return ak.contents.RegularArray(
-                recurse(array.reshape((-1,) + array.shape[2:])),
+                recurse(array.reshape((-1,) + array.shape[2:]), mask),
                 array.shape[1],
                 array.shape[0],
             )

--- a/tests/test_1735-from-numpy-mask.py
+++ b/tests/test_1735-from-numpy-mask.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    np_array = np.ma.MaskedArray(
+        [[1, 2, 3], [4, 5, 6]], mask=[[False, True, False], [True, True, False]]
+    )
+    ak_array = ak.from_numpy(np_array)
+
+    assert ak_array.to_list() == [[1, None, 3], [None, None, 6]]


### PR DESCRIPTION
Fixes #1735 