### PR TITLE
fix: separate contiguity from dimension test in `NumpyArray._reduce_next`

### DIFF
--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -918,3 +918,6 @@ class TypeTracer(ak.nplikes.NumpyLike):
     @classmethod
     def is_own_array(cls, obj) -> bool:
         return isinstance(obj, TypeTracerArray)
+
+    def is_c_contiguous(self, array) -> bool:
+        return True

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -505,24 +505,7 @@ class NumpyArray(Content):
 
     @property
     def is_contiguous(self):
-        if isinstance(self._nplike, ak._typetracer.TypeTracer):
-            return True
-
-        # Alternatively, self._data.flags["C_CONTIGUOUS"], but the following assumes
-        # less of the nplike.
-
-        if isinstance(self.nplike, ak.nplikes.Jax):
-            return True
-
-        x = self._data.dtype.itemsize
-
-        for i in range(len(self._data.shape), 0, -1):
-            if x != self._data.strides[i - 1]:
-                return False
-            else:
-                x = x * self._data.shape[i - 1]
-
-        return True
+        return self._nplike.is_c_contiguous(self._data)
 
     def _subranges_equal(self, starts, stops, length, sorted=True):
         is_equal = ak.index.Index64.zeros(1, self._nplike)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1071,8 +1071,8 @@ class NumpyArray(Content):
         keepdims,
         behavior,
     ):
