### PR TITLE
fix: use the flag for non-persistence

### DIFF
--- a/src/awkward/_connect/cling.py
+++ b/src/awkward/_connect/cling.py
@@ -149,7 +149,7 @@ namespace awkward {
     ssize_t stop_;
     ssize_t which_;
     ssize_t* ptrs_;
-    PyObject* lookup_;
+    PyObject* lookup_; //! lookup
   };
 }
 """.strip()
@@ -186,7 +186,7 @@ namespace awkward {
     ssize_t at_;
     ssize_t which_;
     ssize_t* ptrs_;
-    PyObject* lookup_;
+    PyObject* lookup_; //! lookup
 
   };
 }

--- a/tests/test_1781-rdataframe-snapshot.py
+++ b/tests/test_1781-rdataframe-snapshot.py
@@ -1,0 +1,88 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+ROOT = pytest.importorskip("ROOT")
+
+
+compiler = ROOT.gInterpreter.Declare
+
+
+def test_data_frame_integers():
+    ak_array_x = ak.Array([1, 2, 3, 4, 5])
+    ak_array_y = ak.Array([1.1, 2.2, 3.3, 4.4, 5.5])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_x, "y": ak_array_y})
+
+    assert data_frame.GetColumnType("x") == "int64_t"
+    assert data_frame.GetColumnType("y") == "double"
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        columns=("x", "y"),
+    )
+    assert ak_array_x.to_list() == ak_array_out["x"].to_list()
+    assert ak_array_y.to_list() == ak_array_out["y"].to_list()
+
+    data_frame.Snapshot("Test", "test-integers.root", ("x", "y"))
+
+
+def test_data_frame_vec_of_vec_of_real():
+    ak_array_in = ak.Array([[[1.1], [2.2]], [[3.3], [4.4, 5.5]]])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_in})
+
+    assert data_frame.GetColumnType("x").startswith("awkward::ListArray_")
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        columns=("x",),
+    )
+    assert ak_array_in.to_list() == ak_array_out["x"].to_list()
+
+    with pytest.raises(SystemError):
+        data_frame.Snapshot("ListArray", "test-listarray.root", ("x",))
+
+
+def test_data_frame_rvec_filter():
+    ak_array_x = ak.Array([[1, 2], [3], [4, 5]])
+    ak_array_y = ak.Array([[1.0, 1.1], [2.2, 3.3, 4.4], [5.5]])
+
+    data_frame = ak.to_rdataframe({"x": ak_array_x, "y": ak_array_y})
+    rdf3 = data_frame.Filter("x.size() >= 2")
+
+    assert data_frame.GetColumnType("x") == "ROOT::VecOps::RVec<int64_t>"
+    assert data_frame.GetColumnType("y") == "ROOT::VecOps::RVec<double>"
+
+    ak_array_out = ak.from_rdataframe(
+        rdf3,
+        columns=(
+            "x",
+            "y",
+        ),
+    )
+    assert ak_array_out["x"].to_list() == [[1, 2], [4, 5]]
+    assert ak_array_out["y"].to_list() == [[1.0, 1.1], [5.5]]
+
+    rdf4 = data_frame.Filter("y.size() == 2")
+    ak_array_out = ak.from_rdataframe(
+        rdf4,
+        columns=(
+            "x",
+            "y",
+        ),
+    )
+    assert ak_array_out["x"].to_list() == [[1, 2]]
+    assert ak_array_out["y"].to_list() == [[1.0, 1.1]]
+
+    data_frame.Snapshot(
+        "ListArray",
+        "test-listarray.root",
+        (
+            "x",
+            "y",
+        ),
+    )


### PR DESCRIPTION
Using the flag for non-persistence of the PyObject lookup pointers prevents the crash.