### PR TITLE
refactor: `ak._util`

### DIFF
--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -126,7 +126,7 @@ def prepare_advanced_indexing(items):
 
 
 def normalise_item(item, nplike):
-    if ak._util.isint(item):
+    if ak._util.is_integer(item):
         return int(item)
 
     elif isinstance(item, slice):

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -40,7 +40,7 @@ def prepare_advanced_indexing(items):
                     ak.contents.IndexedOptionArray,
                 ),
             )
-            or ak._util.isstr(item)
+            or isinstance(item, str)
             or item is np.newaxis
             or item is Ellipsis
         ):
@@ -132,7 +132,7 @@ def normalise_item(item, nplike):
     elif isinstance(item, slice):
         return item
 
-    elif ak._util.isstr(item):
+    elif isinstance(item, str):
         return item
 
     elif item is np.newaxis:
@@ -160,7 +160,7 @@ def normalise_item(item, nplike):
     elif ak._util.is_sized_iterable(item) and len(item) == 0:
         return nplike.empty(0, dtype=np.int64)
 
-    elif ak._util.is_sized_iterable(item) and all(ak._util.isstr(x) for x in item):
+    elif ak._util.is_sized_iterable(item) and all(isinstance(x, str) for x in item):
         return list(item)
 
     elif ak._util.is_sized_iterable(item):

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -38,9 +38,9 @@ def prepare_advanced_indexing(items):
                     list,  # of strings
                     ak.contents.ListOffsetArray,
                     ak.contents.IndexedOptionArray,
+                    str,
                 ),
             )
-            or isinstance(item, str)
             or item is np.newaxis
             or item is Ellipsis
         ):

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -254,7 +254,7 @@ class TypeTracerArray:
 
     @shape.setter
     def shape(self, value):
-        if ak._util.isint(value):
+        if ak._util.is_integer(value):
             value = (value,)
         elif value is None or isinstance(value, (UnknownLengthType, UnknownScalar)):
             value = (UnknownLength,)
@@ -347,7 +347,7 @@ class TypeTracerArray:
                 missing = max(0, len(self._shape) - (len(before) + len(after)))
                 where = before + (slice(None, None, None),) * missing + after
 
-        if ak._util.isint(where):
+        if ak._util.is_integer(where):
             if len(self._shape) == 1:
                 if where == 0:
                     return UnknownScalar(self._dtype)
@@ -391,7 +391,7 @@ class TypeTracerArray:
             shapes = []
             for j in range(num_basic, len(where)):
                 wh = where[j]
