### PR TITLE
refactor: removed placeholder (-1) intended for Identifier from Lookup.

### DIFF
--- a/src/awkward/_lookup.py
+++ b/src/awkward/_lookup.py
@@ -75,17 +75,15 @@ class ContentLookup:
 
 
 class NumpyLookup(ContentLookup):
-    ARRAY = 1
+    ARRAY = 0
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(layout.contiguous().data)
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         assert fields == ()
         return ak.contents.NumpyArray(
             lookup.positions[pos + self.ARRAY], parameters=self.parameters
@@ -93,20 +91,18 @@ class NumpyLookup(ContentLookup):
 
 
 class RegularLookup(ContentLookup):
-    ZEROS_LENGTH = 1
-    CONTENT = 2
+    ZEROS_LENGTH = 0
+    CONTENT = 1
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(len(layout))
         positions.append(None)
         positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         content = self.contenttype.tolayout(
             lookup, lookup.positions[pos + self.CONTENT], fields
         )
@@ -119,14 +115,13 @@ class RegularLookup(ContentLookup):
 
 
 class ListLookup(ContentLookup):
-    STARTS = 1
-    STOPS = 2
-    CONTENT = 3
+    STARTS = 0
+    STOPS = 1
+    CONTENT = 2
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(layout.starts.data)
         positions.append(layout.stops.data)
         positions.append(None)
@@ -134,7 +129,6 @@ class ListLookup(ContentLookup):
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         starts = self.IndexOf(self.indextype)(lookup.positions[pos + self.STARTS])
         stops = self.IndexOf(self.indextype)(lookup.positions[pos + self.STOPS])
         content = self.contenttype.tolayout(
@@ -144,20 +138,18 @@ class ListLookup(ContentLookup):
 
 
 class IndexedLookup(ContentLookup):
-    INDEX = 1
-    CONTENT = 2
+    INDEX = 0
+    CONTENT = 1
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(layout.index.data)
         positions.append(None)
         positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
         content = self.contenttype.tolayout(
             lookup, lookup.positions[pos + self.CONTENT], fields
@@ -166,20 +158,18 @@ class IndexedLookup(ContentLookup):
 
 
 class IndexedOptionLookup(ContentLookup):
-    INDEX = 1
-    CONTENT = 2
+    INDEX = 0
+    CONTENT = 1
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(layout.index.data)
         positions.append(None)
         positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
         content = self.contenttype.tolayout(
             lookup, lookup.positions[pos + self.CONTENT], fields
@@ -190,20 +180,18 @@ class IndexedOptionLookup(ContentLookup):
 
 
 class ByteMaskedLookup(ContentLookup):
-    MASK = 1
-    CONTENT = 2
+    MASK = 0
+    CONTENT = 1
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(layout.mask.data)
         positions.append(None)
         positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         mask = self.IndexOf(self.masktype)(lookup.positions[pos + self.MASK])
         content = self.contenttype.tolayout(
             lookup, lookup.positions[pos + self.CONTENT], fields
@@ -214,14 +202,13 @@ class ByteMaskedLookup(ContentLookup):
 
 
 class BitMaskedLookup(ContentLookup):
-    LENGTH = 1
-    MASK = 2
-    CONTENT = 3
+    LENGTH = 0
+    MASK = 1
+    CONTENT = 2
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(len(layout))
         positions.append(layout.mask.data)
         positions.append(None)
@@ -229,7 +216,6 @@ class BitMaskedLookup(ContentLookup):
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         mask = self.IndexOf(self.masktype)(lookup.positions[pos + self.MASK])
         content = self.contenttype.tolayout(
             lookup, lookup.positions[pos + self.CONTENT], fields
@@ -245,18 +231,16 @@ class BitMaskedLookup(ContentLookup):
 
 
 class UnmaskedLookup(ContentLookup):
-    CONTENT = 1
+    CONTENT = 0
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(None)
         positions[pos + cls.CONTENT] = tolookup(layout.content, positions)
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         content = self.contenttype.tolayout(
             lookup, lookup.positions[pos + self.CONTENT], fields
         )
@@ -264,13 +248,12 @@ class UnmaskedLookup(ContentLookup):
 
 
 class RecordLookup(ContentLookup):
-    LENGTH = 1
-    CONTENTS = 2
+    LENGTH = 0
+    CONTENTS = 1
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(len(layout))
         positions.extend([None] * len(layout.contents))
         for i, content in enumerate(layout.contents):
@@ -278,7 +261,6 @@ class RecordLookup(ContentLookup):
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         if len(fields) > 0:
             index = self.fieldindex(fields[0])
             assert index is not None
@@ -302,14 +284,13 @@ class RecordLookup(ContentLookup):
 
 
 class UnionLookup(ContentLookup):
-    TAGS = 1
-    INDEX = 2
-    CONTENTS = 3
+    TAGS = 0
+    INDEX = 1
+    CONTENTS = 2
 
     @classmethod
     def tolookup(cls, layout, positions):
         pos = len(positions)
-        positions.append(-1)  # temporary: remove and decrement all CONSTANTS by 1
         positions.append(layout.tags.data)
         positions.append(layout.index.data)
         positions.extend([None] * len(layout.contents))
@@ -318,7 +299,6 @@ class UnionLookup(ContentLookup):
         return pos
 
     def tolayout(self, lookup, pos, fields):
-        assert lookup.positions[pos] == -1
         tags = self.IndexOf(self.tagstype)(lookup.positions[pos + self.TAGS])
         index = self.IndexOf(self.indextype)(lookup.positions[pos + self.INDEX])
         contents = []

--- a/src/awkward/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/cpp-headers/awkward/GrowableBuffer.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <numeric>
 #include <cmath>
+#include <complex>
 #include <iostream>
 #include <utility>
 #include <stdexcept>
@@ -136,6 +137,18 @@ namespace awkward {
     copy_as(TO_PRIMITIVE* to_ptr, size_t offset) {
       for (size_t i = 0; i < length_; i++) {
         to_ptr[offset++] = static_cast<TO_PRIMITIVE>(ptr_.get()[i]);
+      }
+      if (next_) {
+        next_->copy_as(to_ptr, offset);
+      }
+    }
+
+    template <>
+    void
+    copy_as(std::complex<double>* to_ptr, size_t offset) {
+      for (size_t i = 0; i < length_; i++) {
+        double val = static_cast<double>(ptr_.get()[i]);
+        to_ptr[offset++] = std::complex<double>(val);
       }
       if (next_) {
         next_->copy_as(to_ptr, offset);

--- a/src/awkward/cpp-headers/awkward/GrowableBuffer.h
+++ b/src/awkward/cpp-headers/awkward/GrowableBuffer.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include <numeric>
 #include <cmath>
-#include <complex>
 #include <iostream>
 #include <utility>
 #include <stdexcept>
@@ -137,18 +136,6 @@ namespace awkward {
     copy_as(TO_PRIMITIVE* to_ptr, size_t offset) {
       for (size_t i = 0; i < length_; i++) {
         to_ptr[offset++] = static_cast<TO_PRIMITIVE>(ptr_.get()[i]);
-      }
-      if (next_) {
-        next_->copy_as(to_ptr, offset);
-      }
-    }
-
-    template <>
-    void
-    copy_as(std::complex<double>* to_ptr, size_t offset) {
-      for (size_t i = 0; i < length_; i++) {
-        double val = static_cast<double>(ptr_.get()[i]);
-        to_ptr[offset++] = std::complex<double>(val);
       }
       if (next_) {
         next_->copy_as(to_ptr, offset);


### PR DESCRIPTION
This is a follow-up on #1845, which removed Identifers (known as Identities in v1). The `Lookup` arrays used by Awkward's Numba and RDataFrame integration had a placeholder for pointers to (lowered) Identifiers, which this PR removes.

It's a potentially delicate operation, since a misplaced item in a `Lookup` array would lead to a segfault or worse. That's why this is a separate PR, so that it's a clear step in the global history. However, this PR and the 22 files of tests that depend on it:

- tests/test_0118-numba-cpointers.py
- tests/test_0124-strings-in-numba.py
- tests/test_0127b-tomask-operation-numba.py
- tests/test_0290-bug-fixes-for-hats.py
- tests/test_0395-fix-numba-indexedarray.py
- tests/test_0397-arrays-as-constants-in-numba.py
- tests/test_0549-numba-array-asarray.py
- tests/test_0559-fix-booleans-in-numba.py
- tests/test_0572-numba-array-ndim.py
- tests/test_0903-ArrayView-expects-contiguous-NumpyArrays.py
- tests/test_1240-v2-implementation-of-numba-1.py
- tests/test_1300-awkward-to-cpp-converter-with-cling.py
- tests/test_1300b-same-for-numba.py
- tests/test_1374-to-rdataframe.py
- tests/test_1473-from-rdataframe.py
- tests/test_1477-generator-entry-type-as-rvec.py
- tests/test_1508-awkward-from-rdataframe.py
- tests/test_1613-generator-tolayout-records.py
- tests/test_1620-layout-builders.py
- tests/test_1625-multiple-columns-from-rdataframe.py
- tests/test_1781-rdataframe-snapshot.py
- tests/test_1829-to-from-rdataframe-bool.py

Don't seem to have any issues. The tests run both in series and in parallel, all tests and just these. (Toggling things like that change the memory layout.) I know that the tests check exact expected values from compiled Numba and Cling code, so it's pretty secure.

I'll ask @ianna to review this one because it affects code she's working on (both Numba _and_ RDataFrame).

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-removed-identifier-placeholder-from-lookups/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->