### PR TITLE
feat: more concise pretty-print.

### DIFF
--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -66,6 +66,29 @@ def get_field(data, field):
         return out
 
 
+def custom_str(current):
+    if (
+        ak.highlevel.Record in current.__class__.__bases__
+        and not type(current).__str__ is ak.highlevel.Record.__str__
+    ) or (
+        ak.highlevel.Array in current.__class__.__bases__
+        and not type(current).__str__ is ak.highlevel.Array.__str__
+    ):
+        return type(current).__str__(current)
+
+    elif (
+        ak.highlevel.Record in current.__class__.__bases__
+        and not type(current).__repr__ is ak.highlevel.Record.__repr__
+    ) or (
+        ak.highlevel.Array in current.__class__.__bases__
+        and not type(current).__repr__ is ak.highlevel.Array.__repr__
+    ):
+        return type(current).__repr__(current)
+
+    else:
+        return None
+
+
 def valuestr_horiz(data, limit_cols):
     original_limit_cols = limit_cols
 
@@ -89,12 +112,9 @@ def valuestr_horiz(data, limit_cols):
                     for_comma = 0 if which == 0 else 2
                     cols_taken, strs = valuestr_horiz(current, limit_cols - for_comma)
 
-                    if (
-                        ak.highlevel.Record in current.__class__.__bases__
-                        or ak.highlevel.Array in current.__class__.__bases__
-                        and not type(current).__repr__ is ak.highlevel.Array.__repr__
-                    ):
-                        strs = type(current).__repr__(current)
+                    custom = custom_str(current)
+                    if custom is not None:
+                        strs = custom
 
                     if limit_cols - (for_comma + cols_taken) >= 0:
                         if which != 0:
@@ -107,12 +127,9 @@ def valuestr_horiz(data, limit_cols):
                 else:
                     cols_taken, strs = valuestr_horiz(current, limit_cols - 2)
 
-                    if (
-                        ak.highlevel.Record in current.__class__.__bases__
-                        or ak.highlevel.Array in current.__class__.__bases__
-                        and not type(current).__repr__ is ak.highlevel.Array.__repr__
-                    ):
-                        strs = type(current).__repr__(current)
+                    custom = custom_str(current)
+                    if custom is not None:
+                        strs = custom
 
                     if limit_cols - (2 + cols_taken) >= 0:
                         back[:0] = strs

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -68,19 +68,19 @@ def get_field(data, field):
 
 def custom_str(current):
     if (
-        ak.highlevel.Record in current.__class__.__bases__
+        issubclass(type(current), ak.highlevel.Record)
         and not type(current).__str__ is ak.highlevel.Record.__str__
     ) or (
-        ak.highlevel.Array in current.__class__.__bases__
+        issubclass(type(current), ak.highlevel.Array)
         and not type(current).__str__ is ak.highlevel.Array.__str__
     ):
         return str(current)
 
     elif (
-        ak.highlevel.Record in current.__class__.__bases__
+        issubclass(type(current), ak.highlevel.Record)
         and not type(current).__repr__ is ak.highlevel.Record.__repr__
     ) or (
-        ak.highlevel.Array in current.__class__.__bases__
+        issubclass(type(current), ak.highlevel.Array)
         and not type(current).__repr__ is ak.highlevel.Array.__repr__
     ):
         return repr(current)

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -74,7 +74,7 @@ def custom_str(current):
         ak.highlevel.Array in current.__class__.__bases__
         and not type(current).__str__ is ak.highlevel.Array.__str__
     ):
-        return type(current).__str__(current)
+        return str(current)
 
     elif (
         ak.highlevel.Record in current.__class__.__bases__
@@ -83,7 +83,7 @@ def custom_str(current):
         ak.highlevel.Array in current.__class__.__bases__
         and not type(current).__repr__ is ak.highlevel.Array.__repr__
     ):
-        return type(current).__repr__(current)
+        return repr(current)
 
     else:
         return None

--- a/tests/test_0032-replace-dressedtype.py
+++ b/tests/test_0032-replace-dressedtype.py
@@ -63,15 +63,15 @@ def test_types_with_parameters():
 
 def test_dress():
     class Dummy(ak.highlevel.Array):
-        def __repr__(self):
-            return f"<Dummy {str(self)}>"
+        def __str__(self):
+            return f"<Dummy {super().__str__()}>"
 
     ns = {"Dummy": Dummy}
 
     x = ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
     x.parameters["__array__"] = "Dummy"
     a = ak.highlevel.Array(x, behavior=ns, check_valid=True)
-    assert repr(a) == "<Dummy [1.1, 2.2, 3.3, 4.4, 5.5]>"
+    assert str(a) == "<Dummy [1.1, 2.2, 3.3, 4.4, 5.5]>"
 
     x2 = ak.contents.ListOffsetArray(
         ak.index.Index64(np.array([0, 3, 3, 5], dtype=np.int64)),
@@ -85,9 +85,9 @@ def test_dress():
         repr(a2)
         == "<Array [<Dummy [1.1, 2.2, 3.3]>, <Dummy []>, <Dummy [4.4, 5.5]>] type='3 * ...'>"
     )