-                if ak._util.isint(wh):
+                if ak._util.is_integer(wh):
                     shapes.append(numpy.array(0))
                 elif hasattr(wh, "dtype") and hasattr(wh, "shape"):
                     sh = [
@@ -416,7 +416,7 @@ class TypeTracerArray:
         elif (
             isinstance(where, tuple)
             and len(where) > 0
-            and (ak._util.isint(where[0]) or isinstance(where[0], slice))
+            and (ak._util.is_integer(where[0]) or isinstance(where[0], slice))
         ):
             head, tail = where[0], where[1:]
             next = self.__getitem__(head)
@@ -466,8 +466,8 @@ class TypeTracerArray:
             args = args[0]
 
         assert len(args) != 0
-        assert ak._util.isint(args[0]) or isinstance(args[0], UnknownLengthType)
-        assert all(ak._util.isint(x) for x in args[1:])
+        assert ak._util.is_integer(args[0]) or isinstance(args[0], UnknownLengthType)
+        assert all(ak._util.is_integer(x) for x in args[1:])
         assert all(x >= 0 for x in args[1:])
 
         return TypeTracerArray(self._dtype, (UnknownLength,) + args[1:])
@@ -587,7 +587,11 @@ class TypeTracer(ak.nplikes.NumpyLike):
         elif len(args) == 3:
             start, stop, step = args[0], args[1], args[2]
 
-        if ak._util.isint(start) and ak._util.isint(stop) and ak._util.isint(step):
+        if (
+            ak._util.is_integer(start)
+            and ak._util.is_integer(stop)
+            and ak._util.is_integer(step)
+        ):
             length = max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
 
         return TypeTracerArray(kwargs["dtype"], (length,))

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -72,10 +72,6 @@ def is_integer(x):
     return isinstance(x, numbers.Integral) and not isinstance(x, bool)
 
 
-def isstr(x):
-    return isinstance(x, str)
-
-
 def tobytes(array):
     if hasattr(array, "tobytes"):
         return array.tobytes()
@@ -145,12 +141,12 @@ def overlay_behavior(behavior: dict | None) -> collections.abc.Mapping:
 def arrayclass(layout, behavior):
     behavior = overlay_behavior(behavior)
     arr = layout.parameter("__array__")
-    if isstr(arr):
+    if isinstance(arr, str):
         cls = behavior.get(arr)
         if isinstance(cls, type) and issubclass(cls, ak.highlevel.Array):
             return cls
     deeprec = layout.purelist_parameter("__record__")
-    if isstr(deeprec):
+    if isinstance(deeprec, str):
         cls = behavior.get(("*", deeprec))
         if isinstance(cls, type) and issubclass(cls, ak.highlevel.Array):
             return cls
@@ -173,11 +169,11 @@ def custom_cast(obj, behavior):
 def custom_broadcast(layout, behavior):
     behavior = overlay_behavior(behavior)
     custom = layout.parameter("__array__")
-    if not isstr(custom):
+    if not isinstance(custom, str):
         custom = layout.parameter("__record__")
-    if not isstr(custom):
+    if not isinstance(custom, str):
         custom = layout.purelist_parameter("__record__")
-    if isstr(custom):
+    if isinstance(custom, str):
         for key, fcn in behavior.items():
             if (
                 isinstance(key, tuple)
@@ -194,9 +190,9 @@ def custom_ufunc(ufunc, layout, behavior):
 
     behavior = overlay_behavior(behavior)
     custom = layout.parameter("__array__")
-    if not isstr(custom):
+    if not isinstance(custom, str):
         custom = layout.parameter("__record__")
-    if isstr(custom):
+    if isinstance(custom, str):
         for key, fcn in behavior.items():
             if (
                 isinstance(key, tuple)
@@ -211,12 +207,12 @@ def custom_ufunc(ufunc, layout, behavior):
 def numba_array_typer(layouttype, behavior):
     behavior = overlay_behavior(behavior)
     arr = layouttype.parameters.get("__array__")
-    if isstr(arr):
+    if isinstance(arr, str):
         typer = behavior.get(("__numba_typer__", arr))
         if callable(typer):
             return typer
     deeprec = layouttype.parameters.get("__record__")
-    if isstr(deeprec):
+    if isinstance(deeprec, str):
         typer = behavior.get(("__numba_typer__", "*", deeprec))
         if callable(typer):
             return typer
@@ -226,12 +222,12 @@ def numba_array_typer(layouttype, behavior):
 def numba_array_lower(layouttype, behavior):
     behavior = overlay_behavior(behavior)
     arr = layouttype.parameters.get("__array__")
-    if isstr(arr):
+    if isinstance(arr, str):
         lower = behavior.get(("__numba_lower__", arr))
         if callable(lower):
             return lower
     deeprec = layouttype.parameters.get("__record__")
-    if isstr(deeprec):
+    if isinstance(deeprec, str):
         lower = behavior.get(("__numba_lower__", "*", deeprec))
         if callable(lower):
             return lower
@@ -241,7 +237,7 @@ def numba_array_lower(layouttype, behavior):
 def recordclass(layout, behavior):
     behavior = overlay_behavior(behavior)
     rec = layout.parameter("__record__")
-    if isstr(rec):
+    if isinstance(rec, str):
         cls = behavior.get(rec)
         if isinstance(cls, type) and issubclass(cls, ak.highlevel.Record):
             return cls
@@ -251,7 +247,7 @@ def recordclass(layout, behavior):
 def reducer_recordclass(reducer, layout, behavior):
     behavior = overlay_behavior(behavior)
     rec = layout.parameter("__record__")
-    if isstr(rec):
+    if isinstance(rec, str):
         return behavior.get((reducer.highlevel_function(), rec))
 
 
@@ -263,8 +259,8 @@ def typestrs(behavior):
             isinstance(key, tuple)
             and len(key) == 2
             and key[0] == "__typestr__"
-            and isstr(key[1])
-            and isstr(typestr)
+            and isinstance(key[1], str)
+            and isinstance(typestr, str)
         ):
             out[key[1]] = typestr
     return out
@@ -288,7 +284,7 @@ def gettypestr(parameters, typestrs):
 def numba_record_typer(layouttype, behavior):
     behavior = overlay_behavior(behavior)
     rec = layouttype.parameters.get("__record__")
-    if isstr(rec):
+    if isinstance(rec, str):
         typer = behavior.get(("__numba_typer__", rec))
         if callable(typer):
             return typer
@@ -298,7 +294,7 @@ def numba_record_typer(layouttype, behavior):
 def numba_record_lower(layouttype, behavior):
     behavior = overlay_behavior(behavior)
     rec = layouttype.parameters.get("__record__")
-    if isstr(rec):
+    if isinstance(rec, str):
         lower = behavior.get(("__numba_lower__", rec))
         if callable(lower):
             return lower
@@ -327,7 +323,7 @@ def overload(behavior, signature):
 def numba_attrs(layouttype, behavior):
     behavior = overlay_behavior(behavior)
     rec = layouttype.parameters.get("__record__")
-    if isstr(rec):
+    if isinstance(rec, str):
         for key, typer in behavior.items():
             if (
                 isinstance(key, tuple)
@@ -342,7 +338,7 @@ def numba_attrs(layouttype, behavior):
 def numba_methods(layouttype, behavior):
     behavior = overlay_behavior(behavior)
     rec = layouttype.parameters.get("__record__")
-    if isstr(rec):
+    if isinstance(rec, str):
         for key, typer in behavior.items():
             if (
                 isinstance(key, tuple)
@@ -361,7 +357,7 @@ def numba_unaryops(unaryop, left, behavior):
 
     if isinstance(left, ak._connect.numba.layout.ContentType):
         left = left.parameters.get("__record__")
-        if not isstr(left):
+        if not isinstance(left, str):
             done = True
 
     if not done:
@@ -383,12 +379,12 @@ def numba_binops(binop, left, right, behavior):
 
     if isinstance(left, ak._connect.numba.layout.ContentType):
         left = left.parameters.get("__record__")
-        if not isstr(left):
+        if not isinstance(left, str):
             done = True
 
     if isinstance(right, ak._connect.numba.layout.ContentType):
         right = right.parameters.get("__record__")
-        if not isstr(right):
+        if not isinstance(right, str):
             done = True
 
     if not done:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -68,7 +68,7 @@ def is_sized_iterable(obj):
     return isinstance(obj, Iterable) and isinstance(obj, Sized)
 
 
-def isint(x):
+def is_integer(x):
     return isinstance(x, numbers.Integral) and not isinstance(x, bool)
 
 

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -69,15 +69,7 @@ def is_sized_iterable(obj):
 
 
 def isint(x):
-    return isinstance(x, (int, numbers.Integral, np.integer)) and not isinstance(
-        x, (bool, np.bool_)
-    )
-
-
-def isnum(x):
-    return isinstance(x, (int, float, numbers.Real, np.number)) and not isinstance(
-        x, (bool, np.bool_)
-    )
+    return isinstance(x, numbers.Integral) and not isinstance(x, bool)
 
 
 def isstr(x):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -82,7 +82,7 @@ class BitMaskedArray(Content):
                 )
             )
         if not isinstance(length, ak._typetracer.UnknownLengthType):
-            if not (ak._util.isint(length) and length >= 0):
+            if not (ak._util.is_integer(length) and length >= 0):
                 raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'length' must be a non-negative integer, not {}".format(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -388,7 +388,7 @@ class BitMaskedArray(Content):
         ):
             return self.toByteMaskedArray()._getitem_next(head, tail, advanced)
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -427,7 +427,7 @@ class ByteMaskedArray(Content):
             )
             return out2.simplify_optiontype()
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -541,7 +541,7 @@ class ByteMaskedArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -101,7 +101,7 @@ class Content:
             def getkey(layout):
                 return None
 
