### PR TITLE
ci: move to `3.11` from `3.11-dev`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.11-dev'
+          - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.11-dev'
+          - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'
@@ -141,7 +141,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.11-dev'
+          - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/all-repos-autofix_all-repos-sed/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->