### PR TITLE
docs: enable plausible.js analytics

### DIFF
--- a/docs-sphinx/conf.py
+++ b/docs-sphinx/conf.py
@@ -89,6 +89,10 @@ html_theme_options = {
             "url": "https://github.com/scikit-hep/awkward/releases",
         },
     ],
+    "analytics": {
+        "plausible_analytics_domain": "awkward-array.org",
+        "plausible_analytics_url": "https://views.scientific-python.org/js/plausible.js"
+    }
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Fixes #1819 

This was particularly straightforward because the PyData Sphinx Theme already supports Plausible.js, and our redirect system uses pre-rendered HTML (and therefore is not injected with the analytics JS).

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-docs-add-analytics/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->