-        elif ak._util.isstr(form_key):
+        elif isinstance(form_key, str):
 
             def getkey(layout):
                 out = form_key.format(id=hold_id[0])
@@ -170,7 +170,7 @@ class Content:
                 TypeError("cannot call 'to_buffers' on an array without concrete data")
             )
 
-        if ak._util.isstr(buffer_key):
+        if isinstance(buffer_key, str):
 
             def getkey(layout, form, attribute):
                 return buffer_key.format(form_key=form.form_key, attribute=attribute)
@@ -318,7 +318,7 @@ class Content:
     def _getitem_next_fields(self, head, tail, advanced: ak.index.Index | None):
         only_fields, not_fields = [], []
         for x in tail:
-            if ak._util.isstr(x) or isinstance(x, list):
+            if isinstance(x, str) or isinstance(x, list):
                 only_fields.append(x)
             else:
                 not_fields.append(x)
@@ -536,7 +536,7 @@ class Content:
         elif isinstance(where, slice):
             return self._getitem((where,))
 
-        elif ak._util.isstr(where):
+        elif isinstance(where, str):
             return self._getitem_field(where)
 
         elif where is np.newaxis:
@@ -626,7 +626,7 @@ class Content:
             return self._carry(ak.index.Index64.empty(0, self._nplike), allow_lazy=True)
 
         elif ak._util.is_sized_iterable(where) and all(
-            ak._util.isstr(x) for x in where
+            isinstance(x, str) for x in where
         ):
             return self._getitem_fields(where)
 
