### PR TITLE
docs: remove `vector_design_prototype`'s reference

### DIFF
--- a/docs-sphinx/reference/ak.behavior.rst
+++ b/docs-sphinx/reference/ak.behavior.rst
@@ -667,9 +667,10 @@ function takes
    * ``attype``: the Numba integer type of the index position
    * ``atval``: the Numba value of the index position
 
-Complete example
-================
+.. Add back once https://github.com/scikit-hep/vector/issues/273 is completed
+.. Complete example
+.. ================
 
-The
-`Vector design prototype <https://vector.readthedocs.io/en/latest/usage/vector_design_prototype.html>`__
-has a complete example, including Numba.
+.. The
+.. `Vector design prototype <https://vector.readthedocs.io/en/latest/usage/vector_design_prototype.html>`__
+.. has a complete example, including Numba.


### PR DESCRIPTION
`vector_design_prototype` no longer exists in vector - https://github.com/scikit-hep/vector/pull/272. I have commented out the reference as there are plans to bring it back - https://github.com/scikit-hep/vector/issues/273 - in the future.