### PR TITLE
fix: correctly turn `ByteMaskedArray` into `ByteMaskedArray`

### DIFF
--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -92,7 +92,7 @@ def _emptyarray(x):
 
 class UnknownScalar:
     def __init__(self, dtype):
-        self._dtype = dtype
+        self._dtype = np.dtype(dtype)
 
     @property
     def dtype(self):
@@ -810,29 +810,45 @@ class TypeTracer(ak.nplikes.NumpyLike):
         # array1, array2[, out=output]
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def logical_and(self, x, y):
-        # array1, array2
-        is_array = False
-        if isinstance(x, TypeTracerArray):
-            is_array = True
-        if isinstance(y, TypeTracerArray):
-            is_array = True
-        if is_array:
-            return TypeTracerArray(np.dtype(np.bool_))
-        else:
-            return UnknownScalar(np.dtype(np.bool_))
+    def logical_and(self, x, y, *, dtype=None):
+        if dtype is None:
+            dtype = np.bool_
 
-    def logical_or(self, x, y):
-        # array1, array2[, out=]
         is_array = False
         if isinstance(x, TypeTracerArray):
             is_array = True
         if isinstance(y, TypeTracerArray):
             is_array = True
         if is_array:
-            return TypeTracerArray(np.dtype(np.bool_))
+            return TypeTracerArray(dtype)
         else:
-            return UnknownScalar(np.dtype(np.bool_))
+            return UnknownScalar(dtype)
+
+    def logical_or(self, x, y, *, dtype=None):
+        if dtype is None:
+            dtype = np.bool_
+
+        is_array = False
+        if isinstance(x, TypeTracerArray):
+            is_array = True
+        if isinstance(y, TypeTracerArray):
+            is_array = True
+        if is_array:
+            return TypeTracerArray(dtype)
+        else:
+            return UnknownScalar(dtype)
+
+    def logical_not(self, x, *, dtype=None):
+        if dtype is None:
+            dtype = np.bool_
+
+        is_array = False
+        if isinstance(x, TypeTracerArray):
+            is_array = True
+        if is_array:
+            return TypeTracerArray(dtype)
+        else:
+            return UnknownScalar(dtype)
 
     def equal(self, *args, **kwargs):
         # array1, array2

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -193,11 +193,10 @@ class ByteMaskedArray(Content):
         if valid_when == self._valid_when:
             return self
         else:
-            index_nplike = self._nplike.index_nplike
             return ByteMaskedArray(
                 ak.index.Index8(
-                    index_nplike.logical_not(
-                        index_nplike.asarray(self._mask).astype(np.bool_)
+                    self._nplike.index_nplike.logical_not(
+                        self._mask.data.astype(np.bool_)
                     ).astype(dtype=np.int8)
                 ),
                 self._content,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -193,8 +193,13 @@ class ByteMaskedArray(Content):
         if valid_when == self._valid_when:
             return self
         else:
+            index_nplike = self._nplike.index_nplike
             return ByteMaskedArray(
-                ak.Index8(~self._mask.data),
+                ak.index.Index8(
+                    index_nplike.logical_not(
+                        index_nplike.asarray(self._mask).astype(np.bool_)
+                    ).astype(dtype=np.int8)
+                ),
                 self._content,
                 valid_when,
                 self._parameters,

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -254,6 +254,10 @@ class NumpyLike(Singleton):
         # array1, array2
         return self._module.logical_and(*args, **kwargs)
 
+    def logical_not(self, *args, **kwargs):
+        # array1, array2
+        return self._module.logical_not(*args, **kwargs)
+
     def sqrt(self, *args, **kwargs):
         # array
         return self._module.sqrt(*args, **kwargs)

--- a/tests/test_1850-bytemasked-array-to-bytemaskedarray.py
+++ b/tests/test_1850-bytemasked-array-to-bytemaskedarray.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    layout = ak.contents.ByteMaskedArray(
+        ak.index.Index8(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
+        ak.contents.NumpyArray(np.arange(5)),
+        valid_when=True,
+    )
+    result = layout.toByteMaskedArray(False)
+    assert layout.to_list() == [None, 1, None, 3, None]
+    assert result.to_list() == [None, 1, None, 3, None]
+    assert layout.nplike.asarray(result.mask).tolist() == [1, 0, 1, 0, 1]
+
+    # Check this works
+    layout.typetracer.toByteMaskedArray(False)


### PR DESCRIPTION
- Fixes #1850
- Smuggles some changes to pass in `dtype` to the `logical_XXX` functions in `TypeTracer` (though unused in this PR)

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-bytemasked-to-bytemasked/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->