### PR TITLE
fix: visit all layout nodes with `ak.fill_none(..., axis=None)`

### DIFF
--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -107,8 +107,8 @@ def _impl(array, value, axis, highlevel, behavior):
 
     if axis is None:
 
-        def action(layout, depth, depth_context, **kwargs):
-            layout = maybe_fillna(layout)
+        def action(layout, continuation, **kwargs):
+            return maybe_fillna(continuation())
 
     else:
 

--- a/tests/test_1823-fill-none-axis-none.py
+++ b/tests/test_1823-fill-none-axis-none.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array([None, [1, 2, 3, [None, {"x": [None, 2], "y": [1, 4]}]]])
+
+    assert ak.fill_none(array, -1.0, axis=None).to_list() == [
+        -1.0,
+        [1, 2, 3, [-1.0, {"x": [-1.0, 2], "y": [1, 4]}]],
+    ]


### PR DESCRIPTION
Fixes #1823 

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-fill-none-axis-none/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->