### PR TITLE
fix: expose `ak.behaviors.mixins` names at top level

### DIFF
--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -39,8 +39,8 @@ from awkward.highlevel import ArrayBuilder
 
 # behaviors
 import awkward.behaviors.categorical
-import awkward.behaviors.mixins
 import awkward.behaviors.string
+from awkward.behaviors.mixins import mixin_class, mixin_class_method
 
 behavior = {}
 awkward.behaviors.string.register(behavior)  # noqa: F405


### PR DESCRIPTION
Fixes #1834 

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-mixins-top-level-names/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->