### PR TITLE
docs: fix kernel generation

### DIFF
--- a/dev/generate-kerneldocs.py
+++ b/dev/generate-kerneldocs.py
@@ -78,29 +78,6 @@ The functions are implemented in C with templates for integer specializations (c
                         + "\n\n"
                     )
 
-    if os.path.isfile(
-        os.path.join(
-            CURRENT_DIR,
-            "..",
-            "docs-sphinx",
-            "_auto",
-            "toctree.txt",
-        )
-    ):
-        with open(
-            os.path.join(
-                CURRENT_DIR,
-                "..",
-                "docs-sphinx",
-                "_auto",
-                "toctree.txt",
-            ),
-            "r+",
-        ) as f:
-            if "_auto/kernels.rst" not in f.read():
-                print("Updating toctree.txt")
-                f.write(" " * 4 + "_auto/kernels.rst")
-
 
 if __name__ == "__main__":
     genkerneldocs()

--- a/docs-sphinx/conf.py
+++ b/docs-sphinx/conf.py
@@ -152,7 +152,7 @@ subprocess.check_call(
 )
 
 # Generate Python docstrings
-runpy.run_path(HERE / "prepare_docstrings.py")
+runpy.run_path(HERE / "prepare_docstrings.py", run_name="__main__")
 
 # Generate kernel docs
-runpy.run_path(HERE.parent / "dev" / "generate-kerneldocs.py")
+runpy.run_path(HERE.parent / "dev" / "generate-kerneldocs.py", run_name="__main__")


### PR DESCRIPTION
This PR addresses one of the issues in #1799; fixing the kernel docs.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-docs-touchups/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->