@@ -1627,8 +1627,8 @@ class Content:
             isinstance(complex_record_fields, Sized)
             and isinstance(complex_record_fields, Iterable)
             and len(complex_record_fields) == 2
-            and ak._util.isstr(complex_record_fields[0])
-            and ak._util.isstr(complex_record_fields[1])
+            and isinstance(complex_record_fields[0], str)
+            and isinstance(complex_record_fields[1], str)
         ):
             complex_real_string, complex_imag_string = complex_record_fields
         else:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -527,7 +527,7 @@ class Content:
         return self._getitem(where)
 
     def _getitem(self, where):
-        if ak._util.isint(where):
+        if ak._util.is_integer(where):
             return self._getitem_at(where)
 
         elif isinstance(where, slice) and where.step is None:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -318,7 +318,7 @@ class Content:
     def _getitem_next_fields(self, head, tail, advanced: ak.index.Index | None):
         only_fields, not_fields = [], []
         for x in tail:
-            if isinstance(x, str) or isinstance(x, list):
+            if isinstance(x, (str, list)):
                 only_fields.append(x)
             else:
                 not_fields.append(x)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -131,7 +131,7 @@ class EmptyArray(Content):
         elif isinstance(head, slice):
             raise ak._errors.index_error(self, head, "array is empty")
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -163,7 +163,7 @@ class EmptyArray(Content):
 
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -432,7 +432,7 @@ class IndexedArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -275,7 +275,7 @@ class IndexedArray(Content):
             next = self._content._carry(nextcarry, False)
             return next._getitem_next(head, tail, advanced)
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -362,10 +362,10 @@ class IndexedOptionArray(Content):
             out2 = IndexedOptionArray(outindex, out, self._parameters, self._nplike)
             return out2.simplify_optiontype()
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
-        elif isinstance(head, list) and ak._util.isstr(head[0]):
+        elif isinstance(head, list) and isinstance(head[0], str):
             return self._getitem_next_fields(head, tail, advanced)
 
         elif head is np.newaxis:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -517,7 +517,7 @@ class IndexedOptionArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -718,7 +718,7 @@ class ListArray(Content):
                     self._nplike,
                 )
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -881,7 +881,7 @@ class ListArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -610,7 +610,7 @@ class ListOffsetArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -497,7 +497,7 @@ class ListOffsetArray(Content):
                     self._nplike,
                 )
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -338,7 +338,7 @@ class NumpyArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -296,7 +296,7 @@ class NumpyArray(Content):
             out2 = NumpyArray(out, self._parameters, self._nplike)
             return out2
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -106,7 +106,7 @@ class RecordArray(Content):
         if isinstance(fields, Iterable):
             if not isinstance(fields, list):
                 fields = list(fields)
-            if not all(ak._util.isstr(x) for x in fields):
+            if not all(isinstance(x, str) for x in fields):
                 raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'fields' must all be strings, not {}".format(
@@ -323,7 +323,7 @@ class RecordArray(Content):
 
         else:
             nexthead, nexttail = ak._slicing.headtail(only_fields)
-            if ak._util.isstr(nexthead):
+            if isinstance(nexthead, str):
                 return self.content(where)._getitem_field(nexthead, nexttail)
             else:
                 return self.content(where)._getitem_fields(nexthead, nexttail)
@@ -339,7 +339,7 @@ class RecordArray(Content):
             contents = [self.content(i) for i in indexes]
         else:
             nexthead, nexttail = ak._slicing.headtail(only_fields)
-            if ak._util.isstr(nexthead):
+            if isinstance(nexthead, str):
                 contents = [
                     self.content(i)._getitem_field(nexthead, nexttail) for i in indexes
                 ]
@@ -415,7 +415,7 @@ class RecordArray(Content):
         if head == ():
             return self
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -76,7 +76,7 @@ class RecordArray(Content):
             else:
                 length = min(lengths)
         if not isinstance(length, ak._typetracer.UnknownLengthType) and not (
-            ak._util.isint(length) and length >= 0
+            ak._util.is_integer(length) and length >= 0
         ):
             raise ak._errors.wrap_error(
                 TypeError(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -56,7 +56,7 @@ class RegularArray(Content):
                 )
             )
         if not isinstance(size, ak._typetracer.UnknownLengthType):
