### PR TITLE
docs: add notes on "declaring `ArrayBuilder` type"

### DIFF
--- a/docs-sphinx/user-guide/how-to-create-arraybuilder.md
+++ b/docs-sphinx/user-guide/how-to-create-arraybuilder.md
@@ -380,8 +380,8 @@ Above, we see that `new_array` is just making references ({class}`ak.layout.Inde
 
 +++
 
-Declaring the type of empty arrays
-----------------------------------
+Setting the type of empty lists
+-------------------------------
 In addition to supporting type-discovery at execution time, {class}`ak.ArrayBuilder` also makes it convenient to work with complex, ragged arrays when the type is known ahead of time. Although it is not the most performant means of constructing an array whose type is already known, it provides a readable abstraction in the event that building the array is not a limiting factor for performance. However, due to this "on-line" type-discovery, it is possible that for certain data the result of {meth}`ak.ArrayBuilder.snapshot` will have different types. Consider this function that builds an array from the contents of some iterable:
 
 ```{code-cell}


### PR DESCRIPTION
In my view, `ak.ArrayBuilder` serves many purposes:
- Construction of Awkward Arrays whose sizes are unknown (dynamic lengths)
- Construction of Awkward Arrays whose types are unknown (dynamic types)

`ak.LayoutBuilder()` also serves the former point (dynamic lengths), but we are removing the Python API in v2. Therefore, I think it worth improving the docs for `ak.ArrayBuilder()` (the next best thing) to handle the cases that `ak.LayoutBuilder()` previously handled.This small PR adds notes to the user guide on `ak.ArrayBuilder()` that explain how to stabilise the output type. 


<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-docs-arraybuilder-schema/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->