-        if not self.is_contiguous:
-            return self.contiguous()._reduce_next(
+        if self._data.ndim > 1:
+            return self.toRegularArray()._reduce_next(
                 reducer,
                 negaxis,
                 starts,
@@ -1083,9 +1083,8 @@ class NumpyArray(Content):
                 keepdims,
                 behavior,
             )
-
-        elif self._data.ndim > 1:
-            return self.toRegularArray()._reduce_next(
+        elif not self.is_contiguous:
+            return self.contiguous()._reduce_next(
                 reducer,
                 negaxis,
                 starts,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1071,7 +1071,20 @@ class NumpyArray(Content):
         keepdims,
         behavior,
     ):
-        if len(self._data.shape) != 1 or not self.is_contiguous:
+        if not self.is_contiguous:
+            return self.contiguous()._reduce_next(
+                reducer,
+                negaxis,
+                starts,
+                shifts,
+                parents,
+                outlength,
+                mask,
+                keepdims,
+                behavior,
+            )
+
+        elif self._data.ndim > 1:
             return self.toRegularArray()._reduce_next(
                 reducer,
                 negaxis,
@@ -1083,6 +1096,10 @@ class NumpyArray(Content):
                 keepdims,
                 behavior,
             )
+
+        # Yes, we've just tested these, but we need to be explicit that they are invariants
+        assert self.is_contiguous
+        assert self._data.ndim == 1
 
         if isinstance(self.nplike, ak.nplikes.Jax):
             from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -374,6 +374,9 @@ class NumpyLike(Singleton):
         """
         raise NotImplementedError
 
+    def is_c_contiguous(self, array) -> bool:
+        return array.flags["C_CONTIGUOUS"]
+
 
 class NumpyKernel:
     def __init__(self, kernel, name_and_types):

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -375,7 +375,7 @@ class NumpyLike(Singleton):
         raise NotImplementedError
 
     def is_c_contiguous(self, array) -> bool:
-        return array.flags["C_CONTIGUOUS"]
+        raise ak._errors.wrap_error(NotImplementedError)
 
 
 class NumpyKernel:
@@ -543,6 +543,9 @@ class Numpy(NumpyLike):
 
         """
         return isinstance(obj, numpy.ndarray)
+
+    def is_c_contiguous(self, array) -> bool:
+        return array.flags["C_CONTIGUOUS"]
 
 
 class Cupy(NumpyLike):
@@ -757,6 +760,9 @@ class Cupy(NumpyLike):
         module, _, suffix = type(obj).__module__.partition(".")
         return module == "cupy"
 
+    def is_c_contiguous(self, array) -> bool:
+        return array.flags["C_CONTIGUOUS"]
+
 
 class Jax(NumpyLike):
     @property
@@ -928,6 +934,9 @@ class Jax(NumpyLike):
         """
         module, _, suffix = type(obj).__module__.partition(".")
         return module == "jax"
+
+    def is_c_contiguous(self, array) -> bool:
+        return True
 
 
 # Temporary sentinel marking "argument not given"

--- a/tests/test_1847-numpy-array-contiguous.py
+++ b/tests/test_1847-numpy-array-contiguous.py
@@ -37,33 +37,3 @@ def test_reduce_2d():
         ak.sum(layout, axis=-1).to_list()
         == np.sum(non_contiguous_array, axis=-1).tolist()
     )
-
-
-def test_unique_1d_strided():
-    non_contiguous_array = np.array([0, 0, 1, 1, 2, 2, 3, 3], dtype=np.int64)[::2]
-    layout = ak.contents.NumpyArray(
-        non_contiguous_array,
-    )
-    assert not layout.is_contiguous
-    assert layout.unique(-1).to_list() == [0, 1, 2, 3]
-    assert layout.is_unique(-1)
-
-    non_contiguous_array = np.array([0, 0, 0, 1, 1, 2, 2, 3, 3], dtype=np.int64)[::2]
-    layout = ak.contents.NumpyArray(
-        non_contiguous_array,
-    )
-    assert not layout.is_contiguous
-    assert layout.unique(-1).to_list() == [0, 1, 2, 3]
-    assert not layout.is_unique(-1)
-
-
-def test_unique_2d_strided():
-    transposed_array = (
-        np.array([0, 0, 1, 0, 2, 2, 3, 2, 3, 3, 4, 4, 4, 5, 6], dtype=np.int64)
-        .reshape(-1, 3)
-        .T
-    )
-    layout = ak.contents.NumpyArray(transposed_array)
-    assert not layout.is_contiguous
-    assert layout.unique(-1).to_list() == [[0, 3, 4], [0, 2, 4, 5], [1, 2, 3, 4, 6]]
-    assert not layout.is_unique(-1)

--- a/tests/test_1847-numpy-array-contiguous.py
+++ b/tests/test_1847-numpy-array-contiguous.py
@@ -1,0 +1,69 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test_reduce_1d_strided():
+    non_contiguous_array = np.arange(64, dtype=np.int64)[::3]
+    layout = ak.contents.NumpyArray(
+        non_contiguous_array,
+    )
+    assert not layout.is_contiguous
+    assert ak.sum(layout, axis=-1) == np.sum(non_contiguous_array, axis=-1)
+
+
+def test_reduce_transpose_2d():
+    non_contiguous_array = np.arange(6 * 8, dtype=np.int64).reshape(6, 8).T
+    layout = ak.contents.NumpyArray(
+        non_contiguous_array,
+    )
+    assert not layout.is_contiguous
+    assert (
+        ak.sum(layout, axis=-1).to_list()
+        == np.sum(non_contiguous_array, axis=-1).tolist()
+    )
+
+
+def test_reduce_2d():
+    non_contiguous_array = np.arange(6 * 8, dtype=np.int64).reshape(6, 8)
+    layout = ak.contents.NumpyArray(
+        non_contiguous_array,
+    )
+    assert layout.is_contiguous
+    assert (
+        ak.sum(layout, axis=-1).to_list()
+        == np.sum(non_contiguous_array, axis=-1).tolist()
+    )
+
+
+def test_unique_1d_strided():
+    non_contiguous_array = np.array([0, 0, 1, 1, 2, 2, 3, 3], dtype=np.int64)[::2]
+    layout = ak.contents.NumpyArray(
+        non_contiguous_array,
+    )
+    assert not layout.is_contiguous
+    assert layout.unique(-1).to_list() == [0, 1, 2, 3]
+    assert layout.is_unique(-1)
+
+    non_contiguous_array = np.array([0, 0, 0, 1, 1, 2, 2, 3, 3], dtype=np.int64)[::2]
+    layout = ak.contents.NumpyArray(
+        non_contiguous_array,
+    )
+    assert not layout.is_contiguous
+    assert layout.unique(-1).to_list() == [0, 1, 2, 3]
+    assert not layout.is_unique(-1)
+
+
+def test_unique_2d_strided():
+    transposed_array = (
+        np.array([0, 0, 1, 0, 2, 2, 3, 2, 3, 3, 4, 4, 4, 5, 6], dtype=np.int64)
+        .reshape(-1, 3)
+        .T
+    )
+    layout = ak.contents.NumpyArray(transposed_array)
+    assert not layout.is_contiguous
+    assert layout.unique(-1).to_list() == [[0, 3, 4], [0, 2, 4, 5], [1, 2, 3, 4, 6]]
+    assert not layout.is_unique(-1)


### PR DESCRIPTION
~Reshaping an ND NumPy with `np.reshape(-1)` will produce a contiguous array as a byproduct.~ However, for 1D arrays, this does not ensure that the result is contiguous. This PR therefore separates these two tests. Additionally, I *think* there was something awry with our contiguity test. I've just add an `nplike` function for this, as it seems like the proper solution anyway.

This PR *doesn't* tackle `unique`, which will need further changes.

Fixes #1847

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-numpy-array-non-contiguous/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->