### PR TITLE
feat: add `cumsum` and `cumprod`

### DIFF
--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -5513,6 +5513,109 @@ kernels:
     automatic-tests: true
     manual-tests: []
 
+  - name: awkward_transform_cumsum
+    specializations:
+      - name: awkward_transform_cumsum_int32_int8_64
+        args:
+          - {name: toptr, type: "List[int32_t]", dir: out}
+          - {name: fromptr, type: "Const[List[int8_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_int32_int16_64
+        args:
+          - {name: toptr, type: "List[int32_t]", dir: out}
+          - {name: fromptr, type: "Const[List[int16_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_int32_int32_64
+        args:
+          - {name: toptr, type: "List[int32_t]", dir: out}
+          - {name: fromptr, type: "Const[List[int32_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_int64_int8_64
+        args:
+          - {name: toptr, type: "List[int64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[int8_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_int64_int16_64
+        args:
+          - {name: toptr, type: "List[int64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[int16_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_int64_int32_64
+        args:
+          - {name: toptr, type: "List[int64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[int32_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_int64_int64_64
+        args:
+          - {name: toptr, type: "List[int64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[int64_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_uint32_uint8_64
+        args:
+          - {name: toptr, type: "List[uint32_t]", dir: out}
+          - {name: fromptr, type: "Const[List[uint8_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_uint32_uint16_64
+        args:
+          - {name: toptr, type: "List[uint32_t]", dir: out}
+          - {name: fromptr, type: "Const[List[uint16_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_uint32_uint32_64
+        args:
+          - {name: toptr, type: "List[uint32_t]", dir: out}
+          - {name: fromptr, type: "Const[List[uint32_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_uint64_uint8_64
+        args:
+          - {name: toptr, type: "List[uint64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[uint8_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_uint64_uint16_64
+        args:
+          - {name: toptr, type: "List[uint64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[uint16_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_uint64_uint32_64
+        args:
+          - {name: toptr, type: "List[uint64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[uint32_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_uint64_uint64_64
+        args:
+          - {name: toptr, type: "List[uint64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[uint64_t]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_float32_float32_64
+        args:
+          - {name: toptr, type: "List[float]", dir: out}
+          - {name: fromptr, type: "Const[List[float]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_float64_float64_64
+        args:
+          - {name: toptr, type: "List[double]", dir: out}
+          - {name: fromptr, type: "Const[List[double]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+    description: null
+    definition: |
+    automatic-tests: false
+    manual-tests: []
+
   - name: awkward_reduce_sum_complex
     specializations:
       - name: awkward_reduce_sum_complex64_complex64_64

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -605,7 +605,6 @@ kernels:
       - name: awkward_IndexedArray_local_preparenext_64
         args:
           - {name: tocarry, type: "List[int64_t]", dir: out}
-          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: ListArray-starts}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
           - {name: parentslength, type: "Const[int64_t]", dir: in, role: default}
           - {name: nextparents, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -5515,6 +5515,18 @@ kernels:
 
   - name: awkward_transform_cumsum
     specializations:
+      - name: awkward_transform_cumsum_int64_bool_64
+        args:
+          - {name: toptr, type: "List[int64_t]", dir: out}
+          - {name: fromptr, type: "Const[List[bool]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
+      - name: awkward_transform_cumsum_int32_bool_64
+        args:
+          - {name: toptr, type: "List[int32_t]", dir: out}
+          - {name: fromptr, type: "Const[List[bool]]", dir: in, role: reducer-fromptr}
+          - {name: offsets, type: "Const[List[int64_t]]", dir: in, role: transformer-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: transformer-offsetslength}
       - name: awkward_transform_cumsum_int32_int8_64
         args:
           - {name: toptr, type: "List[int32_t]", dir: out}

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -20,6 +20,8 @@ import awkward.forms
 import awkward._slicing
 import awkward._broadcasting
 import awkward._typetracer
+import awkward._reducers
+import awkward._transformers
 
 # internal
 import awkward._util

--- a/src/awkward/_transformers.py
+++ b/src/awkward/_transformers.py
@@ -138,13 +138,6 @@ class ArgSort(Transformer):
 
 
 class CumSum(Transformer):
-    def __init__(self, dtype):
-        self._dtype = dtype
-
-    @property
-    def dtype(self):
-        return self._dtype
-
     def apply(self, array, offsets, parents):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind == "M":

--- a/src/awkward/_transformers.py
+++ b/src/awkward/_transformers.py
@@ -7,12 +7,15 @@ class Transformer:
     needs_position = False
     through_record = False
 
-    @classmethod
-    def highlevel_function(cls):
-        return getattr(ak.operations, cls.name)
+    @property
+    def name(self):
+        raise ak._errors.wrap_error(NotImplementedError)
 
-    @classmethod
-    def return_dtype(cls, given_dtype):
+    @property
+    def highlevel_function(self):
+        return getattr(ak.operations, self.name)
+
+    def return_dtype(self, given_dtype):
         if given_dtype in (np.bool_, np.int8, np.int16, np.int32):
             return np.int32 if ak._util.win or ak._util.bits32 else np.int64
 
@@ -21,12 +24,10 @@ class Transformer:
 
         return given_dtype
 
-    @classmethod
-    def maybe_double_length(cls, type, length):
+    def maybe_double_length(self, type, length):
         return 2 * length if type in (np.complex128, np.complex64) else length
 
-    @classmethod
-    def maybe_other_type(cls, dtype):
+    def maybe_other_type(self, dtype):
         type = np.int64 if dtype.kind.upper() == "M" else dtype.type
         if dtype == np.complex128:
             type = np.float64

--- a/src/awkward/_transformers.py
+++ b/src/awkward/_transformers.py
@@ -1,0 +1,134 @@
+import awkward as ak
+
+np = ak.nplikes.NumpyMetadata.instance()
+
+
+class Transformer:
+    needs_position = False
+    through_record = False
+
+    @classmethod
+    def highlevel_function(cls):
+        return getattr(ak.operations, cls.name)
+
+    @classmethod
+    def return_dtype(cls, given_dtype):
+        if given_dtype in (np.bool_, np.int8, np.int16, np.int32):
+            return np.int32 if ak._util.win or ak._util.bits32 else np.int64
+
+        if given_dtype in (np.uint8, np.uint16, np.uint32):
+            return np.uint32 if ak._util.win or ak._util.bits32 else np.uint64
+
+        return given_dtype
+
+    @classmethod
+    def maybe_double_length(cls, type, length):
+        return 2 * length if type in (np.complex128, np.complex64) else length
+
+    @classmethod
+    def maybe_other_type(cls, dtype):
+        type = np.int64 if dtype.kind.upper() == "M" else dtype.type
+        if dtype == np.complex128:
+            type = np.float64
+        if dtype == np.complex64:
+            type = np.float32
+        return type
+
+    def apply(
+        self,
+        array: "ak.contents.NumpyArray",
+        offsets: "ak.index.Index",
+        parents: "ak.index.Index",
+    ):
+        """Apply the transform function to the given array.
+
+        Args:
+            array: array to transform
+            offsets: the indices of the start and stop positions for contiguous sublists in parents
+            parents: the identity of the sublist associated with each value in array
+
+        Returns:
+
+        """
+        raise NotImplementedError
+
+
+class Sort(Transformer):
+    through_record = True
+
+    def __init__(self, ascending: bool, stable: bool):
+        self._ascending = ascending
+        self._stable = stable
+
+    @property
+    def ascending(self):
+        return self._ascending
+
+    @property
+    def stable(self):
+        return self._stable
+
+    def apply(self, array, offsets, parents):
+        dtype = self.maybe_other_type(array.dtype)
+        out = array.nplike.empty(array.length, dtype)
+        assert offsets.nplike is array.nplike
+        array._handle_error(
+            array.nplike[  # noqa: E231
+                "awkward_sort",
+                dtype,
+                dtype,
+                offsets.dtype.type,
+            ](
+                out,
+                array.data,
+                array.shape[0],
+                offsets.data,
+                offsets.length,
+                parents.length,
+                self._ascending,
+                self._stable,
+            )
+        )
+        return ak.contents.NumpyArray(
+            array.nplike.asarray(out, array.dtype), None, None, array.nplike
+        )
+
+
+class ArgSort(Transformer):
+    needs_position = True
+
+    def __init__(self, ascending: bool, stable: bool):
+        self._ascending = ascending
+        self._stable = stable
+
+    @property
+    def ascending(self):
+        return self._ascending
+
+    @property
+    def stable(self):
+        return self._stable
+
+    def apply(self, array, offsets, parents):
+        dtype = self.maybe_other_type(array.dtype)
+        nextcarry = ak.index.Index64.empty(len(array), array.nplike)
+        assert offsets.nplike is array.nplike
+        array._handle_error(
+            array.nplike[  # noqa: E231
+                "awkward_argsort",
+                nextcarry.dtype.type,
+                dtype,
+                offsets.dtype.type,
+            ](
+                nextcarry.data,
+                array.data,
+                len(array),
+                offsets.data,
+                offsets.length,
+                self._ascending,
+                self._stable,
+            )
+        )
+        return ak.contents.NumpyArray(
+            array.nplike.asarray(nextcarry, nextcarry.dtype), None, None, array.nplike
+        )

--- a/src/awkward/_transformers.py
+++ b/src/awkward/_transformers.py
@@ -5,6 +5,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 class Transformer:
     needs_position = False
+    maintain_none_position = True
     through_record = False
     preferred_dtype = None
 
@@ -57,6 +58,7 @@ class Transformer:
 
 class Sort(Transformer):
     through_record = True
+    maintain_none_position = False
 
     def __init__(self, ascending: bool, stable: bool):
         self._ascending = ascending
@@ -98,6 +100,7 @@ class Sort(Transformer):
 
 class ArgSort(Transformer):
     needs_position = True
+    maintain_none_position = False
     preferred_dtype = np.int64
 
     def __init__(self, ascending: bool, stable: bool):
@@ -168,7 +171,6 @@ class CumSum(Transformer):
                     offsets.length,
                 )
             )
-
         if array.dtype.kind == "m":
             return ak.contents.NumpyArray(array.nplike.asarray(result, array.dtype))
         elif array.dtype.type in (np.complex128, np.complex64):

--- a/src/awkward/_transformers.py
+++ b/src/awkward/_transformers.py
@@ -6,6 +6,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 class Transformer:
     needs_position = False
     through_record = False
+    preferred_dtype = None
 
     @property
     def name(self):
@@ -97,6 +98,7 @@ class Sort(Transformer):
 
 class ArgSort(Transformer):
     needs_position = True
+    preferred_dtype = np.int64
 
     def __init__(self, ascending: bool, stable: bool):
         self._ascending = ascending

--- a/src/awkward/_transformers.py
+++ b/src/awkward/_transformers.py
@@ -155,9 +155,7 @@ class CumSum(Transformer):
             dtype=self.return_dtype(dtype),
         )
 
-        if array.dtype == np.bool_:
-            raise NotImplementedError
-        elif array.dtype.type in (np.complex128, np.complex64):
+        if array.dtype.type in (np.complex128, np.complex64):
             raise NotImplementedError
         else:
             assert parents.nplike is array.nplike

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -504,42 +504,17 @@ class BitMaskedArray(Content):
         else:
             return out._content
 
-    def _argsort_next(
+    def _transform_next(
         self,
+        transformer,
         negaxis,
         starts,
         shifts,
         parents,
         outlength,
-        ascending,
-        stable,
-        kind,
-        order,
     ):
-        return self.toIndexedOptionArray64()._argsort_next(
-            negaxis,
-            starts,
-            shifts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
-
-    def _sort_next(
-        self, negaxis, starts, parents, outlength, ascending, stable, kind, order
-    ):
-        return self.toIndexedOptionArray64()._sort_next(
-            negaxis,
-            starts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
+        return self.toIndexedOptionArray64()._transform_next(
+            transformer, negaxis, starts, shifts, parents, outlength
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -716,42 +716,17 @@ class ByteMaskedArray(Content):
             negaxis, starts, parents, outlength
         )
 
-    def _argsort_next(
+    def _transform_next(
         self,
+        transformer,
         negaxis,
         starts,
         shifts,
         parents,
         outlength,
-        ascending,
-        stable,
-        kind,
-        order,
     ):
-        return self.toIndexedOptionArray64()._argsort_next(
-            negaxis,
-            starts,
-            shifts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
-
-    def _sort_next(
-        self, negaxis, starts, parents, outlength, ascending, stable, kind, order
-    ):
-        return self.toIndexedOptionArray64()._sort_next(
-            negaxis,
-            starts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
+        return self.toIndexedOptionArray64()._transform_next(
+            transformer, negaxis, starts, shifts, parents, outlength
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -940,17 +940,8 @@ class Content:
 
         starts = ak.index.Index64.zeros(1, self._nplike)
         parents = ak.index.Index64.zeros(self.length, self._nplike)
-        return self._argsort_next(
-            negaxis,
-            starts,
-            None,
-            parents,
-            1,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
+        transformer = ak._transformers.Sort(ascending, stable)
+        return self._transform_next(transformer, negaxis, starts, None, parents, 1)
 
     def sort(self, axis=-1, ascending=True, stable=False, kind=None, order=None):
         negaxis = -axis
@@ -986,16 +977,8 @@ class Content:
 
         starts = ak.index.Index64.zeros(1, self._nplike)
         parents = ak.index.Index64.zeros(self.length, self._nplike)
-        return self._sort_next(
-            negaxis,
-            starts,
-            parents,
-            1,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
+        transformer = ak._transformers.Sort(ascending, stable)
+        return self._transform_next(transformer, negaxis, starts, None, parents, 1)
 
     def _combinations_axis0(self, n, replacement, recordlookup, parameters):
         size = self.length

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -907,88 +907,16 @@ class Content:
         )
 
     def argsort(self, axis=-1, ascending=True, stable=False, kind=None, order=None):
-        negaxis = -axis
-        branch, depth = self.branch_depth
-        if branch:
-            if negaxis <= 0:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "cannot use non-negative axis on a nested list structure "
-                        "of variable depth (negative axis counts from the leaves "
-                        "of the tree; non-negative from the root)"
-                    )
-                )
-            if negaxis > depth:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "cannot use axis={} on a nested list structure that splits into "
-                        "different depths, the minimum of which is depth={} from the leaves".format(
-                            axis, depth
-                        )
-                    )
-                )
-        else:
-            if negaxis <= 0:
-                negaxis = negaxis + depth
-            if not (0 < negaxis and negaxis <= depth):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "axis={} exceeds the depth of the nested list structure "
-                        "(which is {})".format(axis, depth)
-                    )
-                )
-
-        starts = ak.index.Index64.zeros(1, self._nplike)
-        parents = ak.index.Index64.zeros(self.length, self._nplike)
         transformer = ak._transformers.ArgSort(ascending, stable)
-        return self._transform_next(transformer, negaxis, starts, None, parents, 1)
+        return self._transform(transformer, axis)
 
     def cumsum(self, axis=None, dtype=None):
         transformer = ak._transformers.CumSum(dtype)
-        starts = ak.index.Index64.zeros(1, self._nplike)
-        parents = ak.index.Index64.zeros(self.length, self._nplike)
-        if axis is not None:
-            negaxis = -axis
-        else:
-            negaxis = None
-        return self._transform_next(transformer, negaxis, starts, None, parents, 1)
+        return self._transform(transformer, axis)
 
     def sort(self, axis=-1, ascending=True, stable=False, kind=None, order=None):
-        negaxis = -axis
-        branch, depth = self.branch_depth
-        if branch:
-            if negaxis <= 0:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "cannot use non-negative axis on a nested list structure "
-                        "of variable depth (negative axis counts from the leaves "
-                        "of the tree; non-negative from the root)"
-                    )
-                )
-            if negaxis > depth:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "cannot use axis={} on a nested list structure that splits into "
-                        "different depths, the minimum of which is depth={} from the leaves".format(
-                            axis, depth
-                        )
-                    )
-                )
-        else:
-            if negaxis <= 0:
-                negaxis = negaxis + depth
-            if not (0 < negaxis and negaxis <= depth):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "axis={} exceeds the depth of the nested list structure "
-                        "(which is {})".format(axis, depth)
-                    )
-                )
-
-        starts = ak.index.Index64.zeros(1, self._nplike)
-        parents = ak.index.Index64.zeros(self.length, self._nplike)
         transformer = ak._transformers.Sort(ascending, stable)
-        return self._transform_next(transformer, negaxis, starts, None, parents, 1)
+        return self._transform(transformer, axis)
 
     def _combinations_axis0(self, n, replacement, recordlookup, parameters):
         size = self.length
@@ -1547,3 +1475,39 @@ class Content:
 
     def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
         raise ak._errors.wrap_error(NotImplementedError)
+
+    def _transform(self, transformer, axis=-1):
+        negaxis = -axis
+        branch, depth = self.branch_depth
+        if branch:
+            if negaxis <= 0:
+                raise ak._errors.wrap_error(
+                    ValueError(
+                        "cannot use non-negative axis on a nested list structure "
+                        "of variable depth (negative axis counts from the leaves "
+                        "of the tree; non-negative from the root)"
+                    )
+                )
+            if negaxis > depth:
+                raise ak._errors.wrap_error(
+                    ValueError(
+                        "cannot use axis={} on a nested list structure that splits into "
+                        "different depths, the minimum of which is depth={} from the leaves".format(
+                            axis, depth
+                        )
+                    )
+                )
+        else:
+            if negaxis <= 0:
+                negaxis = negaxis + depth
+            if not (0 < negaxis and negaxis <= depth):
+                raise ak._errors.wrap_error(
+                    ValueError(
+                        "axis={} exceeds the depth of the nested list structure "
+                        "(which is {})".format(axis, depth)
+                    )
+                )
+
+        starts = ak.index.Index64.zeros(1, self._nplike)
+        parents = ak.index.Index64.zeros(self.length, self._nplike)
+        return self._transform_next(transformer, negaxis, starts, None, parents, 1)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -943,6 +943,16 @@ class Content:
         transformer = ak._transformers.Sort(ascending, stable)
         return self._transform_next(transformer, negaxis, starts, None, parents, 1)
 
+    def cumsum(self, axis=None, dtype=None):
+        transformer = ak._transformers.CumSum(dtype)
+        starts = ak.index.Index64.zeros(1, self._nplike)
+        parents = ak.index.Index64.zeros(self.length, self._nplike)
+        if axis is not None:
+            negaxis = -axis
+        else:
+            negaxis = None
+        return self._transform_next(transformer, negaxis, starts, None, parents, 1)
+
     def sort(self, axis=-1, ascending=True, stable=False, kind=None, order=None):
         negaxis = -axis
         branch, depth = self.branch_depth

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1551,3 +1551,6 @@ class Content:
             )
             and self._layout_equal(other, index_dtype, numpyarray)
         )
+
+    def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
+        raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -940,7 +940,7 @@ class Content:
 
         starts = ak.index.Index64.zeros(1, self._nplike)
         parents = ak.index.Index64.zeros(self.length, self._nplike)
-        transformer = ak._transformers.Sort(ascending, stable)
+        transformer = ak._transformers.ArgSort(ascending, stable)
         return self._transform_next(transformer, negaxis, starts, None, parents, 1)
 
     def cumsum(self, axis=None, dtype=None):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1477,6 +1477,9 @@ class Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def _transform(self, transformer, axis=-1):
+        if axis is None:
+            raise ak._errors.wrap_error(NotImplementedError)
+
         negaxis = -axis
         branch, depth = self.branch_depth
         if branch:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -910,8 +910,8 @@ class Content:
         transformer = ak._transformers.ArgSort(ascending, stable)
         return self._transform(transformer, axis)
 
-    def cumsum(self, axis=None, dtype=None):
-        transformer = ak._transformers.CumSum(dtype)
+    def cumsum(self, axis=None):
+        transformer = ak._transformers.CumSum()
         return self._transform(transformer, axis)
 
     def sort(self, axis=-1, ascending=True, stable=False, kind=None, order=None):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -226,8 +226,8 @@ class EmptyArray(Content):
         return self
 
     def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
-        if transformer.needs_position:
-            as_numpy = self.toNumpyArray(np.int64)
+        if transformer.preferred_dtype is not None:
+            as_numpy = self.toNumpyArray(transformer.preferred_dtype)
             return as_numpy._transform_next(
                 transformer,
                 negaxis,

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -226,15 +226,18 @@ class EmptyArray(Content):
         return self
 
     def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
-        as_numpy = self.toNumpyArray(np.float64)
-        return as_numpy._transform_next(
-            transformer,
-            negaxis,
-            starts,
-            shifts,
-            parents,
-            outlength,
-        )
+        if transformer.needs_position:
+            as_numpy = self.toNumpyArray(np.int64)
+            return as_numpy._transform_next(
+                transformer,
+                negaxis,
+                starts,
+                shifts,
+                parents,
+                outlength,
+            )
+        else:
+            return self
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         return ak.contents.EmptyArray(self._identifier, self._parameters, self._nplike)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -225,35 +225,16 @@ class EmptyArray(Content):
     def _unique(self, negaxis, starts, parents, outlength):
         return self
 
-    def _argsort_next(
-        self,
-        negaxis,
-        starts,
-        shifts,
-        parents,
-        outlength,
-        ascending,
-        stable,
-        kind,
-        order,
-    ):
+    def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
         as_numpy = self.toNumpyArray(np.float64)
-        return as_numpy._argsort_next(
+        return as_numpy._transform_next(
+            transformer,
             negaxis,
             starts,
             shifts,
             parents,
             outlength,
-            ascending,
-            stable,
-            kind,
-            order,
         )
-
-    def _sort_next(
-        self, negaxis, starts, parents, outlength, ascending, stable, kind, order
-    ):
-        return self
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         return ak.contents.EmptyArray(self._identifier, self._parameters, self._nplike)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -887,54 +887,6 @@ class IndexedArray(Content):
 
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _argsort_next(
-        self,
-        negaxis,
-        starts,
-        shifts,
-        parents,
-        outlength,
-        ascending,
-        stable,
-        kind,
-        order,
-    ):
-        next = self._content._carry(self._index, False)
-        return next._argsort_next(
-            negaxis,
-            starts,
-            shifts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
-
-    def _sort_next(
-        self,
-        negaxis,
-        starts,
-        parents,
-        outlength,
-        ascending,
-        stable,
-        kind,
-        order,
-    ):
-        next = self._content._carry(self._index, False)
-        return next._sort_next(
-            negaxis,
-            starts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
-
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
@@ -943,6 +895,25 @@ class IndexedArray(Content):
             return self.project()._combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
+
+    def _transform_next(
+        self,
+        transformer,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+    ):
+        next = self._content._carry(self._index, False)
+        return next._transform_next(
+            transformer,
+            negaxis,
+            starts,
+            shifts,
+            parents,
+            outlength,
+        )
 
     def _reduce_next(
         self,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1195,7 +1195,6 @@ class IndexedOptionArray(Content):
         nextoutindex = ak.index.Index64.empty(parents.length, self._nplike)
         assert (
             nextoutindex.nplike is self._nplike
-            and starts.nplike is self._nplike
             and parents.nplike is self._nplike
             and nextparents.nplike is self._nplike
         )
@@ -1203,12 +1202,10 @@ class IndexedOptionArray(Content):
             self._nplike[
                 "awkward_IndexedArray_local_preparenext",
                 nextoutindex.dtype.type,
-                starts.dtype.type,
                 parents.dtype.type,
                 nextparents.dtype.type,
             ](
                 nextoutindex.data,
-                starts.data,
                 parents.data,
                 parents.length,
                 nextparents.data,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1248,7 +1248,11 @@ class IndexedOptionArray(Content):
 
         # Always inject nones if branching / not transforming this axis. Otherwise,
         # let the transformer decide e.g. cumsum maintains option position.
-        maintain_none_positions = True if not (branch or negaxis == depth) else False
+        maintain_none_positions = (
+            True
+            if not (branch or negaxis == depth)
+            else transformer.maintain_none_position
+        )
 
         if maintain_none_positions:
             # At this point, `out` will always have the `None`-associated values at the

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1248,13 +1248,7 @@ class IndexedOptionArray(Content):
 
         # Always inject nones if branching / not transforming this axis. Otherwise,
         # let the transformer decide e.g. cumsum maintains option position.
-        maintain_none_positions = (
-            True
-            if not (branch or negaxis == depth)
-            else transformer.maintain_none_position
-        )
-
-        if maintain_none_positions:
+        if not (branch or negaxis == depth) or transformer.maintain_none_position:
             # At this point, `out` will always have the `None`-associated values at the
             # end of the array. If we want to maintain correspondence between the input
             # and transformed array `None` positions, then we must re-arrange them now.

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1166,45 +1166,12 @@ class ListArray(Content):
             negaxis, starts, parents, outlength
         )
 
-    def _argsort_next(
-        self,
-        negaxis,
-        starts,
-        shifts,
-        parents,
-        outlength,
-        ascending,
-        stable,
-        kind,
-        order,
-    ):
+    def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
         next = self.toListOffsetArray64(True)
-        out = next._argsort_next(
-            negaxis,
-            starts,
-            shifts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
+        out = next._transform_next(
+            transformer, negaxis, starts, shifts, parents, outlength
         )
         return out
-
-    def _sort_next(
-        self, negaxis, starts, parents, outlength, ascending, stable, kind, order
-    ):
-        return self.toListOffsetArray64(True)._sort_next(
-            negaxis,
-            starts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         return ListOffsetArray._combinations(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1018,6 +1018,7 @@ class ListOffsetArray(Content):
         ) and isinstance(
             transformer, (ak._transformers.Sort, ak._transformers.ArgSort)
         ):
+            is_argsort = isinstance(transformer, ak._transformers.ArgSort)
             if branch or (negaxis != depth):
                 raise ak._errors.wrap_error(
                     np.AxisError("array with strings can only be sorted with axis=-1")
@@ -1054,13 +1055,13 @@ class ListOffsetArray(Content):
                         stops.data,
                         transformer.stable,
                         transformer.ascending,
-                        False,
+                        is_argsort,
                     )
                 )
-                if isinstance(transformer, ak._transformers.Sort):
-                    return self._carry(nextcarry, False)
-                else:
+                if is_argsort:
                     return ak.contents.NumpyArray(nextcarry, None, None, self._nplike)
+                else:
+                    return self._carry(nextcarry, False)
 
         if not branch and (negaxis == depth):
             if self._nplike.known_shape and parents.nplike.known_shape:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -865,7 +865,10 @@ class NumpyArray(Content):
                 TypeError(f"{type(self).__name__} attempting to transform a scalar ")
             )
         elif len(self.shape) != 1 or not self.is_contiguous:
-            raise NotImplementedError
+            contiguous_self = self if self.is_contiguous else self.contiguous()
+            return contiguous_self.toRegularArray()._transform_next(
+                transformer, negaxis, starts, shifts, parents, outlength
+            )
 
         else:
             parents_length = parents.length

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -743,23 +743,14 @@ class RecordArray(Content):
     def _unique(self, negaxis, starts, parents, outlength):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _argsort_next(
-        self,
-        negaxis,
-        starts,
-        shifts,
-        parents,
-        outlength,
-        ascending,
-        stable,
-        kind,
-        order,
-    ):
-        raise ak._errors.wrap_error(NotImplementedError)
+    def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
+        if not transformer.through_record:
+            raise ak._errors.wrap_error(
+                NotImplementedError(
+                    f"cannot apply transformer {transformer.name} through records"
+                )
+            )
 
-    def _sort_next(
-        self, negaxis, starts, parents, outlength, ascending, stable, kind, order
-    ):
         if self._fields is None or len(self._fields) == 0:
             return ak.contents.NumpyArray(
                 self._nplike.instance().empty(0, np.int64), None, None, self._nplike
@@ -768,15 +759,8 @@ class RecordArray(Content):
         contents = []
         for content in self._contents:
             contents.append(
-                content._sort_next(
-                    negaxis,
-                    starts,
-                    parents,
-                    outlength,
-                    ascending,
-                    stable,
-                    kind,
-                    order,
+                content._transform_next(
+                    transformer, negaxis, starts, parents, outlength
                 )
             )
         return RecordArray(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -760,7 +760,7 @@ class RecordArray(Content):
         for content in self._contents:
             contents.append(
                 content._transform_next(
-                    transformer, negaxis, starts, parents, outlength
+                    transformer, negaxis, starts, shifts, parents, outlength
                 )
             )
         return RecordArray(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -807,29 +807,10 @@ class RegularArray(Content):
 
         return out
 
-    def _argsort_next(
-        self,
-        negaxis,
-        starts,
-        shifts,
-        parents,
-        outlength,
-        ascending,
-        stable,
-        kind,
-        order,
-    ):
+    def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
         next = self.toListOffsetArray64(True)
-        out = next._argsort_next(
-            negaxis,
-            starts,
-            shifts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
+        out = next._transform_next(
+            transformer, negaxis, starts, shifts, parents, outlength
         )
 
         if isinstance(out, ak.contents.RegularArray):
@@ -842,34 +823,6 @@ class RegularArray(Content):
                     out._parameters,
                     self._nplike,
                 )
-
-        return out
-
-    def _sort_next(
-        self, negaxis, starts, parents, outlength, ascending, stable, kind, order
-    ):
-        out = self.toListOffsetArray64(True)._sort_next(
-            negaxis,
-            starts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
-
-        # FIXME
-        # if isinstance(out, ak.contents.RegularArray):
-        #     if isinstance(out._content, ak.contents.ListOffsetArray):
-        #         return ak.contents.RegularArray(
-        #             out._content.toRegularArray(),
-        #             out._size,
-        #             out._length,
-        #             None,
-        #             out._parameters,
-        #             self._nplike,
-        #         )
 
         return out
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1068,18 +1068,7 @@ class UnionArray(Content):
 
         return simplified._unique(negaxis, starts, parents, outlength)
 
-    def _argsort_next(
-        self,
-        negaxis,
-        starts,
-        shifts,
-        parents,
-        outlength,
-        ascending,
-        stable,
-        kind,
-        order,
-    ):
+    def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
         simplified = self.simplify_uniontype(mergebool=True)
         if simplified.length == 0:
             return ak.contents.NumpyArray(
@@ -1088,30 +1077,11 @@ class UnionArray(Content):
 
         if isinstance(simplified, ak.contents.UnionArray):
             raise ak._errors.wrap_error(
-                ValueError("cannot argsort an irreducible UnionArray")
+                ValueError("cannot transform an irreducible UnionArray")
             )
 
-        return simplified._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable, kind, order
-        )
-
-    def _sort_next(
-        self, negaxis, starts, parents, outlength, ascending, stable, kind, order
-    ):
-        if self.length == 0:
-            return self
-
-        simplified = self.simplify_uniontype(mergebool=True)
-        if simplified.length == 0:
-            return simplified
-
-        if isinstance(simplified, ak.contents.UnionArray):
-            raise ak._errors.wrap_error(
-                ValueError("cannot sort an irreducible UnionArray")
-            )
-
-        return simplified._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable, kind, order
+        return simplified._transform_next(
+            transformer, negaxis, starts, shifts, parents, outlength
         )
 
     def _reduce_next(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -381,28 +381,9 @@ class UnmaskedArray(Content):
             return self
         return self._content._unique(negaxis, starts, parents, outlength)
 
-    def _argsort_next(
-        self,
-        negaxis,
-        starts,
-        shifts,
-        parents,
-        outlength,
-        ascending,
-        stable,
-        kind,
-        order,
-    ):
-        out = self._content._argsort_next(
-            negaxis,
-            starts,
-            shifts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
+    def _transform_next(self, transformer, negaxis, starts, shifts, parents, outlength):
+        out = self._content._transform_next(
+            transformer, negaxis, starts, shifts, parents, outlength
         )
 
         if isinstance(out, ak.contents.RegularArray):
@@ -419,40 +400,6 @@ class UnmaskedArray(Content):
                 out._length,
                 None,
                 None,
-                self._nplike,
-            )
-
-        else:
-            return out
-
-    def _sort_next(
-        self, negaxis, starts, parents, outlength, ascending, stable, kind, order
-    ):
-        out = self._content._sort_next(
-            negaxis,
-            starts,
-            parents,
-            outlength,
-            ascending,
-            stable,
-            kind,
-            order,
-        )
-
-        if isinstance(out, ak.contents.RegularArray):
-            tmp = ak.contents.UnmaskedArray(
-                out._content,
-                self._identifier,
-                self._parameters,
-                self._nplike,
-            ).simplify_optiontype()
-
-            return ak.contents.RegularArray(
-                tmp,
-                out._size,
-                out._length,
-                self._identifier,
-                self._parameters,
                 self._nplike,
             )
 

--- a/src/awkward/operations/__init__.py
+++ b/src/awkward/operations/__init__.py
@@ -18,6 +18,7 @@ from awkward.operations.ak_corr import corr
 from awkward.operations.ak_count import count
 from awkward.operations.ak_count_nonzero import count_nonzero
 from awkward.operations.ak_covar import covar
+from awkward.operations.ak_cumsum import cumsum
 from awkward.operations.ak_fields import fields
 from awkward.operations.ak_fill_none import fill_none
 from awkward.operations.ak_firsts import firsts

--- a/src/awkward/operations/ak_cumsum.py
+++ b/src/awkward/operations/ak_cumsum.py
@@ -1,0 +1,105 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+np = ak.nplikes.NumpyMetadata.instance()
+
+
+@ak._connect.numpy.implements("cumsum")
+def cumsum(
+    array, axis=None, keepdims=False, mask_identity=False, flatten_records=False
+):
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        axis (None or int): If None, compute the cumulative sum over the
+            flattened array; if an int, compute the cumsum along that axis:
+            `0` is the outermost, `1` is the first level of nested lists, etc.,
+            and negative `axis` counts from the innermost: `-1` is the innermost,
+            `-2` is the next level up, etc.
+
+    Performs the cumulative sum over `array` (many types supported, including all
+    Awkward Arrays and Records). This operation is the same as NumPy's
+    [cumsum](https://docs.scipy.org/doc/numpy/reference/generated/numpy.cumsum.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    For example, consider this `array`, in which all lists at a given dimension
+    have the same length.
+
+        ak.Array([[1, 10],
+                  [2, 20],
+                  [3, 30]])
+
+    A cumsum over `axis=-1` accumulates over the inner lists:
+
+        >>> ak.cumsum(array, axis=-1)
+        <Array [[1, 11], [2, 22], [3, 33]] type='3 * 2 * int64'>
+
+    while a cumsum over `axis=0` accumulates over the outer lists:
+
+        >>> ak.cumsum(array, axis=0)
+        <Array [[1, 10], [3, 30], [6, 60]] type='3 * 2 * int64'>
+
+    Now with some values missing,
+
+        ak.Array([[1,    10],
+                  [None, 20],
+                  [3,  None]])
+
+    The cumsum over `axis=-1` results in
+
+        >>> ak.cumsum(array, axis=-1)
+        <Array [[1, 11], [None, 20], [3, None]] type='3 * var * ?int64'>
+
+    and the cumsum over `axis=0` results in
+
+        >>> ak.cumsum(array, axis=0)
+        <Array [[1, 10], [None, 30], [4, None]] type='3 * var * ?int64'>
+
+    See also #ak.nansum.
+    """
+    with ak._errors.OperationErrorContext(
+        "ak.cumsum",
+        dict(
+            array=array,
+            axis=axis,
+        ),
+    ):
+        return _impl(array, axis)
+
+
+def _impl(array, axis):
+    layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
+
+    if axis is None:
+        if not layout.nplike.known_data or not layout.nplike.known_shape:
+            raise ak._errors.wrap_error(NotImplementedError)  # TODO: FIXME
+
+        else:
+
+            def map(x):
+                return layout.nplike.cumsum(x)
+
+        def reduce(xs):
+            if len(xs) == 1:
+                return xs[0]
+            else:
+                return layout.nplike.add(xs[0], reduce(xs[1:]))
+
+        return layout.nplike.concatenate(
+            [
+                map(x)
+                for x in layout.completely_flatten(
+                    function_name="ak.sum", flatten_records=False
+                )
+            ]
+        )
+
+    else:
+        behavior = ak._util.behavior_of(array)
+        out = layout.cumsum(axis=axis, behavior=behavior)
+        if isinstance(out, (ak.contents.Content, ak.record.Record)):
+            return ak._util.wrap(out, behavior)
+        else:
+            return out

--- a/src/awkward/operations/ak_cumsum.py
+++ b/src/awkward/operations/ak_cumsum.py
@@ -98,7 +98,7 @@ def _impl(array, axis):
 
     else:
         behavior = ak._util.behavior_of(array)
-        out = layout.cumsum(axis=axis, behavior=behavior)
+        out = layout.cumsum(axis=axis)
         if isinstance(out, (ak.contents.Content, ak.record.Record)):
             return ak._util.wrap(out, behavior)
         else:

--- a/src/cpu-kernels/awkward_IndexedArray_local_preparenext_64.cpp
+++ b/src/cpu-kernels/awkward_IndexedArray_local_preparenext_64.cpp
@@ -6,17 +6,14 @@
 
 ERROR awkward_IndexedArray_local_preparenext_64(
     int64_t* tocarry,
-    const int64_t* starts,
     const int64_t* parents,
     const int64_t parentslength,
     const int64_t* nextparents,
     const int64_t nextlen) {
   int64_t j = 0;
   int64_t parent = 0;
-  int64_t start = 0;
   for (int64_t i = 0;  i < parentslength;  i++) {
     parent = parents[i];
-    start = starts[parent];
     if (j < nextlen  &&  parent == nextparents[j]) {
       tocarry[i] = j;
       ++j;

--- a/src/cpu-kernels/awkward_transform_cumsum.cpp
+++ b/src/cpu-kernels/awkward_transform_cumsum.cpp
@@ -1,0 +1,209 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/awkward_transform_cumsum.cpp", line)
+
+#include <cmath>
+
+#include "awkward/kernels.h"
+
+
+template <typename OUT, typename IN>
+ERROR awkward_transform_cumsum(
+  OUT* toptr,
+  const IN* fromptr,
+  const int64_t* offsets,
+  int64_t offsetslength
+) {
+  // For each sublist
+  for (int64_t i=0; i < offsetslength - 1; i++) {
+    int64_t start = offsets[i];
+    int64_t stop = offsets[i+1];
+
+    if (start == stop) {
+        continue;
+    }
+    // Within this sublist, for each item
+    toptr[start] = fromptr[start];
+    for (int64_t j=start + 1; j < stop; j++) {
+        toptr[j] = fromptr[j] + toptr[j-1];
+    }
+  }
+
+  return success();
+}
+ERROR awkward_transform_cumsum_int64_int8_64(
+    int64_t* toptr,
+    const int8_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int64_t, int8_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_uint64_uint8_64(
+    uint64_t* toptr,
+    const uint8_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<uint64_t, uint8_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_int64_int16_64(
+    int64_t* toptr,
+    const int16_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int64_t, int16_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_uint64_uint16_64(
+    uint64_t* toptr,
+    const uint16_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<uint64_t, uint16_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_int64_int32_64(
+    int64_t* toptr,
+    const int32_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int64_t, int32_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_uint64_uint32_64(
+    uint64_t* toptr,
+    const uint32_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<uint64_t, uint32_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_int64_int64_64(
+    int64_t* toptr,
+    const int64_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int64_t, int64_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_uint64_uint64_64(
+    uint64_t* toptr,
+    const uint64_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<uint64_t, uint64_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_float32_float32_64(
+    float* toptr,
+    const float* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<float, float>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_float64_float64_64(
+    double* toptr,
+    const double* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<double, double>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_int32_int8_64(
+    int32_t* toptr,
+    const int8_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int32_t, int8_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_uint32_uint8_64(
+    uint32_t* toptr,
+    const uint8_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<uint32_t, uint8_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_int32_int16_64(
+    int32_t* toptr,
+    const int16_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int32_t, int16_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_uint32_uint16_64(
+    uint32_t* toptr,
+    const uint16_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<uint32_t, uint16_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_int32_int32_64(
+    int32_t* toptr,
+    const int32_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int32_t, int32_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_uint32_uint32_64(
+    uint32_t* toptr,
+    const uint32_t* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<uint32_t, uint32_t>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}

--- a/src/cpu-kernels/awkward_transform_cumsum.cpp
+++ b/src/cpu-kernels/awkward_transform_cumsum.cpp
@@ -31,6 +31,28 @@ ERROR awkward_transform_cumsum(
 
   return success();
 }
+ERROR awkward_transform_cumsum_int64_bool_64(
+    int64_t* toptr,
+    const bool* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int64_t, bool>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
+ERROR awkward_transform_cumsum_int32_bool_64(
+    int32_t* toptr,
+    const bool* fromptr,
+    const int64_t* offsets,
+    int64_t offsetslength) {
+  return awkward_transform_cumsum<int32_t, bool>(
+      toptr,
+      fromptr,
+      offsets,
+      offsetslength);
+}
 ERROR awkward_transform_cumsum_int64_int8_64(
     int64_t* toptr,
     const int8_t* fromptr,

--- a/tests/test_1786-transformers-cumsum-cumprod.py
+++ b/tests/test_1786-transformers-cumsum-cumprod.py
@@ -13,10 +13,10 @@ def test():
     )
     nparray = ak.to_numpy(akarray)
 
-    assert ak.cumsum(akarray, axis=3).tolist() == np.sum(nparray, axis=3).tolist()
-    assert ak.cumsum(akarray, axis=2).tolist() == np.sum(nparray, axis=2).tolist()
-    assert ak.cumsum(akarray, axis=1).tolist() == np.sum(nparray, axis=1).tolist()
-    assert ak.cumsum(akarray, axis=0).tolist() == np.sum(nparray, axis=0).tolist()
+    assert ak.cumsum(akarray, axis=3).tolist() == np.cumsum(nparray, axis=3).tolist()
+    assert ak.cumsum(akarray, axis=2).tolist() == np.cumsum(nparray, axis=2).tolist()
+    assert ak.cumsum(akarray, axis=1).tolist() == np.cumsum(nparray, axis=1).tolist()
+    assert ak.cumsum(akarray, axis=0).tolist() == np.cumsum(nparray, axis=0).tolist()
 
 
 def test_nones():
@@ -28,7 +28,7 @@ def test_nones():
     )
     nparray = ak.to_numpy(akarray)
 
-    assert ak.cumsum(akarray, axis=3).tolist() == np.sum(nparray, axis=3).tolist()
-    assert ak.cumsum(akarray, axis=2).tolist() == np.sum(nparray, axis=2).tolist()
-    assert ak.cumsum(akarray, axis=1).tolist() == np.sum(nparray, axis=1).tolist()
-    assert ak.cumsum(akarray, axis=0).tolist() == np.sum(nparray, axis=0).tolist()
+    assert ak.cumsum(akarray, axis=3).tolist() == np.cumsum(nparray, axis=3).tolist()
+    assert ak.cumsum(akarray, axis=2).tolist() == np.cumsum(nparray, axis=2).tolist()
+    assert ak.cumsum(akarray, axis=1).tolist() == np.cumsum(nparray, axis=1).tolist()
+    assert ak.cumsum(akarray, axis=0).tolist() == np.cumsum(nparray, axis=0).tolist()

--- a/tests/test_1786-transformers-cumsum-cumprod.py
+++ b/tests/test_1786-transformers-cumsum-cumprod.py
@@ -1,0 +1,34 @@
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    akarray = ak.highlevel.Array(
+        [
+            [[[1, 2, 7], [4, 3, 9]], [[5, 0, 6], [8, 8, 3]]],
+            [[[9, 5, 6], [12, 31, 55]], [[1, 73, 4], [10, 20, 106]]],
+        ]
+    )
+    nparray = ak.to_numpy(akarray)
+
+    assert ak.cumsum(akarray, axis=3).tolist() == np.sum(nparray, axis=3).tolist()
+    assert ak.cumsum(akarray, axis=2).tolist() == np.sum(nparray, axis=2).tolist()
+    assert ak.cumsum(akarray, axis=1).tolist() == np.sum(nparray, axis=1).tolist()
+    assert ak.cumsum(akarray, axis=0).tolist() == np.sum(nparray, axis=0).tolist()
+
+
+def test_nones():
+    akarray = ak.highlevel.Array(
+        [
+            [[[1, 2, 7], [4, 3, 9]], [[5, 0, None], [8, 8, 3]]],
+            [[[9, None, 6], [12, 31, 55]], [[None, 73, 4], [10, 20, 106]]],
+        ]
+    )
+    nparray = ak.to_numpy(akarray)
+
+    assert ak.cumsum(akarray, axis=3).tolist() == np.sum(nparray, axis=3).tolist()
+    assert ak.cumsum(akarray, axis=2).tolist() == np.sum(nparray, axis=2).tolist()
+    assert ak.cumsum(akarray, axis=1).tolist() == np.sum(nparray, axis=1).tolist()
+    assert ak.cumsum(akarray, axis=0).tolist() == np.sum(nparray, axis=0).tolist()


### PR DESCRIPTION
The mechanisms by which list-types compute reductions, unique values, and sorting, are all very similar (and involve many of the same kernels). This PR identifies a "transformer" class to complement reducers as operations that leave the array structure intact; the result can be trivially broadcast against the original array.
In doing so, it paves the way for the addition of `nancumsum`, `cumsum`, `nancumprod`, and `cumprod` functions. 

Unfortunately, whilst `np.unique` _looks_ like a transformer, the fact that it changes the shape of the result (keeping only unique values) means that it requires some additional code to implement. It seems cleaner therefore to treat `unique` as a separate case. In general, it's not clear how to reconstruct `None` values in the event that the transformation changes the length of the array. 

The string special-casing is now even more obviously distinct from the normal transformer handling.

- [x] Refactor to use transformers
- [ ] Add `cumsum`
- [ ] Add `nancumsum`
- [ ] Add `cumprod`
- [ ] Add `nancumprod`
- [ ] Closes #1855 