-            if not (ak._util.isint(size) and size >= 0):
+            if not (ak._util.is_integer(size) and size >= 0):
                 raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'size' must be a non-negative integer, not {}".format(
@@ -67,7 +67,7 @@ class RegularArray(Content):
             else:
                 size = int(size)
         if not isinstance(zeros_length, ak._typetracer.UnknownLengthType):
-            if not (ak._util.isint(zeros_length) and zeros_length >= 0):
+            if not (ak._util.is_integer(zeros_length) and zeros_length >= 0):
                 raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'zeros_length' must be a non-negative integer, not {}".format(
@@ -614,7 +614,7 @@ class RegularArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self._length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -443,7 +443,7 @@ class RegularArray(Content):
                     self._nplike,
                 )
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -652,7 +652,7 @@ class UnionArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -440,7 +440,7 @@ class UnionArray(Content):
             )
             return out.simplify_uniontype()
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -267,7 +267,7 @@ class UnmaskedArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             out = self.length
-            if ak._util.isint(out):
+            if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -218,7 +218,7 @@ class UnmaskedArray(Content):
                 self._nplike,
             ).simplify_optiontype()
 
-        elif ak._util.isstr(head):
+        elif isinstance(head, str):
             return self._getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -16,7 +16,7 @@ class BitMaskedForm(Form):
         parameters=None,
         form_key=None,
     ):
-        if not ak._util.isstr(mask):
+        if not isinstance(mask, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'mask' must be of type str, not {}".format(

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -15,7 +15,7 @@ class ByteMaskedForm(Form):
         parameters=None,
         form_key=None,
     ):
-        if not ak._util.isstr(mask):
+        if not isinstance(mask, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'mask' must be of type str, not {}".format(

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -15,7 +15,7 @@ def from_dict(input: dict) -> Form:
     if input is None:
         return None
 
-    if ak._util.isstr(input):
+    if isinstance(input, str):
         return ak.forms.NumpyForm(primitive=input)
 
     assert isinstance(input, dict)
@@ -271,7 +271,7 @@ class Form:
                     )
                 )
             )
-        if form_key is not None and not ak._util.isstr(form_key):
+        if form_key is not None and not isinstance(form_key, str):
             raise _errors.wrap_error(
                 TypeError(
                     "{} 'form_key' must be of type string or None, not {}".format(
@@ -371,11 +371,11 @@ class Form:
         return output
 
     def select_columns(self, specifier, expand_braces=True):
-        if ak._util.isstr(specifier):
+        if isinstance(specifier, str):
             specifier = [specifier]
 
         for item in specifier:
-            if not ak._util.isstr(item):
+            if not isinstance(item, str):
                 raise _errors.wrap_error(
                     TypeError("a column-selection specifier must be a list of strings")
                 )

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -14,7 +14,7 @@ class IndexedForm(Form):
         parameters=None,
         form_key=None,
     ):
-        if not ak._util.isstr(index):
+        if not isinstance(index, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'index' must be of type str, not {}".format(

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -15,7 +15,7 @@ class IndexedOptionForm(Form):
         parameters=None,
         form_key=None,
     ):
-        if not ak._util.isstr(index):
+        if not isinstance(index, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'index' must be of type str, not {}".format(

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -15,7 +15,7 @@ class ListForm(Form):
         parameters=None,
         form_key=None,
     ):
-        if not ak._util.isstr(starts):
+        if not isinstance(starts, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'starts' must be of type str, not {}".format(
@@ -23,7 +23,7 @@ class ListForm(Form):
                     )
                 )
             )
-        if not ak._util.isstr(stops):
+        if not isinstance(stops, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'starts' must be of type str, not {}".format(

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -8,7 +8,7 @@ class ListOffsetForm(Form):
     is_ListType = True
 
     def __init__(self, offsets, content, parameters=None, form_key=None):
-        if not ak._util.isstr(offsets):
+        if not isinstance(offsets, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'offsets' must be of type str, not {}".format(

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -119,7 +119,7 @@ class RecordForm(Form):
     def content(self, index_or_field):
         if ak._util.is_integer(index_or_field):
             index = index_or_field
-        elif ak._util.isstr(index_or_field):
+        elif isinstance(index_or_field, str):
             index = self.field_to_index(index_or_field)
         else:
             raise ak._errors.wrap_error(

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -117,7 +117,7 @@ class RecordForm(Form):
             return field in self._fields
 
     def content(self, index_or_field):
-        if ak._util.isint(index_or_field):
+        if ak._util.is_integer(index_or_field):
             index = index_or_field
         elif ak._util.isstr(index_or_field):
             index = self.field_to_index(index_or_field)

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -17,7 +17,7 @@ class RegularForm(Form):
                     )
                 )
             )
