### PR TITLE
Merge reducer correction from #1827 into #1825 so that the latter can be tested.

### DIFF
--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -229,7 +229,6 @@ class Sum(Reducer):
         if array.dtype == np.bool_:
             if result.dtype in (np.int64, np.uint64):
                 assert parents.nplike is array.nplike
-                assert parents.nplike is array.nplike
                 array._handle_error(
                     array.nplike[
                         "awkward_reduce_sum_int64_bool_64",
@@ -314,11 +313,11 @@ class Prod(Reducer):
             raise ak._errors.wrap_error(
                 ValueError(f"cannot compute the product (ak.prod) of {array.dtype!r}")
             )
-        result = array.nplike.empty(
-            cls.maybe_double_length(array.dtype.type, outlength),
-            dtype=cls.return_dtype(array.dtype),
-        )
         if array.dtype == np.bool_:
+            result = array.nplike.empty(
+                cls.maybe_double_length(array.dtype.type, outlength),
+                dtype=np.dtype(np.bool_),
+            )
             assert parents.nplike is array.nplike
             array._handle_error(
                 array.nplike[
@@ -334,7 +333,12 @@ class Prod(Reducer):
                     outlength,
                 )
             )
+            result = result.astype(cls.return_dtype(array.dtype))
         elif array.dtype.type in (np.complex128, np.complex64):
+            result = array.nplike.empty(
+                cls.maybe_double_length(array.dtype.type, outlength),
+                dtype=cls.return_dtype(array.dtype),
+            )
             assert parents.nplike is array.nplike
             array._handle_error(
                 array.nplike[
@@ -351,6 +355,10 @@ class Prod(Reducer):
                 )
             )
         else:
+            result = array.nplike.empty(
+                cls.maybe_double_length(array.dtype.type, outlength),
+                dtype=cls.return_dtype(array.dtype),
+            )
             assert parents.nplike is array.nplike
             array._handle_error(
                 array.nplike[

--- a/tests/test_0115-generic-reducer-operation.py
+++ b/tests/test_0115-generic-reducer-operation.py
@@ -1804,3 +1804,30 @@ def test_softmax():
         [],
         pytest.approx([0.5, 0.5]),
     ]
+
+
+def test_prod_bool():
+    # this had been silently broken
+    array = np.array([[True, False, False], [True, False, False]])
+    content2 = ak.contents.NumpyArray(array.reshape(-1))
+    offsets3 = ak.index.Index64(np.array([0, 3, 3, 5, 6], dtype=np.int64))
+    depth1 = ak.contents.ListOffsetArray(offsets3, content2)
+    assert to_list(depth1.prod(axis=-1)) == [0, 1, 0, 0]
+    assert to_list(depth1.all(axis=-1)) == [False, True, False, False]
+    assert to_list(depth1.min(axis=-1)) == [False, None, False, False]
+
+    array = np.array([[True, False, False], [True, False, False]]).view(np.uint8)
+    content2 = ak.contents.NumpyArray(array.reshape(-1))
+    offsets3 = ak.index.Index64(np.array([0, 3, 3, 5, 6], dtype=np.int64))
+    depth1 = ak.contents.ListOffsetArray(offsets3, content2)
+    assert to_list(depth1.prod(axis=-1)) == [0, 1, 0, 0]
+    assert to_list(depth1.all(axis=-1)) == [0, 1, 0, 0]
+    assert to_list(depth1.min(axis=-1)) == [0, None, 0, 0]
+
+    array = np.array([[True, False, False], [True, False, False]]).astype(np.int32)
+    content2 = ak.contents.NumpyArray(array.reshape(-1))
+    offsets3 = ak.index.Index64(np.array([0, 3, 3, 5, 6], dtype=np.int64))
+    depth1 = ak.contents.ListOffsetArray(offsets3, content2)
+    assert to_list(depth1.prod(axis=-1)) == [0, 1, 0, 0]
+    assert to_list(depth1.all(axis=-1)) == [0, 1, 0, 0]
+    assert to_list(depth1.min(axis=-1)) == [0, None, 0, 0]


### PR DESCRIPTION
Since this is not going into `main`, I believe that I can merge it right away.

I just want to see that it fixes the tests in #1825.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-fix-boolean-prod-reducer-bug/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->