### PR TITLE
fix: produce valid offsets for reducing with empty trailing lists

### DIFF
--- a/src/cpu-kernels/awkward_ListOffsetArray_reduce_nonlocal_outstartsstops_64.cpp
+++ b/src/cpu-kernels/awkward_ListOffsetArray_reduce_nonlocal_outstartsstops_64.cpp
@@ -43,8 +43,8 @@ ERROR awkward_ListOffsetArray_reduce_nonlocal_outstartsstops_64(
   }
 
   for (;  k < outlength;  k++) {
-    outstarts[k] = lendistincts + 1;
-    outstops[k] = lendistincts + 1;
+    outstarts[k] = maxdistinct + 1;
+    outstops[k] = maxdistinct + 1;
   }
 
   return success();

--- a/tests/test_1791-reduce-trailing-sublist.py
+++ b/tests/test_1791-reduce-trailing-sublist.py
@@ -1,0 +1,33 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array(
+        ak.contents.ListOffsetArray(
+            ak.index.Index64(
+                np.array(
+                    [0, 1, 1],
+                    dtype=np.int64,
+                )
+            ),
+            ak.contents.ListOffsetArray(
+                ak.index.Index64(
+                    np.array(
+                        [0, 1],
+                        dtype=np.int64,
+                    )
+                ),
+                ak.contents.NumpyArray(np.arange(1)),
+            ),
+        )
+    )
+
+    reduced = ak.sum(array, axis=1)
+    # We currently get a ListArray here. Ensure that the start/stops are correct
+    assert np.asarray(reduced.layout.starts).tolist() == [0, 1]
+    assert np.asarray(reduced.layout.stops).tolist() == [1, 1]


### PR DESCRIPTION
This appears to fix #1791, and follows from what I'd expect the kernel to be doing. The fact that this wasn't right beforehand _seems_ to me like a human error rather than an oversight, so it gives me more confidence that this simple fix is correct.

- [ ] Add test for v1 (though the v2 test should catch it, as we only change the kernel)