-    assert repr(a2[0]) == "<Dummy [1.1, 2.2, 3.3]>"
-    assert repr(a2[1]) == "<Dummy []>"
-    assert repr(a2[2]) == "<Dummy [4.4, 5.5]>"
+    assert str(a2[0]) == "<Dummy [1.1, 2.2, 3.3]>"
+    assert str(a2[1]) == "<Dummy []>"
+    assert str(a2[2]) == "<Dummy [4.4, 5.5]>"
 
 
 def test_record_name():

--- a/tests/test_0049-distinguish-record-and-recordarray-behaviors.py
+++ b/tests/test_0049-distinguish-record-and-recordarray-behaviors.py
@@ -7,7 +7,7 @@ import awkward as ak  # noqa: F401
 
 
 class Pointy(ak.highlevel.Record):
-    def __repr__(self):
+    def __str__(self):
         return "<{} {}>".format(self["x"], self["y"])
 
 
@@ -25,7 +25,7 @@ def test():
         behavior=behavior,
         check_valid=True,
     )
-    assert repr(array[0, 0]) == "<1 [1.1]>"
+    assert str(array[0, 0]) == "<1 [1.1]>"
     assert repr(array[0]) == "<Array [<1 [1.1]>, <2 [2, 0.2]>] type='2 * P'>"
     assert (
         repr(array)


### PR DESCRIPTION
This bothered me when I saw it, and just as I was scanning through issues to fix something, I remembered it.

An Awkward Array in Vector looks like this:

```python
>>> import awkward as ak, vector
>>> vector.awk({"x": [1, 2, 3], "y": [1.1, 2.2, 3.3]})
<VectorArray2D [<VectorRecord2D {x: 1, y: 1.1} type='Vector2D[x: int64, y: float64]'>, ..., <VectorRecord2D {x: 3, y: 3.3} type='Vector2D[x: int64, y: float64]'>] type='...'>
```

and that's way too verbose; the nested `<VectorRecord2D ...>` certainly wasn't intended.

An `ak.Array`'s `__repr__` doesn't loop over all the data in an array, calling the `__repr__` of each item, because we expect that an array is going to be large. Unlike NumPy, which nominally only contains numbers (disregarding `dtype="O"`), Awkward Arrays contain data that might be overridden as subclasses, and those subclasses might have a custom `__repr__` or `__str__`. If a subclass (in `ak.behaviors`) applies to some data in an array and that subclass has an overloaded string representation, we should print that string, rather than the ellipsis-collapsed thing we would ordinarily print.

Vectors and arrays of Vectors are overloaded subclasses, but they don't have any `__repr__` or `__str__` defined. So why do we see `<VectorRecord2D ...>` in the above?

**First mistake:** the code that checks for this case says

https://github.com/scikit-hep/awkward/blob/edc0d67f6fa51831299c7e7d10893003d8956bfa/src/awkward/_prettyprint.py#L92-L97

instead of

```python
    if (
        ak.highlevel.Record in current.__class__.__bases__
        and not type(current).__repr__ is ak.highlevel.Record.__repr__
    ) or (
        ak.highlevel.Array in current.__class__.__bases__
        and not type(current).__repr__ is ak.highlevel.Array.__repr__
    ):
        strs = type(current).__repr__(current)
```

The Vector is an `ak.Record`, so it always passes this check and its `strs` gets replaced with whatever `repr(current)` would be.

**Second mistake:** we should probably favor the `str`, rather than the `repr`, for strings that are going to be included inside of an array print-out. If someone does overload the `__repr__`, they'll likely want to overload it to look like an `ak.Array`/`ak.Record`'s `__repr__`, which is verbose, with type information, and that would get repeated for each item in the array. The `ak.Array`/`ak.Record`'s `__str__` is more concise, and if a developer overloads it similarly, the final result will look right. So I'll make it first check for an overloaded `__str__`, and failing that, then an overloaded `__repr__`.

In the end, an array of Vectors now looks like this:

```python
>>> import awkward as ak, vector
>>> vector.awk({"x": [1, 2, 3], "y": [1.1, 2.2, 3.3]})
<VectorArray2D [{x: 1, y: 1.1}, ..., {x: 3, ...}] type='3 * Vector2D[x: int...'>
```

Since the motivating case is Vector and @henryiii has criticized the use of "`if type(current).__repr__ is ak.highlevel.Record.__repr__`" in the past, I'll ask him to review this one. (Hence the detailed justification for why we need that idiom in the first place, not just the fix that leaves the idiom as-is.)

Oh, there's one more thing I think I can do:

* `type(current).__repr__(current)` → `repr(current)`.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-more-concise-prettyprint/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->