### PR TITLE
refactor: eliminate many of the compiler warnings.

### DIFF
--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -99,7 +99,7 @@ namespace awkward {
     const BuilderOptions&
       options() const { return options_; }
 
-    const int64_t nullcount() const { return nullcount_; }
+    int64_t nullcount() const { return nullcount_; }
 
   private:
     const BuilderOptions options_;

--- a/include/awkward/io/json.h
+++ b/include/awkward/io/json.h
@@ -267,6 +267,8 @@ namespace awkward {
             reinterpret_cast<double*>(external_pointer)
           );
           break;
+        default:
+          break;
       }
     }
 

--- a/include/awkward/io/json.h
+++ b/include/awkward/io/json.h
@@ -124,7 +124,7 @@ namespace awkward {
       for (int64_t i = stringsstart;  i < argument3();  i++) {
         start = offsets[i];
         stop = offsets[i + 1];
-        if (strncmp(str, &chars[start], stop - start) == 0) {
+        if (strncmp(str, &chars[start], (size_t)(stop - start)) == 0) {
           return i - stringsstart;
         }
       }
@@ -142,7 +142,7 @@ namespace awkward {
         stringi = instructions_.data()[i * 4 + 1];
         start = offsets[stringi];
         stop = offsets[stringi + 1];
-        if (strncmp(str, &chars[start], stop - start) == 0) {
+        if (strncmp(str, &chars[start], (size_t)(stop - start)) == 0) {
           return instructions_.data()[i * 4 + 2];
         }
       }
@@ -151,42 +151,42 @@ namespace awkward {
 
     /// @brief HERE
     inline void write_int8(int64_t index, int8_t x) noexcept {
-      buffers_uint8_[index].append(*reinterpret_cast<uint8_t*>(&x));
+      buffers_uint8_[(size_t)index].append(*reinterpret_cast<uint8_t*>(&x));
     }
 
     /// @brief HERE
     inline void write_uint8(int64_t index, uint8_t x) noexcept {
-      buffers_uint8_[index].append(x);
+      buffers_uint8_[(size_t)index].append(x);
     }
 
     /// @brief HERE
     inline void write_many_uint8(int64_t index, int64_t num_items, const uint8_t* values) noexcept {
-      buffers_uint8_[index].extend(values, num_items);
+      buffers_uint8_[(size_t)index].extend(values, (size_t)num_items);
     }
 
     /// @brief HERE
     inline void write_int64(int64_t index, int64_t x) noexcept {
-      buffers_int64_[index].append(x);
+      buffers_int64_[(size_t)index].append(x);
     }
 
     /// @brief HERE
     inline void write_uint64(int64_t index, uint64_t x) noexcept {
-      buffers_int64_[index].append(static_cast<int64_t>(x));
+      buffers_int64_[(size_t)index].append(static_cast<int64_t>(x));
     }
 
     /// @brief HERE
     inline void write_add_int64(int64_t index, int64_t x) noexcept {
-      buffers_int64_[index].append(buffers_int64_[index].last() + x);
+      buffers_int64_[(size_t)index].append(buffers_int64_[(size_t)index].last() + x);
     }
 
     /// @brief HERE
     inline void write_float64(int64_t index, double x) noexcept {
-      buffers_float64_[index].append(x);
+      buffers_float64_[(size_t)index].append(x);
     }
 
     /// @brief HERE
     inline int64_t get_and_increment(int64_t index) noexcept {
-      return counters_[index]++;
+      return counters_[(size_t)index]++;
     }
 
     /// @brief HERE
@@ -204,17 +204,17 @@ namespace awkward {
 
     /// @brief HERE
     int64_t num_outputs() const {
-      return output_names_.size();
+      return (int64_t)output_names_.size();
     }
 
     /// @brief HERE
     std::string output_name(int64_t i) const {
-      return output_names_[i];
+      return output_names_[(size_t)i];
     }
 
     /// @brief HERE
     std::string output_dtype(int64_t i) const {
-      switch (output_dtypes_[i]) {
+      switch (output_dtypes_[(size_t)i]) {
         case util::dtype::int8:
           return "int8";
         case util::dtype::uint8:
@@ -230,15 +230,15 @@ namespace awkward {
 
     /// @brief HERE
     int64_t output_num_items(int64_t i) const {
-      switch (output_dtypes_[i]) {
+      switch (output_dtypes_[(size_t)i]) {
         case util::dtype::int8:
-          return buffers_uint8_[output_which_[i]].nbytes();
+          return (int64_t)buffers_uint8_[(size_t)output_which_[(size_t)i]].nbytes();
         case util::dtype::uint8:
-          return buffers_uint8_[output_which_[i]].nbytes();
+          return (int64_t)buffers_uint8_[(size_t)output_which_[(size_t)i]].nbytes();
         case util::dtype::int64:
-          return buffers_int64_[output_which_[i]].nbytes() / 8;
+          return (int64_t)buffers_int64_[(size_t)output_which_[(size_t)i]].nbytes() / 8;
         case util::dtype::float64:
-          return buffers_float64_[output_which_[i]].nbytes() / 8;
+          return (int64_t)buffers_float64_[(size_t)output_which_[(size_t)i]].nbytes() / 8;
         default:
           return -1;
       }
@@ -246,24 +246,24 @@ namespace awkward {
 
     /// @brief HERE
     void output_fill(int64_t i, void* external_pointer) const {
-      switch (output_dtypes_[i]) {
+      switch (output_dtypes_[(size_t)i]) {
         case util::dtype::int8:
-          buffers_uint8_[output_which_[i]].concatenate(
+          buffers_uint8_[(size_t)output_which_[(size_t)i]].concatenate(
             reinterpret_cast<uint8_t*>(external_pointer)
           );
           break;
         case util::dtype::uint8:
-          buffers_uint8_[output_which_[i]].concatenate(
+          buffers_uint8_[(size_t)output_which_[(size_t)i]].concatenate(
             reinterpret_cast<uint8_t*>(external_pointer)
           );
           break;
         case util::dtype::int64:
-          buffers_int64_[output_which_[i]].concatenate(
+          buffers_int64_[(size_t)output_which_[(size_t)i]].concatenate(
             reinterpret_cast<int64_t*>(external_pointer)
           );
           break;
         case util::dtype::float64:
-          buffers_float64_[output_which_[i]].concatenate(
+          buffers_float64_[(size_t)output_which_[(size_t)i]].concatenate(
             reinterpret_cast<double*>(external_pointer)
           );
           break;

--- a/include/awkward/python/content.h
+++ b/include/awkward/python/content.h
@@ -76,39 +76,16 @@ namespace {
   class EmptyBuffersContainer: public ak::BuffersContainer {
   public:
     void*
-      empty_buffer(const std::string& name, int64_t num_bytes) override {
+      empty_buffer(const std::string&, int64_t) override {
         return nullptr;
       }
 
     void
-      copy_buffer(const std::string& name, const void* source, int64_t num_bytes) override { }
+      copy_buffer(const std::string&, const void*, int64_t) override { }
 
     void
-      full_buffer(const std::string& name, int64_t length, int64_t value, const std::string& dtype) override { }
+      full_buffer(const std::string&, int64_t, int64_t, const std::string&) override { }
   };
-
-  /// @brief Turns the accumulated data into a Content array.
-  ///
-  /// This operation only converts Builder nodes into Content nodes; the
-  /// buffers holding array data are shared between the Builder and the
-  /// Content. Hence, taking a snapshot is a constant-time operation.
-  ///
-  /// It is safe to take multiple snapshots while accumulating data. The
-  /// shared buffers are only appended to, which affects elements beyond
-  /// the limited view of old snapshots.
-  py::object
-  builder_snapshot(const ak::BuilderPtr builder) {
-    ::NumpyBuffersContainer container;
-    int64_t form_key_id = 0;
-    std::string form = builder.get()->to_buffers(container, form_key_id);
-    py::dict kwargs;
-    kwargs[py::str("form")] = py::str(form);
-    kwargs[py::str("length")] = py::int_(builder.get()->length());
-    kwargs[py::str("container")] = container.container();
-    kwargs[py::str("key_format")] = py::str("{form_key}-{attribute}");
-    kwargs[py::str("highlevel")] = py::bool_(false);
-    return py::module::import("awkward").attr("from_buffers")(**kwargs);
-  }
 }
 
 #endif // AWKWARDPY_CONTENT_H_

--- a/include/awkward/python/content.h
+++ b/include/awkward/python/content.h
@@ -76,15 +76,15 @@ namespace {
   class EmptyBuffersContainer: public ak::BuffersContainer {
   public:
     void*
-      empty_buffer(const std::string&, int64_t) override {
+      empty_buffer(const std::string& /* name */, int64_t /* num_bytes */) override {
         return nullptr;
       }
 
     void
-      copy_buffer(const std::string&, const void*, int64_t) override { }
+      copy_buffer(const std::string& /* name */, const void* /* source */, int64_t /* num_bytes */) override { }
 
     void
-      full_buffer(const std::string&, int64_t, int64_t, const std::string&) override { }
+      full_buffer(const std::string& /* name */, int64_t /* length */, int64_t /* value */, const std::string& /* dtype */) override { }
   };
 }
 

--- a/include/awkward/python/util.h
+++ b/include/awkward/python/util.h
@@ -31,7 +31,7 @@ public:
   }
   /// @brief Called by `std::shared_ptr` when its reference count reaches
   /// zero.
-  void operator()(T const *) {
+  void operator()(T const * /* p */) {
     Py_DECREF(pyobj_);
   }
 private:

--- a/include/awkward/python/util.h
+++ b/include/awkward/python/util.h
@@ -31,7 +31,7 @@ public:
   }
   /// @brief Called by `std::shared_ptr` when its reference count reaches
   /// zero.
-  void operator()(T const *p) {
+  void operator()(T const *) {
     Py_DECREF(pyobj_);
   }
 private:

--- a/src/awkward/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/cpp-headers/awkward/GrowableBuffer.h
@@ -277,7 +277,7 @@ namespace awkward {
     template <typename TO_PRIMITIVE>
     static GrowableBuffer<TO_PRIMITIVE>
     copy_as(const GrowableBuffer<PRIMITIVE>& other) {
-      int64_t len = other.length();
+      int64_t len = (int64_t)other.length();
       int64_t actual =
           (len < other.options_.initial()) ? other.options_.initial() : len;
 
@@ -383,7 +383,7 @@ namespace awkward {
     void
     append(PRIMITIVE datum) {
       if (ptr_->current_length() == ptr_->reserved()) {
-        add_panel((size_t)ceil(ptr_->reserved() * options_.resize()));
+        add_panel((size_t)ceil((double)ptr_->reserved() * (double)options_.resize()));
       }
       fill_panel(datum);
     }

--- a/src/awkward/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/cpp-headers/awkward/GrowableBuffer.h
@@ -277,7 +277,7 @@ namespace awkward {
     template <typename TO_PRIMITIVE>
     static GrowableBuffer<TO_PRIMITIVE>
     copy_as(const GrowableBuffer<PRIMITIVE>& other) {
-      auto len = other.length();
+      int64_t len = other.length();
       int64_t actual =
           (len < other.options_.initial()) ? other.options_.initial() : len;
 

--- a/src/awkward/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/cpp-headers/awkward/LayoutBuilder.h
@@ -120,7 +120,7 @@ namespace awkward {
 
       /// @brief Checks for validity and consistency.
       bool
-      is_valid(std::string&) const noexcept {
+      is_valid(std::string& /* error */) const noexcept {
         return true;
       }
 
@@ -585,7 +585,7 @@ namespace awkward {
       }
 
       void
-      set_id(size_t&) noexcept {}
+      set_id(size_t& /* id */) noexcept {}
 
       void
       clear() noexcept {}
@@ -603,18 +603,18 @@ namespace awkward {
       }
 
       void
-      buffer_nbytes(std::map<std::string, size_t>&) const
+      buffer_nbytes(std::map<std::string, size_t>& /* names_nbytes */) const
           noexcept {}
 
       void
-      to_buffers(std::map<std::string, void*>&) const noexcept {}
+      to_buffers(std::map<std::string, void*>& /* buffers */) const noexcept {}
 
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.
       ///
       /// The map keys and the buffer sizes are obtained from #buffer_nbytes
       void
-      to_char_buffers(std::map<std::string, uint8_t*>&) const noexcept {}
+      to_char_buffers(std::map<std::string, uint8_t*>& /* buffers */) const noexcept {}
 
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
@@ -705,11 +705,11 @@ namespace awkward {
       }
 
       void
-      buffer_nbytes(std::map<std::string, size_t>&) const
+      buffer_nbytes(std::map<std::string, size_t>& /* names_nbytes */) const
           noexcept {}
 
       void
-      to_buffers(std::map<std::string, void*>&) const noexcept {}
+      to_buffers(std::map<std::string, void*>& /* buffers */) const noexcept {}
 
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.

--- a/src/awkward/cpp-headers/awkward/LayoutBuilder.h
+++ b/src/awkward/cpp-headers/awkward/LayoutBuilder.h
@@ -120,7 +120,7 @@ namespace awkward {
 
       /// @brief Checks for validity and consistency.
       bool
-      is_valid(std::string& error) const noexcept {
+      is_valid(std::string&) const noexcept {
         return true;
       }
 
@@ -286,7 +286,7 @@ namespace awkward {
       /// @brief Checks for validity and consistency.
       bool
       is_valid(std::string& error) const noexcept {
-        if (content_.length() != offsets_.last()) {
+        if ((int64_t)content_.length() != (int64_t)offsets_.last()) {
           std::stringstream out;
           out << "ListOffset node" << id_ << "has content length "
               << content_.length() << "but last offset " << offsets_.last()
@@ -585,7 +585,7 @@ namespace awkward {
       }
 
       void
-      set_id(size_t& id) noexcept {}
+      set_id(size_t&) noexcept {}
 
       void
       clear() noexcept {}
@@ -603,18 +603,18 @@ namespace awkward {
       }
 
       void
-      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+      buffer_nbytes(std::map<std::string, size_t>&) const
           noexcept {}
 
       void
-      to_buffers(std::map<std::string, void*>& buffers) const noexcept {}
+      to_buffers(std::map<std::string, void*>&) const noexcept {}
 
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.
       ///
       /// The map keys and the buffer sizes are obtained from #buffer_nbytes
       void
-      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {}
+      to_char_buffers(std::map<std::string, uint8_t*>&) const noexcept {}
 
       /// @brief Generates a unique description of the builder and its
       /// contents in the form of a JSON-like string.
@@ -705,11 +705,11 @@ namespace awkward {
       }
 
       void
-      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+      buffer_nbytes(std::map<std::string, size_t>&) const
           noexcept {}
 
       void
-      to_buffers(std::map<std::string, void*>& buffers) const noexcept {}
+      to_buffers(std::map<std::string, void*>&) const noexcept {}
 
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.
@@ -862,7 +862,7 @@ namespace awkward {
       }
 
       /// @brief Current number of records in first field.
-      const size_t
+      size_t
       length() const noexcept {
         return (std::get<0>(contents).builder.length());
       }
@@ -872,13 +872,13 @@ namespace awkward {
       is_valid(std::string& error) const noexcept {
         auto index_sequence((std::index_sequence_for<BUILDERS...>()));
 
-        size_t length = -1;
-        bool result = false;
+        int64_t length = -1;
         std::vector<size_t> lengths = field_lengths(index_sequence);
         for (size_t i = 0; i < lengths.size(); i++) {
           if (length == -1) {
             length = lengths[i];
-          } else if (length != lengths[i]) {
+          }
+          else if (length != (int64_t)lengths[i]) {
             std::stringstream out;
             out << "Record node" << id_ << " has field \""
                 << field_names().at(i) << "\" length " << lengths[i]
@@ -1071,7 +1071,7 @@ namespace awkward {
       }
 
       /// @brief Current number of records in the first index of the tuple.
-      const size_t
+      size_t
       length() const noexcept {
         return (std::get<0>(contents).builder.length());
       }
@@ -1081,13 +1081,13 @@ namespace awkward {
       is_valid(std::string& error) const noexcept {
         auto index_sequence((std::index_sequence_for<BUILDERS...>()));
 
-        size_t length = -1;
-        bool result = false;
+        int64_t length = -1;
         std::vector<size_t> lengths = content_lengths(index_sequence);
         for (size_t i = 0; i < lengths.size(); i++) {
           if (length == -1) {
-            length = lengths[i];
-          } else if (length != lengths[i]) {
+            length = (int64_t)lengths[i];
+          }
+          else if (length != (int64_t)lengths[i]) {
             std::stringstream out;
             out << "Record node" << id_ << " has index \"" << i << "\" length "
                 << lengths[i] << " that differs from the first length "

--- a/src/cpu-kernels/awkward_IndexedArray_local_preparenext_64.cpp
+++ b/src/cpu-kernels/awkward_IndexedArray_local_preparenext_64.cpp
@@ -6,17 +6,15 @@
 
 ERROR awkward_IndexedArray_local_preparenext_64(
     int64_t* tocarry,
-    const int64_t* starts,
+    const int64_t*,
     const int64_t* parents,
     const int64_t parentslength,
     const int64_t* nextparents,
     const int64_t nextlen) {
   int64_t j = 0;
   int64_t parent = 0;
-  int64_t start = 0;
   for (int64_t i = 0;  i < parentslength;  i++) {
     parent = parents[i];
-    start = starts[parent];
     if (j < nextlen  &&  parent == nextparents[j]) {
       tocarry[i] = j;
       ++j;

--- a/src/cpu-kernels/awkward_IndexedArray_local_preparenext_64.cpp
+++ b/src/cpu-kernels/awkward_IndexedArray_local_preparenext_64.cpp
@@ -6,7 +6,7 @@
 
 ERROR awkward_IndexedArray_local_preparenext_64(
     int64_t* tocarry,
-    const int64_t*,
+    const int64_t* /* starts */,   // FIXME: this argument is not needed
     const int64_t* parents,
     const int64_t parentslength,
     const int64_t* nextparents,

--- a/src/cpu-kernels/awkward_ListArray_getitem_next_array_advanced.cpp
+++ b/src/cpu-kernels/awkward_ListArray_getitem_next_array_advanced.cpp
@@ -13,7 +13,7 @@ ERROR awkward_ListArray_getitem_next_array_advanced(
   const T* fromarray,
   const T* fromadvanced,
   int64_t lenstarts,
-  int64_t,
+  int64_t /* lenarray */,  // FIXME: this argument is not needed
   int64_t lencontent) {
   for (int64_t i = 0;  i < lenstarts;  i++) {
     if (fromstops[i] < fromstarts[i]) {

--- a/src/cpu-kernels/awkward_ListArray_getitem_next_array_advanced.cpp
+++ b/src/cpu-kernels/awkward_ListArray_getitem_next_array_advanced.cpp
@@ -13,7 +13,7 @@ ERROR awkward_ListArray_getitem_next_array_advanced(
   const T* fromarray,
   const T* fromadvanced,
   int64_t lenstarts,
-  int64_t lenarray,
+  int64_t,
   int64_t lencontent) {
   for (int64_t i = 0;  i < lenstarts;  i++) {
     if (fromstops[i] < fromstarts[i]) {

--- a/src/cpu-kernels/awkward_ListOffsetArray_argsort_strings.cpp
+++ b/src/cpu-kernels/awkward_ListOffsetArray_argsort_strings.cpp
@@ -19,7 +19,7 @@ ERROR awkward_ListOffsetArray_argsort_strings_impl(
   const int64_t* stringstops) {
 
   auto sorter =
-        [&stringdata, &stringstarts, &stringstops](int left, int right) -> bool {
+        [&stringdata, &stringstarts, &stringstops](int64_t left, int64_t right) -> bool {
           size_t left_n = stringstops[left] - stringstarts[left];
           size_t right_n = stringstops[right] - stringstarts[right];
           const char* left_str = &stringdata[stringstarts[left]];

--- a/src/cpu-kernels/awkward_ListOffsetArray_argsort_strings.cpp
+++ b/src/cpu-kernels/awkward_ListOffsetArray_argsort_strings.cpp
@@ -42,7 +42,6 @@ ERROR awkward_ListOffsetArray_argsort_strings_impl(
 
   int64_t firstindex = 0;
   int64_t lastparent = -1;
-  int64_t k = 0;
   std::vector<int64_t> index;
   for (int64_t i = 0;  i < length + 1;  i++) {
     if (i == length  ||  fromparents[i] != lastparent) {

--- a/src/cpu-kernels/awkward_ListOffsetArray_flatten_offsets.cpp
+++ b/src/cpu-kernels/awkward_ListOffsetArray_flatten_offsets.cpp
@@ -10,7 +10,7 @@ ERROR awkward_ListOffsetArray_flatten_offsets(
   const C* outeroffsets,
   int64_t outeroffsetslen,
   const T* inneroffsets,
-  int64_t) {
+  int64_t /* inneroffsetslen */) {  // FIXME: this argument is not needed
   for (int64_t i = 0;  i < outeroffsetslen;  i++) {
     tooffsets[i] =
       inneroffsets[outeroffsets[i]];

--- a/src/cpu-kernels/awkward_ListOffsetArray_flatten_offsets.cpp
+++ b/src/cpu-kernels/awkward_ListOffsetArray_flatten_offsets.cpp
@@ -10,7 +10,7 @@ ERROR awkward_ListOffsetArray_flatten_offsets(
   const C* outeroffsets,
   int64_t outeroffsetslen,
   const T* inneroffsets,
-  int64_t inneroffsetslen) {
+  int64_t) {
   for (int64_t i = 0;  i < outeroffsetslen;  i++) {
     tooffsets[i] =
       inneroffsets[outeroffsets[i]];

--- a/src/cpu-kernels/awkward_NumpyArray_rearrange_shifted.cpp
+++ b/src/cpu-kernels/awkward_NumpyArray_rearrange_shifted.cpp
@@ -12,9 +12,9 @@ awkward_NumpyArray_rearrange_shifted(TO* toptr,
                                      const FROM* offsets,
                                      int64_t offsetslength,
                                      const FROM* parents,
-                                     int64_t parentslength,
+                                     int64_t,
                                      const FROM* starts,
-                                     int64_t startslength) {
+                                     int64_t) {
   int64_t k = 0;
   for (int64_t i = 0; i < offsetslength - 1; i++) {
     for (int64_t j = 0; j < offsets[i + 1] - offsets[i]; j++) {

--- a/src/cpu-kernels/awkward_NumpyArray_rearrange_shifted.cpp
+++ b/src/cpu-kernels/awkward_NumpyArray_rearrange_shifted.cpp
@@ -12,9 +12,9 @@ awkward_NumpyArray_rearrange_shifted(TO* toptr,
                                      const FROM* offsets,
                                      int64_t offsetslength,
                                      const FROM* parents,
-                                     int64_t,
+                                     int64_t /* parentslength */,  // FIXME: these arguments are not needed
                                      const FROM* starts,
-                                     int64_t) {
+                                     int64_t /* startslength */) {
   int64_t k = 0;
   for (int64_t i = 0; i < offsetslength - 1; i++) {
     for (int64_t j = 0; j < offsets[i + 1] - offsets[i]; j++) {

--- a/src/cpu-kernels/awkward_RegularArray_getitem_next_array_advanced.cpp
+++ b/src/cpu-kernels/awkward_RegularArray_getitem_next_array_advanced.cpp
@@ -11,7 +11,7 @@ ERROR awkward_RegularArray_getitem_next_array_advanced(
   const T* fromadvanced,
   const T* fromarray,
   int64_t length,
-  int64_t lenarray,
+  int64_t,
   int64_t size) {
   for (int64_t i = 0;  i < length;  i++) {
     tocarry[i] = i*size + fromarray[fromadvanced[i]];

--- a/src/cpu-kernels/awkward_RegularArray_getitem_next_array_advanced.cpp
+++ b/src/cpu-kernels/awkward_RegularArray_getitem_next_array_advanced.cpp
@@ -11,7 +11,7 @@ ERROR awkward_RegularArray_getitem_next_array_advanced(
   const T* fromadvanced,
   const T* fromarray,
   int64_t length,
-  int64_t,
+  int64_t /* lenarray */,  // FIXME: this argument is not needed
   int64_t size) {
   for (int64_t i = 0;  i < length;  i++) {
     tocarry[i] = i*size + fromarray[fromadvanced[i]];

--- a/src/cpu-kernels/awkward_UnionArray_regular_index.cpp
+++ b/src/cpu-kernels/awkward_UnionArray_regular_index.cpp
@@ -11,7 +11,6 @@ ERROR awkward_UnionArray_regular_index(
   int64_t size,
   const C* fromtags,
   int64_t length) {
-  int64_t count = 0;
   for (int64_t k = 0;  k < size;  k++) {
     current[k] = 0;
   }

--- a/src/cpu-kernels/awkward_unique_ranges.cpp
+++ b/src/cpu-kernels/awkward_unique_ranges.cpp
@@ -7,7 +7,7 @@
 template <typename T>
 ERROR awkward_unique_ranges(
   T* toptr,
-  int64_t,
+  int64_t /* length */,   // FIXME: this argument is not needed
   const int64_t* fromoffsets,
   int64_t offsetslength,
   int64_t* tooffsets) {

--- a/src/cpu-kernels/awkward_unique_ranges.cpp
+++ b/src/cpu-kernels/awkward_unique_ranges.cpp
@@ -7,7 +7,7 @@
 template <typename T>
 ERROR awkward_unique_ranges(
   T* toptr,
-  int64_t length,
+  int64_t,
   const int64_t* fromoffsets,
   int64_t offsetslength,
   int64_t* tooffsets) {

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -34,7 +34,7 @@ namespace awkward {
     buffer_.concatenate(
       reinterpret_cast<uint8_t*>(
         container.empty_buffer(form_key.str() + "-data",
-        buffer_.length() * (int64_t)sizeof(bool))));
+        (int64_t)buffer_.length() * (int64_t)sizeof(bool))));
 
     return "{\"class\": \"NumpyArray\", \"primitive\": \"bool\", \"form_key\": \""
            + form_key.str() + "\"}";

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -59,7 +59,7 @@ namespace awkward {
   BoolBuilder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -72,49 +72,49 @@ namespace awkward {
   BoolBuilder::integer(int64_t x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->integer(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   BoolBuilder::real(double x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->real(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   BoolBuilder::complex(std::complex<double> x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->complex(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   BoolBuilder::datetime(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   BoolBuilder::timedelta(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   BoolBuilder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -128,11 +128,11 @@ namespace awkward {
   BoolBuilder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
-  BoolBuilder::index(int64_t index) {
+  BoolBuilder::index(int64_t) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begintuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -149,11 +149,11 @@ namespace awkward {
   BoolBuilder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
-    return std::move(out);
+    return out;
   }
 
   void
-  BoolBuilder::field(const char* key, bool check) {
+  BoolBuilder::field(const char*, bool) {
     throw std::invalid_argument(
       std::string("called 'field' without 'beginrecord' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -132,7 +132,7 @@ namespace awkward {
   }
 
   const BuilderPtr
-  BoolBuilder::index(int64_t) {
+  BoolBuilder::index(int64_t /* index */) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begintuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -153,7 +153,7 @@ namespace awkward {
   }
 
   void
-  BoolBuilder::field(const char*, bool) {
+  BoolBuilder::field(const char* /* key */, bool /* check */) {
     throw std::invalid_argument(
       std::string("called 'field' without 'beginrecord' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/Complex128Builder.cpp
+++ b/src/libawkward/builder/Complex128Builder.cpp
@@ -48,7 +48,7 @@ namespace awkward {
     form_key << "node" << (form_key_id++);
 
     void* ptr = container.empty_buffer(form_key.str() + "-data",
-      buffer_.length() * (int64_t)sizeof(std::complex<double>));
+      (int64_t)buffer_.length() * (int64_t)sizeof(std::complex<double>));
 
     buffer_.concatenate(reinterpret_cast<std::complex<double>*>(ptr));
 

--- a/src/libawkward/builder/Complex128Builder.cpp
+++ b/src/libawkward/builder/Complex128Builder.cpp
@@ -75,14 +75,14 @@ namespace awkward {
   Complex128Builder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Complex128Builder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -107,28 +107,28 @@ namespace awkward {
   Complex128Builder::datetime(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Complex128Builder::timedelta(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Complex128Builder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Complex128Builder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -142,11 +142,11 @@ namespace awkward {
   Complex128Builder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
-  Complex128Builder::index(int64_t index) {
+  Complex128Builder::index(int64_t) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -163,11 +163,11 @@ namespace awkward {
   Complex128Builder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
-    return std::move(out);
+    return out;
   }
 
   void
-  Complex128Builder::field(const char* key, bool check) {
+  Complex128Builder::field(const char*, bool) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/Complex128Builder.cpp
+++ b/src/libawkward/builder/Complex128Builder.cpp
@@ -146,7 +146,7 @@ namespace awkward {
   }
 
   const BuilderPtr
-  Complex128Builder::index(int64_t) {
+  Complex128Builder::index(int64_t /* index */) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -167,7 +167,7 @@ namespace awkward {
   }
 
   void
-  Complex128Builder::field(const char*, bool) {
+  Complex128Builder::field(const char* /* key */, bool /* check */) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/DatetimeBuilder.cpp
+++ b/src/libawkward/builder/DatetimeBuilder.cpp
@@ -42,7 +42,7 @@ namespace awkward {
     content_.concatenate(
       reinterpret_cast<int64_t*>(
         container.empty_buffer(form_key.str() + "-data",
-        content_.length() * (int64_t)sizeof(int64_t))));
+        (int64_t)content_.length() * (int64_t)sizeof(int64_t))));
 
     std::string primitive(units_);
 

--- a/src/libawkward/builder/DatetimeBuilder.cpp
+++ b/src/libawkward/builder/DatetimeBuilder.cpp
@@ -84,35 +84,35 @@ namespace awkward {
   DatetimeBuilder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   DatetimeBuilder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   DatetimeBuilder::integer(int64_t x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->integer(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   DatetimeBuilder::real(double x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->real(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   DatetimeBuilder::complex(std::complex<double> x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->complex(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -124,7 +124,7 @@ namespace awkward {
     else {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->datetime(x, unit);
-      return std::move(out);
+      return out;
     }
   }
 
@@ -137,7 +137,7 @@ namespace awkward {
     else {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->timedelta(x, unit);
-      return std::move(out);
+      return out;
     }
   }
 
@@ -145,14 +145,14 @@ namespace awkward {
   DatetimeBuilder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   DatetimeBuilder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -166,11 +166,11 @@ namespace awkward {
   DatetimeBuilder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
-  DatetimeBuilder::index(int64_t index) {
+  DatetimeBuilder::index(int64_t) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -187,11 +187,11 @@ namespace awkward {
   DatetimeBuilder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
-    return std::move(out);
+    return out;
   }
 
   void
-  DatetimeBuilder::field(const char* key, bool check) {
+  DatetimeBuilder::field(const char*, bool) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/DatetimeBuilder.cpp
+++ b/src/libawkward/builder/DatetimeBuilder.cpp
@@ -170,7 +170,7 @@ namespace awkward {
   }
 
   const BuilderPtr
-  DatetimeBuilder::index(int64_t) {
+  DatetimeBuilder::index(int64_t /* index */) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -191,7 +191,7 @@ namespace awkward {
   }
 
   void
-  DatetimeBuilder::field(const char*, bool) {
+  DatetimeBuilder::field(const char* /* key */, bool /* check */) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -74,14 +74,14 @@ namespace awkward {
   Float64Builder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Float64Builder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -100,35 +100,35 @@ namespace awkward {
   Float64Builder::complex(std::complex<double> x) {
     BuilderPtr out = Complex128Builder::fromfloat64(options_, std::move(buffer_));
     out.get()->complex(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Float64Builder::datetime(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Float64Builder::timedelta(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Float64Builder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Float64Builder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -142,11 +142,11 @@ namespace awkward {
   Float64Builder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
-  Float64Builder::index(int64_t index) {
+  Float64Builder::index(int64_t) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -163,11 +163,11 @@ namespace awkward {
   Float64Builder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
-    return std::move(out);
+    return out;
   }
 
   void
-  Float64Builder::field(const char* key, bool check) {
+  Float64Builder::field(const char*, bool) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -49,7 +49,7 @@ namespace awkward {
     buffer_.concatenate(
       reinterpret_cast<double*>(
         container.empty_buffer(form_key.str() + "-data",
-        buffer_.length() * (int64_t)sizeof(double))));
+        (int64_t)buffer_.length() * (int64_t)sizeof(double))));
 
     return "{\"class\": \"NumpyArray\", \"primitive\": \"float64\", \"form_key\": \""
            + form_key.str() + "\"}";

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -146,7 +146,7 @@ namespace awkward {
   }
 
   const BuilderPtr
-  Float64Builder::index(int64_t) {
+  Float64Builder::index(int64_t /* index */) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -167,7 +167,7 @@ namespace awkward {
   }
 
   void
-  Float64Builder::field(const char*, bool) {
+  Float64Builder::field(const char* /* key */, bool /* check */) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -42,7 +42,7 @@ namespace awkward {
     buffer_.concatenate(
       reinterpret_cast<int64_t*>(
         container.empty_buffer(form_key.str() + "-data",
-        buffer_.length() * (int64_t)sizeof(int64_t))));
+        (int64_t)buffer_.length() * (int64_t)sizeof(int64_t))));
 
     return "{\"class\": \"NumpyArray\", \"primitive\": \"int64\", \"form_key\": \""
            + form_key.str() + "\"}";

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -67,14 +67,14 @@ namespace awkward {
   Int64Builder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Int64Builder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -87,42 +87,42 @@ namespace awkward {
   Int64Builder::real(double x) {
     BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
     out.get()->real(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Int64Builder::complex(std::complex<double> x) {
     BuilderPtr out = Complex128Builder::fromint64(options_, buffer_);
     out.get()->complex(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Int64Builder::datetime(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Int64Builder::timedelta(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Int64Builder::string(const char* x, int64_t length, const char* encoding) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->string(x, length, encoding);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   Int64Builder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -136,11 +136,11 @@ namespace awkward {
   Int64Builder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
-  Int64Builder::index(int64_t index) {
+  Int64Builder::index(int64_t) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -157,11 +157,11 @@ namespace awkward {
   Int64Builder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
-    return std::move(out);
+    return out;
   }
 
   void
-  Int64Builder::field(const char* key, bool check) {
+  Int64Builder::field(const char*, bool) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -140,7 +140,7 @@ namespace awkward {
   }
 
   const BuilderPtr
-  Int64Builder::index(int64_t) {
+  Int64Builder::index(int64_t /* index */) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -161,7 +161,7 @@ namespace awkward {
   }
 
   void
-  Int64Builder::field(const char*, bool) {
+  Int64Builder::field(const char* /* key */, bool /* check */) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -41,7 +41,7 @@ namespace awkward {
     form_key << "node" << (form_key_id++);
 
     void* ptr = container.empty_buffer(form_key.str() + "-offsets",
-      offsets_.length() * (int64_t)sizeof(int64_t));
+      (int64_t)offsets_.length() * (int64_t)sizeof(int64_t));
 
     offsets_.concatenate(reinterpret_cast<int64_t*>(ptr));
 

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -72,7 +72,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
       out.get()->null();
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->null());
@@ -85,7 +85,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->boolean(x);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->boolean(x));
@@ -98,7 +98,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->integer(x);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->integer(x));
@@ -111,7 +111,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->real(x);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->real(x));
@@ -124,7 +124,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->complex(x);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->complex(x));
@@ -137,7 +137,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->datetime(x, unit);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->datetime(x, unit));
@@ -150,7 +150,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->timedelta(x, unit);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->timedelta(x, unit));
@@ -163,7 +163,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->string(x, length, encoding);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->string(x, length, encoding));
@@ -204,7 +204,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->begintuple(numfields);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->begintuple(numfields));
@@ -243,7 +243,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginrecord(name, check);
-      return std::move(out);
+      return out;
     }
     else {
       maybeupdate(content_.get()->beginrecord(name, check));

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -28,7 +28,7 @@ namespace awkward {
                                            content);
   }
 
-  OptionBuilder::OptionBuilder(const BuilderOptions& options,
+  OptionBuilder::OptionBuilder(const BuilderOptions&,
                                GrowableBuffer<int64_t> index,
                                const BuilderPtr content)
     : index_(std::move(index))

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -45,7 +45,7 @@ namespace awkward {
     form_key << "node" << (form_key_id++);
 
     void* ptr = container.empty_buffer(form_key.str() + "-index",
-      index_.length() * (int64_t)sizeof(int64_t));
+      (int64_t)index_.length() * (int64_t)sizeof(int64_t));
 
     index_.concatenate(reinterpret_cast<int64_t*>(ptr));
 

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -117,7 +117,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
       out.get()->null();
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -138,7 +138,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->boolean(x);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -159,7 +159,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->integer(x);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -180,7 +180,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->real(x);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -201,7 +201,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->complex(x);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -222,7 +222,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->datetime(x, unit);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -243,7 +243,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->timedelta(x, unit);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -264,7 +264,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->string(x, length, encoding);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -288,7 +288,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginlist();
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -329,7 +329,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->begintuple(numfields);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -407,7 +407,7 @@ namespace awkward {
     else if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginrecord(name, check);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -102,53 +102,53 @@ namespace awkward {
   StringBuilder::null() {
     BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
     out.get()->null();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   StringBuilder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->boolean(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   StringBuilder::integer(int64_t x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->integer(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   StringBuilder::real(double x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->real(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   StringBuilder::complex(std::complex<double> x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->complex(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   StringBuilder::datetime(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->datetime(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
   StringBuilder::timedelta(int64_t x, const std::string& unit) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->timedelta(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
-  StringBuilder::string(const char* x, int64_t length, const char* encoding) {
+  StringBuilder::string(const char* x, int64_t length, const char*) {
     if (length < 0) {
       for (int64_t i = 0;  x[i] != 0;  i++) {
         content_.append((uint8_t)x[i]);
@@ -167,7 +167,7 @@ namespace awkward {
   StringBuilder::beginlist() {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginlist();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -181,11 +181,11 @@ namespace awkward {
   StringBuilder::begintuple(int64_t numfields) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->begintuple(numfields);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
-  StringBuilder::index(int64_t index) {
+  StringBuilder::index(int64_t) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -202,11 +202,11 @@ namespace awkward {
   StringBuilder::beginrecord(const char* name, bool check) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
     out.get()->beginrecord(name, check);
-    return std::move(out);
+    return out;
   }
 
   void
-  StringBuilder::field(const char* key, bool check) {
+  StringBuilder::field(const char*, bool) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -148,7 +148,7 @@ namespace awkward {
   }
 
   const BuilderPtr
-  StringBuilder::string(const char* x, int64_t length, const char*) {
+  StringBuilder::string(const char* x, int64_t length, const char* /* encoding */) {
     if (length < 0) {
       for (int64_t i = 0;  x[i] != 0;  i++) {
         content_.append((uint8_t)x[i]);
@@ -185,7 +185,7 @@ namespace awkward {
   }
 
   const BuilderPtr
-  StringBuilder::index(int64_t) {
+  StringBuilder::index(int64_t /* index */) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -206,7 +206,7 @@ namespace awkward {
   }
 
   void
-  StringBuilder::field(const char*, bool) {
+  StringBuilder::field(const char* /* key */, bool /* check */) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -52,12 +52,12 @@ namespace awkward {
     offsets_.concatenate(
       reinterpret_cast<int64_t*>(
         container.empty_buffer(outer_form_key.str() + "-offsets",
-        offsets_.length() * (int64_t)sizeof(int64_t))));
+        (int64_t)offsets_.length() * (int64_t)sizeof(int64_t))));
 
     content_.concatenate(
       reinterpret_cast<uint8_t*>(
         container.empty_buffer(inner_form_key.str() + "-data",
-        content_.length() * (int64_t)sizeof(uint8_t))));
+        (int64_t)content_.length() * (int64_t)sizeof(uint8_t))));
 
     std::string char_parameter;
     std::string string_parameter;

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -83,7 +83,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
       out.get()->null();
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -104,7 +104,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->boolean(x);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -125,7 +125,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->integer(x);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -146,7 +146,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->real(x);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -167,7 +167,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->complex(x);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -188,7 +188,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->datetime(x, unit);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -209,7 +209,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->timedelta(x, unit);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -230,7 +230,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->string(x, length, encoding);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -254,7 +254,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginlist();
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -306,7 +306,7 @@ namespace awkward {
     else if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->begintuple(numfields);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(
@@ -382,7 +382,7 @@ namespace awkward {
     if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
       out.get()->beginrecord(name, check);
-      return std::move(out);
+      return out;
     }
     else if (nextindex_ == -1) {
       throw std::invalid_argument(

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -51,12 +51,12 @@ namespace awkward {
     tags_.concatenate(
       reinterpret_cast<int8_t*>(
         container.empty_buffer(form_key.str() + "-tags",
-        tags_.length() * (int64_t)sizeof(int8_t))));
+        (int64_t)tags_.length() * (int64_t)sizeof(int8_t))));
 
     index_.concatenate(
       reinterpret_cast<int64_t*>(
         container.empty_buffer(form_key.str() + "-index",
-        index_.length() * (int64_t)sizeof(int64_t))));
+        (int64_t)index_.length() * (int64_t)sizeof(int64_t))));
 
     std::stringstream out;
     out << "{\"class\": \"UnionArray\", \"tags\": \"i8\", \"index\": \"i64\", \"contents\": [";

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -94,7 +94,7 @@ namespace awkward {
     if (current_ == -1) {
       BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
       out.get()->null();
-      return std::move(out);
+      return out;
     }
     else {
       contents_[(size_t)current_].get()->null();

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -85,7 +85,7 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->boolean(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -95,7 +95,7 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->integer(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -105,7 +105,7 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->real(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -115,7 +115,7 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->complex(x);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -125,7 +125,7 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->datetime(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -135,7 +135,7 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->timedelta(x, unit);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -145,7 +145,7 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->string(x, length, encoding);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -155,7 +155,7 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->beginlist();
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
@@ -172,11 +172,11 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->begintuple(numfields);
-    return std::move(out);
+    return out;
   }
 
   const BuilderPtr
-  UnknownBuilder::index(int64_t index) {
+  UnknownBuilder::index(int64_t) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -196,11 +196,11 @@ namespace awkward {
       out = OptionBuilder::fromnulls(options_, nullcount_, out);
     }
     out.get()->beginrecord(name, check);
-    return std::move(out);
+    return out;
   }
 
   void
-  UnknownBuilder::field(const char* key, bool check) {
+  UnknownBuilder::field(const char*, bool) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -176,7 +176,7 @@ namespace awkward {
   }
 
   const BuilderPtr
-  UnknownBuilder::index(int64_t) {
+  UnknownBuilder::index(int64_t /* index */) {
     throw std::invalid_argument(
       std::string("called 'index' without 'begin_tuple' at the same level before it")
       + FILENAME(__LINE__));
@@ -200,7 +200,7 @@ namespace awkward {
   }
 
   void
-  UnknownBuilder::field(const char*, bool) {
+  UnknownBuilder::field(const char* /* key */, bool /* check */) {
     throw std::invalid_argument(
       std::string("called 'field' without 'begin_record' at the same level before it")
       + FILENAME(__LINE__));

--- a/src/libawkward/forth/ForthInputBuffer.cpp
+++ b/src/libawkward/forth/ForthInputBuffer.cpp
@@ -67,7 +67,7 @@ namespace awkward {
 
     int64_t i = 0;
     int64_t howmany = stop - start;
-    size_t len;
+    int64_t len;
 
     for (auto it = strings.begin() + start;  i < howmany;  i++) {
       len = it->length();

--- a/src/libawkward/forth/ForthInputBuffer.cpp
+++ b/src/libawkward/forth/ForthInputBuffer.cpp
@@ -70,9 +70,9 @@ namespace awkward {
     int64_t len;
 
     for (auto it = strings.begin() + start;  i < howmany;  i++) {
-      len = it->length();
+      len = (int64_t)it->length();
       if (pos_ + len <= length_) {
-        if (strncmp(it->data(), ptr, len) == 0) {
+        if (strncmp(it->data(), ptr, (size_t)len) == 0) {
           pos_ += len;
           return i;
         }
@@ -301,7 +301,7 @@ namespace awkward {
       pos_++;
     } while (pos_ != length_ && ptr[pos_] >= '0' && ptr[pos_] <= '9');
 
-    double result = integral;
+    double result = (double)integral;
 
     if (pos_ != length_ && ptr[pos_] == '.') {
       pos_++;
@@ -320,7 +320,7 @@ namespace awkward {
         pos_++;
       } while (pos_ != length_ && ptr[pos_] >= '0' && ptr[pos_] <= '9');
 
-      result += (double)fractional / power;
+      result += (double)fractional / (double)power;
     }
 
     if (pos_ != length_ && (ptr[pos_] == 'e' || ptr[pos_] == 'E')) {
@@ -446,7 +446,7 @@ namespace awkward {
           case '\"':
           case '/':
           case '\\':
-            string_buffer[length] = ptr[pos_];
+            string_buffer[length] = (char)ptr[pos_];
             break;
           case 'u':
             // check all the positions that will be used *in the following loop*
@@ -474,16 +474,16 @@ namespace awkward {
             }
             // https://stackoverflow.com/a/4609989/1623645
             if (code_point < 0x80) {
-              string_buffer[length] = code_point;
+              string_buffer[length] = (char)code_point;
             }
             else if (code_point < 0x800) {
               if (length + 1 >= max_string_size) {
                 err = util::ForthError::quoted_string_missing;
                 return;
               }
-              string_buffer[length] = 192 + code_point / 64;
+              string_buffer[length] = (char)(192 + code_point / 64);
               length++;
-              string_buffer[length] = 128 + code_point % 64;
+              string_buffer[length] = (char)(128 + code_point % 64);
             }
             else if (code_point - 0xd800u < 0x800) {
               err = util::ForthError::quoted_string_missing;
@@ -494,11 +494,11 @@ namespace awkward {
                 err = util::ForthError::quoted_string_missing;
                 return;
               }
-              string_buffer[length] = 224 + code_point / 4096;
+              string_buffer[length] = (char)(224 + code_point / 4096);
               length++;
-              string_buffer[length] = 128 + code_point / 64 % 64;
+              string_buffer[length] = (char)(128 + code_point / 64 % 64);
               length++;
-              string_buffer[length] = 128 + code_point % 64;
+              string_buffer[length] = (char)(128 + code_point % 64);
             }
             else if (code_point < 0x110000) {
               // this one can't be reached by 4 hex-digits in JSON, but for completeness...
@@ -506,13 +506,13 @@ namespace awkward {
                 err = util::ForthError::quoted_string_missing;
                 return;
               }
-              string_buffer[length] = 240 + code_point / 262144;
+              string_buffer[length] = (char)(240 + code_point / 262144);
               length++;
-              string_buffer[length] = 128 + code_point / 4096 % 64;
+              string_buffer[length] = (char)(128 + code_point / 4096 % 64);
               length++;
-              string_buffer[length] = 128 + code_point / 64 % 64;
+              string_buffer[length] = (char)(128 + code_point / 64 % 64);
               length++;
-              string_buffer[length] = 128 + code_point % 64;
+              string_buffer[length] = (char)(128 + code_point % 64);
             }
             else {
               err = util::ForthError::quoted_string_missing;
@@ -526,7 +526,7 @@ namespace awkward {
       }
       // else unescaped character
       else {
-        string_buffer[length] = ptr[pos_];
+        string_buffer[length] = (char)ptr[pos_];
       }
 
       // whether the input was an escaped sequence or not, pos_ ended on an interpreted byte

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -3821,7 +3821,7 @@ namespace awkward {
             }
 
             case CODE_PRINT_STACK: {
-              printf("<%lld> ", stack_depth_);
+              printf("<%lld> ", (long long int)stack_depth_);
               for (int64_t i = 0;  i < stack_depth_;  i++) {
                 print_number(stack_buffer_[i]);
               }
@@ -4298,7 +4298,7 @@ namespace awkward {
   template <>
   void
   ForthMachineOf<int64_t, int32_t>::print_number(int64_t num) noexcept {
-    printf("%lld ", num);
+    printf("%lld ", (long long int)num);
   }
 
   template class EXPORT_TEMPLATE_INST ForthMachineOf<int32_t, int32_t>;

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -341,7 +341,7 @@ namespace awkward {
   ForthMachineOf<T, I>::decompiled_segment(int64_t segment_position,
                                            const std::string& indent,
                                            bool endline) const {
-    if ((IndexTypeOf<int64_t>)segment_position < 0  ||  (IndexTypeOf<int64_t>)segment_position + 1 >= bytecodes_offsets_.size()) {
+    if (segment_position < 0  ||  (IndexTypeOf<int64_t>)segment_position + 1 >= bytecodes_offsets_.size()) {
       throw std::runtime_error(
         std::string("segment ") + std::to_string(segment_position)
         + std::string(" does not exist in the bytecode") + FILENAME(__LINE__));
@@ -1253,7 +1253,7 @@ namespace awkward {
 
   template <typename T, typename I>
   void
-  ForthMachineOf<T, I>::maybe_throw(util::ForthError err,
+  ForthMachineOf<T, I>::maybe_throw(util::ForthError,
                                     const std::set<util::ForthError>& ignore) const {
     if (ignore.count(current_error_) == 0) {
       switch (current_error_) {
@@ -2110,7 +2110,7 @@ namespace awkward {
             + FILENAME(__LINE__)
           );
         }
-        for (int64_t i = 0;  i < ofs.size();  i++) {
+        for (int64_t i = 0;  (size_t)i < ofs.size();  i++) {
           if (ofs[i] > endofs[i]) {
           throw std::invalid_argument(
             err_linecol(linecol, pos, stop, "in 'case' .. 'endcase', there must be an 'endof' for every 'of'")
@@ -2124,12 +2124,12 @@ namespace awkward {
         I alternate;
 
         I first_bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
-        for(I i = 0; i < ofs.size() + 1; i++){
+        for(I i = 0;  (size_t)i < ofs.size() + 1;  i++){
           dictionary.push_back({});
         }
         bool can_specialize = true;
         int64_t substart = pos + 1;
-        for (int64_t i = 0;  i < ofs.size();  i++) {
+        for (int64_t i = 0;  (size_t)i < ofs.size();  i++) {
           I pred_bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
           std::vector<I> pred;
           dictionary.push_back(pred);
@@ -2216,7 +2216,7 @@ namespace awkward {
           //
           // But the regular case should become a jump table with CODE_CASE_REGULAR.
 
-          for (int64_t i = 0;  i < ofs.size();  i++) {
+          for (int64_t i = 0;  (size_t)i < ofs.size();  i++) {
             auto pred = dictionary.begin() + (predicates[i] - BOUND_DICTIONARY);
             pred->push_back(CODE_OVER);  // append "over"
             pred->push_back(CODE_EQ);    // append "="
@@ -3821,7 +3821,7 @@ namespace awkward {
             }
 
             case CODE_PRINT_STACK: {
-              printf("<%lld> ", stack_depth_);
+              printf("<%ld> ", stack_depth_);
               for (int64_t i = 0;  i < stack_depth_;  i++) {
                 print_number(stack_buffer_[i]);
               }
@@ -4298,7 +4298,7 @@ namespace awkward {
   template <>
   void
   ForthMachineOf<int64_t, int32_t>::print_number(int64_t num) noexcept {
-    printf("%lld ", num);
+    printf("%ld ", num);
   }
 
   template class EXPORT_TEMPLATE_INST ForthMachineOf<int32_t, int32_t>;

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -232,25 +232,25 @@ namespace awkward {
     , output_initial_size_(output_initial_size)
     , output_resize_factor_(output_resize_factor)
 
-    , stack_buffer_(new T[stack_max_depth])
+    , stack_buffer_(new T[(size_t)stack_max_depth])
     , stack_depth_(0)
     , stack_max_depth_(stack_max_depth)
 
-    , string_buffer_(new char[string_buffer_size])
+    , string_buffer_(new char[(size_t)string_buffer_size])
     , string_buffer_size_(string_buffer_size)
 
     , current_inputs_()
     , current_outputs_()
     , is_ready_(false)
 
-    , current_which_(new int64_t[recursion_max_depth])
-    , current_where_(new int64_t[recursion_max_depth])
+    , current_which_(new int64_t[(size_t)recursion_max_depth])
+    , current_where_(new int64_t[(size_t)recursion_max_depth])
     , recursion_current_depth_(0)
     , recursion_max_depth_(recursion_max_depth)
 
-    , do_recursion_depth_(new int64_t[recursion_max_depth])
-    , do_stop_(new int64_t[recursion_max_depth])
-    , do_i_(new int64_t[recursion_max_depth])
+    , do_recursion_depth_(new int64_t[(size_t)recursion_max_depth])
+    , do_stop_(new int64_t[(size_t)recursion_max_depth])
+    , do_i_(new int64_t[(size_t)recursion_max_depth])
     , do_current_depth_(0)
 
     , current_error_(util::ForthError::none)
@@ -531,7 +531,7 @@ namespace awkward {
           out << "case ( regular )\n";
           for (int64_t i = 0;  i < num_cases;  i++) {
             out << indent << "  " << i << " of";
-            I consequent = start + i;
+            I consequent = (I)(start + i);
             if (segment_nonempty(consequent)) {
               out << "\n" << indent << "    ";
               out << decompiled_segment(consequent, indent + "    ");
@@ -588,7 +588,7 @@ namespace awkward {
           std::stringstream out;
           out << input_names_[(IndexTypeOf<int64_t>)in_num] << " enum";
           for (int64_t i = start;  i < stop;  i++) {
-            out << " s\" " << strings_[i] << "\"";
+            out << " s\" " << strings_[(size_t)i] << "\"";
           }
           return out.str();
         }
@@ -599,7 +599,7 @@ namespace awkward {
           std::stringstream out;
           out << input_names_[(IndexTypeOf<int64_t>)in_num] << " enumonly";
           for (int64_t i = start;  i < stop;  i++) {
-            out << " s\" " << strings_[i] << "\"";
+            out << " s\" " << strings_[(size_t)i] << "\"";
           }
           return out.str();
         }
@@ -2111,7 +2111,7 @@ namespace awkward {
           );
         }
         for (int64_t i = 0;  (size_t)i < ofs.size();  i++) {
-          if (ofs[i] > endofs[i]) {
+          if (ofs[(size_t)i] > endofs[(size_t)i]) {
           throw std::invalid_argument(
             err_linecol(linecol, pos, stop, "in 'case' .. 'endcase', there must be an 'endof' for every 'of'")
             + FILENAME(__LINE__)
@@ -2137,7 +2137,7 @@ namespace awkward {
                 tokenized,
                 linecol,
                 substart,
-                ofs[i],
+                ofs[(size_t)i],
                 pred,
                 dictionary,
                 exitdepth + 1,
@@ -2148,13 +2148,13 @@ namespace awkward {
           dictionary[(IndexTypeOf<int64_t>)pred_bytecode - BOUND_DICTIONARY] = pred;
           predicates.push_back(pred_bytecode);
 
-          I cons_bytecode = first_bytecode + i;
+          I cons_bytecode = first_bytecode + (I)i;
           std::vector<I> cons;
           parse(defn,
                 tokenized,
                 linecol,
-                ofs[i] + 1,
-                endofs[i],
+                ofs[(size_t)i] + 1,
+                endofs[(size_t)i],
                 cons,
                 dictionary,
                 exitdepth + 1,
@@ -2162,11 +2162,11 @@ namespace awkward {
           dictionary[(IndexTypeOf<int64_t>)cons_bytecode - BOUND_DICTIONARY] = cons;
           consequents.push_back(cons_bytecode);
 
-          substart = endofs[i] + 1;
+          substart = endofs[(size_t)i] + 1;
         }
 
         {
-          I alt_bytecode = first_bytecode + ofs.size();
+          I alt_bytecode = first_bytecode + (I)ofs.size();
           std::vector<I> alt;
           parse(defn,
                 tokenized,
@@ -2217,10 +2217,10 @@ namespace awkward {
           // But the regular case should become a jump table with CODE_CASE_REGULAR.
 
           for (int64_t i = 0;  (size_t)i < ofs.size();  i++) {
-            auto pred = dictionary.begin() + (predicates[i] - BOUND_DICTIONARY);
+            auto pred = dictionary.begin() + (predicates[(size_t)i] - BOUND_DICTIONARY);
             pred->push_back(CODE_OVER);  // append "over"
             pred->push_back(CODE_EQ);    // append "="
-            auto cons = dictionary.begin() + (consequents[i] - BOUND_DICTIONARY);
+            auto cons = dictionary.begin() + (consequents[(size_t)i] - BOUND_DICTIONARY);
             cons->insert(cons->begin(), CODE_DROP);  // prepend "drop"
           }
           auto alt = dictionary.begin() + (alternate - BOUND_DICTIONARY);
@@ -2228,12 +2228,12 @@ namespace awkward {
 
           I bytecode2 = alternate;
           for (int64_t i = (int64_t)ofs.size() - 1;  i >= 0;  i--) {
-            I bytecode1 = consequents[i];
+            I bytecode1 = consequents[(size_t)i];
 
             I ifthenelse_bytecode = (I)dictionary.size() + BOUND_DICTIONARY;
             std::vector<I> ifthenelse;
             dictionary.push_back(ifthenelse);
-            ifthenelse.push_back(predicates[i]);
+            ifthenelse.push_back(predicates[(size_t)i]);
             ifthenelse.push_back(CODE_IF_ELSE);
             ifthenelse.push_back(bytecode1);
             ifthenelse.push_back(bytecode2);
@@ -3442,7 +3442,7 @@ namespace awkward {
               }
               else {
                 stack_depth_--;
-                which = start + *value;
+                which = start + (I)(*value);
               }
 
               if (recursion_current_depth_ == recursion_max_depth_) {
@@ -3597,7 +3597,7 @@ namespace awkward {
               bytecodes_pointer_where()++;
               I stop = bytecode_get();
               bytecodes_pointer_where()++;
-              T result = current_inputs_[(IndexTypeOf<int64_t>)in_num].get()->read_enum(strings_, start, stop);
+              T result = (T)(current_inputs_[(IndexTypeOf<int64_t>)in_num].get()->read_enum(strings_, start, stop));
               if (stack_cannot_push()) {
                 current_error_ = util::ForthError::stack_overflow;
                 return;
@@ -3613,7 +3613,7 @@ namespace awkward {
               bytecodes_pointer_where()++;
               I stop = bytecode_get();
               bytecodes_pointer_where()++;
-              T result = current_inputs_[(IndexTypeOf<int64_t>)in_num].get()->read_enum(strings_, start, stop);
+              T result = (T)(current_inputs_[(IndexTypeOf<int64_t>)in_num].get()->read_enum(strings_, start, stop));
               if (result == -1) {
                 current_error_ = util::ForthError::enumeration_missing;
                 return;
@@ -3795,7 +3795,7 @@ namespace awkward {
                 return;
               }
               stack_push((T)string_num);
-              stack_push((T)strings_[string_num].size());
+              stack_push((T)strings_[(size_t)string_num].size());
               break;
             }
 
@@ -3821,7 +3821,7 @@ namespace awkward {
             }
 
             case CODE_PRINT_STACK: {
-              printf("<%ld> ", stack_depth_);
+              printf("<%lld> ", stack_depth_);
               for (int64_t i = 0;  i < stack_depth_;  i++) {
                 print_number(stack_buffer_[i]);
               }
@@ -4298,7 +4298,7 @@ namespace awkward {
   template <>
   void
   ForthMachineOf<int64_t, int32_t>::print_number(int64_t num) noexcept {
-    printf("%ld ", num);
+    printf("%lld ", num);
   }
 
   template class EXPORT_TEMPLATE_INST ForthMachineOf<int32_t, int32_t>;

--- a/src/libawkward/forth/ForthMachine.cpp
+++ b/src/libawkward/forth/ForthMachine.cpp
@@ -1253,7 +1253,7 @@ namespace awkward {
 
   template <typename T, typename I>
   void
-  ForthMachineOf<T, I>::maybe_throw(util::ForthError,
+  ForthMachineOf<T, I>::maybe_throw(util::ForthError /* err */,  // FIXME: this argument is not needed
                                     const std::set<util::ForthError>& ignore) const {
     if (ignore.count(current_error_) == 0) {
       switch (current_error_) {

--- a/src/libawkward/forth/ForthOutputBuffer.cpp
+++ b/src/libawkward/forth/ForthOutputBuffer.cpp
@@ -196,13 +196,13 @@ namespace awkward {
 
   template <typename OUT>
   void
-  ForthOutputBufferOf<OUT>::write_one_bool(bool value, bool byteswap) noexcept {
+  ForthOutputBufferOf<OUT>::write_one_bool(bool value, bool) noexcept {
     write_one(value);
   }
 
   template <typename OUT>
   void
-  ForthOutputBufferOf<OUT>::write_one_int8(int8_t value, bool byteswap) noexcept {
+  ForthOutputBufferOf<OUT>::write_one_int8(int8_t value, bool) noexcept {
     write_one(value);
   }
 
@@ -249,7 +249,7 @@ namespace awkward {
 
   template <typename OUT>
   void
-  ForthOutputBufferOf<OUT>::write_one_uint8(uint8_t value, bool byteswap) noexcept {
+  ForthOutputBufferOf<OUT>::write_one_uint8(uint8_t value, bool) noexcept {
     write_one(value);
   }
 
@@ -325,7 +325,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<OUT>::write_bool(int64_t num_items,
                                        bool* values,
-                                       bool byteswap) noexcept {
+                                       bool) noexcept {
     write_copy(num_items, values);
   }
 
@@ -333,7 +333,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<OUT>::write_int8(int64_t num_items,
                                        int8_t* values,
-                                       bool byteswap) noexcept {
+                                       bool) noexcept {
     write_copy(num_items, values);
   }
 
@@ -414,7 +414,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<OUT>::write_uint8(int64_t num_items,
                                         uint8_t* values,
-                                        bool byteswap) noexcept {
+                                        bool) noexcept {
     write_copy(num_items, values);
   }
 
@@ -516,7 +516,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<bool>::write_bool(int64_t num_items,
                                         bool* values,
-                                        bool byteswap) noexcept {
+                                        bool) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
     std::memcpy(&ptr_.get()[length_], values, sizeof(bool) * (size_t)num_items);
@@ -527,7 +527,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<int8_t>::write_int8(int64_t num_items,
                                           int8_t* values,
-                                          bool byteswap) noexcept {
+                                          bool) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
     std::memcpy(&ptr_.get()[length_], values, sizeof(int8_t) * (size_t)num_items);
@@ -590,7 +590,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<uint8_t>::write_uint8(int64_t num_items,
                                             uint8_t* values,
-                                            bool byteswap) noexcept {
+                                            bool) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
     std::memcpy(&ptr_.get()[length_], values, sizeof(uint8_t) * (size_t)num_items);

--- a/src/libawkward/forth/ForthOutputBuffer.cpp
+++ b/src/libawkward/forth/ForthOutputBuffer.cpp
@@ -196,13 +196,13 @@ namespace awkward {
 
   template <typename OUT>
   void
-  ForthOutputBufferOf<OUT>::write_one_bool(bool value, bool) noexcept {
+  ForthOutputBufferOf<OUT>::write_one_bool(bool value, bool /* byteswap */) noexcept {
     write_one(value);
   }
 
   template <typename OUT>
   void
-  ForthOutputBufferOf<OUT>::write_one_int8(int8_t value, bool) noexcept {
+  ForthOutputBufferOf<OUT>::write_one_int8(int8_t value, bool /* byteswap */) noexcept {
     write_one(value);
   }
 
@@ -249,7 +249,7 @@ namespace awkward {
 
   template <typename OUT>
   void
-  ForthOutputBufferOf<OUT>::write_one_uint8(uint8_t value, bool) noexcept {
+  ForthOutputBufferOf<OUT>::write_one_uint8(uint8_t value, bool /* byteswap */) noexcept {
     write_one(value);
   }
 
@@ -325,7 +325,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<OUT>::write_bool(int64_t num_items,
                                        bool* values,
-                                       bool) noexcept {
+                                       bool /* byteswap */) noexcept {
     write_copy(num_items, values);
   }
 
@@ -333,7 +333,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<OUT>::write_int8(int64_t num_items,
                                        int8_t* values,
-                                       bool) noexcept {
+                                       bool /* byteswap */) noexcept {
     write_copy(num_items, values);
   }
 
@@ -414,7 +414,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<OUT>::write_uint8(int64_t num_items,
                                         uint8_t* values,
-                                        bool) noexcept {
+                                        bool /* byteswap */) noexcept {
     write_copy(num_items, values);
   }
 
@@ -516,7 +516,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<bool>::write_bool(int64_t num_items,
                                         bool* values,
-                                        bool) noexcept {
+                                        bool /* byteswap */) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
     std::memcpy(&ptr_.get()[length_], values, sizeof(bool) * (size_t)num_items);
@@ -527,7 +527,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<int8_t>::write_int8(int64_t num_items,
                                           int8_t* values,
-                                          bool) noexcept {
+                                          bool /* byteswap */) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
     std::memcpy(&ptr_.get()[length_], values, sizeof(int8_t) * (size_t)num_items);
@@ -590,7 +590,7 @@ namespace awkward {
   void
   ForthOutputBufferOf<uint8_t>::write_uint8(int64_t num_items,
                                             uint8_t* values,
-                                            bool) noexcept {
+                                            bool /* byteswap */) noexcept {
     int64_t next = length_ + num_items;
     maybe_resize(next);
     std::memcpy(&ptr_.get()[length_], values, sizeof(uint8_t) * (size_t)num_items);

--- a/src/libawkward/forth/ForthOutputBuffer.cpp
+++ b/src/libawkward/forth/ForthOutputBuffer.cpp
@@ -125,7 +125,7 @@ namespace awkward {
   template <typename OUT>
   ForthOutputBufferOf<OUT>::ForthOutputBufferOf(int64_t initial, double resize)
     : ForthOutputBuffer(initial, resize)
-    , ptr_(new OUT[initial], util::array_deleter<OUT>()) { }
+    , ptr_(new OUT[(size_t)initial], util::array_deleter<OUT>()) { }
 
   template <typename OUT>
   const std::shared_ptr<void>
@@ -317,7 +317,7 @@ namespace awkward {
   ForthOutputBufferOf<OUT>::write_one_string(char* string_buffer, int64_t length) noexcept {
     int64_t next = length_ + length;
     maybe_resize(next);
-    std::memcpy(&ptr_.get()[length_], string_buffer, length);
+    std::memcpy(&ptr_.get()[length_], string_buffer, (size_t)length);
     length_ = next;
   }
 
@@ -713,9 +713,9 @@ namespace awkward {
     if (next > reserved_) {
       int64_t reservation = reserved_;
       while (next > reservation) {
-        reservation = (int64_t)std::ceil(reservation * resize_);
+        reservation = (int64_t)std::ceil((double)reservation * (double)resize_);
       }
-      std::shared_ptr<OUT> new_buffer = std::shared_ptr<OUT>(new OUT[reservation],
+      std::shared_ptr<OUT> new_buffer = std::shared_ptr<OUT>(new OUT[(size_t)reservation],
                                                              util::array_deleter<OUT>());
       std::memcpy(new_buffer.get(), ptr_.get(), sizeof(OUT) * (size_t)reserved_);
       ptr_ = new_buffer;

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -86,7 +86,7 @@ namespace awkward {
     }
 
     bool
-    String(const char* str, rj::SizeType length, bool) {
+    String(const char* str, rj::SizeType length, bool /* copy */) {
       moved_ = true;
       if (nan_string_ != nullptr  &&  strcmp(str, nan_string_) == 0) {
         builder_.real(std::numeric_limits<double>::quiet_NaN());
@@ -114,7 +114,7 @@ namespace awkward {
     }
 
     bool
-    EndArray(rj::SizeType) {
+    EndArray(rj::SizeType /* numfields */) {
       moved_ = true;
       builder_.endlist();
       return true;
@@ -128,14 +128,14 @@ namespace awkward {
     }
 
     bool
-    EndObject(rj::SizeType) {
+    EndObject(rj::SizeType /* numfields */) {
       moved_ = true;
       builder_.endrecord();
       return true;
     }
 
     bool
-    Key(const char* str, rj::SizeType, bool) {
+    Key(const char* str, rj::SizeType /* length */, bool /* copy */) {
       moved_ = true;
       builder_.field_check(str);
       return true;
@@ -823,7 +823,7 @@ namespace awkward {
     }
 
     bool
-    EndObject(rj::SizeType) {
+    EndObject(rj::SizeType /* numfields */) {
       moved_ = true;
       // std::cout << "endobject " << specializedjson_->debug() << std::endl;
       // std::cout << "  ignore state " << ignore_ << std::endl;
@@ -853,7 +853,7 @@ namespace awkward {
     }
 
     bool
-    Key(const char* str, rj::SizeType, bool) {
+    Key(const char* str, rj::SizeType /* length */, bool /* copy */) {
       moved_ = true;
       // std::cout << "key " << str << " " << specializedjson_->debug() << std::endl;
       // std::cout << "  ignore state " << ignore_ << std::endl;

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -161,7 +161,7 @@ namespace awkward {
       , readcount_(0)
       , count_(0)
       , eof_(false) {
-      buffer_ = new char[buffersize];
+      buffer_ = new char[(size_t)buffersize];
       read();
     }
 
@@ -178,7 +178,7 @@ namespace awkward {
       return c;
     }
     size_t Tell() const {
-      return count_ + static_cast<size_t>(current_ - buffer_);
+      return (size_t)count_ + static_cast<size_t>(current_ - buffer_);
     }
 
     std::string error_context() const {
@@ -197,10 +197,10 @@ namespace awkward {
         stop = bufferafter;
       }
 
-      std::string context = std::string(buffer_, (size_t)stop).substr(start);
-      int64_t arrow = current - start;
+      std::string context = std::string(buffer_, (size_t)stop).substr((size_t)start);
+      size_t arrow = (size_t)(current - start);
 
-      int64_t pos;
+      size_t pos;
 
       pos = 0;
       while ((size_t)(pos = context.find(9, pos)) != std::string::npos) {
@@ -560,7 +560,7 @@ namespace awkward {
           specializedjson_->write_int64(specializedjson_->argument1(), x);
           return true;
         case FillNumber:
-          specializedjson_->write_float64(specializedjson_->argument1(), x);
+          specializedjson_->write_float64(specializedjson_->argument1(), (double)x);
           return true;
         default:
           return schema_okay_ = false;
@@ -594,10 +594,10 @@ namespace awkward {
           specializedjson_->step_backward();
           return schema_okay_ = out;
         case FillInteger:
-          specializedjson_->write_int64(specializedjson_->argument1(), x);
+          specializedjson_->write_int64(specializedjson_->argument1(), (int64_t)x);
           return true;
         case FillNumber:
-          specializedjson_->write_float64(specializedjson_->argument1(), x);
+          specializedjson_->write_float64(specializedjson_->argument1(), (double)x);
           return true;
         default:
           return schema_okay_ = false;
@@ -977,7 +977,7 @@ namespace awkward {
         }
         output_names_.push_back(item[1].GetString());
         output_dtypes_.push_back(util::dtype::int8);
-        int64_t outi = buffers_uint8_.size();
+        int64_t outi = (int64_t)buffers_uint8_.size();
         output_which_.push_back(outi);
         buffers_uint8_.push_back(GrowableBuffer<uint8_t>(options));
         instructions_.push_back(FillByteMaskedArray);
@@ -999,10 +999,10 @@ namespace awkward {
         }
         output_names_.push_back(item[1].GetString());
         output_dtypes_.push_back(util::dtype::int64);
-        int64_t outi = buffers_int64_.size();
+        int64_t outi = (int64_t)buffers_int64_.size();
         output_which_.push_back(outi);
         buffers_int64_.push_back(GrowableBuffer<int64_t>(options));
-        int64_t counti = counters_.size();
+        int64_t counti = (int64_t)counters_.size();
         counters_.push_back(0);
         instructions_.push_back(FillIndexedOptionArray);
         instructions_.push_back(outi);
@@ -1023,7 +1023,7 @@ namespace awkward {
         }
         output_names_.push_back(item[1].GetString());
         output_dtypes_.push_back(util::dtype::uint8);
-        int64_t outi = buffers_uint8_.size();
+        int64_t outi = (int64_t)buffers_uint8_.size();
         output_which_.push_back(outi);
         buffers_uint8_.push_back(GrowableBuffer<uint8_t>(options));
         instructions_.push_back(FillBoolean);
@@ -1045,7 +1045,7 @@ namespace awkward {
         }
         output_names_.push_back(item[1].GetString());
         output_dtypes_.push_back(util::dtype::int64);
-        int64_t outi = buffers_int64_.size();
+        int64_t outi = (int64_t)buffers_int64_.size();
         output_which_.push_back(outi);
         buffers_int64_.push_back(GrowableBuffer<int64_t>(options));
         instructions_.push_back(FillInteger);
@@ -1067,7 +1067,7 @@ namespace awkward {
         }
         output_names_.push_back(item[1].GetString());
         output_dtypes_.push_back(util::dtype::float64);
-        int64_t outi = buffers_float64_.size();
+        int64_t outi = (int64_t)buffers_float64_.size();
         output_which_.push_back(outi);
         buffers_float64_.push_back(GrowableBuffer<double>(options));
         instructions_.push_back(FillNumber);
@@ -1089,10 +1089,10 @@ namespace awkward {
         }
         output_names_.push_back(item[1].GetString());
         output_dtypes_.push_back(util::dtype::int64);
-        int64_t offsetsi = buffers_int64_.size();
+        int64_t offsetsi = (int64_t)buffers_int64_.size();
         output_which_.push_back(offsetsi);
         buffers_int64_.push_back(GrowableBuffer<int64_t>(options));
-        buffers_int64_[offsetsi].append(0);
+        buffers_int64_[(size_t)offsetsi].append(0);
         if (std::string("uint8") != item[4].GetString()) {
           throw std::invalid_argument(
             "FillString argument 4 (dtype:str) must be 'uint8'" + FILENAME(__LINE__)
@@ -1100,7 +1100,7 @@ namespace awkward {
         }
         output_names_.push_back(item[3].GetString());
         output_dtypes_.push_back(util::dtype::uint8);
-        int64_t contenti = buffers_uint8_.size();
+        int64_t contenti = (int64_t)buffers_uint8_.size();
         output_which_.push_back(contenti);
         buffers_uint8_.push_back(GrowableBuffer<uint8_t>(options));
         instructions_.push_back(FillString);
@@ -1124,10 +1124,10 @@ namespace awkward {
         }
         output_names_.push_back(item[1].GetString());
         output_dtypes_.push_back(util::dtype::int64);
-        int64_t outi = buffers_int64_.size();
+        int64_t outi = (int64_t)buffers_int64_.size();
         output_which_.push_back(outi);
         buffers_int64_.push_back(GrowableBuffer<int64_t>(options));
-        int64_t start = strings.size();
+        int64_t start = (int64_t)strings.size();
         for (auto& x : item[3].GetArray()) {
           if (!x.IsString()) {
             throw std::invalid_argument(
@@ -1137,7 +1137,7 @@ namespace awkward {
           }
           strings.push_back(x.GetString());
         }
-        int64_t stop = strings.size();
+        int64_t stop = (int64_t)strings.size();
         if (std::string("FillEnumString") == item[0].GetString()) {
           instructions_.push_back(FillEnumString);
         }
@@ -1165,10 +1165,10 @@ namespace awkward {
         }
         output_names_.push_back(item[1].GetString());
         output_dtypes_.push_back(util::dtype::int64);
-        int64_t outi = buffers_int64_.size();
+        int64_t outi = (int64_t)buffers_int64_.size();
         output_which_.push_back(outi);
         buffers_int64_.push_back(GrowableBuffer<int64_t>(options));
-        buffers_int64_[outi].append(0);
+        buffers_int64_[(size_t)outi].append(0);
         instructions_.push_back(VarLengthList);
         instructions_.push_back(outi);
         instructions_.push_back(-1);
@@ -1207,7 +1207,7 @@ namespace awkward {
             "KeyTableItem arguments: key:str jump_to:int" + FILENAME(__LINE__)
           );
         }
-        int64_t stringi = strings.size();
+        int64_t stringi = (int64_t)strings.size();
         strings.push_back(item[1].GetString());
         instructions_.push_back(KeyTableItem);
         instructions_.push_back(stringi);
@@ -1225,7 +1225,7 @@ namespace awkward {
 
     string_offsets_.push_back(0);
     for (auto string : strings) {
-      string_offsets_.push_back(string_offsets_[string_offsets_.size() - 1] + string.length());
+      string_offsets_.push_back(string_offsets_[string_offsets_.size() - 1] + (int64_t)string.length());
       for (auto c : string) {
         characters_.push_back(c);
       }
@@ -1306,7 +1306,7 @@ namespace awkward {
   std::string
   FromJsonObjectSchema::debug() const noexcept {
     std::stringstream out;
-    out << "at " << current_instruction_ << " | " << instructions_[current_instruction_ * 4] << " stack";
+    out << "at " << current_instruction_ << " | " << instructions_[(size_t)current_instruction_ * 4] << " stack";
     for (int64_t i = 0;  (size_t)i < instruction_stack_.size();  i++) {
       if (i == current_stack_depth_) {
         out << " ;";

--- a/src/libawkward/io/json.cpp
+++ b/src/libawkward/io/json.cpp
@@ -86,7 +86,7 @@ namespace awkward {
     }
 
     bool
-    String(const char* str, rj::SizeType length, bool copy) {
+    String(const char* str, rj::SizeType length, bool) {
       moved_ = true;
       if (nan_string_ != nullptr  &&  strcmp(str, nan_string_) == 0) {
         builder_.real(std::numeric_limits<double>::quiet_NaN());
@@ -114,7 +114,7 @@ namespace awkward {
     }
 
     bool
-    EndArray(rj::SizeType numfields) {
+    EndArray(rj::SizeType) {
       moved_ = true;
       builder_.endlist();
       return true;
@@ -128,14 +128,14 @@ namespace awkward {
     }
 
     bool
-    EndObject(rj::SizeType numfields) {
+    EndObject(rj::SizeType) {
       moved_ = true;
       builder_.endrecord();
       return true;
     }
 
     bool
-    Key(const char* str, rj::SizeType length, bool copy) {
+    Key(const char* str, rj::SizeType, bool) {
       moved_ = true;
       builder_.field_check(str);
       return true;
@@ -200,10 +200,10 @@ namespace awkward {
       std::string context = std::string(buffer_, (size_t)stop).substr(start);
       int64_t arrow = current - start;
 
-      size_t pos;
+      int64_t pos;
 
       pos = 0;
-      while ((pos = context.find(9, pos)) != std::string::npos) {
+      while ((size_t)(pos = context.find(9, pos)) != std::string::npos) {
         context.replace(pos, 1, "\\t");
         pos++;
         if (pos < arrow) {
@@ -212,7 +212,7 @@ namespace awkward {
       }
 
       pos = 0;
-      while ((pos = context.find(10, pos)) != std::string::npos) {
+      while ((size_t)(pos = context.find(10, pos)) != std::string::npos) {
         context.replace(pos, 1, "\\n");
         pos++;
         if (pos < arrow) {
@@ -221,7 +221,7 @@ namespace awkward {
       }
 
       pos = 0;
-      while ((pos = context.find(13, pos)) != std::string::npos) {
+      while ((size_t)(pos = context.find(13, pos)) != std::string::npos) {
         context.replace(pos, 1, "\\r");
         pos++;
         if (pos < arrow) {
@@ -355,9 +355,9 @@ namespace awkward {
       , nan_string_(nan_string)
       , posinf_string_(posinf_string)
       , neginf_string_(neginf_string)
-      , ignore_(0)
       , moved_(false)
-      , schema_okay_(true) { }
+      , schema_okay_(true)
+      , ignore_(0) { }
 
     void
     reset_moved() {
@@ -823,7 +823,7 @@ namespace awkward {
     }
 
     bool
-    EndObject(rj::SizeType numfields) {
+    EndObject(rj::SizeType) {
       moved_ = true;
       // std::cout << "endobject " << specializedjson_->debug() << std::endl;
       // std::cout << "  ignore state " << ignore_ << std::endl;
@@ -853,7 +853,7 @@ namespace awkward {
     }
 
     bool
-    Key(const char* str, rj::SizeType length, bool copy) {
+    Key(const char* str, rj::SizeType, bool) {
       moved_ = true;
       // std::cout << "key " << str << " " << specializedjson_->debug() << std::endl;
       // std::cout << "  ignore state " << ignore_ << std::endl;
@@ -1307,13 +1307,13 @@ namespace awkward {
   FromJsonObjectSchema::debug() const noexcept {
     std::stringstream out;
     out << "at " << current_instruction_ << " | " << instructions_[current_instruction_ * 4] << " stack";
-    for (int64_t i = 0;  i < instruction_stack_.size();  i++) {
+    for (int64_t i = 0;  (size_t)i < instruction_stack_.size();  i++) {
       if (i == current_stack_depth_) {
         out << " ;";
       }
       out << " " << instruction_stack_.data()[i];
     }
-    if (current_stack_depth_ == instruction_stack_.size()) {
+    if ((size_t)current_stack_depth_ == instruction_stack_.size()) {
       out << " ;";
     }
     return out.str();

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -481,7 +481,7 @@ namespace awkward {
         try {
           out = (int64_t) std::stoi(key);
         }
-        catch (std::invalid_argument err) {
+        catch (std::invalid_argument const&) {
           throw std::invalid_argument(
             std::string("key ") + quote(key)
             + std::string(" does not exist (not in record)") + FILENAME(__LINE__));
@@ -520,7 +520,7 @@ namespace awkward {
       try {
         fieldindex(recordlookup, key, numfields);
       }
-      catch (std::invalid_argument err) {
+      catch (std::invalid_argument const&) {
         return false;
       }
       return true;

--- a/src/libawkward/util.cpp
+++ b/src/libawkward/util.cpp
@@ -481,7 +481,7 @@ namespace awkward {
         try {
           out = (int64_t) std::stoi(key);
         }
-        catch (std::invalid_argument const&) {
+        catch (std::invalid_argument const& /* err */) {
           throw std::invalid_argument(
             std::string("key ") + quote(key)
             + std::string(" does not exist (not in record)") + FILENAME(__LINE__));
@@ -520,7 +520,7 @@ namespace awkward {
       try {
         fieldindex(recordlookup, key, numfields);
       }
-      catch (std::invalid_argument const&) {
+      catch (std::invalid_argument const& /* err */) {
         return false;
       }
       return true;

--- a/src/python/forth.cpp
+++ b/src/python/forth.cpp
@@ -139,7 +139,7 @@ template <typename T, typename I>
 py::object machine_bytecodes_at_to_python_content(std::shared_ptr<ak::ForthMachineOf<T, I>> machine, int64_t index) {
   // Single-copy into shared-ptr for offsets and bytecodes
   const auto offsets = machine->bytecodes_offsets();
-  const auto length = offsets.size() - 1;
+  const auto length = (int64_t)offsets.size() - 1;
   const auto bytecodes_holder = std::make_shared<std::vector<I>>(std::move(machine->bytecodes()));
 
   // Build capsules which release their usage of the held memory on GC
@@ -200,7 +200,7 @@ make_ForthMachineOf(const py::handle& m, const std::string& name) {
             else if (self.get()->is_defined(key)) {
               const std::vector<std::string> dictionary = self.get()->dictionary();
               int64_t index = 0;
-              for (;  index < dictionary.size();  index++) {
+              for (;  (size_t)index < dictionary.size();  index++) {
                 if (dictionary[index] == key) {
                   break;
                 }

--- a/tests-cpp/test_1494-layout-builder.cpp
+++ b/tests-cpp/test_1494-layout-builder.cpp
@@ -1154,6 +1154,7 @@ void
 test_Regular_size0() {
   RegularBuilder<0, NumpyBuilder<double>> builder;
 
+  builder.begin_list();
   builder.end_list();
 
   builder.begin_list();

--- a/tests-cpp/test_1494-layout-builder.cpp
+++ b/tests-cpp/test_1494-layout-builder.cpp
@@ -1154,7 +1154,6 @@ void
 test_Regular_size0() {
   RegularBuilder<0, NumpyBuilder<double>> builder;
 
-  auto& subbuilder = builder.begin_list();
   builder.end_list();
 
   builder.begin_list();

--- a/tests-cpp/test_1542-growable-buffer.cpp
+++ b/tests-cpp/test_1542-growable-buffer.cpp
@@ -170,7 +170,6 @@ void test_extend() {
 }
 
 void test_append_and_get_ref() {
-  size_t data_size = 15;
   awkward::BuilderOptions options { 5, 1 };
 
   double data[15] = {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,


### PR DESCRIPTION
I haven't done anything about the linker warnings (the whole build process is changing in #1778), and I wasn't sure what to do about warnings against aliasing arrays in the ForthMachine. That's kinda how the whole thing works...

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-squash-compiler-warnings/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->