### PR TITLE
ci: enable versions for built docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -117,7 +117,9 @@ jobs:
         name: jupyter-cache
         path: docs-sphinx/_build/.jupyter_cache
     - name: Trigger RTD Build
-      # NB: head_ref is only valid for PR triggers
+      env:
+          RTD_TOKEN: "${{ secrets.RTD_TOKEN }}"
       run: |
+        # NB: head_ref is only valid for PR triggers
         python3 dev/activate-docs-version.py "${{ github.head_ref || github.ref_name }}"
         python3 dev/trigger-docs-build.py "${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -117,6 +117,7 @@ jobs:
         name: jupyter-cache
         path: docs-sphinx/_build/.jupyter_cache
     - name: Trigger RTD Build
-      if: github.ref_name != 'main'
       # NB: head_ref is only valid for PR triggers
-      run: curl -X POST -d "branches=${{ github.head_ref || github.ref_name }}" -d "token=${{ secrets.RTD_WEBHOOK_TOKEN }}" "${{ secrets.RTD_WEBHOOK_URL }}"
+      run: |
+        python3 dev/activate-docs-version.py "${{ github.head_ref || github.ref_name }}"
+        python3 dev/trigger-docs-build.py "${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/pr-docs-links.yml
+++ b/.github/workflows/pr-docs-links.yml
@@ -1,0 +1,16 @@
+name: readthedocs/actions
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pull-request-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "awkward-array"

--- a/.github/workflows/pr-docs-links.yml
+++ b/.github/workflows/pr-docs-links.yml
@@ -1,4 +1,4 @@
-name: readthedocs/actions
+name: Preview Docs
 on:
   pull_request_target:
     types:

--- a/dev/activate-docs-version.py
+++ b/dev/activate-docs-version.py
@@ -19,4 +19,4 @@ if __name__ == "__main__":
         json={"active": True, "hidden": not args.show},
         headers={"Authorization": f"token {token}"},
     )
-    print(response)
+    response.raise_for_status()

--- a/dev/activate-docs-version.py
+++ b/dev/activate-docs-version.py
@@ -1,0 +1,22 @@
+import argparse
+import os
+import re
+
+import requests
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument("-s", "--show", action="store_true")
+    args = parser.parse_args()
+
+    version_slug = re.sub(r"[\-/]", "-", args.version)
+
+    url = f"https://readthedocs.org/api/v3/projects/awkward-array/versions/{version_slug}/"
+    token = os.environ["RTD_TOKEN"]
+    response = requests.patch(
+        url,
+        json={"active": True, "hidden": not args.show},
+        headers={"Authorization": f"token {token}"},
+    )
+    print(response)

--- a/dev/trigger-docs-build.py
+++ b/dev/trigger-docs-build.py
@@ -1,0 +1,23 @@
+"""
+Trigger a build on ReadTheDocs of the given branch
+"""
+import argparse
+import os
+import re
+
+import requests
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    args = parser.parse_args()
+
+    version_slug = re.sub(r"[\-/]", "-", args.version)
+
+    url = f"https://readthedocs.org/api/v3/projects/awkward-array/versions/{version_slug}/builds/"
+    token = os.environ["RTD_TOKEN"]
+    response = requests.post(
+        url,
+        headers={"Authorization": f"token {token}"},
+    )
+    print(response)

--- a/dev/trigger-docs-build.py
+++ b/dev/trigger-docs-build.py
@@ -20,4 +20,5 @@ if __name__ == "__main__":
         url,
         headers={"Authorization": f"token {token}"},
     )
-    print(response)
+    response.raise_for_status()
+    print(response.json())


### PR DESCRIPTION
Now we explicitly enable a version on RTD, and then build it. A separate workflow edits the PR description to show a link to the rendered docs.