-        if not ak._util.isint(size):
+        if not ak._util.is_integer(size):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'size' must be of type int, not {}".format(

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -17,7 +17,7 @@ class UnionForm(Form):
         parameters=None,
         form_key=None,
     ):
-        if not ak._util.isstr(tags):
+        if not isinstance(tags, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'tags' must be of type str, not {}".format(
@@ -25,7 +25,7 @@ class UnionForm(Form):
                     )
                 )
             )
-        if not ak._util.isstr(index):
+        if not isinstance(index, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'index' must be of type str, not {}".format(

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -249,7 +249,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         self.behavior = behavior
 
         docstr = layout.purelist_parameter("__doc__")
-        if ak._util.isstr(docstr):
+        if isinstance(docstr, str):
             self.__doc__ = docstr
 
         if check_valid:
@@ -1027,8 +1027,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             dict(self=self, field_name=where, field_value=what),
         ):
             if not (
-                ak._util.isstr(where)
-                or (isinstance(where, tuple) and all(ak._util.isstr(x) for x in where))
+                isinstance(where, str)
+                or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
                 raise ak._errors.wrap_error(
                     TypeError("only fields may be assigned in-place (by field name)")
@@ -1513,7 +1513,7 @@ class Record(NDArrayOperatorsMixin):
         self.behavior = behavior
 
         docstr = layout.purelist_parameter("__doc__")
-        if ak._util.isstr(docstr):
+        if isinstance(docstr, str):
             self.__doc__ = docstr
 
         if check_valid:
@@ -1737,8 +1737,8 @@ class Record(NDArrayOperatorsMixin):
             dict(self=self, field_name=where, field_value=what),
         ):
             if not (
-                ak._util.isstr(where)
-                or (isinstance(where, tuple) and all(ak._util.isstr(x) for x in where))
+                isinstance(where, str)
+                or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
                 raise ak._errors.wrap_error(
                     TypeError("only fields may be assigned in-place (by field name)")

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1392,7 +1392,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             )
         else:
             form, length, container, behavior = state
-            if ak._util.isint(length):
+            if ak._util.is_integer(length):
                 layout = ak.operations.from_buffers(
                     form,
                     length,
@@ -2002,7 +2002,7 @@ class Record(NDArrayOperatorsMixin):
             )
         else:
             form, length, container, behavior, at = state
-            if ak._util.isint(length):
+            if ak._util.is_integer(length):
                 layout = ak.operations.from_buffers(
                     form,
                     length,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -141,9 +141,9 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                 length = ak._typetracer.UnknownLength
                 for x in inputs:
                     if isinstance(x, ak.contents.Content):
-                        if not ak._util.isint(length):
+                        if not ak._util.is_integer(length):
                             length = x.length
-                        elif length != x.length and ak._util.isint(x.length):
+                        elif length != x.length and ak._util.is_integer(x.length):
                             raise ak._errors.wrap_error(
                                 ValueError(
                                     "all arrays must have the same length for "

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -82,7 +82,7 @@ def _impl(form, length, container, buffer_key, nplike, highlevel, behavior):
     elif isinstance(form, dict):
         form = ak.forms.from_dict(form)
 
-    if not (ak._util.isint(length) and length >= 0):
+    if not (ak._util.is_integer(length) and length >= 0):
         raise ak._errors.wrap_error(
             TypeError("'length' argument must be a non-negative integer")
         )

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -74,7 +74,7 @@ def from_buffers(
 
 
 def _impl(form, length, container, buffer_key, nplike, highlevel, behavior):
-    if ak._util.isstr(form):
+    if isinstance(form, str):
         if ak.types.numpytype.is_primitive(form):
             form = ak.forms.NumpyForm(form)
         else:
@@ -94,7 +94,7 @@ def _impl(form, length, container, buffer_key, nplike, highlevel, behavior):
             )
         )
 
-    if ak._util.isstr(buffer_key):
+    if isinstance(buffer_key, str):
 
         def getkey(form, attribute):
             return buffer_key.format(form_key=form.form_key, attribute=attribute)

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -718,7 +718,7 @@ def build_assembly(schema, container, instructions):
             )
 
         if schema.get("minItems") == schema.get("maxItems") != None:  # noqa: E711
-            assert ak._util.isint(schema.get("minItems"))
+            assert ak._util.is_integer(schema.get("minItems"))
 
             if is_optional:
                 mask = f"node{len(container)}"

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -419,8 +419,8 @@ def _record_to_complex(layout, complex_record_fields):
         isinstance(complex_record_fields, Sized)
         and isinstance(complex_record_fields, Iterable)
         and len(complex_record_fields) == 2
-        and ak._util.isstr(complex_record_fields[0])
-        and ak._util.isstr(complex_record_fields[1])
+        and isinstance(complex_record_fields[0], str)
+        and isinstance(complex_record_fields[1], str)
     ):
 
         def action(node, **kwargs):
@@ -516,7 +516,7 @@ def _yes_schema(
     highlevel,
     behavior,
 ):
-    if isinstance(schema, bytes) or ak._util.isstr(schema):
+    if isinstance(schema, bytes) or isinstance(schema, str):
         schema = json.loads(schema)
 
     if not isinstance(schema, dict):
@@ -641,7 +641,7 @@ def build_assembly(schema, container, instructions):
             strings = schema["enum"]
             assert isinstance(strings, list)
             assert len(strings) >= 1
-            assert all(ak._util.isstr(x) for x in strings)
+            assert all(isinstance(x, str) for x in strings)
             bytestrings = [x.encode("utf-8", errors="surrogateescape") for x in strings]
 
             index = f"node{len(container)}"

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -516,7 +516,7 @@ def _yes_schema(
     highlevel,
     behavior,
 ):
-    if isinstance(schema, bytes) or isinstance(schema, str):
+    if isinstance(schema, (bytes, str)):
         schema = json.loads(schema)
 
     if not isinstance(schema, dict):

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -101,7 +101,7 @@ def metadata(
     import fsspec.parquet
 
     if row_groups is not None:
-        if not all(ak._util.isint(x) and x >= 0 for x in row_groups):
+        if not all(ak._util.is_integer(x) and x >= 0 for x in row_groups):
             raise ak._errors.wrap_error(
                 ValueError("row_groups must be a set of non-negative integers")
             )

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -200,7 +200,7 @@ def _impl(
     )
 
     if file is not None:
-        if isinstance(file, str) or isinstance(file, pathlib.Path):
+        if isinstance(file, (str, pathlib.Path)):
             parsed_url = urlparse(file)
             if parsed_url.scheme == "" or parsed_url.netloc == "":
 

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -191,7 +191,7 @@ def _impl(
         behavior=ak._util.behavior_of(array),
     )
 
-    if line_delimited and not ak._util.isstr(line_delimited):
+    if line_delimited and not isinstance(line_delimited, str):
         line_delimited = "\n"
 
     separators = (
@@ -200,7 +200,7 @@ def _impl(
     )
 
     if file is not None:
-        if ak._util.isstr(file) or isinstance(file, pathlib.Path):
+        if isinstance(file, str) or isinstance(file, pathlib.Path):
             parsed_url = urlparse(file)
             if parsed_url.scheme == "" or parsed_url.netloc == "":
 

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -57,7 +57,7 @@ def _impl(
         raise ak._errors.wrap_error(
             TypeError("'arrays' must be a dict (to provide C++ names for the arrays)")
         )
-    elif not all(ak._util.isstr(name) for name in arrays):
+    elif not all(isinstance(name, str) for name in arrays):
         raise ak._errors.wrap_error(
             TypeError(
                 "keys of 'arrays' dict must be strings (to provide C++ names for the arrays)"

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -41,8 +41,8 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 def _impl(base, what, where, highlevel, behavior):
     if not (
         where is None
-        or ak._util.isstr(where)
-        or (isinstance(where, Iterable) and all(ak._util.isstr(x) for x in where))
+        or isinstance(where, str)
+        or (isinstance(where, Iterable) and all(isinstance(x, str) for x in where))
     ):
         raise ak._errors.wrap_error(
             TypeError(
@@ -51,13 +51,13 @@ def _impl(base, what, where, highlevel, behavior):
             )
         )
 
-    if not ak._util.isstr(where) and isinstance(where, Iterable):
+    if not isinstance(where, str) and isinstance(where, Iterable):
         where = list(where)
 
     if (
-        not ak._util.isstr(where)
+        not isinstance(where, str)
         and isinstance(where, Iterable)
-        and all(ak._util.isstr(x) for x in where)
+        and all(isinstance(x, str) for x in where)
         and len(where) > 1
     ):
         return _impl(
@@ -75,7 +75,7 @@ def _impl(base, what, where, highlevel, behavior):
         )
     else:
 
-        if not (ak._util.isstr(where) or where is None):
+        if not (isinstance(where, str) or where is None):
             where = where[0]
 
         behavior = ak._util.behavior_of(base, what, behavior=behavior)

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -15,7 +15,7 @@ class Record:
             raise ak._errors.wrap_error(
                 TypeError(f"Record 'array' must be a RecordArray, not {array!r}")
             )
-        if not ak._util.isint(at):
+        if not ak._util.is_integer(at):
             raise ak._errors.wrap_error(
                 TypeError(f"Record 'at' must be an integer, not {array!r}")
             )
@@ -122,7 +122,7 @@ class Record:
             return self._getitem(where)
 
     def _getitem(self, where):
-        if ak._util.isint(where):
+        if ak._util.is_integer(where):
             raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by an integer")
             )

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -132,7 +132,7 @@ class Record:
                 IndexError("scalar Record cannot be sliced by a range slice (`:`)")
             )
 
-        elif ak._util.isstr(where):
+        elif isinstance(where, str):
             return self._getitem_field(where)
 
         elif where is np.newaxis:
@@ -151,7 +151,7 @@ class Record:
         elif isinstance(where, tuple) and len(where) == 1:
             return self._getitem(where[0])
 
-        elif isinstance(where, tuple) and ak._util.isstr(where[0]):
+        elif isinstance(where, tuple) and isinstance(where[0], str):
             return self._getitem_field(where[0])._getitem(where[1:])
 
         elif isinstance(where, ak.highlevel.Array):
@@ -169,7 +169,7 @@ class Record:
                 IndexError("scalar Record cannot be sliced by an array")
             )
 
-        elif isinstance(where, Iterable) and all(ak._util.isstr(x) for x in where):
+        elif isinstance(where, Iterable) and all(isinstance(x, str) for x in where):
             return self._getitem_fields(where)
 
         elif isinstance(where, Iterable):

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -16,7 +16,7 @@ class ArrayType:
                     )
                 )
             )
-        if not ak._util.isint(length) or length < 0:
+        if not ak._util.is_integer(length) or length < 0:
             raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'length' must be of a positive integer, not {}".format(

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -23,7 +23,7 @@ class ListType(Type):
                     )
                 )
             )
