### PR TITLE
ci: allow pushes to main to deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -169,8 +169,8 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-22.04
     needs: [build-docs]
-    # We can only deploy for PRs on host repo
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # We can only deploy for PRs on host repo, or pushes to main
+    if: ${{ !(github.event_name == "pull_request" && (github.event.pull_request.head.repo.full_name != github.repository)) }}
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [build-docs]
     # We can only deploy for PRs on host repo, or pushes to main
-    if: ${{ !(github.event_name == "pull_request" && (github.event.pull_request.head.repo.full_name != github.repository)) }}
+    if: ${{ !(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository)) }}
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
I noticed that #1836 didn't trigger an RTD build for pushes to `main`, so I've updated `docs.yml`

I find the expression `NOT (X AND NOT Y)` clearer than `(NOT X) OR Y` because in this case `X` and `Y` are related. We only avoid deploying the docs if the event was a PR event, and the PR does not originate from `scikit-hep/awkward`

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-ci-docs-deploy-on-main/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->