### PR TITLE
ci: don't run PR job on `main`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -198,6 +198,7 @@ jobs:
               "https://readthedocs.org/api/v3/projects/awkward-array/versions/$VERSION_SLUG/builds/"
 
     - name: Edit PR description
+      if: github.event_name == 'pull_request'
       uses: actions/github-script@v6
       with:
         script: |


### PR DESCRIPTION


<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-ci-fix-deploy-main/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->