-        if typestr is not None and not ak._util.isstr(typestr):
+        if typestr is not None and not isinstance(typestr, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -103,7 +103,7 @@ class NumpyType(Type):
                     )
                 )
             )
-        if typestr is not None and not ak._util.isstr(typestr):
+        if typestr is not None and not isinstance(typestr, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -26,7 +26,7 @@ class OptionType(Type):
                     )
                 )
             )
-        if typestr is not None and not ak._util.isstr(typestr):
+        if typestr is not None and not isinstance(typestr, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -46,7 +46,7 @@ class RecordType(Type):
                     )
                 )
             )
-        if typestr is not None and not ak._util.isstr(typestr):
+        if typestr is not None and not isinstance(typestr, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -15,7 +15,7 @@ class RegularType(Type):
                     )
                 )
             )
-        if not ak._util.isint(size) or size < 0:
+        if not ak._util.is_integer(size) or size < 0:
             raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'size' must be of a positive integer, not {}".format(

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -31,7 +31,7 @@ class RegularType(Type):
                     )
                 )
             )
-        if typestr is not None and not ak._util.isstr(typestr):
+        if typestr is not None and not isinstance(typestr, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -36,7 +36,7 @@ class UnionType(Type):
                     )
                 )
             )
-        if typestr is not None and not ak._util.isstr(typestr):
+        if typestr is not None and not isinstance(typestr, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -15,7 +15,7 @@ class UnknownType(Type):
                     )
                 )
             )
-        if typestr is not None and not ak._util.isstr(typestr):
+        if typestr is not None and not isinstance(typestr, str):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'typestr' must be of type string or None, not {}".format(


### PR DESCRIPTION
This is a small PR to refactor `ak._util`. Visibly,

- remove `ak._util.isstr`
- rename `ak._util.isint` with `ak._util.is_integer`

This is refactoring work that was motivated by other PRs.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-refactor-ak-util/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->