### PR TITLE
fix: array.dtype.type will never be in ak.types.numpytype._dtype_to_primitive_dict

### DIFF
--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -72,15 +72,7 @@ def _impl(array):
         primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array))
         return ak.types.NumpyType(primitive)
 
-    elif isinstance(array, builtins.type) and issubclass(
-        array,
-        tuple(x.type for x in ak.types.numpytype._dtype_to_primitive_dict),
-    ):
-        return ak.types.NumpyType(
-            ak.types.numpytype._dtype_to_primitive_dict[np.dtype(array)]
-        )
-
-    elif isinstance(array, (bool, np.bool_)):
+    elif isinstance(array, bool):
         return ak.types.NumpyType("bool")
 
     elif isinstance(array, numbers.Integral):
@@ -103,7 +95,7 @@ def _impl(array):
         if len(array.shape) == 0:
             return _impl(array.reshape((1,))[0])
         else:
-            primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array.dtype))
+            primitive = ak.types.numpytype.dtype_to_primitive(array.dtype)
             out = ak.types.NumpyType(primitive)
             for x in array.shape[-1:0:-1]:
                 out = ak.types.RegularType(out, x)

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -76,7 +76,7 @@ def _impl(array):
         primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array))
         return ak.types.NumpyType(primitive)
 
-    elif isinstance(array, bool):
+    elif isinstance(array, (bool, np.bool_)):
         return ak.types.NumpyType("bool")
 
     elif isinstance(array, numbers.Integral):

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -96,7 +96,7 @@ def _impl(array):
             return _impl(array.reshape((1,))[0])
         else:
             try:
-                out = ak.types.numpytype._dtype_to_primitive_dict[array.dtype.type]
+                out = ak.types.numpytype._dtype_to_primitive_dict[array.dtype]
             except KeyError as err:
                 raise ak._errors.wrap_error(
                     TypeError(

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -1,5 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import builtins
 import numbers
 
 import awkward as ak
@@ -70,6 +71,17 @@ def _impl(array):
     ):
         return ak.types.NumpyType(
             ak.types.numpytype._dtype_to_primitive_dict[array.dtype]
+        )
+
+    elif isinstance(array, np.dtype):
+        return ak.types.NumpyType(ak.types.numpytype._dtype_to_primitive_dict[array])
+
+    elif isinstance(array, builtins.type) and issubclass(
+        array,
+        tuple(x.type for x in ak.types.numpytype._dtype_to_primitive_dict),
+    ):
+        return ak.types.NumpyType(
+            ak.types.numpytype._dtype_to_primitive_dict[np.dtype(array)]
         )
 
     elif isinstance(array, (bool, np.bool_)):

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -68,7 +68,11 @@ def _impl(array):
     elif isinstance(array, np.dtype):
         return ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(array))
 
-    elif isinstance(array, builtins.type) and issubclass(array, np.generic):
+    elif (
+        isinstance(array, np.generic)
+        or isinstance(array, builtins.type)
+        and issubclass(array, np.generic)
+    ):
         primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array))
         return ak.types.NumpyType(primitive)
 

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -65,16 +65,12 @@ def _impl(array):
     if array is None:
         return ak.types.UnknownType()
 
-    elif isinstance(
-        array,
-        tuple(x.type for x in ak.types.numpytype._dtype_to_primitive_dict),
-    ):
-        return ak.types.NumpyType(
-            ak.types.numpytype._dtype_to_primitive_dict[array.dtype]
-        )
-
     elif isinstance(array, np.dtype):
-        return ak.types.NumpyType(ak.types.numpytype._dtype_to_primitive_dict[array])
+        return ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(array))
+
+    elif isinstance(array, builtins.type) and issubclass(array, np.generic):
+        primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array))
+        return ak.types.NumpyType(primitive)
 
     elif isinstance(array, builtins.type) and issubclass(
         array,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -2,6 +2,7 @@
 
 import builtins
 import numbers
+from datetime import datetime, timedelta
 
 import awkward as ak
 
@@ -76,7 +77,7 @@ def _impl(array):
         primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array))
         return ak.types.NumpyType(primitive)
 
-    elif isinstance(array, (bool, np.bool_)):
+    elif isinstance(array, bool):  # np.bool_ in np.generic (above)
         return ak.types.NumpyType("bool")
 
     elif isinstance(array, numbers.Integral):
@@ -84,6 +85,15 @@ def _impl(array):
 
     elif isinstance(array, numbers.Real):
         return ak.types.NumpyType("float64")
+
+    elif isinstance(array, numbers.Complex):
+        return ak.types.NumpyType("complex128")
+
+    elif isinstance(array, datetime):  # np.datetime64 in np.generic (above)
+        return ak.types.NumpyType("datetime64")
+
+    elif isinstance(array, timedelta):  # np.timedelta64 in np.generic (above)
+        return ak.types.NumpyType("timedelta")
 
     elif isinstance(
         array,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -103,16 +103,8 @@ def _impl(array):
         if len(array.shape) == 0:
             return _impl(array.reshape((1,))[0])
         else:
-            try:
-                out = ak.types.numpytype._dtype_to_primitive_dict[array.dtype]
-            except KeyError as err:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "numpy array type is unrecognized by awkward: %r"
-                        % array.dtype.type
-                    )
-                ) from err
-            out = ak.types.NumpyType(out)
+            primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array.dtype))
+            out = ak.types.NumpyType(primitive)
             for x in array.shape[-1:0:-1]:
                 out = ak.types.RegularType(out, x)
             return ak.types.ArrayType(out, array.shape[0])

--- a/tests/test_1840-ak_type-to-handle-ndarray-dtype-and-nptypes.py
+++ b/tests/test_1840-ak_type-to-handle-ndarray-dtype-and-nptypes.py
@@ -17,3 +17,7 @@ def test_dtype():
 
 def test_type():
     assert ak.type(np.float64) == ak.types.NumpyType("float64")
+
+
+def test_type_instance():
+    assert ak.type(np.float64(10.0)) == ak.types.NumpyType("float64")

--- a/tests/test_1840-ak_type-to-handle-ndarray-dtype-and-nptypes.py
+++ b/tests/test_1840-ak_type-to-handle-ndarray-dtype-and-nptypes.py
@@ -6,6 +6,14 @@ import pytest  # noqa: F401
 import awkward as ak  # noqa: F401
 
 
-def test():
+def test_array():
     array = np.random.random(size=512).astype(dtype=np.float64)
     assert ak.type(array) == ak.types.ArrayType(ak.types.NumpyType("float64"), 512)
+
+
+def test_dtype():
+    assert ak.type(np.dtype(np.float64)) == ak.types.NumpyType("float64")
+
+
+def test_type():
+    assert ak.type(np.float64) == ak.types.NumpyType("float64")

--- a/tests/test_1840.py
+++ b/tests/test_1840.py
@@ -1,0 +1,13 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = np.random.random(size=512).astype(dtype=np.float64)
+    assert ak.type(array) == ak.types.ArrayType(
+        ak.types.NumpyType("float64"), 512
+    )

--- a/tests/test_1840.py
+++ b/tests/test_1840.py
@@ -8,6 +8,4 @@ import awkward as ak  # noqa: F401
 
 def test():
     array = np.random.random(size=512).astype(dtype=np.float64)
-    assert ak.type(array) == ak.types.ArrayType(
-        ak.types.NumpyType("float64"), 512
-    )
+    assert ak.type(array) == ak.types.ArrayType(ak.types.NumpyType("float64"), 512)


### PR DESCRIPTION
Fixes #1840 

Original input to square brackets would never work?