### PR TITLE
test: fastjet clang-format configuration [DO NOT MERGE]

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -189,4 +189,3 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
 ...
-

--- a/.clang-format
+++ b/.clang-format
@@ -1,23 +1,191 @@
 ---
 Language:        Cpp
-BasedOnStyle:  Google
-ColumnLimit:     80
-NamespaceIndentation: All
-SortIncludes:    false
-IndentWidth:     2
+# BasedOnStyle:  LLVM
 AccessModifierOffset: -2
-PenaltyBreakComment: 30
-PenaltyExcessCharacter: 100
 AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
-AllowShortLambdasOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterReturnType: All
-BinPackParameters: false
-AlwaysBreakTemplateDeclarations: Yes
-ReflowComments: false
-BinPackArguments: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...

--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ AlignArrayOfStructures: None
 AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None
-AlignConsecutiveDeclarations: None
+AlignConsecutiveDeclarations: true
 AlignEscapedNewlines: Right
 AlignOperands:   Align
 AlignTrailingComments: true
@@ -122,7 +122,7 @@ ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
+PenaltyBreakComment: 300000000
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000

--- a/.clang-format
+++ b/.clang-format
@@ -189,3 +189,4 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
 ...
+

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -7,369 +7,316 @@
 #include <string>
 #include <vector>
 
-#include "awkward/common.h"
-#include "awkward/builder/Builder.h"
 #include "awkward/BuilderOptions.h"
+#include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
-  class Builder;
-  using BuilderPtr = std::shared_ptr<Builder>;
+class Builder;
+using BuilderPtr = std::shared_ptr<Builder>;
 
-  /// @class ArrayBuilder
+/// @class ArrayBuilder
+///
+/// @brief User interface to the Builder system: the ArrayBuilder is a
+/// fixed reference while the Builder subclass instances change in
+/// response to accumulating data.
+class LIBAWKWARD_EXPORT_SYMBOL ArrayBuilder {
+public:
+  /// @brief Creates an ArrayBuilder from a full set of parameters.
   ///
-  /// @brief User interface to the Builder system: the ArrayBuilder is a
-  /// fixed reference while the Builder subclass instances change in
-  /// response to accumulating data.
-  class LIBAWKWARD_EXPORT_SYMBOL ArrayBuilder {
-  public:
-    /// @brief Creates an ArrayBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    ArrayBuilder(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  ArrayBuilder(const BuilderOptions &options);
 
-    /// @brief Copy the current snapshot into the BuffersContainer and
-    /// return a Form as a std::string (JSON).
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const;
+  /// @brief Copy the current snapshot into the BuffersContainer and
+  /// return a Form as a std::string (JSON).
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const;
 
-    /// @brief Current length of the accumulated array.
-    int64_t
-      length() const;
+  /// @brief Current length of the accumulated array.
+  int64_t length() const;
 
-    /// @brief Removes all accumulated data without resetting the type
-    /// knowledge.
-    void
-      clear();
+  /// @brief Removes all accumulated data without resetting the type
+  /// knowledge.
+  void clear();
 
-    /// @brief Adds a `null` value to the accumulated data.
-    void
-      null();
+  /// @brief Adds a `null` value to the accumulated data.
+  void null();
 
-    /// @brief Adds a boolean value `x` to the accumulated data.
-    void
-      boolean(bool x);
+  /// @brief Adds a boolean value `x` to the accumulated data.
+  void boolean(bool x);
 
-    /// @brief Adds an integer value `x` to the accumulated data.
-    void
-      integer(int64_t x);
+  /// @brief Adds an integer value `x` to the accumulated data.
+  void integer(int64_t x);
 
-    /// @brief Adds a real value `x` to the accumulated data.
-    void
-      real(double x);
+  /// @brief Adds a real value `x` to the accumulated data.
+  void real(double x);
 
-    /// @brief Adds a complex value `x` to the accumulated data.
-    void
-      complex(std::complex<double> x);
+  /// @brief Adds a complex value `x` to the accumulated data.
+  void complex(std::complex<double> x);
 
-    /// @brief Adds a datetime value `x` to the accumulated data.
-    void
-      datetime(int64_t x, const std::string& unit);
+  /// @brief Adds a datetime value `x` to the accumulated data.
+  void datetime(int64_t x, const std::string &unit);
 
-    /// @brief Adds a timedelta value `x` to the accumulated data.
-    void
-      timedelta(int64_t x, const std::string& unit);
+  /// @brief Adds a timedelta value `x` to the accumulated data.
+  void timedelta(int64_t x, const std::string &unit);
 
-    /// @brief Adds an unencoded, null-terminated bytestring value `x` to the
-    /// accumulated data.
-    void
-      bytestring(const char* x);
+  /// @brief Adds an unencoded, null-terminated bytestring value `x` to the
+  /// accumulated data.
+  void bytestring(const char *x);
 
-    /// @brief Adds an unencoded bytestring value `x` with a given `length`
-    /// to the accumulated data.
-    ///
-    /// The string does not need to be null-terminated.
-    void
-      bytestring(const char* x, int64_t length);
+  /// @brief Adds an unencoded bytestring value `x` with a given `length`
+  /// to the accumulated data.
+  ///
+  /// The string does not need to be null-terminated.
+  void bytestring(const char *x, int64_t length);
 
-    /// @brief Adds an unencoded bytestring `x` in STL format to the
-    /// accumulated data.
-    void
-      bytestring(const std::string& x);
+  /// @brief Adds an unencoded bytestring `x` in STL format to the
+  /// accumulated data.
+  void bytestring(const std::string &x);
 
-    /// @brief Adds a UTF-8 encoded, null-terminated bytestring value `x` to
-    /// the accumulated data.
-    void
-      string(const char* x);
+  /// @brief Adds a UTF-8 encoded, null-terminated bytestring value `x` to
+  /// the accumulated data.
+  void string(const char *x);
 
-    /// @brief Adds a UTF-8 encoded bytestring value `x` with a given `length`
-    /// to the accumulated data.
-    ///
-    /// The string does not need to be null-terminated.
-    void
-      string(const char* x, int64_t length);
+  /// @brief Adds a UTF-8 encoded bytestring value `x` with a given `length`
+  /// to the accumulated data.
+  ///
+  /// The string does not need to be null-terminated.
+  void string(const char *x, int64_t length);
 
-    /// @brief Adds a UTF-8 encoded bytestring `x` in STL format to the
-    /// accumulated data.
-    void
-      string(const std::string& x);
+  /// @brief Adds a UTF-8 encoded bytestring `x` in STL format to the
+  /// accumulated data.
+  void string(const std::string &x);
 
-    /// @brief Begins building a nested list.
-    void
-      beginlist();
+  /// @brief Begins building a nested list.
+  void beginlist();
 
-    /// @brief Ends a nested list.
-    void
-      endlist();
+  /// @brief Ends a nested list.
+  void endlist();
 
-    /// @brief Begins building a tuple with a fixed number of fields.
-    void
-      begintuple(int64_t numfields);
+  /// @brief Begins building a tuple with a fixed number of fields.
+  void begintuple(int64_t numfields);
 
-    /// @brief Sets the pointer to a given tuple field index; the next
-    /// command will fill that slot.
-    void
-      index(int64_t index);
+  /// @brief Sets the pointer to a given tuple field index; the next
+  /// command will fill that slot.
+  void index(int64_t index);
 
-    /// @brief Ends a tuple.
-    void
-      endtuple();
+  /// @brief Ends a tuple.
+  void endtuple();
 
-    /// @brief Begins building a record without a name.
-    ///
-    /// See #beginrecord_fast and #beginrecord_check.
-    void
-      beginrecord();
+  /// @brief Begins building a record without a name.
+  ///
+  /// See #beginrecord_fast and #beginrecord_check.
+  void beginrecord();
 
-    /// @brief Begins building a record with a name.
-    ///
-    /// @param name This name is used to distinguish
-    /// records of different types in heterogeneous data (to build a
-    /// union of record arrays, rather than a record array with union
-    /// fields and optional values) and it also sets the `"__record__"`
-    /// parameter to later add custom behaviors in Python.
-    ///
-    /// In the `_fast` version of this method, a string comparison is not
-    /// performed: the same pointer is assumed to have the same value each time
-    /// (safe for string literals).
-    ///
-    /// See #beginrecord and #beginrecord_check.
-    void
-      beginrecord_fast(const char* name);
+  /// @brief Begins building a record with a name.
+  ///
+  /// @param name This name is used to distinguish
+  /// records of different types in heterogeneous data (to build a
+  /// union of record arrays, rather than a record array with union
+  /// fields and optional values) and it also sets the `"__record__"`
+  /// parameter to later add custom behaviors in Python.
+  ///
+  /// In the `_fast` version of this method, a string comparison is not
+  /// performed: the same pointer is assumed to have the same value each time
+  /// (safe for string literals).
+  ///
+  /// See #beginrecord and #beginrecord_check.
+  void beginrecord_fast(const char *name);
 
-    /// @brief Begins building a record with a name.
-    ///
-    /// @param name This name is used to distinguish
-    /// records of different types in heterogeneous data (to build a
-    /// union of record arrays, rather than a record array with union
-    /// fields and optional values) and it also sets the `"__record__"`
-    /// parameter to later add custom behaviors in Python.
-    ///
-    /// In the `_check` version of this method, a string comparison is
-    /// performed every time it is called to verify that the `name` matches
-    /// a stored `name`.
-    ///
-    /// See #beginrecord and #beginrecord_fast.
-    void
-      beginrecord_check(const char* name);
+  /// @brief Begins building a record with a name.
+  ///
+  /// @param name This name is used to distinguish
+  /// records of different types in heterogeneous data (to build a
+  /// union of record arrays, rather than a record array with union
+  /// fields and optional values) and it also sets the `"__record__"`
+  /// parameter to later add custom behaviors in Python.
+  ///
+  /// In the `_check` version of this method, a string comparison is
+  /// performed every time it is called to verify that the `name` matches
+  /// a stored `name`.
+  ///
+  /// See #beginrecord and #beginrecord_fast.
+  void beginrecord_check(const char *name);
 
-    /// @brief Begins building a record with a name.
-    ///
-    /// @param name This name is used to distinguish
-    /// records of different types in heterogeneous data (to build a
-    /// union of record arrays, rather than a record array with union
-    /// fields and optional values) and it also sets the `"__record__"`
-    /// parameter to later add custom behaviors in Python.
-    ///
-    /// In the `_check` version of this method, a string comparison is
-    /// performed every time it is called to verify that the `name` matches
-    /// a stored `name`.
-    ///
-    /// See #beginrecord and #beginrecord_fast.
-    void
-      beginrecord_check(const std::string& name);
+  /// @brief Begins building a record with a name.
+  ///
+  /// @param name This name is used to distinguish
+  /// records of different types in heterogeneous data (to build a
+  /// union of record arrays, rather than a record array with union
+  /// fields and optional values) and it also sets the `"__record__"`
+  /// parameter to later add custom behaviors in Python.
+  ///
+  /// In the `_check` version of this method, a string comparison is
+  /// performed every time it is called to verify that the `name` matches
+  /// a stored `name`.
+  ///
+  /// See #beginrecord and #beginrecord_fast.
+  void beginrecord_check(const std::string &name);
 
-    /// @brief Sets the pointer to a given record field `key`; the next
-    /// command will fill that slot.
-    ///
-    /// In the `_fast` version of this method, a string comparison is not
-    /// performed: the same pointer is assumed to have the same value each time
-    /// (safe for string literals). See #field_check.
-    ///
-    /// Record keys are checked in round-robin order. The best performance
-    /// will be achieved by filling them in the same order for each record.
-    /// Lookup time for random order scales with the number of fields.
-    void
-      field_fast(const char* key);
+  /// @brief Sets the pointer to a given record field `key`; the next
+  /// command will fill that slot.
+  ///
+  /// In the `_fast` version of this method, a string comparison is not
+  /// performed: the same pointer is assumed to have the same value each time
+  /// (safe for string literals). See #field_check.
+  ///
+  /// Record keys are checked in round-robin order. The best performance
+  /// will be achieved by filling them in the same order for each record.
+  /// Lookup time for random order scales with the number of fields.
+  void field_fast(const char *key);
 
-    /// @brief Sets the pointer to a given record field `key`; the next
-    /// command will fill that slot.
-    ///
-    /// In the `_check` version of this method, a string comparison is
-    /// performed every time it is called to verify that the `key` matches
-    /// a stored `key`. See #field_fast.
-    ///
-    /// Record keys are checked in round-robin order. The best performance
-    /// will be achieved by filling them in the same order for each record.
-    /// Lookup time for random order scales with the number of fields.
-    void
-      field_check(const char* key);
+  /// @brief Sets the pointer to a given record field `key`; the next
+  /// command will fill that slot.
+  ///
+  /// In the `_check` version of this method, a string comparison is
+  /// performed every time it is called to verify that the `key` matches
+  /// a stored `key`. See #field_fast.
+  ///
+  /// Record keys are checked in round-robin order. The best performance
+  /// will be achieved by filling them in the same order for each record.
+  /// Lookup time for random order scales with the number of fields.
+  void field_check(const char *key);
 
-    /// @brief Sets the pointer to a given record field `key`; the next
-    /// command will fill that slot.
-    ///
-    /// In the `_check` version of this method, a string comparison is
-    /// performed every time it is called to verify that the `key` matches
-    /// a stored `key`. See #field_fast.
-    ///
-    /// Record keys are checked in round-robin order. The best performance
-    /// will be achieved by filling them in the same order for each record.
-    /// Lookup time for random order scales with the number of fields.
-    void
-      field_check(const std::string& key);
+  /// @brief Sets the pointer to a given record field `key`; the next
+  /// command will fill that slot.
+  ///
+  /// In the `_check` version of this method, a string comparison is
+  /// performed every time it is called to verify that the `key` matches
+  /// a stored `key`. See #field_fast.
+  ///
+  /// Record keys are checked in round-robin order. The best performance
+  /// will be achieved by filling them in the same order for each record.
+  /// Lookup time for random order scales with the number of fields.
+  void field_check(const std::string &key);
 
-    /// @brief Ends a record.
-    void
-      endrecord();
+  /// @brief Ends a record.
+  void endrecord();
 
-    // @brief Root node of the Builder tree.
-    const BuilderPtr builder() const { return builder_; }
+  // @brief Root node of the Builder tree.
+  const BuilderPtr builder() const { return builder_; }
 
-    void builder_update(BuilderPtr builder) { builder_ = builder; }
+  void builder_update(BuilderPtr builder) { builder_ = builder; }
 
-    /// @brief Internal function to replace the root node of the ArrayBuilder's
-    /// Builder tree with a new root.
-    void
-      maybeupdate(const BuilderPtr builder);
+  /// @brief Internal function to replace the root node of the ArrayBuilder's
+  /// Builder tree with a new root.
+  void maybeupdate(const BuilderPtr builder);
 
 private:
-    /// @brief Constant equal to `nullptr`.
-    static const char* no_encoding;
-    /// @brief Constant equal to `"utf-8"`.
-    static const char* utf8_encoding;
-    /// @brief Root node of the Builder tree.
-    BuilderPtr builder_;
-  };
-}
+  /// @brief Constant equal to `nullptr`.
+  static const char *no_encoding;
+  /// @brief Constant equal to `"utf-8"`.
+  static const char *utf8_encoding;
+  /// @brief Root node of the Builder tree.
+  BuilderPtr builder_;
+};
+} // namespace awkward
 
 extern "C" {
-  /// @brief C interface to {@link awkward::ArrayBuilder#length ArrayBuilder::length}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_length(void* arraybuilder,
-                                int64_t* result);
-  /// @brief C interface to {@link awkward::ArrayBuilder#clear ArrayBuilder::clear}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_clear(void* arraybuilder);
+/// @brief C interface to {@link awkward::ArrayBuilder#length ArrayBuilder::length}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_length(void *arraybuilder,
+                                                             int64_t *result);
+/// @brief C interface to {@link awkward::ArrayBuilder#clear ArrayBuilder::clear}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_clear(void *arraybuilder);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#null ArrayBuilder::null}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_null(void* arraybuilder);
+/// @brief C interface to {@link awkward::ArrayBuilder#null ArrayBuilder::null}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_null(void *arraybuilder);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#boolean ArrayBuilder::boolean}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_boolean(void* arraybuilder,
-                                 bool x);
+/// @brief C interface to {@link awkward::ArrayBuilder#boolean ArrayBuilder::boolean}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_boolean(void *arraybuilder, bool x);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#integer ArrayBuilder::integer}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_integer(void* arraybuilder,
-                                 int64_t x);
+/// @brief C interface to {@link awkward::ArrayBuilder#integer ArrayBuilder::integer}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_integer(void *arraybuilder, int64_t x);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#real ArrayBuilder::real}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_real(void* arraybuilder,
-                              double x);
+/// @brief C interface to {@link awkward::ArrayBuilder#real ArrayBuilder::real}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_real(void  *arraybuilder,
+                                                           double x);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#complex ArrayBuilder::complex}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_complex(void* arraybuilder,
-                                 double real,
-                                 double imag);
+/// @brief C interface to {@link awkward::ArrayBuilder#complex ArrayBuilder::complex}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_complex(void *arraybuilder, double real, double imag);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#datetime ArrayBuilder::datetime}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_datetime(void* arraybuilder,
-                                  int64_t x,
-                                  const char* unit);
+/// @brief C interface to {@link awkward::ArrayBuilder#datetime ArrayBuilder::datetime}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_datetime(void *arraybuilder, int64_t x, const char *unit);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#timedelta ArrayBuilder::timedelta}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_timedelta(void* arraybuilder,
-                                   int64_t x,
-                                   const char* unit);
+/// @brief C interface to {@link awkward::ArrayBuilder#timedelta ArrayBuilder::timedelta}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_timedelta(void *arraybuilder, int64_t x, const char *unit);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_bytestring(void* arraybuilder,
-                                    const char* x);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_bytestring(void *arraybuilder, const char *x);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
-                                           const char* x,
-                                           int64_t length);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_bytestring_length(
+    void *arraybuilder, const char *x, int64_t length);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_string(void* arraybuilder,
-                                const char* x);
+/// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_string(void *arraybuilder,
+                                                             const char *x);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_string_length(void* arraybuilder,
-                                       const char* x,
-                                       int64_t length);
+/// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_string_length(
+    void *arraybuilder, const char *x, int64_t length);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#beginlist ArrayBuilder::beginlist}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_beginlist(void* arraybuilder);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#beginlist ArrayBuilder::beginlist}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_beginlist(void *arraybuilder);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#endlist ArrayBuilder::endlist}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_endlist(void* arraybuilder);
+/// @brief C interface to {@link awkward::ArrayBuilder#endlist ArrayBuilder::endlist}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_endlist(void *arraybuilder);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#begintuple ArrayBuilder::begintuple}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_begintuple(void* arraybuilder,
-                                    int64_t numfields);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#begintuple ArrayBuilder::begintuple}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_begintuple(void *arraybuilder, int64_t numfields);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#index ArrayBuilder::index}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_index(void* arraybuilder,
-                               int64_t index);
+/// @brief C interface to {@link awkward::ArrayBuilder#index ArrayBuilder::index}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_index(void *arraybuilder,
+                                                            int64_t index);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#endtuple ArrayBuilder::endtuple}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_endtuple(void* arraybuilder);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#endtuple ArrayBuilder::endtuple}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_endtuple(void *arraybuilder);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#beginrecord ArrayBuilder::beginrecord}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_beginrecord(void* arraybuilder);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#beginrecord ArrayBuilder::beginrecord}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_beginrecord(void *arraybuilder);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#beginrecord_fast ArrayBuilder::beginrecord_fast}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
-                                          const char* name);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#beginrecord_fast ArrayBuilder::beginrecord_fast}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_beginrecord_fast(void *arraybuilder, const char *name);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#beginrecord_check ArrayBuilder::beginrecord_check}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
-                                           const char* name);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#beginrecord_check ArrayBuilder::beginrecord_check}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_beginrecord_check(void *arraybuilder, const char *name);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#field_fast ArrayBuilder::field_fast}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_field_fast(void* arraybuilder,
-                                    const char* key);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#field_fast ArrayBuilder::field_fast}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_field_fast(void *arraybuilder, const char *key);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#field_check ArrayBuilder::field_check}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_field_check(void* arraybuilder,
-                                     const char* key);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#field_check ArrayBuilder::field_check}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_field_check(void *arraybuilder, const char *key);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#endrecord ArrayBuilder::endrecord}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_endrecord(void* arraybuilder);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#endrecord ArrayBuilder::endrecord}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_endrecord(void *arraybuilder);
 }
 
 #endif // AWKWARD_ARRAYBUILDER_H_

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -1,5 +1,4 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_ARRAYBUILDER_H_
 #define AWKWARD_ARRAYBUILDER_H_
@@ -8,329 +7,369 @@
 #include <string>
 #include <vector>
 
-#include "awkward/BuilderOptions.h"
-#include "awkward/builder/Builder.h"
 #include "awkward/common.h"
+#include "awkward/builder/Builder.h"
+#include "awkward/BuilderOptions.h"
 
 namespace awkward {
-class Builder;
-using BuilderPtr = std::shared_ptr<Builder>;
+  class Builder;
+  using BuilderPtr = std::shared_ptr<Builder>;
 
-/// @class ArrayBuilder
-///
-/// @brief User interface to the Builder system: the ArrayBuilder is a
-/// fixed reference while the Builder subclass instances change in
-/// response to accumulating data.
-class LIBAWKWARD_EXPORT_SYMBOL ArrayBuilder {
-public:
-  /// @brief Creates an ArrayBuilder from a full set of parameters.
+  /// @class ArrayBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  ArrayBuilder(const BuilderOptions &options);
+  /// @brief User interface to the Builder system: the ArrayBuilder is a
+  /// fixed reference while the Builder subclass instances change in
+  /// response to accumulating data.
+  class LIBAWKWARD_EXPORT_SYMBOL ArrayBuilder {
+  public:
+    /// @brief Creates an ArrayBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    ArrayBuilder(const BuilderOptions& options);
 
-  /// @brief Copy the current snapshot into the BuffersContainer and
-  /// return a Form as a std::string (JSON).
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const;
+    /// @brief Copy the current snapshot into the BuffersContainer and
+    /// return a Form as a std::string (JSON).
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const;
 
-  /// @brief Current length of the accumulated array.
-  int64_t length() const;
+    /// @brief Current length of the accumulated array.
+    int64_t
+      length() const;
 
-  /// @brief Removes all accumulated data without resetting the type
-  /// knowledge.
-  void clear();
+    /// @brief Removes all accumulated data without resetting the type
+    /// knowledge.
+    void
+      clear();
 
-  /// @brief Adds a `null` value to the accumulated data.
-  void null();
+    /// @brief Adds a `null` value to the accumulated data.
+    void
+      null();
 
-  /// @brief Adds a boolean value `x` to the accumulated data.
-  void boolean(bool x);
+    /// @brief Adds a boolean value `x` to the accumulated data.
+    void
+      boolean(bool x);
 
-  /// @brief Adds an integer value `x` to the accumulated data.
-  void integer(int64_t x);
+    /// @brief Adds an integer value `x` to the accumulated data.
+    void
+      integer(int64_t x);
 
-  /// @brief Adds a real value `x` to the accumulated data.
-  void real(double x);
+    /// @brief Adds a real value `x` to the accumulated data.
+    void
+      real(double x);
 
-  /// @brief Adds a complex value `x` to the accumulated data.
-  void complex(std::complex<double> x);
+    /// @brief Adds a complex value `x` to the accumulated data.
+    void
+      complex(std::complex<double> x);
 
-  /// @brief Adds a datetime value `x` to the accumulated data.
-  void datetime(int64_t x, const std::string &unit);
+    /// @brief Adds a datetime value `x` to the accumulated data.
+    void
+      datetime(int64_t x, const std::string& unit);
 
-  /// @brief Adds a timedelta value `x` to the accumulated data.
-  void timedelta(int64_t x, const std::string &unit);
+    /// @brief Adds a timedelta value `x` to the accumulated data.
+    void
+      timedelta(int64_t x, const std::string& unit);
 
-  /// @brief Adds an unencoded, null-terminated bytestring value `x` to the
-  /// accumulated data.
-  void bytestring(const char *x);
+    /// @brief Adds an unencoded, null-terminated bytestring value `x` to the
+    /// accumulated data.
+    void
+      bytestring(const char* x);
 
-  /// @brief Adds an unencoded bytestring value `x` with a given `length`
-  /// to the accumulated data.
-  ///
-  /// The string does not need to be null-terminated.
-  void bytestring(const char *x, int64_t length);
+    /// @brief Adds an unencoded bytestring value `x` with a given `length`
+    /// to the accumulated data.
+    ///
+    /// The string does not need to be null-terminated.
+    void
+      bytestring(const char* x, int64_t length);
 
-  /// @brief Adds an unencoded bytestring `x` in STL format to the
-  /// accumulated data.
-  void bytestring(const std::string &x);
+    /// @brief Adds an unencoded bytestring `x` in STL format to the
+    /// accumulated data.
+    void
+      bytestring(const std::string& x);
 
-  /// @brief Adds a UTF-8 encoded, null-terminated bytestring value `x` to
-  /// the accumulated data.
-  void string(const char *x);
+    /// @brief Adds a UTF-8 encoded, null-terminated bytestring value `x` to
+    /// the accumulated data.
+    void
+      string(const char* x);
 
-  /// @brief Adds a UTF-8 encoded bytestring value `x` with a given `length`
-  /// to the accumulated data.
-  ///
-  /// The string does not need to be null-terminated.
-  void string(const char *x, int64_t length);
+    /// @brief Adds a UTF-8 encoded bytestring value `x` with a given `length`
+    /// to the accumulated data.
+    ///
+    /// The string does not need to be null-terminated.
+    void
+      string(const char* x, int64_t length);
 
-  /// @brief Adds a UTF-8 encoded bytestring `x` in STL format to the
-  /// accumulated data.
-  void string(const std::string &x);
+    /// @brief Adds a UTF-8 encoded bytestring `x` in STL format to the
+    /// accumulated data.
+    void
+      string(const std::string& x);
 
-  /// @brief Begins building a nested list.
-  void beginlist();
+    /// @brief Begins building a nested list.
+    void
+      beginlist();
 
-  /// @brief Ends a nested list.
-  void endlist();
+    /// @brief Ends a nested list.
+    void
+      endlist();
 
-  /// @brief Begins building a tuple with a fixed number of fields.
-  void begintuple(int64_t numfields);
+    /// @brief Begins building a tuple with a fixed number of fields.
+    void
+      begintuple(int64_t numfields);
 
-  /// @brief Sets the pointer to a given tuple field index; the next
-  /// command will fill that slot.
-  void index(int64_t index);
+    /// @brief Sets the pointer to a given tuple field index; the next
+    /// command will fill that slot.
+    void
+      index(int64_t index);
 
-  /// @brief Ends a tuple.
-  void endtuple();
+    /// @brief Ends a tuple.
+    void
+      endtuple();
 
-  /// @brief Begins building a record without a name.
-  ///
-  /// See #beginrecord_fast and #beginrecord_check.
-  void beginrecord();
+    /// @brief Begins building a record without a name.
+    ///
+    /// See #beginrecord_fast and #beginrecord_check.
+    void
+      beginrecord();
 
-  /// @brief Begins building a record with a name.
-  ///
-  /// @param name This name is used to distinguish
-  /// records of different types in heterogeneous data (to build a
-  /// union of record arrays, rather than a record array with union
-  /// fields and optional values) and it also sets the `"__record__"`
-  /// parameter to later add custom behaviors in Python.
-  ///
-  /// In the `_fast` version of this method, a string comparison is not
-  /// performed: the same pointer is assumed to have the same value each time
-  /// (safe for string literals).
-  ///
-  /// See #beginrecord and #beginrecord_check.
-  void beginrecord_fast(const char *name);
+    /// @brief Begins building a record with a name.
+    ///
+    /// @param name This name is used to distinguish
+    /// records of different types in heterogeneous data (to build a
+    /// union of record arrays, rather than a record array with union
+    /// fields and optional values) and it also sets the `"__record__"`
+    /// parameter to later add custom behaviors in Python.
+    ///
+    /// In the `_fast` version of this method, a string comparison is not
+    /// performed: the same pointer is assumed to have the same value each time
+    /// (safe for string literals).
+    ///
+    /// See #beginrecord and #beginrecord_check.
+    void
+      beginrecord_fast(const char* name);
 
-  /// @brief Begins building a record with a name.
-  ///
-  /// @param name This name is used to distinguish
-  /// records of different types in heterogeneous data (to build a
-  /// union of record arrays, rather than a record array with union
-  /// fields and optional values) and it also sets the `"__record__"`
-  /// parameter to later add custom behaviors in Python.
-  ///
-  /// In the `_check` version of this method, a string comparison is
-  /// performed every time it is called to verify that the `name` matches
-  /// a stored `name`.
-  ///
-  /// See #beginrecord and #beginrecord_fast.
-  void beginrecord_check(const char *name);
+    /// @brief Begins building a record with a name.
+    ///
+    /// @param name This name is used to distinguish
+    /// records of different types in heterogeneous data (to build a
+    /// union of record arrays, rather than a record array with union
+    /// fields and optional values) and it also sets the `"__record__"`
+    /// parameter to later add custom behaviors in Python.
+    ///
+    /// In the `_check` version of this method, a string comparison is
+    /// performed every time it is called to verify that the `name` matches
+    /// a stored `name`.
+    ///
+    /// See #beginrecord and #beginrecord_fast.
+    void
+      beginrecord_check(const char* name);
 
-  /// @brief Begins building a record with a name.
-  ///
-  /// @param name This name is used to distinguish
-  /// records of different types in heterogeneous data (to build a
-  /// union of record arrays, rather than a record array with union
-  /// fields and optional values) and it also sets the `"__record__"`
-  /// parameter to later add custom behaviors in Python.
-  ///
-  /// In the `_check` version of this method, a string comparison is
-  /// performed every time it is called to verify that the `name` matches
-  /// a stored `name`.
-  ///
-  /// See #beginrecord and #beginrecord_fast.
-  void beginrecord_check(const std::string &name);
+    /// @brief Begins building a record with a name.
+    ///
+    /// @param name This name is used to distinguish
+    /// records of different types in heterogeneous data (to build a
+    /// union of record arrays, rather than a record array with union
+    /// fields and optional values) and it also sets the `"__record__"`
+    /// parameter to later add custom behaviors in Python.
+    ///
+    /// In the `_check` version of this method, a string comparison is
+    /// performed every time it is called to verify that the `name` matches
+    /// a stored `name`.
+    ///
+    /// See #beginrecord and #beginrecord_fast.
+    void
+      beginrecord_check(const std::string& name);
 
-  /// @brief Sets the pointer to a given record field `key`; the next
-  /// command will fill that slot.
-  ///
-  /// In the `_fast` version of this method, a string comparison is not
-  /// performed: the same pointer is assumed to have the same value each time
-  /// (safe for string literals). See #field_check.
-  ///
-  /// Record keys are checked in round-robin order. The best performance
-  /// will be achieved by filling them in the same order for each record.
-  /// Lookup time for random order scales with the number of fields.
-  void field_fast(const char *key);
+    /// @brief Sets the pointer to a given record field `key`; the next
+    /// command will fill that slot.
+    ///
+    /// In the `_fast` version of this method, a string comparison is not
+    /// performed: the same pointer is assumed to have the same value each time
+    /// (safe for string literals). See #field_check.
+    ///
+    /// Record keys are checked in round-robin order. The best performance
+    /// will be achieved by filling them in the same order for each record.
+    /// Lookup time for random order scales with the number of fields.
+    void
+      field_fast(const char* key);
 
-  /// @brief Sets the pointer to a given record field `key`; the next
-  /// command will fill that slot.
-  ///
-  /// In the `_check` version of this method, a string comparison is
-  /// performed every time it is called to verify that the `key` matches
-  /// a stored `key`. See #field_fast.
-  ///
-  /// Record keys are checked in round-robin order. The best performance
-  /// will be achieved by filling them in the same order for each record.
-  /// Lookup time for random order scales with the number of fields.
-  void field_check(const char *key);
+    /// @brief Sets the pointer to a given record field `key`; the next
+    /// command will fill that slot.
+    ///
+    /// In the `_check` version of this method, a string comparison is
+    /// performed every time it is called to verify that the `key` matches
+    /// a stored `key`. See #field_fast.
+    ///
+    /// Record keys are checked in round-robin order. The best performance
+    /// will be achieved by filling them in the same order for each record.
+    /// Lookup time for random order scales with the number of fields.
+    void
+      field_check(const char* key);
 
-  /// @brief Sets the pointer to a given record field `key`; the next
-  /// command will fill that slot.
-  ///
-  /// In the `_check` version of this method, a string comparison is
-  /// performed every time it is called to verify that the `key` matches
-  /// a stored `key`. See #field_fast.
-  ///
-  /// Record keys are checked in round-robin order. The best performance
-  /// will be achieved by filling them in the same order for each record.
-  /// Lookup time for random order scales with the number of fields.
-  void field_check(const std::string &key);
+    /// @brief Sets the pointer to a given record field `key`; the next
+    /// command will fill that slot.
+    ///
+    /// In the `_check` version of this method, a string comparison is
+    /// performed every time it is called to verify that the `key` matches
+    /// a stored `key`. See #field_fast.
+    ///
+    /// Record keys are checked in round-robin order. The best performance
+    /// will be achieved by filling them in the same order for each record.
+    /// Lookup time for random order scales with the number of fields.
+    void
+      field_check(const std::string& key);
 
-  /// @brief Ends a record.
-  void endrecord();
+    /// @brief Ends a record.
+    void
+      endrecord();
 
-  // @brief Root node of the Builder tree.
-  const BuilderPtr builder() const { return builder_; }
+    // @brief Root node of the Builder tree.
+    const BuilderPtr builder() const { return builder_; }
 
-  void builder_update(BuilderPtr builder) { builder_ = builder; }
+    void builder_update(BuilderPtr builder) { builder_ = builder; }
 
-  /// @brief Internal function to replace the root node of the ArrayBuilder's
-  /// Builder tree with a new root.
-  void maybeupdate(const BuilderPtr builder);
+    /// @brief Internal function to replace the root node of the ArrayBuilder's
+    /// Builder tree with a new root.
+    void
+      maybeupdate(const BuilderPtr builder);
 
 private:
-  /// @brief Constant equal to `nullptr`.
-  static const char *no_encoding;
-  /// @brief Constant equal to `"utf-8"`.
-  static const char *utf8_encoding;
-  /// @brief Root node of the Builder tree.
-  BuilderPtr builder_;
-};
-} // namespace awkward
+    /// @brief Constant equal to `nullptr`.
+    static const char* no_encoding;
+    /// @brief Constant equal to `"utf-8"`.
+    static const char* utf8_encoding;
+    /// @brief Root node of the Builder tree.
+    BuilderPtr builder_;
+  };
+}
 
 extern "C" {
-/// @brief C interface to {@link awkward::ArrayBuilder#length
-/// ArrayBuilder::length}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_length(void *arraybuilder,
-                                                             int64_t *result);
-/// @brief C interface to {@link awkward::ArrayBuilder#clear
-/// ArrayBuilder::clear}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_clear(void *arraybuilder);
+  /// @brief C interface to {@link awkward::ArrayBuilder#length ArrayBuilder::length}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_length(void* arraybuilder,
+                                int64_t* result);
+  /// @brief C interface to {@link awkward::ArrayBuilder#clear ArrayBuilder::clear}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_clear(void* arraybuilder);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#null ArrayBuilder::null}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_null(void *arraybuilder);
+  /// @brief C interface to {@link awkward::ArrayBuilder#null ArrayBuilder::null}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_null(void* arraybuilder);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#boolean
-/// ArrayBuilder::boolean}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_boolean(void *arraybuilder, bool x);
+  /// @brief C interface to {@link awkward::ArrayBuilder#boolean ArrayBuilder::boolean}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_boolean(void* arraybuilder,
+                                 bool x);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#integer
-/// ArrayBuilder::integer}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_integer(void *arraybuilder, int64_t x);
+  /// @brief C interface to {@link awkward::ArrayBuilder#integer ArrayBuilder::integer}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_integer(void* arraybuilder,
+                                 int64_t x);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#real ArrayBuilder::real}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_real(void *arraybuilder,
-                                                           double x);
+  /// @brief C interface to {@link awkward::ArrayBuilder#real ArrayBuilder::real}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_real(void* arraybuilder,
+                              double x);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#complex
-/// ArrayBuilder::complex}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_complex(void *arraybuilder, double real, double imag);
+  /// @brief C interface to {@link awkward::ArrayBuilder#complex ArrayBuilder::complex}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_complex(void* arraybuilder,
+                                 double real,
+                                 double imag);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#datetime
-/// ArrayBuilder::datetime}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_datetime(void *arraybuilder, int64_t x, const char *unit);
+  /// @brief C interface to {@link awkward::ArrayBuilder#datetime ArrayBuilder::datetime}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_datetime(void* arraybuilder,
+                                  int64_t x,
+                                  const char* unit);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#timedelta
-/// ArrayBuilder::timedelta}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_timedelta(void *arraybuilder, int64_t x, const char *unit);
+  /// @brief C interface to {@link awkward::ArrayBuilder#timedelta ArrayBuilder::timedelta}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_timedelta(void* arraybuilder,
+                                   int64_t x,
+                                   const char* unit);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_bytestring(void *arraybuilder, const char *x);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_bytestring(void* arraybuilder,
+                                    const char* x);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_bytestring_length(
-    void *arraybuilder, const char *x, int64_t length);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
+                                           const char* x,
+                                           int64_t length);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#string
-/// ArrayBuilder::string}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_string(void *arraybuilder,
-                                                             const char *x);
+  /// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_string(void* arraybuilder,
+                                const char* x);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#string
-/// ArrayBuilder::string}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_string_length(
-    void *arraybuilder, const char *x, int64_t length);
+  /// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_string_length(void* arraybuilder,
+                                       const char* x,
+                                       int64_t length);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#beginlist ArrayBuilder::beginlist}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_beginlist(void *arraybuilder);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#beginlist ArrayBuilder::beginlist}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_beginlist(void* arraybuilder);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#endlist
-/// ArrayBuilder::endlist}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_endlist(void *arraybuilder);
+  /// @brief C interface to {@link awkward::ArrayBuilder#endlist ArrayBuilder::endlist}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_endlist(void* arraybuilder);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#begintuple ArrayBuilder::begintuple}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_begintuple(void *arraybuilder, int64_t numfields);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#begintuple ArrayBuilder::begintuple}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_begintuple(void* arraybuilder,
+                                    int64_t numfields);
 
-/// @brief C interface to {@link awkward::ArrayBuilder#index
-/// ArrayBuilder::index}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_index(void *arraybuilder,
-                                                            int64_t index);
+  /// @brief C interface to {@link awkward::ArrayBuilder#index ArrayBuilder::index}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_index(void* arraybuilder,
+                               int64_t index);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#endtuple ArrayBuilder::endtuple}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_endtuple(void *arraybuilder);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#endtuple ArrayBuilder::endtuple}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_endtuple(void* arraybuilder);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#beginrecord ArrayBuilder::beginrecord}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_beginrecord(void *arraybuilder);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#beginrecord ArrayBuilder::beginrecord}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_beginrecord(void* arraybuilder);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#beginrecord_fast
-/// ArrayBuilder::beginrecord_fast}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_beginrecord_fast(void *arraybuilder, const char *name);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#beginrecord_fast ArrayBuilder::beginrecord_fast}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
+                                          const char* name);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#beginrecord_check
-/// ArrayBuilder::beginrecord_check}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_beginrecord_check(void *arraybuilder, const char *name);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#beginrecord_check ArrayBuilder::beginrecord_check}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
+                                           const char* name);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#field_fast ArrayBuilder::field_fast}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_field_fast(void *arraybuilder, const char *key);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#field_fast ArrayBuilder::field_fast}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_field_fast(void* arraybuilder,
+                                    const char* key);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#field_check ArrayBuilder::field_check}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_field_check(void *arraybuilder, const char *key);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#field_check ArrayBuilder::field_check}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_field_check(void* arraybuilder,
+                                     const char* key);
 
-/// @brief C interface to
-/// {@link awkward::ArrayBuilder#endrecord ArrayBuilder::endrecord}.
-LIBAWKWARD_EXPORT_SYMBOL uint8_t
-awkward_ArrayBuilder_endrecord(void *arraybuilder);
+  /// @brief C interface to
+  /// {@link awkward::ArrayBuilder#endrecord ArrayBuilder::endrecord}.
+  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+    awkward_ArrayBuilder_endrecord(void* arraybuilder);
 }
 
 #endif // AWKWARD_ARRAYBUILDER_H_

--- a/include/awkward/builder/ArrayBuilder.h
+++ b/include/awkward/builder/ArrayBuilder.h
@@ -1,4 +1,5 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_ARRAYBUILDER_H_
 #define AWKWARD_ARRAYBUILDER_H_
@@ -7,369 +8,329 @@
 #include <string>
 #include <vector>
 
-#include "awkward/common.h"
-#include "awkward/builder/Builder.h"
 #include "awkward/BuilderOptions.h"
+#include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
-  class Builder;
-  using BuilderPtr = std::shared_ptr<Builder>;
+class Builder;
+using BuilderPtr = std::shared_ptr<Builder>;
 
-  /// @class ArrayBuilder
+/// @class ArrayBuilder
+///
+/// @brief User interface to the Builder system: the ArrayBuilder is a
+/// fixed reference while the Builder subclass instances change in
+/// response to accumulating data.
+class LIBAWKWARD_EXPORT_SYMBOL ArrayBuilder {
+public:
+  /// @brief Creates an ArrayBuilder from a full set of parameters.
   ///
-  /// @brief User interface to the Builder system: the ArrayBuilder is a
-  /// fixed reference while the Builder subclass instances change in
-  /// response to accumulating data.
-  class LIBAWKWARD_EXPORT_SYMBOL ArrayBuilder {
-  public:
-    /// @brief Creates an ArrayBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    ArrayBuilder(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  ArrayBuilder(const BuilderOptions &options);
 
-    /// @brief Copy the current snapshot into the BuffersContainer and
-    /// return a Form as a std::string (JSON).
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const;
+  /// @brief Copy the current snapshot into the BuffersContainer and
+  /// return a Form as a std::string (JSON).
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const;
 
-    /// @brief Current length of the accumulated array.
-    int64_t
-      length() const;
+  /// @brief Current length of the accumulated array.
+  int64_t length() const;
 
-    /// @brief Removes all accumulated data without resetting the type
-    /// knowledge.
-    void
-      clear();
+  /// @brief Removes all accumulated data without resetting the type
+  /// knowledge.
+  void clear();
 
-    /// @brief Adds a `null` value to the accumulated data.
-    void
-      null();
+  /// @brief Adds a `null` value to the accumulated data.
+  void null();
 
-    /// @brief Adds a boolean value `x` to the accumulated data.
-    void
-      boolean(bool x);
+  /// @brief Adds a boolean value `x` to the accumulated data.
+  void boolean(bool x);
 
-    /// @brief Adds an integer value `x` to the accumulated data.
-    void
-      integer(int64_t x);
+  /// @brief Adds an integer value `x` to the accumulated data.
+  void integer(int64_t x);
 
-    /// @brief Adds a real value `x` to the accumulated data.
-    void
-      real(double x);
+  /// @brief Adds a real value `x` to the accumulated data.
+  void real(double x);
 
-    /// @brief Adds a complex value `x` to the accumulated data.
-    void
-      complex(std::complex<double> x);
+  /// @brief Adds a complex value `x` to the accumulated data.
+  void complex(std::complex<double> x);
 
-    /// @brief Adds a datetime value `x` to the accumulated data.
-    void
-      datetime(int64_t x, const std::string& unit);
+  /// @brief Adds a datetime value `x` to the accumulated data.
+  void datetime(int64_t x, const std::string &unit);
 
-    /// @brief Adds a timedelta value `x` to the accumulated data.
-    void
-      timedelta(int64_t x, const std::string& unit);
+  /// @brief Adds a timedelta value `x` to the accumulated data.
+  void timedelta(int64_t x, const std::string &unit);
 
-    /// @brief Adds an unencoded, null-terminated bytestring value `x` to the
-    /// accumulated data.
-    void
-      bytestring(const char* x);
+  /// @brief Adds an unencoded, null-terminated bytestring value `x` to the
+  /// accumulated data.
+  void bytestring(const char *x);
 
-    /// @brief Adds an unencoded bytestring value `x` with a given `length`
-    /// to the accumulated data.
-    ///
-    /// The string does not need to be null-terminated.
-    void
-      bytestring(const char* x, int64_t length);
+  /// @brief Adds an unencoded bytestring value `x` with a given `length`
+  /// to the accumulated data.
+  ///
+  /// The string does not need to be null-terminated.
+  void bytestring(const char *x, int64_t length);
 
-    /// @brief Adds an unencoded bytestring `x` in STL format to the
-    /// accumulated data.
-    void
-      bytestring(const std::string& x);
+  /// @brief Adds an unencoded bytestring `x` in STL format to the
+  /// accumulated data.
+  void bytestring(const std::string &x);
 
-    /// @brief Adds a UTF-8 encoded, null-terminated bytestring value `x` to
-    /// the accumulated data.
-    void
-      string(const char* x);
+  /// @brief Adds a UTF-8 encoded, null-terminated bytestring value `x` to
+  /// the accumulated data.
+  void string(const char *x);
 
-    /// @brief Adds a UTF-8 encoded bytestring value `x` with a given `length`
-    /// to the accumulated data.
-    ///
-    /// The string does not need to be null-terminated.
-    void
-      string(const char* x, int64_t length);
+  /// @brief Adds a UTF-8 encoded bytestring value `x` with a given `length`
+  /// to the accumulated data.
+  ///
+  /// The string does not need to be null-terminated.
+  void string(const char *x, int64_t length);
 
-    /// @brief Adds a UTF-8 encoded bytestring `x` in STL format to the
-    /// accumulated data.
-    void
-      string(const std::string& x);
+  /// @brief Adds a UTF-8 encoded bytestring `x` in STL format to the
+  /// accumulated data.
+  void string(const std::string &x);
 
-    /// @brief Begins building a nested list.
-    void
-      beginlist();
+  /// @brief Begins building a nested list.
+  void beginlist();
 
-    /// @brief Ends a nested list.
-    void
-      endlist();
+  /// @brief Ends a nested list.
+  void endlist();
 
-    /// @brief Begins building a tuple with a fixed number of fields.
-    void
-      begintuple(int64_t numfields);
+  /// @brief Begins building a tuple with a fixed number of fields.
+  void begintuple(int64_t numfields);
 
-    /// @brief Sets the pointer to a given tuple field index; the next
-    /// command will fill that slot.
-    void
-      index(int64_t index);
+  /// @brief Sets the pointer to a given tuple field index; the next
+  /// command will fill that slot.
+  void index(int64_t index);
 
-    /// @brief Ends a tuple.
-    void
-      endtuple();
+  /// @brief Ends a tuple.
+  void endtuple();
 
-    /// @brief Begins building a record without a name.
-    ///
-    /// See #beginrecord_fast and #beginrecord_check.
-    void
-      beginrecord();
+  /// @brief Begins building a record without a name.
+  ///
+  /// See #beginrecord_fast and #beginrecord_check.
+  void beginrecord();
 
-    /// @brief Begins building a record with a name.
-    ///
-    /// @param name This name is used to distinguish
-    /// records of different types in heterogeneous data (to build a
-    /// union of record arrays, rather than a record array with union
-    /// fields and optional values) and it also sets the `"__record__"`
-    /// parameter to later add custom behaviors in Python.
-    ///
-    /// In the `_fast` version of this method, a string comparison is not
-    /// performed: the same pointer is assumed to have the same value each time
-    /// (safe for string literals).
-    ///
-    /// See #beginrecord and #beginrecord_check.
-    void
-      beginrecord_fast(const char* name);
+  /// @brief Begins building a record with a name.
+  ///
+  /// @param name This name is used to distinguish
+  /// records of different types in heterogeneous data (to build a
+  /// union of record arrays, rather than a record array with union
+  /// fields and optional values) and it also sets the `"__record__"`
+  /// parameter to later add custom behaviors in Python.
+  ///
+  /// In the `_fast` version of this method, a string comparison is not
+  /// performed: the same pointer is assumed to have the same value each time
+  /// (safe for string literals).
+  ///
+  /// See #beginrecord and #beginrecord_check.
+  void beginrecord_fast(const char *name);
 
-    /// @brief Begins building a record with a name.
-    ///
-    /// @param name This name is used to distinguish
-    /// records of different types in heterogeneous data (to build a
-    /// union of record arrays, rather than a record array with union
-    /// fields and optional values) and it also sets the `"__record__"`
-    /// parameter to later add custom behaviors in Python.
-    ///
-    /// In the `_check` version of this method, a string comparison is
-    /// performed every time it is called to verify that the `name` matches
-    /// a stored `name`.
-    ///
-    /// See #beginrecord and #beginrecord_fast.
-    void
-      beginrecord_check(const char* name);
+  /// @brief Begins building a record with a name.
+  ///
+  /// @param name This name is used to distinguish
+  /// records of different types in heterogeneous data (to build a
+  /// union of record arrays, rather than a record array with union
+  /// fields and optional values) and it also sets the `"__record__"`
+  /// parameter to later add custom behaviors in Python.
+  ///
+  /// In the `_check` version of this method, a string comparison is
+  /// performed every time it is called to verify that the `name` matches
+  /// a stored `name`.
+  ///
+  /// See #beginrecord and #beginrecord_fast.
+  void beginrecord_check(const char *name);
 
-    /// @brief Begins building a record with a name.
-    ///
-    /// @param name This name is used to distinguish
-    /// records of different types in heterogeneous data (to build a
-    /// union of record arrays, rather than a record array with union
-    /// fields and optional values) and it also sets the `"__record__"`
-    /// parameter to later add custom behaviors in Python.
-    ///
-    /// In the `_check` version of this method, a string comparison is
-    /// performed every time it is called to verify that the `name` matches
-    /// a stored `name`.
-    ///
-    /// See #beginrecord and #beginrecord_fast.
-    void
-      beginrecord_check(const std::string& name);
+  /// @brief Begins building a record with a name.
+  ///
+  /// @param name This name is used to distinguish
+  /// records of different types in heterogeneous data (to build a
+  /// union of record arrays, rather than a record array with union
+  /// fields and optional values) and it also sets the `"__record__"`
+  /// parameter to later add custom behaviors in Python.
+  ///
+  /// In the `_check` version of this method, a string comparison is
+  /// performed every time it is called to verify that the `name` matches
+  /// a stored `name`.
+  ///
+  /// See #beginrecord and #beginrecord_fast.
+  void beginrecord_check(const std::string &name);
 
-    /// @brief Sets the pointer to a given record field `key`; the next
-    /// command will fill that slot.
-    ///
-    /// In the `_fast` version of this method, a string comparison is not
-    /// performed: the same pointer is assumed to have the same value each time
-    /// (safe for string literals). See #field_check.
-    ///
-    /// Record keys are checked in round-robin order. The best performance
-    /// will be achieved by filling them in the same order for each record.
-    /// Lookup time for random order scales with the number of fields.
-    void
-      field_fast(const char* key);
+  /// @brief Sets the pointer to a given record field `key`; the next
+  /// command will fill that slot.
+  ///
+  /// In the `_fast` version of this method, a string comparison is not
+  /// performed: the same pointer is assumed to have the same value each time
+  /// (safe for string literals). See #field_check.
+  ///
+  /// Record keys are checked in round-robin order. The best performance
+  /// will be achieved by filling them in the same order for each record.
+  /// Lookup time for random order scales with the number of fields.
+  void field_fast(const char *key);
 
-    /// @brief Sets the pointer to a given record field `key`; the next
-    /// command will fill that slot.
-    ///
-    /// In the `_check` version of this method, a string comparison is
-    /// performed every time it is called to verify that the `key` matches
-    /// a stored `key`. See #field_fast.
-    ///
-    /// Record keys are checked in round-robin order. The best performance
-    /// will be achieved by filling them in the same order for each record.
-    /// Lookup time for random order scales with the number of fields.
-    void
-      field_check(const char* key);
+  /// @brief Sets the pointer to a given record field `key`; the next
+  /// command will fill that slot.
+  ///
+  /// In the `_check` version of this method, a string comparison is
+  /// performed every time it is called to verify that the `key` matches
+  /// a stored `key`. See #field_fast.
+  ///
+  /// Record keys are checked in round-robin order. The best performance
+  /// will be achieved by filling them in the same order for each record.
+  /// Lookup time for random order scales with the number of fields.
+  void field_check(const char *key);
 
-    /// @brief Sets the pointer to a given record field `key`; the next
-    /// command will fill that slot.
-    ///
-    /// In the `_check` version of this method, a string comparison is
-    /// performed every time it is called to verify that the `key` matches
-    /// a stored `key`. See #field_fast.
-    ///
-    /// Record keys are checked in round-robin order. The best performance
-    /// will be achieved by filling them in the same order for each record.
-    /// Lookup time for random order scales with the number of fields.
-    void
-      field_check(const std::string& key);
+  /// @brief Sets the pointer to a given record field `key`; the next
+  /// command will fill that slot.
+  ///
+  /// In the `_check` version of this method, a string comparison is
+  /// performed every time it is called to verify that the `key` matches
+  /// a stored `key`. See #field_fast.
+  ///
+  /// Record keys are checked in round-robin order. The best performance
+  /// will be achieved by filling them in the same order for each record.
+  /// Lookup time for random order scales with the number of fields.
+  void field_check(const std::string &key);
 
-    /// @brief Ends a record.
-    void
-      endrecord();
+  /// @brief Ends a record.
+  void endrecord();
 
-    // @brief Root node of the Builder tree.
-    const BuilderPtr builder() const { return builder_; }
+  // @brief Root node of the Builder tree.
+  const BuilderPtr builder() const { return builder_; }
 
-    void builder_update(BuilderPtr builder) { builder_ = builder; }
+  void builder_update(BuilderPtr builder) { builder_ = builder; }
 
-    /// @brief Internal function to replace the root node of the ArrayBuilder's
-    /// Builder tree with a new root.
-    void
-      maybeupdate(const BuilderPtr builder);
+  /// @brief Internal function to replace the root node of the ArrayBuilder's
+  /// Builder tree with a new root.
+  void maybeupdate(const BuilderPtr builder);
 
 private:
-    /// @brief Constant equal to `nullptr`.
-    static const char* no_encoding;
-    /// @brief Constant equal to `"utf-8"`.
-    static const char* utf8_encoding;
-    /// @brief Root node of the Builder tree.
-    BuilderPtr builder_;
-  };
-}
+  /// @brief Constant equal to `nullptr`.
+  static const char *no_encoding;
+  /// @brief Constant equal to `"utf-8"`.
+  static const char *utf8_encoding;
+  /// @brief Root node of the Builder tree.
+  BuilderPtr builder_;
+};
+} // namespace awkward
 
 extern "C" {
-  /// @brief C interface to {@link awkward::ArrayBuilder#length ArrayBuilder::length}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_length(void* arraybuilder,
-                                int64_t* result);
-  /// @brief C interface to {@link awkward::ArrayBuilder#clear ArrayBuilder::clear}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_clear(void* arraybuilder);
+/// @brief C interface to {@link awkward::ArrayBuilder#length
+/// ArrayBuilder::length}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_length(void *arraybuilder,
+                                                             int64_t *result);
+/// @brief C interface to {@link awkward::ArrayBuilder#clear
+/// ArrayBuilder::clear}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_clear(void *arraybuilder);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#null ArrayBuilder::null}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_null(void* arraybuilder);
+/// @brief C interface to {@link awkward::ArrayBuilder#null ArrayBuilder::null}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_null(void *arraybuilder);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#boolean ArrayBuilder::boolean}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_boolean(void* arraybuilder,
-                                 bool x);
+/// @brief C interface to {@link awkward::ArrayBuilder#boolean
+/// ArrayBuilder::boolean}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_boolean(void *arraybuilder, bool x);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#integer ArrayBuilder::integer}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_integer(void* arraybuilder,
-                                 int64_t x);
+/// @brief C interface to {@link awkward::ArrayBuilder#integer
+/// ArrayBuilder::integer}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_integer(void *arraybuilder, int64_t x);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#real ArrayBuilder::real}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_real(void* arraybuilder,
-                              double x);
+/// @brief C interface to {@link awkward::ArrayBuilder#real ArrayBuilder::real}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_real(void *arraybuilder,
+                                                           double x);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#complex ArrayBuilder::complex}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_complex(void* arraybuilder,
-                                 double real,
-                                 double imag);
+/// @brief C interface to {@link awkward::ArrayBuilder#complex
+/// ArrayBuilder::complex}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_complex(void *arraybuilder, double real, double imag);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#datetime ArrayBuilder::datetime}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_datetime(void* arraybuilder,
-                                  int64_t x,
-                                  const char* unit);
+/// @brief C interface to {@link awkward::ArrayBuilder#datetime
+/// ArrayBuilder::datetime}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_datetime(void *arraybuilder, int64_t x, const char *unit);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#timedelta ArrayBuilder::timedelta}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_timedelta(void* arraybuilder,
-                                   int64_t x,
-                                   const char* unit);
+/// @brief C interface to {@link awkward::ArrayBuilder#timedelta
+/// ArrayBuilder::timedelta}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_timedelta(void *arraybuilder, int64_t x, const char *unit);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_bytestring(void* arraybuilder,
-                                    const char* x);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_bytestring(void *arraybuilder, const char *x);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
-                                           const char* x,
-                                           int64_t length);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_bytestring_length(
+    void *arraybuilder, const char *x, int64_t length);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_string(void* arraybuilder,
-                                const char* x);
+/// @brief C interface to {@link awkward::ArrayBuilder#string
+/// ArrayBuilder::string}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_string(void *arraybuilder,
+                                                             const char *x);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_string_length(void* arraybuilder,
-                                       const char* x,
-                                       int64_t length);
+/// @brief C interface to {@link awkward::ArrayBuilder#string
+/// ArrayBuilder::string}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_string_length(
+    void *arraybuilder, const char *x, int64_t length);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#beginlist ArrayBuilder::beginlist}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_beginlist(void* arraybuilder);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#beginlist ArrayBuilder::beginlist}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_beginlist(void *arraybuilder);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#endlist ArrayBuilder::endlist}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_endlist(void* arraybuilder);
+/// @brief C interface to {@link awkward::ArrayBuilder#endlist
+/// ArrayBuilder::endlist}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_endlist(void *arraybuilder);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#begintuple ArrayBuilder::begintuple}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_begintuple(void* arraybuilder,
-                                    int64_t numfields);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#begintuple ArrayBuilder::begintuple}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_begintuple(void *arraybuilder, int64_t numfields);
 
-  /// @brief C interface to {@link awkward::ArrayBuilder#index ArrayBuilder::index}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_index(void* arraybuilder,
-                               int64_t index);
+/// @brief C interface to {@link awkward::ArrayBuilder#index
+/// ArrayBuilder::index}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t awkward_ArrayBuilder_index(void *arraybuilder,
+                                                            int64_t index);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#endtuple ArrayBuilder::endtuple}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_endtuple(void* arraybuilder);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#endtuple ArrayBuilder::endtuple}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_endtuple(void *arraybuilder);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#beginrecord ArrayBuilder::beginrecord}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_beginrecord(void* arraybuilder);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#beginrecord ArrayBuilder::beginrecord}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_beginrecord(void *arraybuilder);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#beginrecord_fast ArrayBuilder::beginrecord_fast}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
-                                          const char* name);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#beginrecord_fast
+/// ArrayBuilder::beginrecord_fast}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_beginrecord_fast(void *arraybuilder, const char *name);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#beginrecord_check ArrayBuilder::beginrecord_check}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
-                                           const char* name);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#beginrecord_check
+/// ArrayBuilder::beginrecord_check}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_beginrecord_check(void *arraybuilder, const char *name);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#field_fast ArrayBuilder::field_fast}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_field_fast(void* arraybuilder,
-                                    const char* key);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#field_fast ArrayBuilder::field_fast}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_field_fast(void *arraybuilder, const char *key);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#field_check ArrayBuilder::field_check}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_field_check(void* arraybuilder,
-                                     const char* key);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#field_check ArrayBuilder::field_check}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_field_check(void *arraybuilder, const char *key);
 
-  /// @brief C interface to
-  /// {@link awkward::ArrayBuilder#endrecord ArrayBuilder::endrecord}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
-    awkward_ArrayBuilder_endrecord(void* arraybuilder);
+/// @brief C interface to
+/// {@link awkward::ArrayBuilder#endrecord ArrayBuilder::endrecord}.
+LIBAWKWARD_EXPORT_SYMBOL uint8_t
+awkward_ArrayBuilder_endrecord(void *arraybuilder);
 }
 
 #endif // AWKWARD_ARRAYBUILDER_H_

--- a/include/awkward/builder/BoolBuilder.h
+++ b/include/awkward/builder/BoolBuilder.h
@@ -6,109 +6,87 @@
 #include <complex>
 #include <string>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class BoolBuilder
+/// @class BoolBuilder
+///
+/// @brief Builder node that accumulates boolean values.
+class LIBAWKWARD_EXPORT_SYMBOL BoolBuilder : public Builder {
+public:
+  /// @brief Create an empty BoolBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a BoolBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates boolean values.
-  class LIBAWKWARD_EXPORT_SYMBOL BoolBuilder: public Builder {
-  public:
-    /// @brief Create an empty BoolBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated boolean values.
+  BoolBuilder(const BuilderOptions &options, GrowableBuffer<uint8_t> buffer);
 
-    /// @brief Create a BoolBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated boolean values.
-    BoolBuilder(const BuilderOptions& options,
-                GrowableBuffer<uint8_t> buffer);
+  /// @brief User-friendly name of this class: `"BoolBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"BoolBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A BoolBuilder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A BoolBuilder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const GrowableBuffer<uint8_t> &buffer() const { return buffer_; }
 
-    const GrowableBuffer<uint8_t>& buffer() const { return buffer_; }
+private:
+  const BuilderOptions    options_;
+  GrowableBuffer<uint8_t> buffer_;
+};
 
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<uint8_t> buffer_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_BOOLBUILDER_H_

--- a/include/awkward/builder/BoolBuilder.h
+++ b/include/awkward/builder/BoolBuilder.h
@@ -1,4 +1,5 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_BOOLBUILDER_H_
 #define AWKWARD_BOOLBUILDER_H_
@@ -6,109 +7,87 @@
 #include <complex>
 #include <string>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class BoolBuilder
+/// @class BoolBuilder
+///
+/// @brief Builder node that accumulates boolean values.
+class LIBAWKWARD_EXPORT_SYMBOL BoolBuilder : public Builder {
+public:
+  /// @brief Create an empty BoolBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a BoolBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates boolean values.
-  class LIBAWKWARD_EXPORT_SYMBOL BoolBuilder: public Builder {
-  public:
-    /// @brief Create an empty BoolBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated boolean values.
+  BoolBuilder(const BuilderOptions &options, GrowableBuffer<uint8_t> buffer);
 
-    /// @brief Create a BoolBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated boolean values.
-    BoolBuilder(const BuilderOptions& options,
-                GrowableBuffer<uint8_t> buffer);
+  /// @brief User-friendly name of this class: `"BoolBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"BoolBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A BoolBuilder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A BoolBuilder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const GrowableBuffer<uint8_t> &buffer() const { return buffer_; }
 
-    const GrowableBuffer<uint8_t>& buffer() const { return buffer_; }
+private:
+  const BuilderOptions options_;
+  GrowableBuffer<uint8_t> buffer_;
+};
 
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<uint8_t> buffer_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_BOOLBUILDER_H_

--- a/include/awkward/builder/BoolBuilder.h
+++ b/include/awkward/builder/BoolBuilder.h
@@ -1,5 +1,4 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_BOOLBUILDER_H_
 #define AWKWARD_BOOLBUILDER_H_
@@ -7,87 +6,109 @@
 #include <complex>
 #include <string>
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class BoolBuilder
-///
-/// @brief Builder node that accumulates boolean values.
-class LIBAWKWARD_EXPORT_SYMBOL BoolBuilder : public Builder {
-public:
-  /// @brief Create an empty BoolBuilder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options);
-
-  /// @brief Create a BoolBuilder from a full set of parameters.
+  /// @class BoolBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param buffer Contains the accumulated boolean values.
-  BoolBuilder(const BuilderOptions &options, GrowableBuffer<uint8_t> buffer);
+  /// @brief Builder node that accumulates boolean values.
+  class LIBAWKWARD_EXPORT_SYMBOL BoolBuilder: public Builder {
+  public:
+    /// @brief Create an empty BoolBuilder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options);
 
-  /// @brief User-friendly name of this class: `"BoolBuilder"`.
-  const std::string classname() const override;
+    /// @brief Create a BoolBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param buffer Contains the accumulated boolean values.
+    BoolBuilder(const BuilderOptions& options,
+                GrowableBuffer<uint8_t> buffer);
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"BoolBuilder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// A BoolBuilder is never active.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// A BoolBuilder is never active.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-  const GrowableBuffer<uint8_t> &buffer() const { return buffer_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
-private:
-  const BuilderOptions options_;
-  GrowableBuffer<uint8_t> buffer_;
-};
+    const GrowableBuffer<uint8_t>& buffer() const { return buffer_; }
 
-} // namespace awkward
+  private:
+    const BuilderOptions options_;
+    GrowableBuffer<uint8_t> buffer_;
+  };
+
+}
 
 #endif // AWKWARD_BOOLBUILDER_H_

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -1,4 +1,5 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_FILLABLE_H_
 #define AWKWARD_FILLABLE_H_
@@ -10,157 +11,138 @@
 #include "awkward/common.h"
 
 namespace awkward {
-  class Builder;
-  using BuilderPtr = std::shared_ptr<Builder>;
+class Builder;
+using BuilderPtr = std::shared_ptr<Builder>;
 
-  /// @class BuffersContainer
+/// @class BuffersContainer
+///
+/// @brief Abstract class to represent the output of ak.to_buffers.
+/// In Python, this would be a dict of NumPy arrays.
+class BuffersContainer {
+public:
+  /// @brief Copy data at `source` with `num_bytes` into the BuffersContainer
+  /// with `name`.
   ///
-  /// @brief Abstract class to represent the output of ak.to_buffers.
-  /// In Python, this would be a dict of NumPy arrays.
-  class BuffersContainer {
-  public:
-    /// @brief Copy data at `source` with `num_bytes` into the BuffersContainer
-    /// with `name`.
-    ///
-    /// In Python, this allocates a NumPy array and copies data into it.
-    virtual void
-      copy_buffer(const std::string& name, const void* source, int64_t num_bytes) = 0;
+  /// In Python, this allocates a NumPy array and copies data into it.
+  virtual void copy_buffer(const std::string &name, const void *source,
+                           int64_t num_bytes) = 0;
 
-    /// @brief Create an array initialized to a given fill value.
-    virtual void
-      full_buffer(const std::string& name, int64_t length, int64_t value, const std::string& dtype) = 0;
+  /// @brief Create an array initialized to a given fill value.
+  virtual void full_buffer(const std::string &name, int64_t length,
+                           int64_t value, const std::string &dtype) = 0;
 
-    virtual void*
-      empty_buffer(const std::string& name, int64_t num_bytes) = 0;
-  };
+  virtual void *empty_buffer(const std::string &name, int64_t num_bytes) = 0;
+};
 
-  /// @class Builder
+/// @class Builder
+///
+/// @brief Abstract base class for nodes within an ArrayBuilder that
+/// cumulatively discover an array's type and fill it.
+class LIBAWKWARD_EXPORT_SYMBOL Builder
+    : public std::enable_shared_from_this<Builder> {
+public:
+  /// @brief Virtual destructor acts as a first non-inline virtual function
+  /// that determines a specific translation unit in which vtable shall be
+  /// emitted.
+  virtual ~Builder();
+
+  /// @brief User-friendly name of this class.
+  virtual const std::string classname() const = 0;
+
+  /// @brief Copy the current snapshot into the BuffersContainer and
+  /// return a Form as a std::string (JSON).
+  virtual const std::string to_buffers(BuffersContainer &container,
+                                       int64_t &form_key_id) const = 0;
+
+  /// @brief Current length of the accumulated array.
+  virtual int64_t length() const = 0;
+
+  /// @brief Removes all accumulated data without resetting the type
+  /// knowledge.
+  virtual void clear() = 0;
+
+  /// @brief If `true`, this node has started but has not finished a
+  /// multi-step command (e.g. `beginX ... endX`).
+  virtual bool active() const = 0;
+
+  /// @brief Adds a `null` value to the accumulated data.
+  virtual const BuilderPtr null() = 0;
+
+  /// @brief Adds a boolean value `x` to the accumulated data.
+  virtual const BuilderPtr boolean(bool x) = 0;
+
+  /// @brief Adds an integer value `x` to the accumulated data.
+  virtual const BuilderPtr integer(int64_t x) = 0;
+
+  /// @brief Adds a real value `x` to the accumulated data.
+  virtual const BuilderPtr real(double x) = 0;
+
+  /// @brief Adds a complex value `x` to the accumulated data.
+  virtual const BuilderPtr complex(std::complex<double> x) = 0;
+
+  /// @brief Adds a datetime value `x` to the accumulated data.
+  virtual const BuilderPtr datetime(int64_t x, const std::string &unit) = 0;
+
+  /// @brief Adds a timedelta value `x` to the accumulated data.
+  virtual const BuilderPtr timedelta(int64_t x, const std::string &unit) = 0;
+
+  /// @brief Adds a string value `x` with a given `length` and `encoding`
+  /// to the accumulated data.
   ///
-  /// @brief Abstract base class for nodes within an ArrayBuilder that
-  /// cumulatively discover an array's type and fill it.
-  class LIBAWKWARD_EXPORT_SYMBOL Builder: public std::enable_shared_from_this<Builder> {
-  public:
-    /// @brief Virtual destructor acts as a first non-inline virtual function
-    /// that determines a specific translation unit in which vtable shall be
-    /// emitted.
-    virtual ~Builder();
+  /// @note Currently, only `encoding =`
+  ///
+  ///    - `nullptr` (no encoding; a bytestring)
+  ///    - `"utf-8"` (variable-length Unicode 8-bit encoding)
+  ///
+  /// are supported.
+  virtual const BuilderPtr string(const char *x, int64_t length,
+                                  const char *encoding) = 0;
 
-    /// @brief User-friendly name of this class.
-    virtual const std::string
-      classname() const = 0;
+  /// @brief Begins building a nested list.
+  virtual const BuilderPtr beginlist() = 0;
 
-    /// @brief Copy the current snapshot into the BuffersContainer and
-    /// return a Form as a std::string (JSON).
-    virtual const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const = 0;
+  /// @brief Ends a nested list.
+  virtual const BuilderPtr endlist() = 0;
 
-    /// @brief Current length of the accumulated array.
-    virtual int64_t
-      length() const = 0;
+  /// @brief Begins building a tuple with a fixed number of fields.
+  virtual const BuilderPtr begintuple(int64_t numfields) = 0;
 
-    /// @brief Removes all accumulated data without resetting the type
-    /// knowledge.
-    virtual void
-      clear() = 0;
+  /// @brief Sets the pointer to a given tuple field index; the next
+  /// command will fill that slot.
+  virtual const BuilderPtr index(int64_t index) = 0;
 
-    /// @brief If `true`, this node has started but has not finished a
-    /// multi-step command (e.g. `beginX ... endX`).
-    virtual bool
-      active() const = 0;
+  /// @brief Ends a tuple.
+  virtual const BuilderPtr endtuple() = 0;
 
-    /// @brief Adds a `null` value to the accumulated data.
-    virtual const BuilderPtr
-      null() = 0;
+  /// @brief Begins building a record with an optional name.
+  ///
+  /// @param name If specified, this name is used to distinguish
+  /// records of different types in heterogeneous data (to build a
+  /// union of record arrays, rather than a record array with union
+  /// fields and optional values) and it also sets the `"__record__"`
+  /// parameter to later add custom behaviors in Python.
+  /// @param check If `true`, actually do a string comparison to see if the
+  /// provided `name` matches the previous `name`; if `false`, assume
+  /// that the same pointer means the same string (safe for string
+  /// literals).
+  virtual const BuilderPtr beginrecord(const char *name, bool check) = 0;
 
-    /// @brief Adds a boolean value `x` to the accumulated data.
-    virtual const BuilderPtr
-      boolean(bool x) = 0;
+  /// @brief Sets the pointer to a given record field `key`; the next
+  /// command will fill that slot.
+  ///
+  /// @param key Indicates the field to fill.
+  /// @param check If `true`, actually do a string comparison to see if
+  /// `key` matches the previous `key`; if `false`, assume that the same
+  /// pointer means the same string (safe for string literals).
+  ///
+  /// Record keys are checked in round-robin order. The best performance
+  /// will be achieved by filling them in the same order for each record.
+  /// Lookup time for random order scales with the number of fields.
+  virtual void field(const char *key, bool check) = 0;
 
-    /// @brief Adds an integer value `x` to the accumulated data.
-    virtual const BuilderPtr
-      integer(int64_t x) = 0;
-
-    /// @brief Adds a real value `x` to the accumulated data.
-    virtual const BuilderPtr
-      real(double x) = 0;
-
-    /// @brief Adds a complex value `x` to the accumulated data.
-    virtual const BuilderPtr
-      complex(std::complex<double> x) = 0;
-
-    /// @brief Adds a datetime value `x` to the accumulated data.
-    virtual const BuilderPtr
-      datetime(int64_t x, const std::string& unit) = 0;
-
-    /// @brief Adds a timedelta value `x` to the accumulated data.
-    virtual const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) = 0;
-
-    /// @brief Adds a string value `x` with a given `length` and `encoding`
-    /// to the accumulated data.
-    ///
-    /// @note Currently, only `encoding =`
-    ///
-    ///    - `nullptr` (no encoding; a bytestring)
-    ///    - `"utf-8"` (variable-length Unicode 8-bit encoding)
-    ///
-    /// are supported.
-    virtual const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) = 0;
-
-    /// @brief Begins building a nested list.
-    virtual const BuilderPtr
-      beginlist() = 0;
-
-    /// @brief Ends a nested list.
-    virtual const BuilderPtr
-      endlist() = 0;
-
-    /// @brief Begins building a tuple with a fixed number of fields.
-    virtual const BuilderPtr
-      begintuple(int64_t numfields) = 0;
-
-    /// @brief Sets the pointer to a given tuple field index; the next
-    /// command will fill that slot.
-    virtual const BuilderPtr
-      index(int64_t index) = 0;
-
-    /// @brief Ends a tuple.
-    virtual const BuilderPtr
-      endtuple() = 0;
-
-    /// @brief Begins building a record with an optional name.
-    ///
-    /// @param name If specified, this name is used to distinguish
-    /// records of different types in heterogeneous data (to build a
-    /// union of record arrays, rather than a record array with union
-    /// fields and optional values) and it also sets the `"__record__"`
-    /// parameter to later add custom behaviors in Python.
-    /// @param check If `true`, actually do a string comparison to see if the
-    /// provided `name` matches the previous `name`; if `false`, assume
-    /// that the same pointer means the same string (safe for string
-    /// literals).
-    virtual const BuilderPtr
-      beginrecord(const char* name, bool check) = 0;
-
-    /// @brief Sets the pointer to a given record field `key`; the next
-    /// command will fill that slot.
-    ///
-    /// @param key Indicates the field to fill.
-    /// @param check If `true`, actually do a string comparison to see if
-    /// `key` matches the previous `key`; if `false`, assume that the same
-    /// pointer means the same string (safe for string literals).
-    ///
-    /// Record keys are checked in round-robin order. The best performance
-    /// will be achieved by filling them in the same order for each record.
-    /// Lookup time for random order scales with the number of fields.
-    virtual void
-      field(const char* key, bool check) = 0;
-
-    /// @brief Ends a record.
-    virtual const BuilderPtr
-      endrecord() = 0;
-  };
-}
+  /// @brief Ends a record.
+  virtual const BuilderPtr endrecord() = 0;
+};
+} // namespace awkward
 
 #endif // AWKWARD_FILLABLE_H_

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -1,5 +1,4 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_FILLABLE_H_
 #define AWKWARD_FILLABLE_H_
@@ -11,138 +10,157 @@
 #include "awkward/common.h"
 
 namespace awkward {
-class Builder;
-using BuilderPtr = std::shared_ptr<Builder>;
+  class Builder;
+  using BuilderPtr = std::shared_ptr<Builder>;
 
-/// @class BuffersContainer
-///
-/// @brief Abstract class to represent the output of ak.to_buffers.
-/// In Python, this would be a dict of NumPy arrays.
-class BuffersContainer {
-public:
-  /// @brief Copy data at `source` with `num_bytes` into the BuffersContainer
-  /// with `name`.
+  /// @class BuffersContainer
   ///
-  /// In Python, this allocates a NumPy array and copies data into it.
-  virtual void copy_buffer(const std::string &name, const void *source,
-                           int64_t num_bytes) = 0;
+  /// @brief Abstract class to represent the output of ak.to_buffers.
+  /// In Python, this would be a dict of NumPy arrays.
+  class BuffersContainer {
+  public:
+    /// @brief Copy data at `source` with `num_bytes` into the BuffersContainer
+    /// with `name`.
+    ///
+    /// In Python, this allocates a NumPy array and copies data into it.
+    virtual void
+      copy_buffer(const std::string& name, const void* source, int64_t num_bytes) = 0;
 
-  /// @brief Create an array initialized to a given fill value.
-  virtual void full_buffer(const std::string &name, int64_t length,
-                           int64_t value, const std::string &dtype) = 0;
+    /// @brief Create an array initialized to a given fill value.
+    virtual void
+      full_buffer(const std::string& name, int64_t length, int64_t value, const std::string& dtype) = 0;
 
-  virtual void *empty_buffer(const std::string &name, int64_t num_bytes) = 0;
-};
+    virtual void*
+      empty_buffer(const std::string& name, int64_t num_bytes) = 0;
+  };
 
-/// @class Builder
-///
-/// @brief Abstract base class for nodes within an ArrayBuilder that
-/// cumulatively discover an array's type and fill it.
-class LIBAWKWARD_EXPORT_SYMBOL Builder
-    : public std::enable_shared_from_this<Builder> {
-public:
-  /// @brief Virtual destructor acts as a first non-inline virtual function
-  /// that determines a specific translation unit in which vtable shall be
-  /// emitted.
-  virtual ~Builder();
-
-  /// @brief User-friendly name of this class.
-  virtual const std::string classname() const = 0;
-
-  /// @brief Copy the current snapshot into the BuffersContainer and
-  /// return a Form as a std::string (JSON).
-  virtual const std::string to_buffers(BuffersContainer &container,
-                                       int64_t &form_key_id) const = 0;
-
-  /// @brief Current length of the accumulated array.
-  virtual int64_t length() const = 0;
-
-  /// @brief Removes all accumulated data without resetting the type
-  /// knowledge.
-  virtual void clear() = 0;
-
-  /// @brief If `true`, this node has started but has not finished a
-  /// multi-step command (e.g. `beginX ... endX`).
-  virtual bool active() const = 0;
-
-  /// @brief Adds a `null` value to the accumulated data.
-  virtual const BuilderPtr null() = 0;
-
-  /// @brief Adds a boolean value `x` to the accumulated data.
-  virtual const BuilderPtr boolean(bool x) = 0;
-
-  /// @brief Adds an integer value `x` to the accumulated data.
-  virtual const BuilderPtr integer(int64_t x) = 0;
-
-  /// @brief Adds a real value `x` to the accumulated data.
-  virtual const BuilderPtr real(double x) = 0;
-
-  /// @brief Adds a complex value `x` to the accumulated data.
-  virtual const BuilderPtr complex(std::complex<double> x) = 0;
-
-  /// @brief Adds a datetime value `x` to the accumulated data.
-  virtual const BuilderPtr datetime(int64_t x, const std::string &unit) = 0;
-
-  /// @brief Adds a timedelta value `x` to the accumulated data.
-  virtual const BuilderPtr timedelta(int64_t x, const std::string &unit) = 0;
-
-  /// @brief Adds a string value `x` with a given `length` and `encoding`
-  /// to the accumulated data.
+  /// @class Builder
   ///
-  /// @note Currently, only `encoding =`
-  ///
-  ///    - `nullptr` (no encoding; a bytestring)
-  ///    - `"utf-8"` (variable-length Unicode 8-bit encoding)
-  ///
-  /// are supported.
-  virtual const BuilderPtr string(const char *x, int64_t length,
-                                  const char *encoding) = 0;
+  /// @brief Abstract base class for nodes within an ArrayBuilder that
+  /// cumulatively discover an array's type and fill it.
+  class LIBAWKWARD_EXPORT_SYMBOL Builder: public std::enable_shared_from_this<Builder> {
+  public:
+    /// @brief Virtual destructor acts as a first non-inline virtual function
+    /// that determines a specific translation unit in which vtable shall be
+    /// emitted.
+    virtual ~Builder();
 
-  /// @brief Begins building a nested list.
-  virtual const BuilderPtr beginlist() = 0;
+    /// @brief User-friendly name of this class.
+    virtual const std::string
+      classname() const = 0;
 
-  /// @brief Ends a nested list.
-  virtual const BuilderPtr endlist() = 0;
+    /// @brief Copy the current snapshot into the BuffersContainer and
+    /// return a Form as a std::string (JSON).
+    virtual const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const = 0;
 
-  /// @brief Begins building a tuple with a fixed number of fields.
-  virtual const BuilderPtr begintuple(int64_t numfields) = 0;
+    /// @brief Current length of the accumulated array.
+    virtual int64_t
+      length() const = 0;
 
-  /// @brief Sets the pointer to a given tuple field index; the next
-  /// command will fill that slot.
-  virtual const BuilderPtr index(int64_t index) = 0;
+    /// @brief Removes all accumulated data without resetting the type
+    /// knowledge.
+    virtual void
+      clear() = 0;
 
-  /// @brief Ends a tuple.
-  virtual const BuilderPtr endtuple() = 0;
+    /// @brief If `true`, this node has started but has not finished a
+    /// multi-step command (e.g. `beginX ... endX`).
+    virtual bool
+      active() const = 0;
 
-  /// @brief Begins building a record with an optional name.
-  ///
-  /// @param name If specified, this name is used to distinguish
-  /// records of different types in heterogeneous data (to build a
-  /// union of record arrays, rather than a record array with union
-  /// fields and optional values) and it also sets the `"__record__"`
-  /// parameter to later add custom behaviors in Python.
-  /// @param check If `true`, actually do a string comparison to see if the
-  /// provided `name` matches the previous `name`; if `false`, assume
-  /// that the same pointer means the same string (safe for string
-  /// literals).
-  virtual const BuilderPtr beginrecord(const char *name, bool check) = 0;
+    /// @brief Adds a `null` value to the accumulated data.
+    virtual const BuilderPtr
+      null() = 0;
 
-  /// @brief Sets the pointer to a given record field `key`; the next
-  /// command will fill that slot.
-  ///
-  /// @param key Indicates the field to fill.
-  /// @param check If `true`, actually do a string comparison to see if
-  /// `key` matches the previous `key`; if `false`, assume that the same
-  /// pointer means the same string (safe for string literals).
-  ///
-  /// Record keys are checked in round-robin order. The best performance
-  /// will be achieved by filling them in the same order for each record.
-  /// Lookup time for random order scales with the number of fields.
-  virtual void field(const char *key, bool check) = 0;
+    /// @brief Adds a boolean value `x` to the accumulated data.
+    virtual const BuilderPtr
+      boolean(bool x) = 0;
 
-  /// @brief Ends a record.
-  virtual const BuilderPtr endrecord() = 0;
-};
-} // namespace awkward
+    /// @brief Adds an integer value `x` to the accumulated data.
+    virtual const BuilderPtr
+      integer(int64_t x) = 0;
+
+    /// @brief Adds a real value `x` to the accumulated data.
+    virtual const BuilderPtr
+      real(double x) = 0;
+
+    /// @brief Adds a complex value `x` to the accumulated data.
+    virtual const BuilderPtr
+      complex(std::complex<double> x) = 0;
+
+    /// @brief Adds a datetime value `x` to the accumulated data.
+    virtual const BuilderPtr
+      datetime(int64_t x, const std::string& unit) = 0;
+
+    /// @brief Adds a timedelta value `x` to the accumulated data.
+    virtual const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) = 0;
+
+    /// @brief Adds a string value `x` with a given `length` and `encoding`
+    /// to the accumulated data.
+    ///
+    /// @note Currently, only `encoding =`
+    ///
+    ///    - `nullptr` (no encoding; a bytestring)
+    ///    - `"utf-8"` (variable-length Unicode 8-bit encoding)
+    ///
+    /// are supported.
+    virtual const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) = 0;
+
+    /// @brief Begins building a nested list.
+    virtual const BuilderPtr
+      beginlist() = 0;
+
+    /// @brief Ends a nested list.
+    virtual const BuilderPtr
+      endlist() = 0;
+
+    /// @brief Begins building a tuple with a fixed number of fields.
+    virtual const BuilderPtr
+      begintuple(int64_t numfields) = 0;
+
+    /// @brief Sets the pointer to a given tuple field index; the next
+    /// command will fill that slot.
+    virtual const BuilderPtr
+      index(int64_t index) = 0;
+
+    /// @brief Ends a tuple.
+    virtual const BuilderPtr
+      endtuple() = 0;
+
+    /// @brief Begins building a record with an optional name.
+    ///
+    /// @param name If specified, this name is used to distinguish
+    /// records of different types in heterogeneous data (to build a
+    /// union of record arrays, rather than a record array with union
+    /// fields and optional values) and it also sets the `"__record__"`
+    /// parameter to later add custom behaviors in Python.
+    /// @param check If `true`, actually do a string comparison to see if the
+    /// provided `name` matches the previous `name`; if `false`, assume
+    /// that the same pointer means the same string (safe for string
+    /// literals).
+    virtual const BuilderPtr
+      beginrecord(const char* name, bool check) = 0;
+
+    /// @brief Sets the pointer to a given record field `key`; the next
+    /// command will fill that slot.
+    ///
+    /// @param key Indicates the field to fill.
+    /// @param check If `true`, actually do a string comparison to see if
+    /// `key` matches the previous `key`; if `false`, assume that the same
+    /// pointer means the same string (safe for string literals).
+    ///
+    /// Record keys are checked in round-robin order. The best performance
+    /// will be achieved by filling them in the same order for each record.
+    /// Lookup time for random order scales with the number of fields.
+    virtual void
+      field(const char* key, bool check) = 0;
+
+    /// @brief Ends a record.
+    virtual const BuilderPtr
+      endrecord() = 0;
+  };
+}
 
 #endif // AWKWARD_FILLABLE_H_

--- a/include/awkward/builder/Builder.h
+++ b/include/awkward/builder/Builder.h
@@ -10,157 +10,138 @@
 #include "awkward/common.h"
 
 namespace awkward {
-  class Builder;
-  using BuilderPtr = std::shared_ptr<Builder>;
+class Builder;
+using BuilderPtr = std::shared_ptr<Builder>;
 
-  /// @class BuffersContainer
+/// @class BuffersContainer
+///
+/// @brief Abstract class to represent the output of ak.to_buffers.
+/// In Python, this would be a dict of NumPy arrays.
+class BuffersContainer {
+public:
+  /// @brief Copy data at `source` with `num_bytes` into the BuffersContainer
+  /// with `name`.
   ///
-  /// @brief Abstract class to represent the output of ak.to_buffers.
-  /// In Python, this would be a dict of NumPy arrays.
-  class BuffersContainer {
-  public:
-    /// @brief Copy data at `source` with `num_bytes` into the BuffersContainer
-    /// with `name`.
-    ///
-    /// In Python, this allocates a NumPy array and copies data into it.
-    virtual void
-      copy_buffer(const std::string& name, const void* source, int64_t num_bytes) = 0;
+  /// In Python, this allocates a NumPy array and copies data into it.
+  virtual void copy_buffer(const std::string &name, const void *source,
+                           int64_t num_bytes) = 0;
 
-    /// @brief Create an array initialized to a given fill value.
-    virtual void
-      full_buffer(const std::string& name, int64_t length, int64_t value, const std::string& dtype) = 0;
+  /// @brief Create an array initialized to a given fill value.
+  virtual void full_buffer(const std::string &name, int64_t length,
+                           int64_t value, const std::string &dtype) = 0;
 
-    virtual void*
-      empty_buffer(const std::string& name, int64_t num_bytes) = 0;
-  };
+  virtual void *empty_buffer(const std::string &name, int64_t num_bytes) = 0;
+};
 
-  /// @class Builder
+/// @class Builder
+///
+/// @brief Abstract base class for nodes within an ArrayBuilder that
+/// cumulatively discover an array's type and fill it.
+class LIBAWKWARD_EXPORT_SYMBOL Builder
+    : public std::enable_shared_from_this<Builder> {
+public:
+  /// @brief Virtual destructor acts as a first non-inline virtual function
+  /// that determines a specific translation unit in which vtable shall be
+  /// emitted.
+  virtual ~Builder();
+
+  /// @brief User-friendly name of this class.
+  virtual const std::string classname() const = 0;
+
+  /// @brief Copy the current snapshot into the BuffersContainer and
+  /// return a Form as a std::string (JSON).
+  virtual const std::string to_buffers(BuffersContainer &container,
+                                       int64_t          &form_key_id) const = 0;
+
+  /// @brief Current length of the accumulated array.
+  virtual int64_t length() const = 0;
+
+  /// @brief Removes all accumulated data without resetting the type
+  /// knowledge.
+  virtual void clear() = 0;
+
+  /// @brief If `true`, this node has started but has not finished a
+  /// multi-step command (e.g. `beginX ... endX`).
+  virtual bool active() const = 0;
+
+  /// @brief Adds a `null` value to the accumulated data.
+  virtual const BuilderPtr null() = 0;
+
+  /// @brief Adds a boolean value `x` to the accumulated data.
+  virtual const BuilderPtr boolean(bool x) = 0;
+
+  /// @brief Adds an integer value `x` to the accumulated data.
+  virtual const BuilderPtr integer(int64_t x) = 0;
+
+  /// @brief Adds a real value `x` to the accumulated data.
+  virtual const BuilderPtr real(double x) = 0;
+
+  /// @brief Adds a complex value `x` to the accumulated data.
+  virtual const BuilderPtr complex(std::complex<double> x) = 0;
+
+  /// @brief Adds a datetime value `x` to the accumulated data.
+  virtual const BuilderPtr datetime(int64_t x, const std::string &unit) = 0;
+
+  /// @brief Adds a timedelta value `x` to the accumulated data.
+  virtual const BuilderPtr timedelta(int64_t x, const std::string &unit) = 0;
+
+  /// @brief Adds a string value `x` with a given `length` and `encoding`
+  /// to the accumulated data.
   ///
-  /// @brief Abstract base class for nodes within an ArrayBuilder that
-  /// cumulatively discover an array's type and fill it.
-  class LIBAWKWARD_EXPORT_SYMBOL Builder: public std::enable_shared_from_this<Builder> {
-  public:
-    /// @brief Virtual destructor acts as a first non-inline virtual function
-    /// that determines a specific translation unit in which vtable shall be
-    /// emitted.
-    virtual ~Builder();
+  /// @note Currently, only `encoding =`
+  ///
+  ///    - `nullptr` (no encoding; a bytestring)
+  ///    - `"utf-8"` (variable-length Unicode 8-bit encoding)
+  ///
+  /// are supported.
+  virtual const BuilderPtr string(const char *x, int64_t length,
+                                  const char *encoding) = 0;
 
-    /// @brief User-friendly name of this class.
-    virtual const std::string
-      classname() const = 0;
+  /// @brief Begins building a nested list.
+  virtual const BuilderPtr beginlist() = 0;
 
-    /// @brief Copy the current snapshot into the BuffersContainer and
-    /// return a Form as a std::string (JSON).
-    virtual const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const = 0;
+  /// @brief Ends a nested list.
+  virtual const BuilderPtr endlist() = 0;
 
-    /// @brief Current length of the accumulated array.
-    virtual int64_t
-      length() const = 0;
+  /// @brief Begins building a tuple with a fixed number of fields.
+  virtual const BuilderPtr begintuple(int64_t numfields) = 0;
 
-    /// @brief Removes all accumulated data without resetting the type
-    /// knowledge.
-    virtual void
-      clear() = 0;
+  /// @brief Sets the pointer to a given tuple field index; the next
+  /// command will fill that slot.
+  virtual const BuilderPtr index(int64_t index) = 0;
 
-    /// @brief If `true`, this node has started but has not finished a
-    /// multi-step command (e.g. `beginX ... endX`).
-    virtual bool
-      active() const = 0;
+  /// @brief Ends a tuple.
+  virtual const BuilderPtr endtuple() = 0;
 
-    /// @brief Adds a `null` value to the accumulated data.
-    virtual const BuilderPtr
-      null() = 0;
+  /// @brief Begins building a record with an optional name.
+  ///
+  /// @param name If specified, this name is used to distinguish
+  /// records of different types in heterogeneous data (to build a
+  /// union of record arrays, rather than a record array with union
+  /// fields and optional values) and it also sets the `"__record__"`
+  /// parameter to later add custom behaviors in Python.
+  /// @param check If `true`, actually do a string comparison to see if the
+  /// provided `name` matches the previous `name`; if `false`, assume
+  /// that the same pointer means the same string (safe for string
+  /// literals).
+  virtual const BuilderPtr beginrecord(const char *name, bool check) = 0;
 
-    /// @brief Adds a boolean value `x` to the accumulated data.
-    virtual const BuilderPtr
-      boolean(bool x) = 0;
+  /// @brief Sets the pointer to a given record field `key`; the next
+  /// command will fill that slot.
+  ///
+  /// @param key Indicates the field to fill.
+  /// @param check If `true`, actually do a string comparison to see if
+  /// `key` matches the previous `key`; if `false`, assume that the same
+  /// pointer means the same string (safe for string literals).
+  ///
+  /// Record keys are checked in round-robin order. The best performance
+  /// will be achieved by filling them in the same order for each record.
+  /// Lookup time for random order scales with the number of fields.
+  virtual void field(const char *key, bool check) = 0;
 
-    /// @brief Adds an integer value `x` to the accumulated data.
-    virtual const BuilderPtr
-      integer(int64_t x) = 0;
-
-    /// @brief Adds a real value `x` to the accumulated data.
-    virtual const BuilderPtr
-      real(double x) = 0;
-
-    /// @brief Adds a complex value `x` to the accumulated data.
-    virtual const BuilderPtr
-      complex(std::complex<double> x) = 0;
-
-    /// @brief Adds a datetime value `x` to the accumulated data.
-    virtual const BuilderPtr
-      datetime(int64_t x, const std::string& unit) = 0;
-
-    /// @brief Adds a timedelta value `x` to the accumulated data.
-    virtual const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) = 0;
-
-    /// @brief Adds a string value `x` with a given `length` and `encoding`
-    /// to the accumulated data.
-    ///
-    /// @note Currently, only `encoding =`
-    ///
-    ///    - `nullptr` (no encoding; a bytestring)
-    ///    - `"utf-8"` (variable-length Unicode 8-bit encoding)
-    ///
-    /// are supported.
-    virtual const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) = 0;
-
-    /// @brief Begins building a nested list.
-    virtual const BuilderPtr
-      beginlist() = 0;
-
-    /// @brief Ends a nested list.
-    virtual const BuilderPtr
-      endlist() = 0;
-
-    /// @brief Begins building a tuple with a fixed number of fields.
-    virtual const BuilderPtr
-      begintuple(int64_t numfields) = 0;
-
-    /// @brief Sets the pointer to a given tuple field index; the next
-    /// command will fill that slot.
-    virtual const BuilderPtr
-      index(int64_t index) = 0;
-
-    /// @brief Ends a tuple.
-    virtual const BuilderPtr
-      endtuple() = 0;
-
-    /// @brief Begins building a record with an optional name.
-    ///
-    /// @param name If specified, this name is used to distinguish
-    /// records of different types in heterogeneous data (to build a
-    /// union of record arrays, rather than a record array with union
-    /// fields and optional values) and it also sets the `"__record__"`
-    /// parameter to later add custom behaviors in Python.
-    /// @param check If `true`, actually do a string comparison to see if the
-    /// provided `name` matches the previous `name`; if `false`, assume
-    /// that the same pointer means the same string (safe for string
-    /// literals).
-    virtual const BuilderPtr
-      beginrecord(const char* name, bool check) = 0;
-
-    /// @brief Sets the pointer to a given record field `key`; the next
-    /// command will fill that slot.
-    ///
-    /// @param key Indicates the field to fill.
-    /// @param check If `true`, actually do a string comparison to see if
-    /// `key` matches the previous `key`; if `false`, assume that the same
-    /// pointer means the same string (safe for string literals).
-    ///
-    /// Record keys are checked in round-robin order. The best performance
-    /// will be achieved by filling them in the same order for each record.
-    /// Lookup time for random order scales with the number of fields.
-    virtual void
-      field(const char* key, bool check) = 0;
-
-    /// @brief Ends a record.
-    virtual const BuilderPtr
-      endrecord() = 0;
-  };
-}
+  /// @brief Ends a record.
+  virtual const BuilderPtr endrecord() = 0;
+};
+} // namespace awkward
 
 #endif // AWKWARD_FILLABLE_H_

--- a/include/awkward/builder/Complex128Builder.h
+++ b/include/awkward/builder/Complex128Builder.h
@@ -1,128 +1,106 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_COMPLEX128BUILDER_H_
 #define AWKWARD_COMPLEX128BUILDER_H_
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 #include <complex>
 
 namespace awkward {
-  /// @class Complex128Builder
+/// @class Complex128Builder
+///
+/// @brief Builder node that accumulates real numbers (`double`).
+class LIBAWKWARD_EXPORT_SYMBOL Complex128Builder : public Builder {
+public:
+  /// @brief Create an empty Complex128Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a Complex128Builder from an existing Int64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param old The Int64Builder's buffer.
+  static const BuilderPtr fromint64(const BuilderOptions &options,
+                                    const GrowableBuffer<int64_t> &old);
+
+  /// @brief Create a Complex128Builder from an existing Float64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param old The Float64Builder's buffer.
+  static const BuilderPtr fromfloat64(const BuilderOptions &options,
+                                      const GrowableBuffer<double> &old);
+
+  /// @brief Create a Complex128Builder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates real numbers (`double`).
-  class LIBAWKWARD_EXPORT_SYMBOL Complex128Builder: public Builder {
-  public:
-    /// @brief Create an empty Complex128Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated real numbers.
+  Complex128Builder(const BuilderOptions &options,
+                    GrowableBuffer<std::complex<double>> buffer);
 
-    /// @brief Create a Complex128Builder from an existing Int64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param old The Int64Builder's buffer.
-    static const BuilderPtr
-      fromint64(const BuilderOptions& options,
-                const GrowableBuffer<int64_t>& old);
+  /// @brief User-friendly name of this class: `"Complex128Builder"`.
+  const std::string classname() const override;
 
-    /// @brief Create a Complex128Builder from an existing Float64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param old The Float64Builder's buffer.
-    static const BuilderPtr
-      fromfloat64(const BuilderOptions& options,
-                  const GrowableBuffer<double>& old);
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    /// @brief Create a Complex128Builder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated real numbers.
-    Complex128Builder(const BuilderOptions& options,
-                      GrowableBuffer<std::complex<double>> buffer);
+  int64_t length() const override;
 
-    /// @brief User-friendly name of this class: `"Complex128Builder"`.
-    const std::string
-      classname() const override;
+  void clear() override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  /// @copydoc Builder::active()
+  ///
+  /// A Complex128Builder is never active.
+  bool active() const override;
 
-    int64_t
-      length() const override;
+  const BuilderPtr null() override;
 
-    void
-      clear() override;
+  const BuilderPtr boolean(bool x) override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A Complex128Builder is never active.
-    bool
-      active() const override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  void field(const char *key, bool check) override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  const BuilderOptions &options() const { return options_; }
 
-    void
-      field(const char* key, bool check) override;
+  const GrowableBuffer<std::complex<double>> &buffer() const { return buffer_; }
 
-    const BuilderPtr
-      endrecord() override;
+private:
+  const BuilderOptions options_;
+  GrowableBuffer<std::complex<double>> buffer_;
+};
 
-    const BuilderOptions&
-      options() const { return options_; }
-
-    const GrowableBuffer<std::complex<double>>& buffer() const { return buffer_; }
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<std::complex<double>> buffer_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_COMPLEX128BUILDER_H_

--- a/include/awkward/builder/Complex128Builder.h
+++ b/include/awkward/builder/Complex128Builder.h
@@ -3,126 +3,103 @@
 #ifndef AWKWARD_COMPLEX128BUILDER_H_
 #define AWKWARD_COMPLEX128BUILDER_H_
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 #include <complex>
 
 namespace awkward {
-  /// @class Complex128Builder
+/// @class Complex128Builder
+///
+/// @brief Builder node that accumulates real numbers (`double`).
+class LIBAWKWARD_EXPORT_SYMBOL Complex128Builder : public Builder {
+public:
+  /// @brief Create an empty Complex128Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a Complex128Builder from an existing Int64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param old The Int64Builder's buffer.
+  static const BuilderPtr fromint64(const BuilderOptions          &options,
+                                    const GrowableBuffer<int64_t> &old);
+
+  /// @brief Create a Complex128Builder from an existing Float64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param old The Float64Builder's buffer.
+  static const BuilderPtr fromfloat64(const BuilderOptions         &options,
+                                      const GrowableBuffer<double> &old);
+
+  /// @brief Create a Complex128Builder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates real numbers (`double`).
-  class LIBAWKWARD_EXPORT_SYMBOL Complex128Builder: public Builder {
-  public:
-    /// @brief Create an empty Complex128Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated real numbers.
+  Complex128Builder(const BuilderOptions                &options,
+                    GrowableBuffer<std::complex<double>> buffer);
 
-    /// @brief Create a Complex128Builder from an existing Int64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param old The Int64Builder's buffer.
-    static const BuilderPtr
-      fromint64(const BuilderOptions& options,
-                const GrowableBuffer<int64_t>& old);
+  /// @brief User-friendly name of this class: `"Complex128Builder"`.
+  const std::string classname() const override;
 
-    /// @brief Create a Complex128Builder from an existing Float64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param old The Float64Builder's buffer.
-    static const BuilderPtr
-      fromfloat64(const BuilderOptions& options,
-                  const GrowableBuffer<double>& old);
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    /// @brief Create a Complex128Builder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated real numbers.
-    Complex128Builder(const BuilderOptions& options,
-                      GrowableBuffer<std::complex<double>> buffer);
+  int64_t length() const override;
 
-    /// @brief User-friendly name of this class: `"Complex128Builder"`.
-    const std::string
-      classname() const override;
+  void clear() override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  /// @copydoc Builder::active()
+  ///
+  /// A Complex128Builder is never active.
+  bool active() const override;
 
-    int64_t
-      length() const override;
+  const BuilderPtr null() override;
 
-    void
-      clear() override;
+  const BuilderPtr boolean(bool x) override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A Complex128Builder is never active.
-    bool
-      active() const override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  void field(const char *key, bool check) override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  const BuilderOptions &options() const { return options_; }
 
-    void
-      field(const char* key, bool check) override;
+  const GrowableBuffer<std::complex<double>> &buffer() const { return buffer_; }
 
-    const BuilderPtr
-      endrecord() override;
+private:
+  const BuilderOptions                 options_;
+  GrowableBuffer<std::complex<double>> buffer_;
+};
 
-    const BuilderOptions&
-      options() const { return options_; }
-
-    const GrowableBuffer<std::complex<double>>& buffer() const { return buffer_; }
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<std::complex<double>> buffer_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_COMPLEX128BUILDER_H_

--- a/include/awkward/builder/Complex128Builder.h
+++ b/include/awkward/builder/Complex128Builder.h
@@ -1,106 +1,128 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_COMPLEX128BUILDER_H_
 #define AWKWARD_COMPLEX128BUILDER_H_
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 #include <complex>
 
 namespace awkward {
-/// @class Complex128Builder
-///
-/// @brief Builder node that accumulates real numbers (`double`).
-class LIBAWKWARD_EXPORT_SYMBOL Complex128Builder : public Builder {
-public:
-  /// @brief Create an empty Complex128Builder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options);
-
-  /// @brief Create a Complex128Builder from an existing Int64Builder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param old The Int64Builder's buffer.
-  static const BuilderPtr fromint64(const BuilderOptions &options,
-                                    const GrowableBuffer<int64_t> &old);
-
-  /// @brief Create a Complex128Builder from an existing Float64Builder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param old The Float64Builder's buffer.
-  static const BuilderPtr fromfloat64(const BuilderOptions &options,
-                                      const GrowableBuffer<double> &old);
-
-  /// @brief Create a Complex128Builder from a full set of parameters.
+  /// @class Complex128Builder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param buffer Contains the accumulated real numbers.
-  Complex128Builder(const BuilderOptions &options,
-                    GrowableBuffer<std::complex<double>> buffer);
+  /// @brief Builder node that accumulates real numbers (`double`).
+  class LIBAWKWARD_EXPORT_SYMBOL Complex128Builder: public Builder {
+  public:
+    /// @brief Create an empty Complex128Builder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options);
 
-  /// @brief User-friendly name of this class: `"Complex128Builder"`.
-  const std::string classname() const override;
+    /// @brief Create a Complex128Builder from an existing Int64Builder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param old The Int64Builder's buffer.
+    static const BuilderPtr
+      fromint64(const BuilderOptions& options,
+                const GrowableBuffer<int64_t>& old);
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief Create a Complex128Builder from an existing Float64Builder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param old The Float64Builder's buffer.
+    static const BuilderPtr
+      fromfloat64(const BuilderOptions& options,
+                  const GrowableBuffer<double>& old);
 
-  int64_t length() const override;
+    /// @brief Create a Complex128Builder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param buffer Contains the accumulated real numbers.
+    Complex128Builder(const BuilderOptions& options,
+                      GrowableBuffer<std::complex<double>> buffer);
 
-  void clear() override;
+    /// @brief User-friendly name of this class: `"Complex128Builder"`.
+    const std::string
+      classname() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// A Complex128Builder is never active.
-  bool active() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  const BuilderPtr null() override;
+    int64_t
+      length() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    void
+      clear() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    /// @copydoc Builder::active()
+    ///
+    /// A Complex128Builder is never active.
+    bool
+      active() const override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr endrecord() override;
+    const BuilderPtr
+      endtuple() override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const GrowableBuffer<std::complex<double>> &buffer() const { return buffer_; }
+    void
+      field(const char* key, bool check) override;
 
-private:
-  const BuilderOptions options_;
-  GrowableBuffer<std::complex<double>> buffer_;
-};
+    const BuilderPtr
+      endrecord() override;
 
-} // namespace awkward
+    const BuilderOptions&
+      options() const { return options_; }
+
+    const GrowableBuffer<std::complex<double>>& buffer() const { return buffer_; }
+
+  private:
+    const BuilderOptions options_;
+    GrowableBuffer<std::complex<double>> buffer_;
+  };
+
+}
 
 #endif // AWKWARD_COMPLEX128BUILDER_H_

--- a/include/awkward/builder/DatetimeBuilder.h
+++ b/include/awkward/builder/DatetimeBuilder.h
@@ -1,96 +1,117 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_DATETIMEBUILDER_H_
 #define AWKWARD_DATETIMEBUILDER_H_
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class DatetimeBuilder
-///
-/// @brief Builder node that accumulates integers (`int64_t`).
-class LIBAWKWARD_EXPORT_SYMBOL DatetimeBuilder : public Builder {
-public:
-  /// @brief Create an empty DatetimeBuilder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options,
-                                    const std::string &units);
-
-  /// @brief Create an DatetimeBuilder from a full set of parameters.
+  /// @class DatetimeBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param buffer Contains the accumulated integers.
-  DatetimeBuilder(const BuilderOptions &options,
-                  GrowableBuffer<int64_t> content, const std::string &units);
+  /// @brief Builder node that accumulates integers (`int64_t`).
+  class LIBAWKWARD_EXPORT_SYMBOL DatetimeBuilder: public Builder {
+  public:
+    /// @brief Create an empty DatetimeBuilder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options, const std::string& units);
 
-  /// @brief User-friendly name of this class: `"DatetimeBuilder"`.
-  const std::string classname() const override;
+    /// @brief Create an DatetimeBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param buffer Contains the accumulated integers.
+    DatetimeBuilder(const BuilderOptions& options,
+                    GrowableBuffer<int64_t> content,
+                    const std::string& units);
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"DatetimeBuilder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// A DatetimeBuilder is never active.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// A DatetimeBuilder is never active.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-  const std::string &units() const;
+    const BuilderOptions&
+      options() const { return options_; }
 
-  const GrowableBuffer<int64_t> &buffer() const { return content_; }
+    const std::string&
+      units() const;
 
-  const std::string &unit() const { return units_; }
+    const GrowableBuffer<int64_t>& buffer() const { return content_; }
 
-private:
-  const BuilderOptions options_;
-  GrowableBuffer<int64_t> content_;
-  const std::string units_;
-};
-} // namespace awkward
+    const std::string& unit() const { return units_; }
+
+  private:
+    const BuilderOptions options_;
+    GrowableBuffer<int64_t> content_;
+    const std::string units_;
+  };
+}
 
 #endif // AWKWARD_DATETIMEBUILDER_H_

--- a/include/awkward/builder/DatetimeBuilder.h
+++ b/include/awkward/builder/DatetimeBuilder.h
@@ -1,117 +1,96 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_DATETIMEBUILDER_H_
 #define AWKWARD_DATETIMEBUILDER_H_
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class DatetimeBuilder
+/// @class DatetimeBuilder
+///
+/// @brief Builder node that accumulates integers (`int64_t`).
+class LIBAWKWARD_EXPORT_SYMBOL DatetimeBuilder : public Builder {
+public:
+  /// @brief Create an empty DatetimeBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options,
+                                    const std::string &units);
+
+  /// @brief Create an DatetimeBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates integers (`int64_t`).
-  class LIBAWKWARD_EXPORT_SYMBOL DatetimeBuilder: public Builder {
-  public:
-    /// @brief Create an empty DatetimeBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options, const std::string& units);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated integers.
+  DatetimeBuilder(const BuilderOptions &options,
+                  GrowableBuffer<int64_t> content, const std::string &units);
 
-    /// @brief Create an DatetimeBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated integers.
-    DatetimeBuilder(const BuilderOptions& options,
-                    GrowableBuffer<int64_t> content,
-                    const std::string& units);
+  /// @brief User-friendly name of this class: `"DatetimeBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"DatetimeBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A DatetimeBuilder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A DatetimeBuilder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const std::string &units() const;
 
-    const std::string&
-      units() const;
+  const GrowableBuffer<int64_t> &buffer() const { return content_; }
 
-    const GrowableBuffer<int64_t>& buffer() const { return content_; }
+  const std::string &unit() const { return units_; }
 
-    const std::string& unit() const { return units_; }
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int64_t> content_;
-    const std::string units_;
-  };
-}
+private:
+  const BuilderOptions options_;
+  GrowableBuffer<int64_t> content_;
+  const std::string units_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_DATETIMEBUILDER_H_

--- a/include/awkward/builder/DatetimeBuilder.h
+++ b/include/awkward/builder/DatetimeBuilder.h
@@ -3,115 +3,93 @@
 #ifndef AWKWARD_DATETIMEBUILDER_H_
 #define AWKWARD_DATETIMEBUILDER_H_
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class DatetimeBuilder
+/// @class DatetimeBuilder
+///
+/// @brief Builder node that accumulates integers (`int64_t`).
+class LIBAWKWARD_EXPORT_SYMBOL DatetimeBuilder : public Builder {
+public:
+  /// @brief Create an empty DatetimeBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options,
+                                    const std::string    &units);
+
+  /// @brief Create an DatetimeBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates integers (`int64_t`).
-  class LIBAWKWARD_EXPORT_SYMBOL DatetimeBuilder: public Builder {
-  public:
-    /// @brief Create an empty DatetimeBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options, const std::string& units);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated integers.
+  DatetimeBuilder(const BuilderOptions   &options,
+                  GrowableBuffer<int64_t> content, const std::string &units);
 
-    /// @brief Create an DatetimeBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated integers.
-    DatetimeBuilder(const BuilderOptions& options,
-                    GrowableBuffer<int64_t> content,
-                    const std::string& units);
+  /// @brief User-friendly name of this class: `"DatetimeBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"DatetimeBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A DatetimeBuilder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A DatetimeBuilder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const std::string &units() const;
 
-    const std::string&
-      units() const;
+  const GrowableBuffer<int64_t> &buffer() const { return content_; }
 
-    const GrowableBuffer<int64_t>& buffer() const { return content_; }
+  const std::string &unit() const { return units_; }
 
-    const std::string& unit() const { return units_; }
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int64_t> content_;
-    const std::string units_;
-  };
-}
+private:
+  const BuilderOptions    options_;
+  GrowableBuffer<int64_t> content_;
+  const std::string       units_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_DATETIMEBUILDER_H_

--- a/include/awkward/builder/Float64Builder.h
+++ b/include/awkward/builder/Float64Builder.h
@@ -1,123 +1,100 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_FLOAT64BUILDER_H_
 #define AWKWARD_FLOAT64BUILDER_H_
 
 #include <string>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class Float64Builder
+/// @class Float64Builder
+///
+/// @brief Builder node that accumulates real numbers (`double`).
+class LIBAWKWARD_EXPORT_SYMBOL Float64Builder : public Builder {
+public:
+  /// @brief Create an empty Float64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a Float64Builder from an existing Int64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param old The Int64Builder's buffer.
+  static const BuilderPtr fromint64(const BuilderOptions &options,
+                                    const GrowableBuffer<int64_t> &old);
+
+  /// @brief Create a Float64Builder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates real numbers (`double`).
-  class LIBAWKWARD_EXPORT_SYMBOL Float64Builder: public Builder {
-  public:
-    /// @brief Create an empty Float64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated real numbers.
+  Float64Builder(const BuilderOptions &options, GrowableBuffer<double> buffer);
 
-    /// @brief Create a Float64Builder from an existing Int64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param old The Int64Builder's buffer.
-    static const BuilderPtr
-      fromint64(const BuilderOptions& options,
-                const GrowableBuffer<int64_t>& old);
+  /// @brief Contains the accumulated real numbers (`double`).
+  GrowableBuffer<double> buffer();
 
-    /// @brief Create a Float64Builder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated real numbers.
-    Float64Builder(const BuilderOptions& options,
-                   GrowableBuffer<double> buffer);
+  /// @brief User-friendly name of this class: `"Float64Builder"`.
+  const std::string classname() const override;
 
-    /// @brief Contains the accumulated real numbers (`double`).
-    GrowableBuffer<double>
-      buffer();
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    /// @brief User-friendly name of this class: `"Float64Builder"`.
-    const std::string
-      classname() const override;
+  int64_t length() const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  void clear() override;
 
-    int64_t
-      length() const override;
+  /// @copydoc Builder::active()
+  ///
+  /// A Float64Builder is never active.
+  bool active() const override;
 
-    void
-      clear() override;
+  const BuilderPtr null() override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A Float64Builder is never active.
-    bool
-      active() const override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      endtuple() override;
+  void field(const char *key, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderPtr
-      endrecord() override;
+private:
+  const BuilderOptions options_;
+  GrowableBuffer<double> buffer_;
+};
 
-    const BuilderOptions&
-      options() const { return options_; }
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<double> buffer_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_FLOAT64BUILDER_H_

--- a/include/awkward/builder/Float64Builder.h
+++ b/include/awkward/builder/Float64Builder.h
@@ -1,100 +1,123 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_FLOAT64BUILDER_H_
 #define AWKWARD_FLOAT64BUILDER_H_
 
 #include <string>
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class Float64Builder
-///
-/// @brief Builder node that accumulates real numbers (`double`).
-class LIBAWKWARD_EXPORT_SYMBOL Float64Builder : public Builder {
-public:
-  /// @brief Create an empty Float64Builder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options);
-
-  /// @brief Create a Float64Builder from an existing Int64Builder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param old The Int64Builder's buffer.
-  static const BuilderPtr fromint64(const BuilderOptions &options,
-                                    const GrowableBuffer<int64_t> &old);
-
-  /// @brief Create a Float64Builder from a full set of parameters.
+  /// @class Float64Builder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param buffer Contains the accumulated real numbers.
-  Float64Builder(const BuilderOptions &options, GrowableBuffer<double> buffer);
+  /// @brief Builder node that accumulates real numbers (`double`).
+  class LIBAWKWARD_EXPORT_SYMBOL Float64Builder: public Builder {
+  public:
+    /// @brief Create an empty Float64Builder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options);
 
-  /// @brief Contains the accumulated real numbers (`double`).
-  GrowableBuffer<double> buffer();
+    /// @brief Create a Float64Builder from an existing Int64Builder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param old The Int64Builder's buffer.
+    static const BuilderPtr
+      fromint64(const BuilderOptions& options,
+                const GrowableBuffer<int64_t>& old);
 
-  /// @brief User-friendly name of this class: `"Float64Builder"`.
-  const std::string classname() const override;
+    /// @brief Create a Float64Builder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param buffer Contains the accumulated real numbers.
+    Float64Builder(const BuilderOptions& options,
+                   GrowableBuffer<double> buffer);
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief Contains the accumulated real numbers (`double`).
+    GrowableBuffer<double>
+      buffer();
 
-  int64_t length() const override;
+    /// @brief User-friendly name of this class: `"Float64Builder"`.
+    const std::string
+      classname() const override;
 
-  void clear() override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// A Float64Builder is never active.
-  bool active() const override;
+    int64_t
+      length() const override;
 
-  const BuilderPtr null() override;
+    void
+      clear() override;
 
-  const BuilderPtr boolean(bool x) override;
+    /// @copydoc Builder::active()
+    ///
+    /// A Float64Builder is never active.
+    bool
+      active() const override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  const BuilderPtr endrecord() override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    void
+      field(const char* key, bool check) override;
 
-private:
-  const BuilderOptions options_;
-  GrowableBuffer<double> buffer_;
-};
+    const BuilderPtr
+      endrecord() override;
 
-} // namespace awkward
+    const BuilderOptions&
+      options() const { return options_; }
+
+  private:
+    const BuilderOptions options_;
+    GrowableBuffer<double> buffer_;
+  };
+
+}
 
 #endif // AWKWARD_FLOAT64BUILDER_H_

--- a/include/awkward/builder/Float64Builder.h
+++ b/include/awkward/builder/Float64Builder.h
@@ -5,119 +5,95 @@
 
 #include <string>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class Float64Builder
+/// @class Float64Builder
+///
+/// @brief Builder node that accumulates real numbers (`double`).
+class LIBAWKWARD_EXPORT_SYMBOL Float64Builder : public Builder {
+public:
+  /// @brief Create an empty Float64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a Float64Builder from an existing Int64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param old The Int64Builder's buffer.
+  static const BuilderPtr fromint64(const BuilderOptions          &options,
+                                    const GrowableBuffer<int64_t> &old);
+
+  /// @brief Create a Float64Builder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates real numbers (`double`).
-  class LIBAWKWARD_EXPORT_SYMBOL Float64Builder: public Builder {
-  public:
-    /// @brief Create an empty Float64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated real numbers.
+  Float64Builder(const BuilderOptions &options, GrowableBuffer<double> buffer);
 
-    /// @brief Create a Float64Builder from an existing Int64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param old The Int64Builder's buffer.
-    static const BuilderPtr
-      fromint64(const BuilderOptions& options,
-                const GrowableBuffer<int64_t>& old);
+  /// @brief Contains the accumulated real numbers (`double`).
+  GrowableBuffer<double> buffer();
 
-    /// @brief Create a Float64Builder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated real numbers.
-    Float64Builder(const BuilderOptions& options,
-                   GrowableBuffer<double> buffer);
+  /// @brief User-friendly name of this class: `"Float64Builder"`.
+  const std::string classname() const override;
 
-    /// @brief Contains the accumulated real numbers (`double`).
-    GrowableBuffer<double>
-      buffer();
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    /// @brief User-friendly name of this class: `"Float64Builder"`.
-    const std::string
-      classname() const override;
+  int64_t length() const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  void clear() override;
 
-    int64_t
-      length() const override;
+  /// @copydoc Builder::active()
+  ///
+  /// A Float64Builder is never active.
+  bool active() const override;
 
-    void
-      clear() override;
+  const BuilderPtr null() override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A Float64Builder is never active.
-    bool
-      active() const override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      endtuple() override;
+  void field(const char *key, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderPtr
-      endrecord() override;
+private:
+  const BuilderOptions   options_;
+  GrowableBuffer<double> buffer_;
+};
 
-    const BuilderOptions&
-      options() const { return options_; }
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<double> buffer_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_FLOAT64BUILDER_H_

--- a/include/awkward/builder/Int64Builder.h
+++ b/include/awkward/builder/Int64Builder.h
@@ -1,90 +1,112 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_INT64BUILDER_H_
 #define AWKWARD_INT64BUILDER_H_
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class Int64Builder
-///
-/// @brief Builder node that accumulates integers (`int64_t`).
-class LIBAWKWARD_EXPORT_SYMBOL Int64Builder : public Builder {
-public:
-  /// @brief Create an empty Int64Builder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options);
-
-  /// @brief Create an Int64Builder from a full set of parameters.
+  /// @class Int64Builder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param buffer Contains the accumulated integers.
-  Int64Builder(const BuilderOptions &options, GrowableBuffer<int64_t> buffer);
+  /// @brief Builder node that accumulates integers (`int64_t`).
+  class LIBAWKWARD_EXPORT_SYMBOL Int64Builder: public Builder {
+  public:
+    /// @brief Create an empty Int64Builder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options);
 
-  /// @brief Contains the accumulated integers.
-  GrowableBuffer<int64_t> buffer();
+    /// @brief Create an Int64Builder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param buffer Contains the accumulated integers.
+    Int64Builder(const BuilderOptions& options,
+                 GrowableBuffer<int64_t> buffer);
 
-  /// @brief User-friendly name of this class: `"Int64Builder"`.
-  const std::string classname() const override;
+    /// @brief Contains the accumulated integers.
+    GrowableBuffer<int64_t>
+      buffer();
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"Int64Builder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// A Int64Builder is never active.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// A Int64Builder is never active.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-private:
-  const BuilderOptions options_;
-  GrowableBuffer<int64_t> buffer_;
-};
-} // namespace awkward
+    const BuilderOptions&
+      options() const { return options_; }
+
+  private:
+    const BuilderOptions options_;
+    GrowableBuffer<int64_t> buffer_;
+  };
+}
 
 #endif // AWKWARD_INT64BUILDER_H_

--- a/include/awkward/builder/Int64Builder.h
+++ b/include/awkward/builder/Int64Builder.h
@@ -3,110 +3,87 @@
 #ifndef AWKWARD_INT64BUILDER_H_
 #define AWKWARD_INT64BUILDER_H_
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class Int64Builder
+/// @class Int64Builder
+///
+/// @brief Builder node that accumulates integers (`int64_t`).
+class LIBAWKWARD_EXPORT_SYMBOL Int64Builder : public Builder {
+public:
+  /// @brief Create an empty Int64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create an Int64Builder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates integers (`int64_t`).
-  class LIBAWKWARD_EXPORT_SYMBOL Int64Builder: public Builder {
-  public:
-    /// @brief Create an empty Int64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated integers.
+  Int64Builder(const BuilderOptions &options, GrowableBuffer<int64_t> buffer);
 
-    /// @brief Create an Int64Builder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated integers.
-    Int64Builder(const BuilderOptions& options,
-                 GrowableBuffer<int64_t> buffer);
+  /// @brief Contains the accumulated integers.
+  GrowableBuffer<int64_t> buffer();
 
-    /// @brief Contains the accumulated integers.
-    GrowableBuffer<int64_t>
-      buffer();
+  /// @brief User-friendly name of this class: `"Int64Builder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"Int64Builder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A Int64Builder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A Int64Builder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int64_t> buffer_;
-  };
-}
+private:
+  const BuilderOptions    options_;
+  GrowableBuffer<int64_t> buffer_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_INT64BUILDER_H_

--- a/include/awkward/builder/Int64Builder.h
+++ b/include/awkward/builder/Int64Builder.h
@@ -1,112 +1,90 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_INT64BUILDER_H_
 #define AWKWARD_INT64BUILDER_H_
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class Int64Builder
+/// @class Int64Builder
+///
+/// @brief Builder node that accumulates integers (`int64_t`).
+class LIBAWKWARD_EXPORT_SYMBOL Int64Builder : public Builder {
+public:
+  /// @brief Create an empty Int64Builder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create an Int64Builder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates integers (`int64_t`).
-  class LIBAWKWARD_EXPORT_SYMBOL Int64Builder: public Builder {
-  public:
-    /// @brief Create an empty Int64Builder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param buffer Contains the accumulated integers.
+  Int64Builder(const BuilderOptions &options, GrowableBuffer<int64_t> buffer);
 
-    /// @brief Create an Int64Builder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param buffer Contains the accumulated integers.
-    Int64Builder(const BuilderOptions& options,
-                 GrowableBuffer<int64_t> buffer);
+  /// @brief Contains the accumulated integers.
+  GrowableBuffer<int64_t> buffer();
 
-    /// @brief Contains the accumulated integers.
-    GrowableBuffer<int64_t>
-      buffer();
+  /// @brief User-friendly name of this class: `"Int64Builder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"Int64Builder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A Int64Builder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A Int64Builder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int64_t> buffer_;
-  };
-}
+private:
+  const BuilderOptions options_;
+  GrowableBuffer<int64_t> buffer_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_INT64BUILDER_H_

--- a/include/awkward/builder/ListBuilder.h
+++ b/include/awkward/builder/ListBuilder.h
@@ -5,125 +5,101 @@
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class ListBuilder
+/// @class ListBuilder
+///
+/// @brief Builder node that accumulates lists.
+class LIBAWKWARD_EXPORT_SYMBOL ListBuilder : public Builder {
+public:
+  /// @brief Create an empty ListBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a ListBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates lists.
-  class LIBAWKWARD_EXPORT_SYMBOL ListBuilder: public Builder {
-  public:
-    /// @brief Create an empty ListBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param offsets Contains the accumulated offsets (like
+  /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
+  /// @param content Builder for the data in the nested lists.
+  /// @param begun If `true`, the ListBuilder is in a state after
+  /// #beginlist and before #endlist and is #active; if `false`,
+  /// it is not.
+  ListBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> offsets,
+              const BuilderPtr &content, bool begun);
 
-    /// @brief Create a ListBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param offsets Contains the accumulated offsets (like
-    /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
-    /// @param content Builder for the data in the nested lists.
-    /// @param begun If `true`, the ListBuilder is in a state after
-    /// #beginlist and before #endlist and is #active; if `false`,
-    /// it is not.
-    ListBuilder(const BuilderOptions& options,
-                GrowableBuffer<int64_t> offsets,
-                const BuilderPtr& content,
-                bool begun);
+  /// @brief User-friendly name of this class: `"ListBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"ListBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// Calling #beginlist makes a ListBuilder active; #endlist makes it
+  /// inactive.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// Calling #beginlist makes a ListBuilder active; #endlist makes it
-    /// inactive.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const GrowableBuffer<int64_t> &buffer() const { return offsets_; }
 
-    const GrowableBuffer<int64_t>& buffer() const { return offsets_; }
+  const BuilderPtr builder() const { return content_; }
 
-    const BuilderPtr builder() const { return content_; }
+  bool begun() { return begun_; }
 
-    bool begun() { return begun_; }
+  void maybeupdate(const BuilderPtr builder);
 
-    void
-      maybeupdate(const BuilderPtr builder);
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int64_t> offsets_;
-    BuilderPtr content_;
-    bool begun_;
-  };
-}
+private:
+  const BuilderOptions    options_;
+  GrowableBuffer<int64_t> offsets_;
+  BuilderPtr              content_;
+  bool                    begun_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_LISTBUILDER_H_

--- a/include/awkward/builder/ListBuilder.h
+++ b/include/awkward/builder/ListBuilder.h
@@ -1,129 +1,106 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_LISTBUILDER_H_
 #define AWKWARD_LISTBUILDER_H_
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class ListBuilder
+/// @class ListBuilder
+///
+/// @brief Builder node that accumulates lists.
+class LIBAWKWARD_EXPORT_SYMBOL ListBuilder : public Builder {
+public:
+  /// @brief Create an empty ListBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a ListBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates lists.
-  class LIBAWKWARD_EXPORT_SYMBOL ListBuilder: public Builder {
-  public:
-    /// @brief Create an empty ListBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param offsets Contains the accumulated offsets (like
+  /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
+  /// @param content Builder for the data in the nested lists.
+  /// @param begun If `true`, the ListBuilder is in a state after
+  /// #beginlist and before #endlist and is #active; if `false`,
+  /// it is not.
+  ListBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> offsets,
+              const BuilderPtr &content, bool begun);
 
-    /// @brief Create a ListBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param offsets Contains the accumulated offsets (like
-    /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
-    /// @param content Builder for the data in the nested lists.
-    /// @param begun If `true`, the ListBuilder is in a state after
-    /// #beginlist and before #endlist and is #active; if `false`,
-    /// it is not.
-    ListBuilder(const BuilderOptions& options,
-                GrowableBuffer<int64_t> offsets,
-                const BuilderPtr& content,
-                bool begun);
+  /// @brief User-friendly name of this class: `"ListBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"ListBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// Calling #beginlist makes a ListBuilder active; #endlist makes it
+  /// inactive.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// Calling #beginlist makes a ListBuilder active; #endlist makes it
-    /// inactive.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const GrowableBuffer<int64_t> &buffer() const { return offsets_; }
 
-    const GrowableBuffer<int64_t>& buffer() const { return offsets_; }
+  const BuilderPtr builder() const { return content_; }
 
-    const BuilderPtr builder() const { return content_; }
+  bool begun() { return begun_; }
 
-    bool begun() { return begun_; }
+  void maybeupdate(const BuilderPtr builder);
 
-    void
-      maybeupdate(const BuilderPtr builder);
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int64_t> offsets_;
-    BuilderPtr content_;
-    bool begun_;
-  };
-}
+private:
+  const BuilderOptions options_;
+  GrowableBuffer<int64_t> offsets_;
+  BuilderPtr content_;
+  bool begun_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_LISTBUILDER_H_

--- a/include/awkward/builder/ListBuilder.h
+++ b/include/awkward/builder/ListBuilder.h
@@ -1,106 +1,129 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_LISTBUILDER_H_
 #define AWKWARD_LISTBUILDER_H_
 
 #include <vector>
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class ListBuilder
-///
-/// @brief Builder node that accumulates lists.
-class LIBAWKWARD_EXPORT_SYMBOL ListBuilder : public Builder {
-public:
-  /// @brief Create an empty ListBuilder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options);
-
-  /// @brief Create a ListBuilder from a full set of parameters.
+  /// @class ListBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param offsets Contains the accumulated offsets (like
-  /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
-  /// @param content Builder for the data in the nested lists.
-  /// @param begun If `true`, the ListBuilder is in a state after
-  /// #beginlist and before #endlist and is #active; if `false`,
-  /// it is not.
-  ListBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> offsets,
-              const BuilderPtr &content, bool begun);
+  /// @brief Builder node that accumulates lists.
+  class LIBAWKWARD_EXPORT_SYMBOL ListBuilder: public Builder {
+  public:
+    /// @brief Create an empty ListBuilder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options);
 
-  /// @brief User-friendly name of this class: `"ListBuilder"`.
-  const std::string classname() const override;
+    /// @brief Create a ListBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param offsets Contains the accumulated offsets (like
+    /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
+    /// @param content Builder for the data in the nested lists.
+    /// @param begun If `true`, the ListBuilder is in a state after
+    /// #beginlist and before #endlist and is #active; if `false`,
+    /// it is not.
+    ListBuilder(const BuilderOptions& options,
+                GrowableBuffer<int64_t> offsets,
+                const BuilderPtr& content,
+                bool begun);
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"ListBuilder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// Calling #beginlist makes a ListBuilder active; #endlist makes it
-  /// inactive.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// Calling #beginlist makes a ListBuilder active; #endlist makes it
+    /// inactive.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-  const GrowableBuffer<int64_t> &buffer() const { return offsets_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
-  const BuilderPtr builder() const { return content_; }
+    const GrowableBuffer<int64_t>& buffer() const { return offsets_; }
 
-  bool begun() { return begun_; }
+    const BuilderPtr builder() const { return content_; }
 
-  void maybeupdate(const BuilderPtr builder);
+    bool begun() { return begun_; }
 
-private:
-  const BuilderOptions options_;
-  GrowableBuffer<int64_t> offsets_;
-  BuilderPtr content_;
-  bool begun_;
-};
-} // namespace awkward
+    void
+      maybeupdate(const BuilderPtr builder);
+
+  private:
+    const BuilderOptions options_;
+    GrowableBuffer<int64_t> offsets_;
+    BuilderPtr content_;
+    bool begun_;
+  };
+}
 
 #endif // AWKWARD_LISTBUILDER_H_

--- a/include/awkward/builder/OptionBuilder.h
+++ b/include/awkward/builder/OptionBuilder.h
@@ -5,129 +5,106 @@
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class OptionBuilder
+/// @class OptionBuilder
+///
+/// @brief Builder node that accumulates data with missing values (`None`).
+class LIBAWKWARD_EXPORT_SYMBOL OptionBuilder : public Builder {
+public:
+  /// @brief Create an OptionBuilder from a number of nulls (all missing).
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param nullcount Length of the purely missing data to create.
+  /// @param content Builder for the non-missing data.
+  static const BuilderPtr fromnulls(const BuilderOptions &options,
+                                    int64_t               nullcount,
+                                    const BuilderPtr     &content);
+
+  /// @brief Create an OptionBuilder from an existing builder (all
+  /// non-missing).
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param content Builder for the non-missing data.
+  static const BuilderPtr fromvalids(const BuilderOptions &options,
+                                     const BuilderPtr     &content);
+
+  /// @brief Create a OptionBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates data with missing values (`None`).
-  class LIBAWKWARD_EXPORT_SYMBOL OptionBuilder: public Builder {
-  public:
-    /// @brief Create an OptionBuilder from a number of nulls (all missing).
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param nullcount Length of the purely missing data to create.
-    /// @param content Builder for the non-missing data.
-    static const BuilderPtr
-      fromnulls(const BuilderOptions& options,
-                int64_t nullcount,
-                const BuilderPtr& content);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param index Contains the accumulated index (like
+  /// {@link IndexedArrayOf#index IndexedOptionArray::index}).
+  /// @param content Builder for the non-missing data.
+  OptionBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> index,
+                const BuilderPtr content);
 
-    /// @brief Create an OptionBuilder from an existing builder (all
-    /// non-missing).
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param content Builder for the non-missing data.
-    static const BuilderPtr
-      fromvalids(const BuilderOptions& options,
-                 const BuilderPtr& content);
+  /// @brief User-friendly name of this class: `"OptionBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief Create a OptionBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param index Contains the accumulated index (like
-    /// {@link IndexedArrayOf#index IndexedOptionArray::index}).
-    /// @param content Builder for the non-missing data.
-    OptionBuilder(const BuilderOptions& options,
-                  GrowableBuffer<int64_t> index,
-                  const BuilderPtr content);
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    /// @brief User-friendly name of this class: `"OptionBuilder"`.
-    const std::string
-      classname() const override;
+  int64_t length() const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  void clear() override;
 
-    int64_t
-      length() const override;
+  /// @copydoc Builder::active()
+  ///
+  /// An OptionBuilder is active if and only if its `content` is active.
+  bool active() const override;
 
-    void
-      clear() override;
+  const BuilderPtr null() override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// An OptionBuilder is active if and only if its `content` is active.
-    bool
-      active() const override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      endtuple() override;
+  void field(const char *key, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    void
-      field(const char* key, bool check) override;
+  const GrowableBuffer<int64_t> &buffer() const { return index_; }
 
-    const BuilderPtr
-      endrecord() override;
+  const GrowableBuffer<int64_t> &index() { return index_; }
 
-    const GrowableBuffer<int64_t>& buffer() const { return index_; }
+  const BuilderPtr builder() const { return content_; }
 
-    const GrowableBuffer<int64_t>& index() { return index_; }
+  void maybeupdate(const BuilderPtr builder);
 
-    const BuilderPtr builder() const { return content_; }
+private:
+  GrowableBuffer<int64_t> index_;
+  BuilderPtr              content_;
+};
 
-    void
-      maybeupdate(const BuilderPtr builder);
-
-  private:
-    GrowableBuffer<int64_t> index_;
-    BuilderPtr content_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_OPTIONBUILDER_H_

--- a/include/awkward/builder/OptionBuilder.h
+++ b/include/awkward/builder/OptionBuilder.h
@@ -1,111 +1,133 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_OPTIONBUILDER_H_
 #define AWKWARD_OPTIONBUILDER_H_
 
 #include <vector>
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class OptionBuilder
-///
-/// @brief Builder node that accumulates data with missing values (`None`).
-class LIBAWKWARD_EXPORT_SYMBOL OptionBuilder : public Builder {
-public:
-  /// @brief Create an OptionBuilder from a number of nulls (all missing).
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param nullcount Length of the purely missing data to create.
-  /// @param content Builder for the non-missing data.
-  static const BuilderPtr fromnulls(const BuilderOptions &options,
-                                    int64_t nullcount,
-                                    const BuilderPtr &content);
-
-  /// @brief Create an OptionBuilder from an existing builder (all
-  /// non-missing).
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param content Builder for the non-missing data.
-  static const BuilderPtr fromvalids(const BuilderOptions &options,
-                                     const BuilderPtr &content);
-
-  /// @brief Create a OptionBuilder from a full set of parameters.
+  /// @class OptionBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param index Contains the accumulated index (like
-  /// {@link IndexedArrayOf#index IndexedOptionArray::index}).
-  /// @param content Builder for the non-missing data.
-  OptionBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> index,
-                const BuilderPtr content);
+  /// @brief Builder node that accumulates data with missing values (`None`).
+  class LIBAWKWARD_EXPORT_SYMBOL OptionBuilder: public Builder {
+  public:
+    /// @brief Create an OptionBuilder from a number of nulls (all missing).
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param nullcount Length of the purely missing data to create.
+    /// @param content Builder for the non-missing data.
+    static const BuilderPtr
+      fromnulls(const BuilderOptions& options,
+                int64_t nullcount,
+                const BuilderPtr& content);
 
-  /// @brief User-friendly name of this class: `"OptionBuilder"`.
-  const std::string classname() const override;
+    /// @brief Create an OptionBuilder from an existing builder (all
+    /// non-missing).
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param content Builder for the non-missing data.
+    static const BuilderPtr
+      fromvalids(const BuilderOptions& options,
+                 const BuilderPtr& content);
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief Create a OptionBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param index Contains the accumulated index (like
+    /// {@link IndexedArrayOf#index IndexedOptionArray::index}).
+    /// @param content Builder for the non-missing data.
+    OptionBuilder(const BuilderOptions& options,
+                  GrowableBuffer<int64_t> index,
+                  const BuilderPtr content);
 
-  int64_t length() const override;
+    /// @brief User-friendly name of this class: `"OptionBuilder"`.
+    const std::string
+      classname() const override;
 
-  void clear() override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// An OptionBuilder is active if and only if its `content` is active.
-  bool active() const override;
+    int64_t
+      length() const override;
 
-  const BuilderPtr null() override;
+    void
+      clear() override;
 
-  const BuilderPtr boolean(bool x) override;
+    /// @copydoc Builder::active()
+    ///
+    /// An OptionBuilder is active if and only if its `content` is active.
+    bool
+      active() const override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  const BuilderPtr endrecord() override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const GrowableBuffer<int64_t> &buffer() const { return index_; }
+    void
+      field(const char* key, bool check) override;
 
-  const GrowableBuffer<int64_t> &index() { return index_; }
+    const BuilderPtr
+      endrecord() override;
 
-  const BuilderPtr builder() const { return content_; }
+    const GrowableBuffer<int64_t>& buffer() const { return index_; }
 
-  void maybeupdate(const BuilderPtr builder);
+    const GrowableBuffer<int64_t>& index() { return index_; }
 
-private:
-  GrowableBuffer<int64_t> index_;
-  BuilderPtr content_;
-};
+    const BuilderPtr builder() const { return content_; }
 
-} // namespace awkward
+    void
+      maybeupdate(const BuilderPtr builder);
+
+  private:
+    GrowableBuffer<int64_t> index_;
+    BuilderPtr content_;
+  };
+
+}
 
 #endif // AWKWARD_OPTIONBUILDER_H_

--- a/include/awkward/builder/OptionBuilder.h
+++ b/include/awkward/builder/OptionBuilder.h
@@ -1,133 +1,111 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_OPTIONBUILDER_H_
 #define AWKWARD_OPTIONBUILDER_H_
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class OptionBuilder
+/// @class OptionBuilder
+///
+/// @brief Builder node that accumulates data with missing values (`None`).
+class LIBAWKWARD_EXPORT_SYMBOL OptionBuilder : public Builder {
+public:
+  /// @brief Create an OptionBuilder from a number of nulls (all missing).
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param nullcount Length of the purely missing data to create.
+  /// @param content Builder for the non-missing data.
+  static const BuilderPtr fromnulls(const BuilderOptions &options,
+                                    int64_t nullcount,
+                                    const BuilderPtr &content);
+
+  /// @brief Create an OptionBuilder from an existing builder (all
+  /// non-missing).
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param content Builder for the non-missing data.
+  static const BuilderPtr fromvalids(const BuilderOptions &options,
+                                     const BuilderPtr &content);
+
+  /// @brief Create a OptionBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates data with missing values (`None`).
-  class LIBAWKWARD_EXPORT_SYMBOL OptionBuilder: public Builder {
-  public:
-    /// @brief Create an OptionBuilder from a number of nulls (all missing).
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param nullcount Length of the purely missing data to create.
-    /// @param content Builder for the non-missing data.
-    static const BuilderPtr
-      fromnulls(const BuilderOptions& options,
-                int64_t nullcount,
-                const BuilderPtr& content);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param index Contains the accumulated index (like
+  /// {@link IndexedArrayOf#index IndexedOptionArray::index}).
+  /// @param content Builder for the non-missing data.
+  OptionBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> index,
+                const BuilderPtr content);
 
-    /// @brief Create an OptionBuilder from an existing builder (all
-    /// non-missing).
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param content Builder for the non-missing data.
-    static const BuilderPtr
-      fromvalids(const BuilderOptions& options,
-                 const BuilderPtr& content);
+  /// @brief User-friendly name of this class: `"OptionBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief Create a OptionBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param index Contains the accumulated index (like
-    /// {@link IndexedArrayOf#index IndexedOptionArray::index}).
-    /// @param content Builder for the non-missing data.
-    OptionBuilder(const BuilderOptions& options,
-                  GrowableBuffer<int64_t> index,
-                  const BuilderPtr content);
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    /// @brief User-friendly name of this class: `"OptionBuilder"`.
-    const std::string
-      classname() const override;
+  int64_t length() const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  void clear() override;
 
-    int64_t
-      length() const override;
+  /// @copydoc Builder::active()
+  ///
+  /// An OptionBuilder is active if and only if its `content` is active.
+  bool active() const override;
 
-    void
-      clear() override;
+  const BuilderPtr null() override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// An OptionBuilder is active if and only if its `content` is active.
-    bool
-      active() const override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      endtuple() override;
+  void field(const char *key, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    void
-      field(const char* key, bool check) override;
+  const GrowableBuffer<int64_t> &buffer() const { return index_; }
 
-    const BuilderPtr
-      endrecord() override;
+  const GrowableBuffer<int64_t> &index() { return index_; }
 
-    const GrowableBuffer<int64_t>& buffer() const { return index_; }
+  const BuilderPtr builder() const { return content_; }
 
-    const GrowableBuffer<int64_t>& index() { return index_; }
+  void maybeupdate(const BuilderPtr builder);
 
-    const BuilderPtr builder() const { return content_; }
+private:
+  GrowableBuffer<int64_t> index_;
+  BuilderPtr content_;
+};
 
-    void
-      maybeupdate(const BuilderPtr builder);
-
-  private:
-    GrowableBuffer<int64_t> index_;
-    BuilderPtr content_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_OPTIONBUILDER_H_

--- a/include/awkward/builder/RecordBuilder.h
+++ b/include/awkward/builder/RecordBuilder.h
@@ -1,162 +1,133 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_RECORDBUILDER_H_
 #define AWKWARD_RECORDBUILDER_H_
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class RecordBuilder
+/// @class RecordBuilder
+///
+/// @brief Builder node for accumulated records.
+class LIBAWKWARD_EXPORT_SYMBOL RecordBuilder : public Builder {
+public:
+  /// @brief Create an empty RecordBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a RecordBuilder from a full set of parameters.
   ///
-  /// @brief Builder node for accumulated records.
-  class LIBAWKWARD_EXPORT_SYMBOL RecordBuilder: public Builder {
-  public:
-    /// @brief Create an empty RecordBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param contents A Builder for each record field.
+  /// @param keys Names for each record field.
+  /// @param pointers String pointers for each record field name.
+  /// @param name String name of the record.
+  /// @param nameptr String pointer for the name of the record.
+  /// @param length Length of accumulated array (same as #length).
+  /// @param begun If `true`, the RecordBuilder is in an active state;
+  /// `false` otherwise.
+  /// @param nextindex The next field index to fill with data.
+  /// @param nexttotry The next field index to check against a key string.
+  RecordBuilder(const BuilderOptions &options,
+                const std::vector<BuilderPtr> &contents,
+                const std::vector<std::string> &keys,
+                const std::vector<const char *> &pointers,
+                const std::string &name, const char *nameptr, int64_t length,
+                bool begun, int64_t nextindex, int64_t nexttotry);
 
-    /// @brief Create a RecordBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param contents A Builder for each record field.
-    /// @param keys Names for each record field.
-    /// @param pointers String pointers for each record field name.
-    /// @param name String name of the record.
-    /// @param nameptr String pointer for the name of the record.
-    /// @param length Length of accumulated array (same as #length).
-    /// @param begun If `true`, the RecordBuilder is in an active state;
-    /// `false` otherwise.
-    /// @param nextindex The next field index to fill with data.
-    /// @param nexttotry The next field index to check against a key string.
-    RecordBuilder(const BuilderOptions& options,
-                  const std::vector<BuilderPtr>& contents,
-                  const std::vector<std::string>& keys,
-                  const std::vector<const char*>& pointers,
-                  const std::string& name,
-                  const char* nameptr,
-                  int64_t length,
-                  bool begun,
-                  int64_t nextindex,
-                  int64_t nexttotry);
+  /// @brief Name of the record (STL wrapped #nameptr).
+  const std::string name() const;
 
-    /// @brief Name of the record (STL wrapped #nameptr).
-    const std::string
-      name() const;
+  /// @brief String pointer for the name of the record.
+  const char *nameptr() const;
 
-    /// @brief String pointer for the name of the record.
-    const char*
-      nameptr() const;
+  /// @brief User-friendly name of this class: `"RecordBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"RecordBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// Calling #beginrecord makes a RecordBuilder active; #endrecord makes it
+  /// inactive.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// Calling #beginrecord makes a RecordBuilder active; #endrecord makes it
-    /// inactive.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const std::vector<std::string> &keys() const { return keys_; }
 
-    const std::vector<std::string>& keys() const { return keys_; }
+  const std::vector<BuilderPtr> &builders() const { return contents_; }
 
-    const std::vector<BuilderPtr>& builders() const { return contents_; }
+  bool begun() { return begun_; }
 
-    bool begun() { return begun_; }
+  int64_t nextindex() { return nextindex_; }
 
-    int64_t nextindex() { return nextindex_; }
+  void maybeupdate(int64_t i, const BuilderPtr builder);
 
-    void
-      maybeupdate(int64_t i, const BuilderPtr builder);
+private:
+  void field_fast(const char *key);
 
-  private:
-    void
-      field_fast(const char* key);
+  void field_check(const char *key);
 
-    void
-      field_check(const char* key);
-
-    const BuilderOptions options_;
-    std::vector<BuilderPtr> contents_;
-    std::vector<std::string> keys_;
-    std::vector<const char*> pointers_;
-    std::string name_;
-    const char* nameptr_;
-    int64_t length_;
-    bool begun_;
-    int64_t nextindex_;
-    int64_t nexttotry_;
-    int64_t keys_size_;
-  };
-}
+  const BuilderOptions options_;
+  std::vector<BuilderPtr> contents_;
+  std::vector<std::string> keys_;
+  std::vector<const char *> pointers_;
+  std::string name_;
+  const char *nameptr_;
+  int64_t length_;
+  bool begun_;
+  int64_t nextindex_;
+  int64_t nexttotry_;
+  int64_t keys_size_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_RECORDBUILDER_H_

--- a/include/awkward/builder/RecordBuilder.h
+++ b/include/awkward/builder/RecordBuilder.h
@@ -1,133 +1,162 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_RECORDBUILDER_H_
 #define AWKWARD_RECORDBUILDER_H_
 
 #include <vector>
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class RecordBuilder
-///
-/// @brief Builder node for accumulated records.
-class LIBAWKWARD_EXPORT_SYMBOL RecordBuilder : public Builder {
-public:
-  /// @brief Create an empty RecordBuilder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options);
-
-  /// @brief Create a RecordBuilder from a full set of parameters.
+  /// @class RecordBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param contents A Builder for each record field.
-  /// @param keys Names for each record field.
-  /// @param pointers String pointers for each record field name.
-  /// @param name String name of the record.
-  /// @param nameptr String pointer for the name of the record.
-  /// @param length Length of accumulated array (same as #length).
-  /// @param begun If `true`, the RecordBuilder is in an active state;
-  /// `false` otherwise.
-  /// @param nextindex The next field index to fill with data.
-  /// @param nexttotry The next field index to check against a key string.
-  RecordBuilder(const BuilderOptions &options,
-                const std::vector<BuilderPtr> &contents,
-                const std::vector<std::string> &keys,
-                const std::vector<const char *> &pointers,
-                const std::string &name, const char *nameptr, int64_t length,
-                bool begun, int64_t nextindex, int64_t nexttotry);
+  /// @brief Builder node for accumulated records.
+  class LIBAWKWARD_EXPORT_SYMBOL RecordBuilder: public Builder {
+  public:
+    /// @brief Create an empty RecordBuilder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options);
 
-  /// @brief Name of the record (STL wrapped #nameptr).
-  const std::string name() const;
+    /// @brief Create a RecordBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param contents A Builder for each record field.
+    /// @param keys Names for each record field.
+    /// @param pointers String pointers for each record field name.
+    /// @param name String name of the record.
+    /// @param nameptr String pointer for the name of the record.
+    /// @param length Length of accumulated array (same as #length).
+    /// @param begun If `true`, the RecordBuilder is in an active state;
+    /// `false` otherwise.
+    /// @param nextindex The next field index to fill with data.
+    /// @param nexttotry The next field index to check against a key string.
+    RecordBuilder(const BuilderOptions& options,
+                  const std::vector<BuilderPtr>& contents,
+                  const std::vector<std::string>& keys,
+                  const std::vector<const char*>& pointers,
+                  const std::string& name,
+                  const char* nameptr,
+                  int64_t length,
+                  bool begun,
+                  int64_t nextindex,
+                  int64_t nexttotry);
 
-  /// @brief String pointer for the name of the record.
-  const char *nameptr() const;
+    /// @brief Name of the record (STL wrapped #nameptr).
+    const std::string
+      name() const;
 
-  /// @brief User-friendly name of this class: `"RecordBuilder"`.
-  const std::string classname() const override;
+    /// @brief String pointer for the name of the record.
+    const char*
+      nameptr() const;
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"RecordBuilder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// Calling #beginrecord makes a RecordBuilder active; #endrecord makes it
-  /// inactive.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// Calling #beginrecord makes a RecordBuilder active; #endrecord makes it
+    /// inactive.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-  const std::vector<std::string> &keys() const { return keys_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
-  const std::vector<BuilderPtr> &builders() const { return contents_; }
+    const std::vector<std::string>& keys() const { return keys_; }
 
-  bool begun() { return begun_; }
+    const std::vector<BuilderPtr>& builders() const { return contents_; }
 
-  int64_t nextindex() { return nextindex_; }
+    bool begun() { return begun_; }
 
-  void maybeupdate(int64_t i, const BuilderPtr builder);
+    int64_t nextindex() { return nextindex_; }
 
-private:
-  void field_fast(const char *key);
+    void
+      maybeupdate(int64_t i, const BuilderPtr builder);
 
-  void field_check(const char *key);
+  private:
+    void
+      field_fast(const char* key);
 
-  const BuilderOptions options_;
-  std::vector<BuilderPtr> contents_;
-  std::vector<std::string> keys_;
-  std::vector<const char *> pointers_;
-  std::string name_;
-  const char *nameptr_;
-  int64_t length_;
-  bool begun_;
-  int64_t nextindex_;
-  int64_t nexttotry_;
-  int64_t keys_size_;
-};
-} // namespace awkward
+    void
+      field_check(const char* key);
+
+    const BuilderOptions options_;
+    std::vector<BuilderPtr> contents_;
+    std::vector<std::string> keys_;
+    std::vector<const char*> pointers_;
+    std::string name_;
+    const char* nameptr_;
+    int64_t length_;
+    bool begun_;
+    int64_t nextindex_;
+    int64_t nexttotry_;
+    int64_t keys_size_;
+  };
+}
 
 #endif // AWKWARD_RECORDBUILDER_H_

--- a/include/awkward/builder/RecordBuilder.h
+++ b/include/awkward/builder/RecordBuilder.h
@@ -5,158 +5,128 @@
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class RecordBuilder
+/// @class RecordBuilder
+///
+/// @brief Builder node for accumulated records.
+class LIBAWKWARD_EXPORT_SYMBOL RecordBuilder : public Builder {
+public:
+  /// @brief Create an empty RecordBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a RecordBuilder from a full set of parameters.
   ///
-  /// @brief Builder node for accumulated records.
-  class LIBAWKWARD_EXPORT_SYMBOL RecordBuilder: public Builder {
-  public:
-    /// @brief Create an empty RecordBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param contents A Builder for each record field.
+  /// @param keys Names for each record field.
+  /// @param pointers String pointers for each record field name.
+  /// @param name String name of the record.
+  /// @param nameptr String pointer for the name of the record.
+  /// @param length Length of accumulated array (same as #length).
+  /// @param begun If `true`, the RecordBuilder is in an active state;
+  /// `false` otherwise.
+  /// @param nextindex The next field index to fill with data.
+  /// @param nexttotry The next field index to check against a key string.
+  RecordBuilder(const BuilderOptions            &options,
+                const std::vector<BuilderPtr>   &contents,
+                const std::vector<std::string>  &keys,
+                const std::vector<const char *> &pointers,
+                const std::string &name, const char *nameptr, int64_t length,
+                bool begun, int64_t nextindex, int64_t nexttotry);
 
-    /// @brief Create a RecordBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param contents A Builder for each record field.
-    /// @param keys Names for each record field.
-    /// @param pointers String pointers for each record field name.
-    /// @param name String name of the record.
-    /// @param nameptr String pointer for the name of the record.
-    /// @param length Length of accumulated array (same as #length).
-    /// @param begun If `true`, the RecordBuilder is in an active state;
-    /// `false` otherwise.
-    /// @param nextindex The next field index to fill with data.
-    /// @param nexttotry The next field index to check against a key string.
-    RecordBuilder(const BuilderOptions& options,
-                  const std::vector<BuilderPtr>& contents,
-                  const std::vector<std::string>& keys,
-                  const std::vector<const char*>& pointers,
-                  const std::string& name,
-                  const char* nameptr,
-                  int64_t length,
-                  bool begun,
-                  int64_t nextindex,
-                  int64_t nexttotry);
+  /// @brief Name of the record (STL wrapped #nameptr).
+  const std::string name() const;
 
-    /// @brief Name of the record (STL wrapped #nameptr).
-    const std::string
-      name() const;
+  /// @brief String pointer for the name of the record.
+  const char *nameptr() const;
 
-    /// @brief String pointer for the name of the record.
-    const char*
-      nameptr() const;
+  /// @brief User-friendly name of this class: `"RecordBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"RecordBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// Calling #beginrecord makes a RecordBuilder active; #endrecord makes it
+  /// inactive.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// Calling #beginrecord makes a RecordBuilder active; #endrecord makes it
-    /// inactive.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const std::vector<std::string> &keys() const { return keys_; }
 
-    const std::vector<std::string>& keys() const { return keys_; }
+  const std::vector<BuilderPtr> &builders() const { return contents_; }
 
-    const std::vector<BuilderPtr>& builders() const { return contents_; }
+  bool begun() { return begun_; }
 
-    bool begun() { return begun_; }
+  int64_t nextindex() { return nextindex_; }
 
-    int64_t nextindex() { return nextindex_; }
+  void maybeupdate(int64_t i, const BuilderPtr builder);
 
-    void
-      maybeupdate(int64_t i, const BuilderPtr builder);
+private:
+  void field_fast(const char *key);
 
-  private:
-    void
-      field_fast(const char* key);
+  void field_check(const char *key);
 
-    void
-      field_check(const char* key);
-
-    const BuilderOptions options_;
-    std::vector<BuilderPtr> contents_;
-    std::vector<std::string> keys_;
-    std::vector<const char*> pointers_;
-    std::string name_;
-    const char* nameptr_;
-    int64_t length_;
-    bool begun_;
-    int64_t nextindex_;
-    int64_t nexttotry_;
-    int64_t keys_size_;
-  };
-}
+  const BuilderOptions      options_;
+  std::vector<BuilderPtr>   contents_;
+  std::vector<std::string>  keys_;
+  std::vector<const char *> pointers_;
+  std::string               name_;
+  const char               *nameptr_;
+  int64_t                   length_;
+  bool                      begun_;
+  int64_t                   nextindex_;
+  int64_t                   nexttotry_;
+  int64_t                   keys_size_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_RECORDBUILDER_H_

--- a/include/awkward/builder/StringBuilder.h
+++ b/include/awkward/builder/StringBuilder.h
@@ -1,110 +1,132 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_STRINGBUILDER_H_
 #define AWKWARD_STRINGBUILDER_H_
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class StringBuilder
-///
-/// @brief Builder node that accumulates strings.
-class LIBAWKWARD_EXPORT_SYMBOL StringBuilder : public Builder {
-public:
-  /// @brief Create an empty StringBuilder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param encoding If `nullptr`, the string is an unencoded bytestring;
-  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-  /// Currently, no other encodings have been defined.
-  static const BuilderPtr fromempty(const BuilderOptions &options,
-                                    const char *encoding);
-
-  /// @brief Create a StringBuilder from a full set of parameters.
+  /// @class StringBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param offsets Contains the accumulated offsets (like
-  /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
-  /// @param content Another GrowableBuffer, but for the characters in all
-  /// the strings.
-  /// @param encoding If `nullptr`, the string is an unencoded bytestring;
-  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-  /// Currently, no other encodings have been defined.
-  StringBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> offsets,
-                GrowableBuffer<uint8_t> content, const char *encoding);
+  /// @brief Builder node that accumulates strings.
+  class LIBAWKWARD_EXPORT_SYMBOL StringBuilder: public Builder {
+  public:
+    /// @brief Create an empty StringBuilder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param encoding If `nullptr`, the string is an unencoded bytestring;
+    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+    /// Currently, no other encodings have been defined.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options, const char* encoding);
 
-  /// @brief If `nullptr`, the string is an unencoded bytestring;
-  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-  /// Currently, no other encodings have been defined.
-  const char *encoding() const;
+    /// @brief Create a StringBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param offsets Contains the accumulated offsets (like
+    /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
+    /// @param content Another GrowableBuffer, but for the characters in all
+    /// the strings.
+    /// @param encoding If `nullptr`, the string is an unencoded bytestring;
+    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+    /// Currently, no other encodings have been defined.
+    StringBuilder(const BuilderOptions& options,
+                  GrowableBuffer<int64_t> offsets,
+                  GrowableBuffer<uint8_t> content,
+                  const char* encoding);
 
-  /// @brief User-friendly name of this class: `"StringBuilder"`.
-  const std::string classname() const override;
+    /// @brief If `nullptr`, the string is an unencoded bytestring;
+    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+    /// Currently, no other encodings have been defined.
+    const char*
+      encoding() const;
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"StringBuilder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// A StringBuilder is never active.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// A StringBuilder is never active.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-  const GrowableBuffer<int64_t> &buffer() const { return offsets_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
-  const GrowableBuffer<uint8_t> &content() const { return content_; }
+    const GrowableBuffer<int64_t>& buffer() const { return offsets_; }
 
-private:
-  const BuilderOptions options_;
-  GrowableBuffer<int64_t> offsets_;
-  GrowableBuffer<uint8_t> content_;
-  const char *encoding_;
-};
+    const GrowableBuffer<uint8_t>& content() const { return content_; }
 
-} // namespace awkward
+  private:
+    const BuilderOptions options_;
+    GrowableBuffer<int64_t> offsets_;
+    GrowableBuffer<uint8_t> content_;
+    const char* encoding_;
+  };
+
+}
 
 #endif // AWKWARD_STRINGBUILDER_H_

--- a/include/awkward/builder/StringBuilder.h
+++ b/include/awkward/builder/StringBuilder.h
@@ -1,132 +1,110 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_STRINGBUILDER_H_
 #define AWKWARD_STRINGBUILDER_H_
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class StringBuilder
+/// @class StringBuilder
+///
+/// @brief Builder node that accumulates strings.
+class LIBAWKWARD_EXPORT_SYMBOL StringBuilder : public Builder {
+public:
+  /// @brief Create an empty StringBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param encoding If `nullptr`, the string is an unencoded bytestring;
+  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+  /// Currently, no other encodings have been defined.
+  static const BuilderPtr fromempty(const BuilderOptions &options,
+                                    const char *encoding);
+
+  /// @brief Create a StringBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates strings.
-  class LIBAWKWARD_EXPORT_SYMBOL StringBuilder: public Builder {
-  public:
-    /// @brief Create an empty StringBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param encoding If `nullptr`, the string is an unencoded bytestring;
-    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-    /// Currently, no other encodings have been defined.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options, const char* encoding);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param offsets Contains the accumulated offsets (like
+  /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
+  /// @param content Another GrowableBuffer, but for the characters in all
+  /// the strings.
+  /// @param encoding If `nullptr`, the string is an unencoded bytestring;
+  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+  /// Currently, no other encodings have been defined.
+  StringBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> offsets,
+                GrowableBuffer<uint8_t> content, const char *encoding);
 
-    /// @brief Create a StringBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param offsets Contains the accumulated offsets (like
-    /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
-    /// @param content Another GrowableBuffer, but for the characters in all
-    /// the strings.
-    /// @param encoding If `nullptr`, the string is an unencoded bytestring;
-    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-    /// Currently, no other encodings have been defined.
-    StringBuilder(const BuilderOptions& options,
-                  GrowableBuffer<int64_t> offsets,
-                  GrowableBuffer<uint8_t> content,
-                  const char* encoding);
+  /// @brief If `nullptr`, the string is an unencoded bytestring;
+  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+  /// Currently, no other encodings have been defined.
+  const char *encoding() const;
 
-    /// @brief If `nullptr`, the string is an unencoded bytestring;
-    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-    /// Currently, no other encodings have been defined.
-    const char*
-      encoding() const;
+  /// @brief User-friendly name of this class: `"StringBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"StringBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A StringBuilder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A StringBuilder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const GrowableBuffer<int64_t> &buffer() const { return offsets_; }
 
-    const GrowableBuffer<int64_t>& buffer() const { return offsets_; }
+  const GrowableBuffer<uint8_t> &content() const { return content_; }
 
-    const GrowableBuffer<uint8_t>& content() const { return content_; }
+private:
+  const BuilderOptions options_;
+  GrowableBuffer<int64_t> offsets_;
+  GrowableBuffer<uint8_t> content_;
+  const char *encoding_;
+};
 
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int64_t> offsets_;
-    GrowableBuffer<uint8_t> content_;
-    const char* encoding_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_STRINGBUILDER_H_

--- a/include/awkward/builder/StringBuilder.h
+++ b/include/awkward/builder/StringBuilder.h
@@ -3,130 +3,107 @@
 #ifndef AWKWARD_STRINGBUILDER_H_
 #define AWKWARD_STRINGBUILDER_H_
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class StringBuilder
+/// @class StringBuilder
+///
+/// @brief Builder node that accumulates strings.
+class LIBAWKWARD_EXPORT_SYMBOL StringBuilder : public Builder {
+public:
+  /// @brief Create an empty StringBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param encoding If `nullptr`, the string is an unencoded bytestring;
+  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+  /// Currently, no other encodings have been defined.
+  static const BuilderPtr fromempty(const BuilderOptions &options,
+                                    const char           *encoding);
+
+  /// @brief Create a StringBuilder from a full set of parameters.
   ///
-  /// @brief Builder node that accumulates strings.
-  class LIBAWKWARD_EXPORT_SYMBOL StringBuilder: public Builder {
-  public:
-    /// @brief Create an empty StringBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param encoding If `nullptr`, the string is an unencoded bytestring;
-    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-    /// Currently, no other encodings have been defined.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options, const char* encoding);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param offsets Contains the accumulated offsets (like
+  /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
+  /// @param content Another GrowableBuffer, but for the characters in all
+  /// the strings.
+  /// @param encoding If `nullptr`, the string is an unencoded bytestring;
+  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+  /// Currently, no other encodings have been defined.
+  StringBuilder(const BuilderOptions &options, GrowableBuffer<int64_t> offsets,
+                GrowableBuffer<uint8_t> content, const char *encoding);
 
-    /// @brief Create a StringBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param offsets Contains the accumulated offsets (like
-    /// {@link ListOffsetArrayOf#offsets ListOffsetArray::offsets}).
-    /// @param content Another GrowableBuffer, but for the characters in all
-    /// the strings.
-    /// @param encoding If `nullptr`, the string is an unencoded bytestring;
-    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-    /// Currently, no other encodings have been defined.
-    StringBuilder(const BuilderOptions& options,
-                  GrowableBuffer<int64_t> offsets,
-                  GrowableBuffer<uint8_t> content,
-                  const char* encoding);
+  /// @brief If `nullptr`, the string is an unencoded bytestring;
+  /// if `"utf-8"`, it is encoded with variable-width UTF-8.
+  /// Currently, no other encodings have been defined.
+  const char *encoding() const;
 
-    /// @brief If `nullptr`, the string is an unencoded bytestring;
-    /// if `"utf-8"`, it is encoded with variable-width UTF-8.
-    /// Currently, no other encodings have been defined.
-    const char*
-      encoding() const;
+  /// @brief User-friendly name of this class: `"StringBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"StringBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A StringBuilder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A StringBuilder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const GrowableBuffer<int64_t> &buffer() const { return offsets_; }
 
-    const GrowableBuffer<int64_t>& buffer() const { return offsets_; }
+  const GrowableBuffer<uint8_t> &content() const { return content_; }
 
-    const GrowableBuffer<uint8_t>& content() const { return content_; }
+private:
+  const BuilderOptions    options_;
+  GrowableBuffer<int64_t> offsets_;
+  GrowableBuffer<uint8_t> content_;
+  const char             *encoding_;
+};
 
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int64_t> offsets_;
-    GrowableBuffer<uint8_t> content_;
-    const char* encoding_;
-  };
-
-}
+} // namespace awkward
 
 #endif // AWKWARD_STRINGBUILDER_H_

--- a/include/awkward/builder/TupleBuilder.h
+++ b/include/awkward/builder/TupleBuilder.h
@@ -1,110 +1,134 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_TUPLEBUILDER_H_
 #define AWKWARD_TUPLEBUILDER_H_
 
 #include <vector>
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class TupleBuilder
-///
-/// @brief Builder node for accumulated tuples.
-class LIBAWKWARD_EXPORT_SYMBOL TupleBuilder : public Builder {
-public:
-  /// @brief Create an empty TupleBuilder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options);
-
-  /// @brief Create a TupleBuilder from a full set of parameters.
+  /// @class TupleBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param contents A Builder for each tuple field.
-  /// @param length Length of accumulated array (same as #length).
-  /// @param begun If `true`, the TupleBuilder is in an active state;
-  /// `false` otherwise.
-  /// @param nextindex The next field index to fill with data.
-  TupleBuilder(const BuilderOptions &options,
-               const std::vector<BuilderPtr> &contents, int64_t length,
-               bool begun, size_t nextindex);
+  /// @brief Builder node for accumulated tuples.
+  class LIBAWKWARD_EXPORT_SYMBOL TupleBuilder: public Builder {
+  public:
+    /// @brief Create an empty TupleBuilder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options);
 
-  /// @brief Current number of fields.
-  int64_t numfields() const;
+    /// @brief Create a TupleBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param contents A Builder for each tuple field.
+    /// @param length Length of accumulated array (same as #length).
+    /// @param begun If `true`, the TupleBuilder is in an active state;
+    /// `false` otherwise.
+    /// @param nextindex The next field index to fill with data.
+    TupleBuilder(const BuilderOptions& options,
+                 const std::vector<BuilderPtr>& contents,
+                 int64_t length,
+                 bool begun,
+                 size_t nextindex);
 
-  /// @brief User-friendly name of this class: `"TupleBuilder"`.
-  const std::string classname() const override;
+    /// @brief Current number of fields.
+    int64_t
+      numfields() const;
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"TupleBuilder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// Calling #begintuple makes a TupleBuilder active; #endtuple makes it
-  /// inactive.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// Calling #begintuple makes a TupleBuilder active; #endtuple makes it
+    /// inactive.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-  const std::vector<BuilderPtr> &contents() const { return contents_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
-  bool begun() { return begun_; }
+    const std::vector<BuilderPtr>& contents() const { return contents_; }
 
-  int64_t nextindex() { return nextindex_; }
+    bool begun() { return begun_; }
 
-  void maybeupdate(int64_t i, const BuilderPtr builder);
+    int64_t nextindex() { return nextindex_; }
 
-private:
-  const BuilderOptions options_;
-  std::vector<BuilderPtr> contents_;
-  int64_t length_;
-  bool begun_;
-  int64_t nextindex_;
-};
-} // namespace awkward
+    void
+      maybeupdate(int64_t i, const BuilderPtr builder);
+
+  private:
+    const BuilderOptions options_;
+    std::vector<BuilderPtr> contents_;
+    int64_t length_;
+    bool begun_;
+    int64_t nextindex_;
+  };
+}
 
 #endif // AWKWARD_TUPLEBUILDER_H_

--- a/include/awkward/builder/TupleBuilder.h
+++ b/include/awkward/builder/TupleBuilder.h
@@ -5,130 +5,105 @@
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class TupleBuilder
+/// @class TupleBuilder
+///
+/// @brief Builder node for accumulated tuples.
+class LIBAWKWARD_EXPORT_SYMBOL TupleBuilder : public Builder {
+public:
+  /// @brief Create an empty TupleBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a TupleBuilder from a full set of parameters.
   ///
-  /// @brief Builder node for accumulated tuples.
-  class LIBAWKWARD_EXPORT_SYMBOL TupleBuilder: public Builder {
-  public:
-    /// @brief Create an empty TupleBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param contents A Builder for each tuple field.
+  /// @param length Length of accumulated array (same as #length).
+  /// @param begun If `true`, the TupleBuilder is in an active state;
+  /// `false` otherwise.
+  /// @param nextindex The next field index to fill with data.
+  TupleBuilder(const BuilderOptions          &options,
+               const std::vector<BuilderPtr> &contents, int64_t length,
+               bool begun, size_t nextindex);
 
-    /// @brief Create a TupleBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param contents A Builder for each tuple field.
-    /// @param length Length of accumulated array (same as #length).
-    /// @param begun If `true`, the TupleBuilder is in an active state;
-    /// `false` otherwise.
-    /// @param nextindex The next field index to fill with data.
-    TupleBuilder(const BuilderOptions& options,
-                 const std::vector<BuilderPtr>& contents,
-                 int64_t length,
-                 bool begun,
-                 size_t nextindex);
+  /// @brief Current number of fields.
+  int64_t numfields() const;
 
-    /// @brief Current number of fields.
-    int64_t
-      numfields() const;
+  /// @brief User-friendly name of this class: `"TupleBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"TupleBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// Calling #begintuple makes a TupleBuilder active; #endtuple makes it
+  /// inactive.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// Calling #begintuple makes a TupleBuilder active; #endtuple makes it
-    /// inactive.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const std::vector<BuilderPtr> &contents() const { return contents_; }
 
-    const std::vector<BuilderPtr>& contents() const { return contents_; }
+  bool begun() { return begun_; }
 
-    bool begun() { return begun_; }
+  int64_t nextindex() { return nextindex_; }
 
-    int64_t nextindex() { return nextindex_; }
+  void maybeupdate(int64_t i, const BuilderPtr builder);
 
-    void
-      maybeupdate(int64_t i, const BuilderPtr builder);
-
-  private:
-    const BuilderOptions options_;
-    std::vector<BuilderPtr> contents_;
-    int64_t length_;
-    bool begun_;
-    int64_t nextindex_;
-  };
-}
+private:
+  const BuilderOptions    options_;
+  std::vector<BuilderPtr> contents_;
+  int64_t                 length_;
+  bool                    begun_;
+  int64_t                 nextindex_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_TUPLEBUILDER_H_

--- a/include/awkward/builder/TupleBuilder.h
+++ b/include/awkward/builder/TupleBuilder.h
@@ -1,134 +1,110 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_TUPLEBUILDER_H_
 #define AWKWARD_TUPLEBUILDER_H_
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class TupleBuilder
+/// @class TupleBuilder
+///
+/// @brief Builder node for accumulated tuples.
+class LIBAWKWARD_EXPORT_SYMBOL TupleBuilder : public Builder {
+public:
+  /// @brief Create an empty TupleBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a TupleBuilder from a full set of parameters.
   ///
-  /// @brief Builder node for accumulated tuples.
-  class LIBAWKWARD_EXPORT_SYMBOL TupleBuilder: public Builder {
-  public:
-    /// @brief Create an empty TupleBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param contents A Builder for each tuple field.
+  /// @param length Length of accumulated array (same as #length).
+  /// @param begun If `true`, the TupleBuilder is in an active state;
+  /// `false` otherwise.
+  /// @param nextindex The next field index to fill with data.
+  TupleBuilder(const BuilderOptions &options,
+               const std::vector<BuilderPtr> &contents, int64_t length,
+               bool begun, size_t nextindex);
 
-    /// @brief Create a TupleBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param contents A Builder for each tuple field.
-    /// @param length Length of accumulated array (same as #length).
-    /// @param begun If `true`, the TupleBuilder is in an active state;
-    /// `false` otherwise.
-    /// @param nextindex The next field index to fill with data.
-    TupleBuilder(const BuilderOptions& options,
-                 const std::vector<BuilderPtr>& contents,
-                 int64_t length,
-                 bool begun,
-                 size_t nextindex);
+  /// @brief Current number of fields.
+  int64_t numfields() const;
 
-    /// @brief Current number of fields.
-    int64_t
-      numfields() const;
+  /// @brief User-friendly name of this class: `"TupleBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"TupleBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// Calling #begintuple makes a TupleBuilder active; #endtuple makes it
+  /// inactive.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// Calling #begintuple makes a TupleBuilder active; #endtuple makes it
-    /// inactive.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const std::vector<BuilderPtr> &contents() const { return contents_; }
 
-    const std::vector<BuilderPtr>& contents() const { return contents_; }
+  bool begun() { return begun_; }
 
-    bool begun() { return begun_; }
+  int64_t nextindex() { return nextindex_; }
 
-    int64_t nextindex() { return nextindex_; }
+  void maybeupdate(int64_t i, const BuilderPtr builder);
 
-    void
-      maybeupdate(int64_t i, const BuilderPtr builder);
-
-  private:
-    const BuilderOptions options_;
-    std::vector<BuilderPtr> contents_;
-    int64_t length_;
-    bool begun_;
-    int64_t nextindex_;
-  };
-}
+private:
+  const BuilderOptions options_;
+  std::vector<BuilderPtr> contents_;
+  int64_t length_;
+  bool begun_;
+  int64_t nextindex_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_TUPLEBUILDER_H_

--- a/include/awkward/builder/UnionBuilder.h
+++ b/include/awkward/builder/UnionBuilder.h
@@ -1,110 +1,131 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_UNIONBUILDER_H_
 #define AWKWARD_UNIONBUILDER_H_
 
 #include <vector>
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
-class TupleBuilder;
-class RecordBuilder;
+  class TupleBuilder;
+  class RecordBuilder;
 
-/// @class UnionBuilder
-///
-/// @brief Builder node for accumulated heterogeneous data.
-class LIBAWKWARD_EXPORT_SYMBOL UnionBuilder : public Builder {
-public:
-  static const BuilderPtr fromsingle(const BuilderOptions &options,
-                                     const BuilderPtr &firstcontent);
-
-  /// @brief Create a UnionBuilder from a full set of parameters.
+  /// @class UnionBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param tags Contains the accumulated tags (like
-  /// {@link UnionArrayOf#tags UnionArray::tags}).
-  /// @param index Contains the accumulated index (like
-  /// {@link UnionArrayOf#index UnionArray::index}).
-  /// @param contents A Builder for each of the union's possibilities.
-  UnionBuilder(const BuilderOptions &options, GrowableBuffer<int8_t> tags,
-               GrowableBuffer<int64_t> index,
-               std::vector<BuilderPtr> &contents);
+  /// @brief Builder node for accumulated heterogeneous data.
+  class LIBAWKWARD_EXPORT_SYMBOL UnionBuilder: public Builder {
+  public:
+    static const BuilderPtr
+      fromsingle(const BuilderOptions& options,
+                 const BuilderPtr& firstcontent);
 
-  /// @brief User-friendly name of this class: `"UnionBuilder"`.
-  const std::string classname() const override;
+    /// @brief Create a UnionBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param tags Contains the accumulated tags (like
+    /// {@link UnionArrayOf#tags UnionArray::tags}).
+    /// @param index Contains the accumulated index (like
+    /// {@link UnionArrayOf#index UnionArray::index}).
+    /// @param contents A Builder for each of the union's possibilities.
+    UnionBuilder(const BuilderOptions& options,
+                 GrowableBuffer<int8_t> tags,
+                 GrowableBuffer<int64_t> index,
+                 std::vector<BuilderPtr>& contents);
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"UnionBuilder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// A UnionBuilder is active if and only if one of its `contents` is
-  /// active.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// A UnionBuilder is active if and only if one of its `contents` is
+    /// active.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-  const GrowableBuffer<int8_t> &tags() const { return tags_; }
-  GrowableBuffer<int8_t> &tags_buffer() { return tags_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
-  const GrowableBuffer<int64_t> &index() const { return index_; }
-  GrowableBuffer<int64_t> &index_buffer() { return index_; }
+    const GrowableBuffer<int8_t>& tags() const {  return tags_; }
+    GrowableBuffer<int8_t>& tags_buffer() {  return tags_; }
 
-  const std::vector<BuilderPtr> &contents() const { return contents_; }
-  std::vector<BuilderPtr> &builders() { return contents_; }
+    const GrowableBuffer<int64_t>& index() const { return index_; }
+    GrowableBuffer<int64_t>& index_buffer() { return index_; }
 
-  int8_t current() { return current_; }
+    const std::vector<BuilderPtr>& contents() const { return contents_; }
+    std::vector<BuilderPtr>& builders() { return contents_; }
 
-private:
-  const BuilderOptions options_;
-  GrowableBuffer<int8_t> tags_;
-  GrowableBuffer<int64_t> index_;
-  std::vector<BuilderPtr> contents_;
-  int8_t current_;
-};
-} // namespace awkward
+    int8_t current() { return current_;}
+
+  private:
+    const BuilderOptions options_;
+    GrowableBuffer<int8_t> tags_;
+    GrowableBuffer<int64_t> index_;
+    std::vector<BuilderPtr> contents_;
+    int8_t current_;
+  };
+}
 
 #endif // AWKWARD_UNIONBUILDER_H_

--- a/include/awkward/builder/UnionBuilder.h
+++ b/include/awkward/builder/UnionBuilder.h
@@ -5,127 +5,105 @@
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
-  class TupleBuilder;
-  class RecordBuilder;
+class TupleBuilder;
+class RecordBuilder;
 
-  /// @class UnionBuilder
+/// @class UnionBuilder
+///
+/// @brief Builder node for accumulated heterogeneous data.
+class LIBAWKWARD_EXPORT_SYMBOL UnionBuilder : public Builder {
+public:
+  static const BuilderPtr fromsingle(const BuilderOptions &options,
+                                     const BuilderPtr     &firstcontent);
+
+  /// @brief Create a UnionBuilder from a full set of parameters.
   ///
-  /// @brief Builder node for accumulated heterogeneous data.
-  class LIBAWKWARD_EXPORT_SYMBOL UnionBuilder: public Builder {
-  public:
-    static const BuilderPtr
-      fromsingle(const BuilderOptions& options,
-                 const BuilderPtr& firstcontent);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param tags Contains the accumulated tags (like
+  /// {@link UnionArrayOf#tags UnionArray::tags}).
+  /// @param index Contains the accumulated index (like
+  /// {@link UnionArrayOf#index UnionArray::index}).
+  /// @param contents A Builder for each of the union's possibilities.
+  UnionBuilder(const BuilderOptions &options, GrowableBuffer<int8_t> tags,
+               GrowableBuffer<int64_t>  index,
+               std::vector<BuilderPtr> &contents);
 
-    /// @brief Create a UnionBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param tags Contains the accumulated tags (like
-    /// {@link UnionArrayOf#tags UnionArray::tags}).
-    /// @param index Contains the accumulated index (like
-    /// {@link UnionArrayOf#index UnionArray::index}).
-    /// @param contents A Builder for each of the union's possibilities.
-    UnionBuilder(const BuilderOptions& options,
-                 GrowableBuffer<int8_t> tags,
-                 GrowableBuffer<int64_t> index,
-                 std::vector<BuilderPtr>& contents);
+  /// @brief User-friendly name of this class: `"UnionBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"UnionBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A UnionBuilder is active if and only if one of its `contents` is
+  /// active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A UnionBuilder is active if and only if one of its `contents` is
-    /// active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const GrowableBuffer<int8_t> &tags() const { return tags_; }
+  GrowableBuffer<int8_t>       &tags_buffer() { return tags_; }
 
-    const GrowableBuffer<int8_t>& tags() const {  return tags_; }
-    GrowableBuffer<int8_t>& tags_buffer() {  return tags_; }
+  const GrowableBuffer<int64_t> &index() const { return index_; }
+  GrowableBuffer<int64_t>       &index_buffer() { return index_; }
 
-    const GrowableBuffer<int64_t>& index() const { return index_; }
-    GrowableBuffer<int64_t>& index_buffer() { return index_; }
+  const std::vector<BuilderPtr> &contents() const { return contents_; }
+  std::vector<BuilderPtr>       &builders() { return contents_; }
 
-    const std::vector<BuilderPtr>& contents() const { return contents_; }
-    std::vector<BuilderPtr>& builders() { return contents_; }
+  int8_t current() { return current_; }
 
-    int8_t current() { return current_;}
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int8_t> tags_;
-    GrowableBuffer<int64_t> index_;
-    std::vector<BuilderPtr> contents_;
-    int8_t current_;
-  };
-}
+private:
+  const BuilderOptions    options_;
+  GrowableBuffer<int8_t>  tags_;
+  GrowableBuffer<int64_t> index_;
+  std::vector<BuilderPtr> contents_;
+  int8_t                  current_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_UNIONBUILDER_H_

--- a/include/awkward/builder/UnionBuilder.h
+++ b/include/awkward/builder/UnionBuilder.h
@@ -1,131 +1,110 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_UNIONBUILDER_H_
 #define AWKWARD_UNIONBUILDER_H_
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/GrowableBuffer.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
-  class TupleBuilder;
-  class RecordBuilder;
+class TupleBuilder;
+class RecordBuilder;
 
-  /// @class UnionBuilder
+/// @class UnionBuilder
+///
+/// @brief Builder node for accumulated heterogeneous data.
+class LIBAWKWARD_EXPORT_SYMBOL UnionBuilder : public Builder {
+public:
+  static const BuilderPtr fromsingle(const BuilderOptions &options,
+                                     const BuilderPtr &firstcontent);
+
+  /// @brief Create a UnionBuilder from a full set of parameters.
   ///
-  /// @brief Builder node for accumulated heterogeneous data.
-  class LIBAWKWARD_EXPORT_SYMBOL UnionBuilder: public Builder {
-  public:
-    static const BuilderPtr
-      fromsingle(const BuilderOptions& options,
-                 const BuilderPtr& firstcontent);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param tags Contains the accumulated tags (like
+  /// {@link UnionArrayOf#tags UnionArray::tags}).
+  /// @param index Contains the accumulated index (like
+  /// {@link UnionArrayOf#index UnionArray::index}).
+  /// @param contents A Builder for each of the union's possibilities.
+  UnionBuilder(const BuilderOptions &options, GrowableBuffer<int8_t> tags,
+               GrowableBuffer<int64_t> index,
+               std::vector<BuilderPtr> &contents);
 
-    /// @brief Create a UnionBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param tags Contains the accumulated tags (like
-    /// {@link UnionArrayOf#tags UnionArray::tags}).
-    /// @param index Contains the accumulated index (like
-    /// {@link UnionArrayOf#index UnionArray::index}).
-    /// @param contents A Builder for each of the union's possibilities.
-    UnionBuilder(const BuilderOptions& options,
-                 GrowableBuffer<int8_t> tags,
-                 GrowableBuffer<int64_t> index,
-                 std::vector<BuilderPtr>& contents);
+  /// @brief User-friendly name of this class: `"UnionBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"UnionBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// A UnionBuilder is active if and only if one of its `contents` is
+  /// active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// A UnionBuilder is active if and only if one of its `contents` is
-    /// active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  const GrowableBuffer<int8_t> &tags() const { return tags_; }
+  GrowableBuffer<int8_t> &tags_buffer() { return tags_; }
 
-    const GrowableBuffer<int8_t>& tags() const {  return tags_; }
-    GrowableBuffer<int8_t>& tags_buffer() {  return tags_; }
+  const GrowableBuffer<int64_t> &index() const { return index_; }
+  GrowableBuffer<int64_t> &index_buffer() { return index_; }
 
-    const GrowableBuffer<int64_t>& index() const { return index_; }
-    GrowableBuffer<int64_t>& index_buffer() { return index_; }
+  const std::vector<BuilderPtr> &contents() const { return contents_; }
+  std::vector<BuilderPtr> &builders() { return contents_; }
 
-    const std::vector<BuilderPtr>& contents() const { return contents_; }
-    std::vector<BuilderPtr>& builders() { return contents_; }
+  int8_t current() { return current_; }
 
-    int8_t current() { return current_;}
-
-  private:
-    const BuilderOptions options_;
-    GrowableBuffer<int8_t> tags_;
-    GrowableBuffer<int64_t> index_;
-    std::vector<BuilderPtr> contents_;
-    int8_t current_;
-  };
-}
+private:
+  const BuilderOptions options_;
+  GrowableBuffer<int8_t> tags_;
+  GrowableBuffer<int64_t> index_;
+  std::vector<BuilderPtr> contents_;
+  int8_t current_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_UNIONBUILDER_H_

--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -1,110 +1,90 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_UNKNOWNBUILDER_H_
 #define AWKWARD_UNKNOWNBUILDER_H_
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class UnknownBuilder
+/// @class UnknownBuilder
+///
+/// @brief Builder node for accumulated data whose type is not yet known.
+class LIBAWKWARD_EXPORT_SYMBOL UnknownBuilder : public Builder {
+public:
+  /// @brief Create an empty UnknownBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a ListBuilder from a full set of parameters.
   ///
-  /// @brief Builder node for accumulated data whose type is not yet known.
-  class LIBAWKWARD_EXPORT_SYMBOL UnknownBuilder: public Builder {
-  public:
-    /// @brief Create an empty UnknownBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param nullcount The number of null values encountered so far.
+  UnknownBuilder(const BuilderOptions &options, int64_t nullcount);
 
-    /// @brief Create a ListBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param nullcount The number of null values encountered so far.
-    UnknownBuilder(const BuilderOptions& options, int64_t nullcount);
+  /// @brief User-friendly name of this class: `"UnknownBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"UnknownBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// An UnknownBuilder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// An UnknownBuilder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  int64_t nullcount() const { return nullcount_; }
 
-    int64_t nullcount() const { return nullcount_; }
-
-  private:
-    const BuilderOptions options_;
-    int64_t nullcount_;
-  };
-}
+private:
+  const BuilderOptions options_;
+  int64_t nullcount_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_UNKNOWNBUILDER_H_

--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -1,90 +1,110 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #ifndef AWKWARD_UNKNOWNBUILDER_H_
 #define AWKWARD_UNKNOWNBUILDER_H_
 
 #include <vector>
 
+#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/builder/Builder.h"
-#include "awkward/common.h"
 
 namespace awkward {
 
-/// @class UnknownBuilder
-///
-/// @brief Builder node for accumulated data whose type is not yet known.
-class LIBAWKWARD_EXPORT_SYMBOL UnknownBuilder : public Builder {
-public:
-  /// @brief Create an empty UnknownBuilder.
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  static const BuilderPtr fromempty(const BuilderOptions &options);
-
-  /// @brief Create a ListBuilder from a full set of parameters.
+  /// @class UnknownBuilder
   ///
-  /// @param options Configuration options for building an array;
-  /// these are passed to every Builder's constructor.
-  /// @param nullcount The number of null values encountered so far.
-  UnknownBuilder(const BuilderOptions &options, int64_t nullcount);
+  /// @brief Builder node for accumulated data whose type is not yet known.
+  class LIBAWKWARD_EXPORT_SYMBOL UnknownBuilder: public Builder {
+  public:
+    /// @brief Create an empty UnknownBuilder.
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    static const BuilderPtr
+      fromempty(const BuilderOptions& options);
 
-  /// @brief User-friendly name of this class: `"UnknownBuilder"`.
-  const std::string classname() const override;
+    /// @brief Create a ListBuilder from a full set of parameters.
+    ///
+    /// @param options Configuration options for building an array;
+    /// these are passed to every Builder's constructor.
+    /// @param nullcount The number of null values encountered so far.
+    UnknownBuilder(const BuilderOptions& options, int64_t nullcount);
 
-  const std::string to_buffers(BuffersContainer &container,
-                               int64_t &form_key_id) const override;
+    /// @brief User-friendly name of this class: `"UnknownBuilder"`.
+    const std::string
+      classname() const override;
 
-  int64_t length() const override;
+    const std::string
+      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
 
-  void clear() override;
+    int64_t
+      length() const override;
 
-  /// @copydoc Builder::active()
-  ///
-  /// An UnknownBuilder is never active.
-  bool active() const override;
+    void
+      clear() override;
 
-  const BuilderPtr null() override;
+    /// @copydoc Builder::active()
+    ///
+    /// An UnknownBuilder is never active.
+    bool
+      active() const override;
 
-  const BuilderPtr boolean(bool x) override;
+    const BuilderPtr
+      null() override;
 
-  const BuilderPtr integer(int64_t x) override;
+    const BuilderPtr
+      boolean(bool x) override;
 
-  const BuilderPtr real(double x) override;
+    const BuilderPtr
+      integer(int64_t x) override;
 
-  const BuilderPtr complex(std::complex<double> x) override;
+    const BuilderPtr
+      real(double x) override;
 
-  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      complex(std::complex<double> x) override;
 
-  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
+    const BuilderPtr
+      datetime(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr string(const char *x, int64_t length,
-                          const char *encoding) override;
+    const BuilderPtr
+      timedelta(int64_t x, const std::string& unit) override;
 
-  const BuilderPtr beginlist() override;
+    const BuilderPtr
+      string(const char* x, int64_t length, const char* encoding) override;
 
-  const BuilderPtr endlist() override;
+    const BuilderPtr
+      beginlist() override;
 
-  const BuilderPtr begintuple(int64_t numfields) override;
+    const BuilderPtr
+      endlist() override;
 
-  const BuilderPtr index(int64_t index) override;
+    const BuilderPtr
+      begintuple(int64_t numfields) override;
 
-  const BuilderPtr endtuple() override;
+    const BuilderPtr
+      index(int64_t index) override;
 
-  const BuilderPtr beginrecord(const char *name, bool check) override;
+    const BuilderPtr
+      endtuple() override;
 
-  void field(const char *key, bool check) override;
+    const BuilderPtr
+      beginrecord(const char* name, bool check) override;
 
-  const BuilderPtr endrecord() override;
+    void
+      field(const char* key, bool check) override;
 
-  const BuilderOptions &options() const { return options_; }
+    const BuilderPtr
+      endrecord() override;
 
-  int64_t nullcount() const { return nullcount_; }
+    const BuilderOptions&
+      options() const { return options_; }
 
-private:
-  const BuilderOptions options_;
-  int64_t nullcount_;
-};
-} // namespace awkward
+    int64_t nullcount() const { return nullcount_; }
+
+  private:
+    const BuilderOptions options_;
+    int64_t nullcount_;
+  };
+}
 
 #endif // AWKWARD_UNKNOWNBUILDER_H_

--- a/include/awkward/builder/UnknownBuilder.h
+++ b/include/awkward/builder/UnknownBuilder.h
@@ -5,106 +5,85 @@
 
 #include <vector>
 
-#include "awkward/common.h"
 #include "awkward/BuilderOptions.h"
 #include "awkward/builder/Builder.h"
+#include "awkward/common.h"
 
 namespace awkward {
 
-  /// @class UnknownBuilder
+/// @class UnknownBuilder
+///
+/// @brief Builder node for accumulated data whose type is not yet known.
+class LIBAWKWARD_EXPORT_SYMBOL UnknownBuilder : public Builder {
+public:
+  /// @brief Create an empty UnknownBuilder.
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  static const BuilderPtr fromempty(const BuilderOptions &options);
+
+  /// @brief Create a ListBuilder from a full set of parameters.
   ///
-  /// @brief Builder node for accumulated data whose type is not yet known.
-  class LIBAWKWARD_EXPORT_SYMBOL UnknownBuilder: public Builder {
-  public:
-    /// @brief Create an empty UnknownBuilder.
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    static const BuilderPtr
-      fromempty(const BuilderOptions& options);
+  /// @param options Configuration options for building an array;
+  /// these are passed to every Builder's constructor.
+  /// @param nullcount The number of null values encountered so far.
+  UnknownBuilder(const BuilderOptions &options, int64_t nullcount);
 
-    /// @brief Create a ListBuilder from a full set of parameters.
-    ///
-    /// @param options Configuration options for building an array;
-    /// these are passed to every Builder's constructor.
-    /// @param nullcount The number of null values encountered so far.
-    UnknownBuilder(const BuilderOptions& options, int64_t nullcount);
+  /// @brief User-friendly name of this class: `"UnknownBuilder"`.
+  const std::string classname() const override;
 
-    /// @brief User-friendly name of this class: `"UnknownBuilder"`.
-    const std::string
-      classname() const override;
+  const std::string to_buffers(BuffersContainer &container,
+                               int64_t          &form_key_id) const override;
 
-    const std::string
-      to_buffers(BuffersContainer& container, int64_t& form_key_id) const override;
+  int64_t length() const override;
 
-    int64_t
-      length() const override;
+  void clear() override;
 
-    void
-      clear() override;
+  /// @copydoc Builder::active()
+  ///
+  /// An UnknownBuilder is never active.
+  bool active() const override;
 
-    /// @copydoc Builder::active()
-    ///
-    /// An UnknownBuilder is never active.
-    bool
-      active() const override;
+  const BuilderPtr null() override;
 
-    const BuilderPtr
-      null() override;
+  const BuilderPtr boolean(bool x) override;
 
-    const BuilderPtr
-      boolean(bool x) override;
+  const BuilderPtr integer(int64_t x) override;
 
-    const BuilderPtr
-      integer(int64_t x) override;
+  const BuilderPtr real(double x) override;
 
-    const BuilderPtr
-      real(double x) override;
+  const BuilderPtr complex(std::complex<double> x) override;
 
-    const BuilderPtr
-      complex(std::complex<double> x) override;
+  const BuilderPtr datetime(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      datetime(int64_t x, const std::string& unit) override;
+  const BuilderPtr timedelta(int64_t x, const std::string &unit) override;
 
-    const BuilderPtr
-      timedelta(int64_t x, const std::string& unit) override;
+  const BuilderPtr string(const char *x, int64_t length,
+                          const char *encoding) override;
 
-    const BuilderPtr
-      string(const char* x, int64_t length, const char* encoding) override;
+  const BuilderPtr beginlist() override;
 
-    const BuilderPtr
-      beginlist() override;
+  const BuilderPtr endlist() override;
 
-    const BuilderPtr
-      endlist() override;
+  const BuilderPtr begintuple(int64_t numfields) override;
 
-    const BuilderPtr
-      begintuple(int64_t numfields) override;
+  const BuilderPtr index(int64_t index) override;
 
-    const BuilderPtr
-      index(int64_t index) override;
+  const BuilderPtr endtuple() override;
 
-    const BuilderPtr
-      endtuple() override;
+  const BuilderPtr beginrecord(const char *name, bool check) override;
 
-    const BuilderPtr
-      beginrecord(const char* name, bool check) override;
+  void field(const char *key, bool check) override;
 
-    void
-      field(const char* key, bool check) override;
+  const BuilderPtr endrecord() override;
 
-    const BuilderPtr
-      endrecord() override;
+  const BuilderOptions &options() const { return options_; }
 
-    const BuilderOptions&
-      options() const { return options_; }
+  int64_t nullcount() const { return nullcount_; }
 
-    int64_t nullcount() const { return nullcount_; }
-
-  private:
-    const BuilderOptions options_;
-    int64_t nullcount_;
-  };
-}
+private:
+  const BuilderOptions options_;
+  int64_t              nullcount_;
+};
+} // namespace awkward
 
 #endif // AWKWARD_UNKNOWNBUILDER_H_

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -1,411 +1,493 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ArrayBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ArrayBuilder.cpp", line)
 
 #include <sstream>
 #include <stdexcept>
 
-#include "awkward/BuilderOptions.h"
-#include "awkward/builder/ArrayBuilder.h"
+#include "awkward/common.h"
 #include "awkward/builder/Builder.h"
 #include "awkward/builder/UnknownBuilder.h"
-#include "awkward/common.h"
+#include "awkward/builder/ArrayBuilder.h"
+#include "awkward/BuilderOptions.h"
 
 namespace awkward {
-ArrayBuilder::ArrayBuilder(const BuilderOptions &options)
-    : builder_(UnknownBuilder::fromempty(options)) {}
+  ArrayBuilder::ArrayBuilder(const BuilderOptions& options)
+      : builder_(UnknownBuilder::fromempty(options)) { }
 
-const std::string ArrayBuilder::to_buffers(BuffersContainer &container,
-                                           int64_t &form_key_id) const {
-  return builder_.get()->to_buffers(container, form_key_id);
-}
-
-int64_t ArrayBuilder::length() const { return builder_.get()->length(); }
-
-void ArrayBuilder::clear() {
-  if (builder_) {
-    builder_.get()->clear();
+  const std::string
+  ArrayBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    return builder_.get()->to_buffers(container, form_key_id);
   }
-}
 
-void ArrayBuilder::null() { maybeupdate(builder_.get()->null()); }
-
-void ArrayBuilder::boolean(bool x) { maybeupdate(builder_.get()->boolean(x)); }
-
-void ArrayBuilder::integer(int64_t x) {
-  maybeupdate(builder_.get()->integer(x));
-}
-
-void ArrayBuilder::real(double x) { maybeupdate(builder_.get()->real(x)); }
-
-void ArrayBuilder::complex(std::complex<double> x) {
-  maybeupdate(builder_.get()->complex(x));
-}
-
-void ArrayBuilder::datetime(int64_t x, const std::string &unit) {
-  maybeupdate(builder_.get()->datetime(x, unit));
-}
-
-void ArrayBuilder::timedelta(int64_t x, const std::string &unit) {
-  maybeupdate(builder_.get()->timedelta(x, unit));
-}
-
-void ArrayBuilder::bytestring(const char *x) {
-  maybeupdate(builder_.get()->string(x, -1, no_encoding));
-}
-
-void ArrayBuilder::bytestring(const char *x, int64_t length) {
-  maybeupdate(builder_.get()->string(x, length, no_encoding));
-}
-
-void ArrayBuilder::bytestring(const std::string &x) {
-  bytestring(x.c_str(), (int64_t)x.length());
-}
-
-void ArrayBuilder::string(const char *x) {
-  maybeupdate(builder_.get()->string(x, -1, utf8_encoding));
-}
-
-void ArrayBuilder::string(const char *x, int64_t length) {
-  maybeupdate(builder_.get()->string(x, length, utf8_encoding));
-}
-
-void ArrayBuilder::string(const std::string &x) {
-  string(x.c_str(), (int64_t)x.length());
-}
-
-void ArrayBuilder::beginlist() { maybeupdate(builder_.get()->beginlist()); }
-
-void ArrayBuilder::endlist() {
-  BuilderPtr tmp = builder_.get()->endlist();
-  if (tmp.get() == nullptr) {
-    throw std::invalid_argument(
-        std::string("endlist doesn't match a corresponding beginlist") +
-        FILENAME(__LINE__));
+  int64_t
+  ArrayBuilder::length() const {
+    return builder_.get()->length();
   }
-  maybeupdate(tmp);
-}
 
-void ArrayBuilder::begintuple(int64_t numfields) {
-  maybeupdate(builder_.get()->begintuple(numfields));
-}
-
-void ArrayBuilder::index(int64_t index) {
-  maybeupdate(builder_.get()->index(index));
-}
-
-void ArrayBuilder::endtuple() { maybeupdate(builder_.get()->endtuple()); }
-
-void ArrayBuilder::beginrecord() { beginrecord_fast(nullptr); }
-
-void ArrayBuilder::beginrecord_fast(const char *name) {
-  maybeupdate(builder_.get()->beginrecord(name, false));
-}
-
-void ArrayBuilder::beginrecord_check(const char *name) {
-  maybeupdate(builder_.get()->beginrecord(name, true));
-}
-
-void ArrayBuilder::beginrecord_check(const std::string &name) {
-  beginrecord_check(name.c_str());
-}
-
-void ArrayBuilder::field_fast(const char *key) {
-  builder_.get()->field(key, false);
-}
-
-void ArrayBuilder::field_check(const char *key) {
-  builder_.get()->field(key, true);
-}
-
-void ArrayBuilder::field_check(const std::string &key) {
-  field_check(key.c_str());
-}
-
-void ArrayBuilder::endrecord() { maybeupdate(builder_.get()->endrecord()); }
-
-void ArrayBuilder::maybeupdate(const BuilderPtr tmp) {
-  if (tmp && tmp.get() != builder_.get()) {
-    builder_ = std::move(tmp);
+  void
+  ArrayBuilder::clear() {
+    if (builder_) {
+      builder_.get()->clear();
+    }
   }
-}
 
-const char *ArrayBuilder::no_encoding = nullptr;
-const char *ArrayBuilder::utf8_encoding = "utf-8";
-} // namespace awkward
+  void
+  ArrayBuilder::null() {
+    maybeupdate(builder_.get()->null());
+  }
+
+  void
+  ArrayBuilder::boolean(bool x) {
+    maybeupdate(builder_.get()->boolean(x));
+  }
+
+  void
+  ArrayBuilder::integer(int64_t x) {
+    maybeupdate(builder_.get()->integer(x));
+  }
+
+  void
+  ArrayBuilder::real(double x) {
+    maybeupdate(builder_.get()->real(x));
+  }
+
+  void
+  ArrayBuilder::complex(std::complex<double> x) {
+    maybeupdate(builder_.get()->complex(x));
+  }
+
+  void
+  ArrayBuilder::datetime(int64_t x, const std::string& unit) {
+    maybeupdate(builder_.get()->datetime(x, unit));
+  }
+
+  void
+  ArrayBuilder::timedelta(int64_t x, const std::string& unit) {
+    maybeupdate(builder_.get()->timedelta(x, unit));
+  }
+
+  void
+  ArrayBuilder::bytestring(const char* x) {
+    maybeupdate(builder_.get()->string(x, -1, no_encoding));
+  }
+
+  void
+  ArrayBuilder::bytestring(const char* x, int64_t length) {
+    maybeupdate(builder_.get()->string(x, length, no_encoding));
+  }
+
+  void
+  ArrayBuilder::bytestring(const std::string& x) {
+    bytestring(x.c_str(), (int64_t)x.length());
+  }
+
+  void
+  ArrayBuilder::string(const char* x) {
+    maybeupdate(builder_.get()->string(x, -1, utf8_encoding));
+  }
+
+  void
+  ArrayBuilder::string(const char* x, int64_t length) {
+    maybeupdate(builder_.get()->string(x, length, utf8_encoding));
+  }
+
+  void
+  ArrayBuilder::string(const std::string& x) {
+    string(x.c_str(), (int64_t)x.length());
+  }
+
+  void
+  ArrayBuilder::beginlist() {
+    maybeupdate(builder_.get()->beginlist());
+  }
+
+  void
+  ArrayBuilder::endlist() {
+    BuilderPtr tmp = builder_.get()->endlist();
+    if (tmp.get() == nullptr) {
+      throw std::invalid_argument(
+        std::string("endlist doesn't match a corresponding beginlist")
+        + FILENAME(__LINE__));
+    }
+    maybeupdate(tmp);
+  }
+
+  void
+  ArrayBuilder::begintuple(int64_t numfields) {
+    maybeupdate(builder_.get()->begintuple(numfields));
+  }
+
+  void
+  ArrayBuilder::index(int64_t index) {
+    maybeupdate(builder_.get()->index(index));
+  }
+
+  void
+  ArrayBuilder::endtuple() {
+    maybeupdate(builder_.get()->endtuple());
+  }
+
+  void
+  ArrayBuilder::beginrecord() {
+    beginrecord_fast(nullptr);
+  }
+
+  void
+  ArrayBuilder::beginrecord_fast(const char* name) {
+    maybeupdate(builder_.get()->beginrecord(name, false));
+  }
+
+  void
+  ArrayBuilder::beginrecord_check(const char* name) {
+    maybeupdate(builder_.get()->beginrecord(name, true));
+  }
+
+  void
+  ArrayBuilder::beginrecord_check(const std::string& name) {
+    beginrecord_check(name.c_str());
+  }
+
+  void
+  ArrayBuilder::field_fast(const char* key) {
+    builder_.get()->field(key, false);
+  }
+
+  void
+  ArrayBuilder::field_check(const char* key) {
+    builder_.get()->field(key, true);
+  }
+
+  void
+  ArrayBuilder::field_check(const std::string& key) {
+    field_check(key.c_str());
+  }
+
+  void
+  ArrayBuilder::endrecord() {
+    maybeupdate(builder_.get()->endrecord());
+  }
+
+  void
+  ArrayBuilder::maybeupdate(const BuilderPtr tmp) {
+    if (tmp  &&  tmp.get() != builder_.get()) {
+      builder_ = std::move(tmp);
+    }
+  }
+
+  const char* ArrayBuilder::no_encoding = nullptr;
+  const char* ArrayBuilder::utf8_encoding = "utf-8";
+}
 
 ////////// extern C interface
 
-uint8_t awkward_ArrayBuilder_length(void *arraybuilder, int64_t *result) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_length(void* arraybuilder,
+                                    int64_t* result) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     *result = obj->length();
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_clear(void *arraybuilder) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_clear(void* arraybuilder) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->clear();
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_null(void *arraybuilder) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_null(void* arraybuilder) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->null();
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_boolean(void *arraybuilder, bool x) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_boolean(void* arraybuilder,
+                                     bool x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->boolean(x);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_integer(void *arraybuilder, int64_t x) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_integer(void* arraybuilder,
+                                     int64_t x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->integer(x);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_real(void *arraybuilder, double x) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_real(void* arraybuilder,
+                                  double x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->real(x);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_complex(void *arraybuilder, double real,
+uint8_t awkward_ArrayBuilder_complex(void* arraybuilder,
+                                     double real,
                                      double imag) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->complex(std::complex<double>(real, imag));
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_datetime(void *arraybuilder, int64_t x,
-                                      const char *unit) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_datetime(void* arraybuilder,
+                                      int64_t x,
+                                      const char* unit) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   std::string unit_str(unit);
   try {
     obj->datetime(x, unit_str);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_timedelta(void *arraybuilder, int64_t x,
-                                       const char *unit) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_timedelta(void* arraybuilder,
+                                       int64_t x,
+                                       const char* unit) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   std::string unit_str(unit);
   try {
     obj->timedelta(x, unit_str);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_bytestring(void *arraybuilder, const char *x) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_bytestring(void* arraybuilder,
+                                        const char* x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->bytestring(x);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_bytestring_length(void *arraybuilder,
-                                               const char *x, int64_t length) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
+                                               const char* x,
+                                               int64_t length) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->bytestring(x, length);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_string(void *arraybuilder, const char *x) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_string(void* arraybuilder,
+                                    const char* x) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->string(x);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_string_length(void *arraybuilder, const char *x,
+uint8_t awkward_ArrayBuilder_string_length(void* arraybuilder,
+                                           const char* x,
                                            int64_t length) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->string(x, length);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginlist(void *arraybuilder) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginlist(void* arraybuilder) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->beginlist();
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endlist(void *arraybuilder) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endlist(void* arraybuilder) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->endlist();
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_begintuple(void *arraybuilder, int64_t numfields) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_begintuple(void* arraybuilder,
+                                        int64_t numfields) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->begintuple(numfields);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_index(void *arraybuilder, int64_t index) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_index(void* arraybuilder,
+                                   int64_t index) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->index(index);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endtuple(void *arraybuilder) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endtuple(void* arraybuilder) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->endtuple();
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord(void *arraybuilder) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord(void* arraybuilder) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->beginrecord();
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord_fast(void *arraybuilder,
-                                              const char *name) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
+                                              const char* name) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->beginrecord_fast(name);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord_check(void *arraybuilder,
-                                               const char *name) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
+                                               const char* name) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->beginrecord_check(name);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_field_fast(void *arraybuilder, const char *key) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_field_fast(void* arraybuilder,
+                                        const char* key) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->field_fast(key);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_field_check(void *arraybuilder, const char *key) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_field_check(void* arraybuilder,
+                                         const char* key) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->field_check(key);
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endrecord(void *arraybuilder) {
-  awkward::ArrayBuilder *obj =
-      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endrecord(void* arraybuilder) {
+  awkward::ArrayBuilder* obj =
+    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
   try {
     obj->endrecord();
-  } catch (...) {
+  }
+  catch (...) {
     return 1;
   }
   return 0;

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -1,493 +1,411 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ArrayBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ArrayBuilder.cpp", line)
 
 #include <sstream>
 #include <stdexcept>
 
-#include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
+#include "awkward/builder/ArrayBuilder.h"
 #include "awkward/builder/Builder.h"
 #include "awkward/builder/UnknownBuilder.h"
-#include "awkward/builder/ArrayBuilder.h"
-#include "awkward/BuilderOptions.h"
+#include "awkward/common.h"
 
 namespace awkward {
-  ArrayBuilder::ArrayBuilder(const BuilderOptions& options)
-      : builder_(UnknownBuilder::fromempty(options)) { }
+ArrayBuilder::ArrayBuilder(const BuilderOptions &options)
+    : builder_(UnknownBuilder::fromempty(options)) {}
 
-  const std::string
-  ArrayBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    return builder_.get()->to_buffers(container, form_key_id);
-  }
-
-  int64_t
-  ArrayBuilder::length() const {
-    return builder_.get()->length();
-  }
-
-  void
-  ArrayBuilder::clear() {
-    if (builder_) {
-      builder_.get()->clear();
-    }
-  }
-
-  void
-  ArrayBuilder::null() {
-    maybeupdate(builder_.get()->null());
-  }
-
-  void
-  ArrayBuilder::boolean(bool x) {
-    maybeupdate(builder_.get()->boolean(x));
-  }
-
-  void
-  ArrayBuilder::integer(int64_t x) {
-    maybeupdate(builder_.get()->integer(x));
-  }
-
-  void
-  ArrayBuilder::real(double x) {
-    maybeupdate(builder_.get()->real(x));
-  }
-
-  void
-  ArrayBuilder::complex(std::complex<double> x) {
-    maybeupdate(builder_.get()->complex(x));
-  }
-
-  void
-  ArrayBuilder::datetime(int64_t x, const std::string& unit) {
-    maybeupdate(builder_.get()->datetime(x, unit));
-  }
-
-  void
-  ArrayBuilder::timedelta(int64_t x, const std::string& unit) {
-    maybeupdate(builder_.get()->timedelta(x, unit));
-  }
-
-  void
-  ArrayBuilder::bytestring(const char* x) {
-    maybeupdate(builder_.get()->string(x, -1, no_encoding));
-  }
-
-  void
-  ArrayBuilder::bytestring(const char* x, int64_t length) {
-    maybeupdate(builder_.get()->string(x, length, no_encoding));
-  }
-
-  void
-  ArrayBuilder::bytestring(const std::string& x) {
-    bytestring(x.c_str(), (int64_t)x.length());
-  }
-
-  void
-  ArrayBuilder::string(const char* x) {
-    maybeupdate(builder_.get()->string(x, -1, utf8_encoding));
-  }
-
-  void
-  ArrayBuilder::string(const char* x, int64_t length) {
-    maybeupdate(builder_.get()->string(x, length, utf8_encoding));
-  }
-
-  void
-  ArrayBuilder::string(const std::string& x) {
-    string(x.c_str(), (int64_t)x.length());
-  }
-
-  void
-  ArrayBuilder::beginlist() {
-    maybeupdate(builder_.get()->beginlist());
-  }
-
-  void
-  ArrayBuilder::endlist() {
-    BuilderPtr tmp = builder_.get()->endlist();
-    if (tmp.get() == nullptr) {
-      throw std::invalid_argument(
-        std::string("endlist doesn't match a corresponding beginlist")
-        + FILENAME(__LINE__));
-    }
-    maybeupdate(tmp);
-  }
-
-  void
-  ArrayBuilder::begintuple(int64_t numfields) {
-    maybeupdate(builder_.get()->begintuple(numfields));
-  }
-
-  void
-  ArrayBuilder::index(int64_t index) {
-    maybeupdate(builder_.get()->index(index));
-  }
-
-  void
-  ArrayBuilder::endtuple() {
-    maybeupdate(builder_.get()->endtuple());
-  }
-
-  void
-  ArrayBuilder::beginrecord() {
-    beginrecord_fast(nullptr);
-  }
-
-  void
-  ArrayBuilder::beginrecord_fast(const char* name) {
-    maybeupdate(builder_.get()->beginrecord(name, false));
-  }
-
-  void
-  ArrayBuilder::beginrecord_check(const char* name) {
-    maybeupdate(builder_.get()->beginrecord(name, true));
-  }
-
-  void
-  ArrayBuilder::beginrecord_check(const std::string& name) {
-    beginrecord_check(name.c_str());
-  }
-
-  void
-  ArrayBuilder::field_fast(const char* key) {
-    builder_.get()->field(key, false);
-  }
-
-  void
-  ArrayBuilder::field_check(const char* key) {
-    builder_.get()->field(key, true);
-  }
-
-  void
-  ArrayBuilder::field_check(const std::string& key) {
-    field_check(key.c_str());
-  }
-
-  void
-  ArrayBuilder::endrecord() {
-    maybeupdate(builder_.get()->endrecord());
-  }
-
-  void
-  ArrayBuilder::maybeupdate(const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != builder_.get()) {
-      builder_ = std::move(tmp);
-    }
-  }
-
-  const char* ArrayBuilder::no_encoding = nullptr;
-  const char* ArrayBuilder::utf8_encoding = "utf-8";
+const std::string ArrayBuilder::to_buffers(BuffersContainer &container,
+                                           int64_t &form_key_id) const {
+  return builder_.get()->to_buffers(container, form_key_id);
 }
+
+int64_t ArrayBuilder::length() const { return builder_.get()->length(); }
+
+void ArrayBuilder::clear() {
+  if (builder_) {
+    builder_.get()->clear();
+  }
+}
+
+void ArrayBuilder::null() { maybeupdate(builder_.get()->null()); }
+
+void ArrayBuilder::boolean(bool x) { maybeupdate(builder_.get()->boolean(x)); }
+
+void ArrayBuilder::integer(int64_t x) {
+  maybeupdate(builder_.get()->integer(x));
+}
+
+void ArrayBuilder::real(double x) { maybeupdate(builder_.get()->real(x)); }
+
+void ArrayBuilder::complex(std::complex<double> x) {
+  maybeupdate(builder_.get()->complex(x));
+}
+
+void ArrayBuilder::datetime(int64_t x, const std::string &unit) {
+  maybeupdate(builder_.get()->datetime(x, unit));
+}
+
+void ArrayBuilder::timedelta(int64_t x, const std::string &unit) {
+  maybeupdate(builder_.get()->timedelta(x, unit));
+}
+
+void ArrayBuilder::bytestring(const char *x) {
+  maybeupdate(builder_.get()->string(x, -1, no_encoding));
+}
+
+void ArrayBuilder::bytestring(const char *x, int64_t length) {
+  maybeupdate(builder_.get()->string(x, length, no_encoding));
+}
+
+void ArrayBuilder::bytestring(const std::string &x) {
+  bytestring(x.c_str(), (int64_t)x.length());
+}
+
+void ArrayBuilder::string(const char *x) {
+  maybeupdate(builder_.get()->string(x, -1, utf8_encoding));
+}
+
+void ArrayBuilder::string(const char *x, int64_t length) {
+  maybeupdate(builder_.get()->string(x, length, utf8_encoding));
+}
+
+void ArrayBuilder::string(const std::string &x) {
+  string(x.c_str(), (int64_t)x.length());
+}
+
+void ArrayBuilder::beginlist() { maybeupdate(builder_.get()->beginlist()); }
+
+void ArrayBuilder::endlist() {
+  BuilderPtr tmp = builder_.get()->endlist();
+  if (tmp.get() == nullptr) {
+    throw std::invalid_argument(
+        std::string("endlist doesn't match a corresponding beginlist") +
+        FILENAME(__LINE__));
+  }
+  maybeupdate(tmp);
+}
+
+void ArrayBuilder::begintuple(int64_t numfields) {
+  maybeupdate(builder_.get()->begintuple(numfields));
+}
+
+void ArrayBuilder::index(int64_t index) {
+  maybeupdate(builder_.get()->index(index));
+}
+
+void ArrayBuilder::endtuple() { maybeupdate(builder_.get()->endtuple()); }
+
+void ArrayBuilder::beginrecord() { beginrecord_fast(nullptr); }
+
+void ArrayBuilder::beginrecord_fast(const char *name) {
+  maybeupdate(builder_.get()->beginrecord(name, false));
+}
+
+void ArrayBuilder::beginrecord_check(const char *name) {
+  maybeupdate(builder_.get()->beginrecord(name, true));
+}
+
+void ArrayBuilder::beginrecord_check(const std::string &name) {
+  beginrecord_check(name.c_str());
+}
+
+void ArrayBuilder::field_fast(const char *key) {
+  builder_.get()->field(key, false);
+}
+
+void ArrayBuilder::field_check(const char *key) {
+  builder_.get()->field(key, true);
+}
+
+void ArrayBuilder::field_check(const std::string &key) {
+  field_check(key.c_str());
+}
+
+void ArrayBuilder::endrecord() { maybeupdate(builder_.get()->endrecord()); }
+
+void ArrayBuilder::maybeupdate(const BuilderPtr tmp) {
+  if (tmp && tmp.get() != builder_.get()) {
+    builder_ = std::move(tmp);
+  }
+}
+
+const char *ArrayBuilder::no_encoding = nullptr;
+const char *ArrayBuilder::utf8_encoding = "utf-8";
+} // namespace awkward
 
 ////////// extern C interface
 
-uint8_t awkward_ArrayBuilder_length(void* arraybuilder,
-                                    int64_t* result) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_length(void *arraybuilder, int64_t *result) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     *result = obj->length();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_clear(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_clear(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->clear();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_null(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_null(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->null();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_boolean(void* arraybuilder,
-                                     bool x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_boolean(void *arraybuilder, bool x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->boolean(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_integer(void* arraybuilder,
-                                     int64_t x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_integer(void *arraybuilder, int64_t x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->integer(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_real(void* arraybuilder,
-                                  double x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_real(void *arraybuilder, double x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->real(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_complex(void* arraybuilder,
-                                     double real,
+uint8_t awkward_ArrayBuilder_complex(void *arraybuilder, double real,
                                      double imag) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->complex(std::complex<double>(real, imag));
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_datetime(void* arraybuilder,
-                                      int64_t x,
-                                      const char* unit) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_datetime(void *arraybuilder, int64_t x,
+                                      const char *unit) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   std::string unit_str(unit);
   try {
     obj->datetime(x, unit_str);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_timedelta(void* arraybuilder,
-                                       int64_t x,
-                                       const char* unit) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_timedelta(void *arraybuilder, int64_t x,
+                                       const char *unit) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   std::string unit_str(unit);
   try {
     obj->timedelta(x, unit_str);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_bytestring(void* arraybuilder,
-                                        const char* x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_bytestring(void *arraybuilder, const char *x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->bytestring(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
-                                               const char* x,
-                                               int64_t length) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_bytestring_length(void *arraybuilder,
+                                               const char *x, int64_t length) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->bytestring(x, length);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_string(void* arraybuilder,
-                                    const char* x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_string(void *arraybuilder, const char *x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->string(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_string_length(void* arraybuilder,
-                                           const char* x,
+uint8_t awkward_ArrayBuilder_string_length(void *arraybuilder, const char *x,
                                            int64_t length) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->string(x, length);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginlist(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginlist(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->beginlist();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endlist(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endlist(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->endlist();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_begintuple(void* arraybuilder,
-                                        int64_t numfields) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_begintuple(void *arraybuilder, int64_t numfields) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->begintuple(numfields);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_index(void* arraybuilder,
-                                   int64_t index) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_index(void *arraybuilder, int64_t index) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->index(index);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endtuple(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endtuple(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->endtuple();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->beginrecord();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
-                                              const char* name) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord_fast(void *arraybuilder,
+                                              const char *name) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->beginrecord_fast(name);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
-                                               const char* name) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord_check(void *arraybuilder,
+                                               const char *name) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->beginrecord_check(name);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_field_fast(void* arraybuilder,
-                                        const char* key) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_field_fast(void *arraybuilder, const char *key) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->field_fast(key);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_field_check(void* arraybuilder,
-                                         const char* key) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_field_check(void *arraybuilder, const char *key) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->field_check(key);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endrecord(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endrecord(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->endrecord();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;

--- a/src/libawkward/builder/ArrayBuilder.cpp
+++ b/src/libawkward/builder/ArrayBuilder.cpp
@@ -1,493 +1,410 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ArrayBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ArrayBuilder.cpp", line)
 
 #include <sstream>
 #include <stdexcept>
 
-#include "awkward/common.h"
+#include "awkward/BuilderOptions.h"
+#include "awkward/builder/ArrayBuilder.h"
 #include "awkward/builder/Builder.h"
 #include "awkward/builder/UnknownBuilder.h"
-#include "awkward/builder/ArrayBuilder.h"
-#include "awkward/BuilderOptions.h"
+#include "awkward/common.h"
 
 namespace awkward {
-  ArrayBuilder::ArrayBuilder(const BuilderOptions& options)
-      : builder_(UnknownBuilder::fromempty(options)) { }
+ArrayBuilder::ArrayBuilder(const BuilderOptions &options)
+    : builder_(UnknownBuilder::fromempty(options)) {}
 
-  const std::string
-  ArrayBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    return builder_.get()->to_buffers(container, form_key_id);
-  }
-
-  int64_t
-  ArrayBuilder::length() const {
-    return builder_.get()->length();
-  }
-
-  void
-  ArrayBuilder::clear() {
-    if (builder_) {
-      builder_.get()->clear();
-    }
-  }
-
-  void
-  ArrayBuilder::null() {
-    maybeupdate(builder_.get()->null());
-  }
-
-  void
-  ArrayBuilder::boolean(bool x) {
-    maybeupdate(builder_.get()->boolean(x));
-  }
-
-  void
-  ArrayBuilder::integer(int64_t x) {
-    maybeupdate(builder_.get()->integer(x));
-  }
-
-  void
-  ArrayBuilder::real(double x) {
-    maybeupdate(builder_.get()->real(x));
-  }
-
-  void
-  ArrayBuilder::complex(std::complex<double> x) {
-    maybeupdate(builder_.get()->complex(x));
-  }
-
-  void
-  ArrayBuilder::datetime(int64_t x, const std::string& unit) {
-    maybeupdate(builder_.get()->datetime(x, unit));
-  }
-
-  void
-  ArrayBuilder::timedelta(int64_t x, const std::string& unit) {
-    maybeupdate(builder_.get()->timedelta(x, unit));
-  }
-
-  void
-  ArrayBuilder::bytestring(const char* x) {
-    maybeupdate(builder_.get()->string(x, -1, no_encoding));
-  }
-
-  void
-  ArrayBuilder::bytestring(const char* x, int64_t length) {
-    maybeupdate(builder_.get()->string(x, length, no_encoding));
-  }
-
-  void
-  ArrayBuilder::bytestring(const std::string& x) {
-    bytestring(x.c_str(), (int64_t)x.length());
-  }
-
-  void
-  ArrayBuilder::string(const char* x) {
-    maybeupdate(builder_.get()->string(x, -1, utf8_encoding));
-  }
-
-  void
-  ArrayBuilder::string(const char* x, int64_t length) {
-    maybeupdate(builder_.get()->string(x, length, utf8_encoding));
-  }
-
-  void
-  ArrayBuilder::string(const std::string& x) {
-    string(x.c_str(), (int64_t)x.length());
-  }
-
-  void
-  ArrayBuilder::beginlist() {
-    maybeupdate(builder_.get()->beginlist());
-  }
-
-  void
-  ArrayBuilder::endlist() {
-    BuilderPtr tmp = builder_.get()->endlist();
-    if (tmp.get() == nullptr) {
-      throw std::invalid_argument(
-        std::string("endlist doesn't match a corresponding beginlist")
-        + FILENAME(__LINE__));
-    }
-    maybeupdate(tmp);
-  }
-
-  void
-  ArrayBuilder::begintuple(int64_t numfields) {
-    maybeupdate(builder_.get()->begintuple(numfields));
-  }
-
-  void
-  ArrayBuilder::index(int64_t index) {
-    maybeupdate(builder_.get()->index(index));
-  }
-
-  void
-  ArrayBuilder::endtuple() {
-    maybeupdate(builder_.get()->endtuple());
-  }
-
-  void
-  ArrayBuilder::beginrecord() {
-    beginrecord_fast(nullptr);
-  }
-
-  void
-  ArrayBuilder::beginrecord_fast(const char* name) {
-    maybeupdate(builder_.get()->beginrecord(name, false));
-  }
-
-  void
-  ArrayBuilder::beginrecord_check(const char* name) {
-    maybeupdate(builder_.get()->beginrecord(name, true));
-  }
-
-  void
-  ArrayBuilder::beginrecord_check(const std::string& name) {
-    beginrecord_check(name.c_str());
-  }
-
-  void
-  ArrayBuilder::field_fast(const char* key) {
-    builder_.get()->field(key, false);
-  }
-
-  void
-  ArrayBuilder::field_check(const char* key) {
-    builder_.get()->field(key, true);
-  }
-
-  void
-  ArrayBuilder::field_check(const std::string& key) {
-    field_check(key.c_str());
-  }
-
-  void
-  ArrayBuilder::endrecord() {
-    maybeupdate(builder_.get()->endrecord());
-  }
-
-  void
-  ArrayBuilder::maybeupdate(const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != builder_.get()) {
-      builder_ = std::move(tmp);
-    }
-  }
-
-  const char* ArrayBuilder::no_encoding = nullptr;
-  const char* ArrayBuilder::utf8_encoding = "utf-8";
+const std::string ArrayBuilder::to_buffers(BuffersContainer &container,
+                                           int64_t &form_key_id) const {
+  return builder_.get()->to_buffers(container, form_key_id);
 }
+
+int64_t ArrayBuilder::length() const { return builder_.get()->length(); }
+
+void ArrayBuilder::clear() {
+  if (builder_) {
+    builder_.get()->clear();
+  }
+}
+
+void ArrayBuilder::null() { maybeupdate(builder_.get()->null()); }
+
+void ArrayBuilder::boolean(bool x) { maybeupdate(builder_.get()->boolean(x)); }
+
+void ArrayBuilder::integer(int64_t x) {
+  maybeupdate(builder_.get()->integer(x));
+}
+
+void ArrayBuilder::real(double x) { maybeupdate(builder_.get()->real(x)); }
+
+void ArrayBuilder::complex(std::complex<double> x) {
+  maybeupdate(builder_.get()->complex(x));
+}
+
+void ArrayBuilder::datetime(int64_t x, const std::string &unit) {
+  maybeupdate(builder_.get()->datetime(x, unit));
+}
+
+void ArrayBuilder::timedelta(int64_t x, const std::string &unit) {
+  maybeupdate(builder_.get()->timedelta(x, unit));
+}
+
+void ArrayBuilder::bytestring(const char *x) {
+  maybeupdate(builder_.get()->string(x, -1, no_encoding));
+}
+
+void ArrayBuilder::bytestring(const char *x, int64_t length) {
+  maybeupdate(builder_.get()->string(x, length, no_encoding));
+}
+
+void ArrayBuilder::bytestring(const std::string &x) {
+  bytestring(x.c_str(), (int64_t)x.length());
+}
+
+void ArrayBuilder::string(const char *x) {
+  maybeupdate(builder_.get()->string(x, -1, utf8_encoding));
+}
+
+void ArrayBuilder::string(const char *x, int64_t length) {
+  maybeupdate(builder_.get()->string(x, length, utf8_encoding));
+}
+
+void ArrayBuilder::string(const std::string &x) {
+  string(x.c_str(), (int64_t)x.length());
+}
+
+void ArrayBuilder::beginlist() { maybeupdate(builder_.get()->beginlist()); }
+
+void ArrayBuilder::endlist() {
+  BuilderPtr tmp = builder_.get()->endlist();
+  if (tmp.get() == nullptr) {
+    throw std::invalid_argument(
+        std::string("endlist doesn't match a corresponding beginlist") +
+        FILENAME(__LINE__));
+  }
+  maybeupdate(tmp);
+}
+
+void ArrayBuilder::begintuple(int64_t numfields) {
+  maybeupdate(builder_.get()->begintuple(numfields));
+}
+
+void ArrayBuilder::index(int64_t index) {
+  maybeupdate(builder_.get()->index(index));
+}
+
+void ArrayBuilder::endtuple() { maybeupdate(builder_.get()->endtuple()); }
+
+void ArrayBuilder::beginrecord() { beginrecord_fast(nullptr); }
+
+void ArrayBuilder::beginrecord_fast(const char *name) {
+  maybeupdate(builder_.get()->beginrecord(name, false));
+}
+
+void ArrayBuilder::beginrecord_check(const char *name) {
+  maybeupdate(builder_.get()->beginrecord(name, true));
+}
+
+void ArrayBuilder::beginrecord_check(const std::string &name) {
+  beginrecord_check(name.c_str());
+}
+
+void ArrayBuilder::field_fast(const char *key) {
+  builder_.get()->field(key, false);
+}
+
+void ArrayBuilder::field_check(const char *key) {
+  builder_.get()->field(key, true);
+}
+
+void ArrayBuilder::field_check(const std::string &key) {
+  field_check(key.c_str());
+}
+
+void ArrayBuilder::endrecord() { maybeupdate(builder_.get()->endrecord()); }
+
+void ArrayBuilder::maybeupdate(const BuilderPtr tmp) {
+  if (tmp && tmp.get() != builder_.get()) {
+    builder_ = std::move(tmp);
+  }
+}
+
+const char *ArrayBuilder::no_encoding = nullptr;
+const char *ArrayBuilder::utf8_encoding = "utf-8";
+} // namespace awkward
 
 ////////// extern C interface
 
-uint8_t awkward_ArrayBuilder_length(void* arraybuilder,
-                                    int64_t* result) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_length(void *arraybuilder, int64_t *result) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     *result = obj->length();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_clear(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_clear(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->clear();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_null(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_null(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->null();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_boolean(void* arraybuilder,
-                                     bool x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_boolean(void *arraybuilder, bool x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->boolean(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_integer(void* arraybuilder,
-                                     int64_t x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_integer(void *arraybuilder, int64_t x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->integer(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_real(void* arraybuilder,
-                                  double x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_real(void *arraybuilder, double x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->real(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_complex(void* arraybuilder,
-                                     double real,
+uint8_t awkward_ArrayBuilder_complex(void *arraybuilder, double real,
                                      double imag) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->complex(std::complex<double>(real, imag));
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_datetime(void* arraybuilder,
-                                      int64_t x,
-                                      const char* unit) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_datetime(void *arraybuilder, int64_t x,
+                                      const char *unit) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   std::string unit_str(unit);
   try {
     obj->datetime(x, unit_str);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_timedelta(void* arraybuilder,
-                                       int64_t x,
-                                       const char* unit) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_timedelta(void *arraybuilder, int64_t x,
+                                       const char *unit) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   std::string unit_str(unit);
   try {
     obj->timedelta(x, unit_str);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_bytestring(void* arraybuilder,
-                                        const char* x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_bytestring(void *arraybuilder, const char *x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->bytestring(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
-                                               const char* x,
-                                               int64_t length) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_bytestring_length(void       *arraybuilder,
+                                               const char *x, int64_t length) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->bytestring(x, length);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_string(void* arraybuilder,
-                                    const char* x) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_string(void *arraybuilder, const char *x) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->string(x);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_string_length(void* arraybuilder,
-                                           const char* x,
+uint8_t awkward_ArrayBuilder_string_length(void *arraybuilder, const char *x,
                                            int64_t length) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->string(x, length);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginlist(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginlist(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->beginlist();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endlist(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endlist(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->endlist();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_begintuple(void* arraybuilder,
-                                        int64_t numfields) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_begintuple(void *arraybuilder, int64_t numfields) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->begintuple(numfields);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_index(void* arraybuilder,
-                                   int64_t index) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_index(void *arraybuilder, int64_t index) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->index(index);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endtuple(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endtuple(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->endtuple();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->beginrecord();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
-                                              const char* name) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord_fast(void       *arraybuilder,
+                                              const char *name) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->beginrecord_fast(name);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
-                                               const char* name) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_beginrecord_check(void       *arraybuilder,
+                                               const char *name) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->beginrecord_check(name);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_field_fast(void* arraybuilder,
-                                        const char* key) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_field_fast(void *arraybuilder, const char *key) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->field_fast(key);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_field_check(void* arraybuilder,
-                                         const char* key) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_field_check(void *arraybuilder, const char *key) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->field_check(key);
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;
 }
 
-uint8_t awkward_ArrayBuilder_endrecord(void* arraybuilder) {
-  awkward::ArrayBuilder* obj =
-    reinterpret_cast<awkward::ArrayBuilder*>(arraybuilder);
+uint8_t awkward_ArrayBuilder_endrecord(void *arraybuilder) {
+  awkward::ArrayBuilder *obj =
+      reinterpret_cast<awkward::ArrayBuilder *>(arraybuilder);
   try {
     obj->endrecord();
-  }
-  catch (...) {
+  } catch (...) {
     return 1;
   }
   return 0;

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/BoolBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/BoolBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -10,160 +11,136 @@
 #include "awkward/builder/BoolBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  BoolBuilder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<BoolBuilder>(options,
-                                         std::move(GrowableBuffer<uint8_t>::empty(options)));
-  }
-
-  BoolBuilder::BoolBuilder(const BuilderOptions& options,
-                           GrowableBuffer<uint8_t> buffer)
-      : options_(options)
-      , buffer_(std::move(buffer)) { }
-
-  const std::string
-  BoolBuilder::classname() const {
-    return "BoolBuilder";
-  };
-
-  const std::string
-  BoolBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    buffer_.concatenate(
-      reinterpret_cast<uint8_t*>(
-        container.empty_buffer(form_key.str() + "-data",
-        (int64_t)buffer_.length() * (int64_t)sizeof(bool))));
-
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"bool\", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
-
-  int64_t
-  BoolBuilder::length() const {
-    return (int64_t)buffer_.length();
-  }
-
-  void
-  BoolBuilder::clear() {
-    buffer_.clear();
-  }
-
-  bool
-  BoolBuilder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  BoolBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::boolean(bool x) {
-    buffer_.append(x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  BoolBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  BoolBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begintuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  BoolBuilder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'endtuple' without 'begintuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  BoolBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  BoolBuilder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'beginrecord' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  BoolBuilder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'endrecord' without 'beginrecord' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr BoolBuilder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<BoolBuilder>(
+      options, std::move(GrowableBuffer<uint8_t>::empty(options)));
 }
+
+BoolBuilder::BoolBuilder(const BuilderOptions   &options,
+                         GrowableBuffer<uint8_t> buffer)
+    : options_(options), buffer_(std::move(buffer)) {}
+
+const std::string BoolBuilder::classname() const { return "BoolBuilder"; };
+
+const std::string BoolBuilder::to_buffers(BuffersContainer &container,
+                                          int64_t          &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  buffer_.concatenate(reinterpret_cast<uint8_t *>(container.empty_buffer(
+      form_key.str() + "-data",
+      (int64_t)buffer_.length() * (int64_t)sizeof(bool))));
+
+  return "{\"class\": \"NumpyArray\", \"primitive\": \"bool\", \"form_key\": "
+         "\"" +
+         form_key.str() + "\"}";
+}
+
+int64_t BoolBuilder::length() const { return (int64_t)buffer_.length(); }
+
+void BoolBuilder::clear() { buffer_.clear(); }
+
+bool BoolBuilder::active() const { return false; }
+
+const BuilderPtr BoolBuilder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr BoolBuilder::boolean(bool x) {
+  buffer_.append(x);
+  return nullptr;
+}
+
+const BuilderPtr BoolBuilder::integer(int64_t x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->integer(x);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::real(double x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::complex(std::complex<double> x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::string(const char *x, int64_t length,
+                                     const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr BoolBuilder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr BoolBuilder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begintuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr BoolBuilder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'endtuple' without 'begintuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr BoolBuilder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void BoolBuilder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'beginrecord' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr BoolBuilder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'endrecord' without 'beginrecord' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/BoolBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/BoolBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -10,160 +12,136 @@
 #include "awkward/builder/BoolBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  BoolBuilder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<BoolBuilder>(options,
-                                         std::move(GrowableBuffer<uint8_t>::empty(options)));
-  }
-
-  BoolBuilder::BoolBuilder(const BuilderOptions& options,
-                           GrowableBuffer<uint8_t> buffer)
-      : options_(options)
-      , buffer_(std::move(buffer)) { }
-
-  const std::string
-  BoolBuilder::classname() const {
-    return "BoolBuilder";
-  };
-
-  const std::string
-  BoolBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    buffer_.concatenate(
-      reinterpret_cast<uint8_t*>(
-        container.empty_buffer(form_key.str() + "-data",
-        (int64_t)buffer_.length() * (int64_t)sizeof(bool))));
-
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"bool\", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
-
-  int64_t
-  BoolBuilder::length() const {
-    return (int64_t)buffer_.length();
-  }
-
-  void
-  BoolBuilder::clear() {
-    buffer_.clear();
-  }
-
-  bool
-  BoolBuilder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  BoolBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::boolean(bool x) {
-    buffer_.append(x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  BoolBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  BoolBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  BoolBuilder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begintuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  BoolBuilder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'endtuple' without 'begintuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  BoolBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  BoolBuilder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'beginrecord' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  BoolBuilder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'endrecord' without 'beginrecord' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr BoolBuilder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<BoolBuilder>(
+      options, std::move(GrowableBuffer<uint8_t>::empty(options)));
 }
+
+BoolBuilder::BoolBuilder(const BuilderOptions &options,
+                         GrowableBuffer<uint8_t> buffer)
+    : options_(options), buffer_(std::move(buffer)) {}
+
+const std::string BoolBuilder::classname() const { return "BoolBuilder"; };
+
+const std::string BoolBuilder::to_buffers(BuffersContainer &container,
+                                          int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  buffer_.concatenate(reinterpret_cast<uint8_t *>(container.empty_buffer(
+      form_key.str() + "-data",
+      (int64_t)buffer_.length() * (int64_t)sizeof(bool))));
+
+  return "{\"class\": \"NumpyArray\", \"primitive\": \"bool\", \"form_key\": "
+         "\"" +
+         form_key.str() + "\"}";
+}
+
+int64_t BoolBuilder::length() const { return (int64_t)buffer_.length(); }
+
+void BoolBuilder::clear() { buffer_.clear(); }
+
+bool BoolBuilder::active() const { return false; }
+
+const BuilderPtr BoolBuilder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr BoolBuilder::boolean(bool x) {
+  buffer_.append(x);
+  return nullptr;
+}
+
+const BuilderPtr BoolBuilder::integer(int64_t x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->integer(x);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::real(double x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::complex(std::complex<double> x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::string(const char *x, int64_t length,
+                                     const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr BoolBuilder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr BoolBuilder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr BoolBuilder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begintuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr BoolBuilder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'endtuple' without 'begintuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr BoolBuilder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void BoolBuilder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'beginrecord' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr BoolBuilder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'endrecord' without 'beginrecord' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/BoolBuilder.cpp
+++ b/src/libawkward/builder/BoolBuilder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/BoolBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/BoolBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -12,136 +10,160 @@
 #include "awkward/builder/BoolBuilder.h"
 
 namespace awkward {
-const BuilderPtr BoolBuilder::fromempty(const BuilderOptions &options) {
-  return std::make_shared<BoolBuilder>(
-      options, std::move(GrowableBuffer<uint8_t>::empty(options)));
+  const BuilderPtr
+  BoolBuilder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<BoolBuilder>(options,
+                                         std::move(GrowableBuffer<uint8_t>::empty(options)));
+  }
+
+  BoolBuilder::BoolBuilder(const BuilderOptions& options,
+                           GrowableBuffer<uint8_t> buffer)
+      : options_(options)
+      , buffer_(std::move(buffer)) { }
+
+  const std::string
+  BoolBuilder::classname() const {
+    return "BoolBuilder";
+  };
+
+  const std::string
+  BoolBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    buffer_.concatenate(
+      reinterpret_cast<uint8_t*>(
+        container.empty_buffer(form_key.str() + "-data",
+        (int64_t)buffer_.length() * (int64_t)sizeof(bool))));
+
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"bool\", \"form_key\": \""
+           + form_key.str() + "\"}";
+  }
+
+  int64_t
+  BoolBuilder::length() const {
+    return (int64_t)buffer_.length();
+  }
+
+  void
+  BoolBuilder::clear() {
+    buffer_.clear();
+  }
+
+  bool
+  BoolBuilder::active() const {
+    return false;
+  }
+
+  const BuilderPtr
+  BoolBuilder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::boolean(bool x) {
+    buffer_.append(x);
+    return nullptr;
+  }
+
+  const BuilderPtr
+  BoolBuilder::integer(int64_t x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::real(double x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::complex(std::complex<double> x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::datetime(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::timedelta(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::endlist() {
+    throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  BoolBuilder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  }
+
+  const BuilderPtr
+  BoolBuilder::index(int64_t /* index */) {
+    throw std::invalid_argument(
+      std::string("called 'index' without 'begintuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  BoolBuilder::endtuple() {
+    throw std::invalid_argument(
+      std::string("called 'endtuple' without 'begintuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  BoolBuilder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  }
+
+  void
+  BoolBuilder::field(const char* /* key */, bool /* check */) {
+    throw std::invalid_argument(
+      std::string("called 'field' without 'beginrecord' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  BoolBuilder::endrecord() {
+    throw std::invalid_argument(
+      std::string("called 'endrecord' without 'beginrecord' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
 }
-
-BoolBuilder::BoolBuilder(const BuilderOptions &options,
-                         GrowableBuffer<uint8_t> buffer)
-    : options_(options), buffer_(std::move(buffer)) {}
-
-const std::string BoolBuilder::classname() const { return "BoolBuilder"; };
-
-const std::string BoolBuilder::to_buffers(BuffersContainer &container,
-                                          int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  buffer_.concatenate(reinterpret_cast<uint8_t *>(container.empty_buffer(
-      form_key.str() + "-data",
-      (int64_t)buffer_.length() * (int64_t)sizeof(bool))));
-
-  return "{\"class\": \"NumpyArray\", \"primitive\": \"bool\", \"form_key\": "
-         "\"" +
-         form_key.str() + "\"}";
-}
-
-int64_t BoolBuilder::length() const { return (int64_t)buffer_.length(); }
-
-void BoolBuilder::clear() { buffer_.clear(); }
-
-bool BoolBuilder::active() const { return false; }
-
-const BuilderPtr BoolBuilder::null() {
-  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-  out.get()->null();
-  return out;
-}
-
-const BuilderPtr BoolBuilder::boolean(bool x) {
-  buffer_.append(x);
-  return nullptr;
-}
-
-const BuilderPtr BoolBuilder::integer(int64_t x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->integer(x);
-  return out;
-}
-
-const BuilderPtr BoolBuilder::real(double x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->real(x);
-  return out;
-}
-
-const BuilderPtr BoolBuilder::complex(std::complex<double> x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->complex(x);
-  return out;
-}
-
-const BuilderPtr BoolBuilder::datetime(int64_t x, const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->datetime(x, unit);
-  return out;
-}
-
-const BuilderPtr BoolBuilder::timedelta(int64_t x, const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->timedelta(x, unit);
-  return out;
-}
-
-const BuilderPtr BoolBuilder::string(const char *x, int64_t length,
-                                     const char *encoding) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->string(x, length, encoding);
-  return out;
-}
-
-const BuilderPtr BoolBuilder::beginlist() {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginlist();
-  return out;
-}
-
-const BuilderPtr BoolBuilder::endlist() {
-  throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr BoolBuilder::begintuple(int64_t numfields) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->begintuple(numfields);
-  return out;
-}
-
-const BuilderPtr BoolBuilder::index(int64_t /* index */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'index' without 'begintuple' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr BoolBuilder::endtuple() {
-  throw std::invalid_argument(
-      std::string("called 'endtuple' without 'begintuple' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr BoolBuilder::beginrecord(const char *name, bool check) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginrecord(name, check);
-  return out;
-}
-
-void BoolBuilder::field(const char * /* key */, bool /* check */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'field' without 'beginrecord' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr BoolBuilder::endrecord() {
-  throw std::invalid_argument(
-      std::string("called 'endrecord' without 'beginrecord' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-} // namespace awkward

--- a/src/libawkward/builder/Builder.cpp
+++ b/src/libawkward/builder/Builder.cpp
@@ -1,7 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #include "awkward/builder/Builder.h"
 
 namespace awkward {
-  Builder::~Builder() = default;
+Builder::~Builder() = default;
 }

--- a/src/libawkward/builder/Builder.cpp
+++ b/src/libawkward/builder/Builder.cpp
@@ -1,8 +1,7 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 #include "awkward/builder/Builder.h"
 
 namespace awkward {
-Builder::~Builder() = default;
+  Builder::~Builder() = default;
 }

--- a/src/libawkward/builder/Builder.cpp
+++ b/src/libawkward/builder/Builder.cpp
@@ -3,5 +3,5 @@
 #include "awkward/builder/Builder.h"
 
 namespace awkward {
-  Builder::~Builder() = default;
+Builder::~Builder() = default;
 }

--- a/src/libawkward/builder/Complex128Builder.cpp
+++ b/src/libawkward/builder/Complex128Builder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Complex128Builder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Complex128Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -10,172 +11,151 @@
 #include "awkward/builder/Complex128Builder.h"
 
 namespace awkward {
-  const BuilderPtr
-  Complex128Builder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<Complex128Builder>(options,
-                                              GrowableBuffer<std::complex<double>>::empty(options));
-  }
+const BuilderPtr Complex128Builder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<Complex128Builder>(
+      options, GrowableBuffer<std::complex<double>>::empty(options));
+}
 
-  const BuilderPtr
-  Complex128Builder::fromint64(const BuilderOptions& options,
-                               const GrowableBuffer<int64_t>& old) {
-    return std::make_shared<Complex128Builder>(
+const BuilderPtr
+Complex128Builder::fromint64(const BuilderOptions          &options,
+                             const GrowableBuffer<int64_t> &old) {
+  return std::make_shared<Complex128Builder>(
       options,
       std::move(GrowableBuffer<int64_t>::copy_as<std::complex<double>>(old)));
-  }
+}
 
-  const BuilderPtr
-  Complex128Builder::fromfloat64(const BuilderOptions& options,
-                                 const GrowableBuffer<double>& old) {
-    return std::make_shared<Complex128Builder>(
+const BuilderPtr
+Complex128Builder::fromfloat64(const BuilderOptions         &options,
+                               const GrowableBuffer<double> &old) {
+  return std::make_shared<Complex128Builder>(
       options,
       std::move(GrowableBuffer<double>::copy_as<std::complex<double>>(old)));
-  }
-
-  Complex128Builder::Complex128Builder(const BuilderOptions& options,
-                                       GrowableBuffer<std::complex<double>> buffer)
-      : options_(options)
-      , buffer_(std::move(buffer)) { }
-
-  const std::string
-  Complex128Builder::classname() const {
-    return "Complex128Builder";
-  }
-
-  const std::string
-  Complex128Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    void* ptr = container.empty_buffer(form_key.str() + "-data",
-      (int64_t)buffer_.length() * (int64_t)sizeof(std::complex<double>));
-
-    buffer_.concatenate(reinterpret_cast<std::complex<double>*>(ptr));
-
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"complex128\", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
-
-  int64_t
-  Complex128Builder::length() const {
-    return (int64_t)buffer_.length();
-  }
-
-  void
-  Complex128Builder::clear() {
-    buffer_.clear();
-  }
-
-  bool
-  Complex128Builder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  Complex128Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::integer(int64_t x) {
-    buffer_.append(std::complex<double>((double)x, 0));
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Complex128Builder::real(double x) {
-    buffer_.append(std::complex<double>((double)x, 0));
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Complex128Builder::complex(std::complex<double> x) {
-    buffer_.append(x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Complex128Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Complex128Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Complex128Builder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Complex128Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  Complex128Builder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Complex128Builder::endrecord() {
-    return shared_from_this();
-  }
-
 }
+
+Complex128Builder::Complex128Builder(
+    const BuilderOptions &options, GrowableBuffer<std::complex<double>> buffer)
+    : options_(options), buffer_(std::move(buffer)) {}
+
+const std::string Complex128Builder::classname() const {
+  return "Complex128Builder";
+}
+
+const std::string Complex128Builder::to_buffers(BuffersContainer &container,
+                                                int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  void *ptr = container.empty_buffer(form_key.str() + "-data",
+                                     (int64_t)buffer_.length() *
+                                         (int64_t)sizeof(std::complex<double>));
+
+  buffer_.concatenate(reinterpret_cast<std::complex<double> *>(ptr));
+
+  return "{\"class\": \"NumpyArray\", \"primitive\": \"complex128\", "
+         "\"form_key\": \"" +
+         form_key.str() + "\"}";
+}
+
+int64_t Complex128Builder::length() const { return (int64_t)buffer_.length(); }
+
+void Complex128Builder::clear() { buffer_.clear(); }
+
+bool Complex128Builder::active() const { return false; }
+
+const BuilderPtr Complex128Builder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr Complex128Builder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::integer(int64_t x) {
+  buffer_.append(std::complex<double>((double)x, 0));
+  return nullptr;
+}
+
+const BuilderPtr Complex128Builder::real(double x) {
+  buffer_.append(std::complex<double>((double)x, 0));
+  return nullptr;
+}
+
+const BuilderPtr Complex128Builder::complex(std::complex<double> x) {
+  buffer_.append(x);
+  return nullptr;
+}
+
+const BuilderPtr Complex128Builder::datetime(int64_t            x,
+                                             const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::timedelta(int64_t            x,
+                                              const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::string(const char *x, int64_t length,
+                                           const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr Complex128Builder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Complex128Builder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Complex128Builder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Complex128Builder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void Complex128Builder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Complex128Builder::endrecord() { return shared_from_this(); }
+
+} // namespace awkward

--- a/src/libawkward/builder/Complex128Builder.cpp
+++ b/src/libawkward/builder/Complex128Builder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Complex128Builder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Complex128Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -10,172 +12,151 @@
 #include "awkward/builder/Complex128Builder.h"
 
 namespace awkward {
-  const BuilderPtr
-  Complex128Builder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<Complex128Builder>(options,
-                                              GrowableBuffer<std::complex<double>>::empty(options));
-  }
+const BuilderPtr Complex128Builder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<Complex128Builder>(
+      options, GrowableBuffer<std::complex<double>>::empty(options));
+}
 
-  const BuilderPtr
-  Complex128Builder::fromint64(const BuilderOptions& options,
-                               const GrowableBuffer<int64_t>& old) {
-    return std::make_shared<Complex128Builder>(
+const BuilderPtr
+Complex128Builder::fromint64(const BuilderOptions &options,
+                             const GrowableBuffer<int64_t> &old) {
+  return std::make_shared<Complex128Builder>(
       options,
       std::move(GrowableBuffer<int64_t>::copy_as<std::complex<double>>(old)));
-  }
+}
 
-  const BuilderPtr
-  Complex128Builder::fromfloat64(const BuilderOptions& options,
-                                 const GrowableBuffer<double>& old) {
-    return std::make_shared<Complex128Builder>(
+const BuilderPtr
+Complex128Builder::fromfloat64(const BuilderOptions &options,
+                               const GrowableBuffer<double> &old) {
+  return std::make_shared<Complex128Builder>(
       options,
       std::move(GrowableBuffer<double>::copy_as<std::complex<double>>(old)));
-  }
-
-  Complex128Builder::Complex128Builder(const BuilderOptions& options,
-                                       GrowableBuffer<std::complex<double>> buffer)
-      : options_(options)
-      , buffer_(std::move(buffer)) { }
-
-  const std::string
-  Complex128Builder::classname() const {
-    return "Complex128Builder";
-  }
-
-  const std::string
-  Complex128Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    void* ptr = container.empty_buffer(form_key.str() + "-data",
-      (int64_t)buffer_.length() * (int64_t)sizeof(std::complex<double>));
-
-    buffer_.concatenate(reinterpret_cast<std::complex<double>*>(ptr));
-
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"complex128\", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
-
-  int64_t
-  Complex128Builder::length() const {
-    return (int64_t)buffer_.length();
-  }
-
-  void
-  Complex128Builder::clear() {
-    buffer_.clear();
-  }
-
-  bool
-  Complex128Builder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  Complex128Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::integer(int64_t x) {
-    buffer_.append(std::complex<double>((double)x, 0));
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Complex128Builder::real(double x) {
-    buffer_.append(std::complex<double>((double)x, 0));
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Complex128Builder::complex(std::complex<double> x) {
-    buffer_.append(x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Complex128Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Complex128Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  Complex128Builder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Complex128Builder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Complex128Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  Complex128Builder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Complex128Builder::endrecord() {
-    return shared_from_this();
-  }
-
 }
+
+Complex128Builder::Complex128Builder(
+    const BuilderOptions &options, GrowableBuffer<std::complex<double>> buffer)
+    : options_(options), buffer_(std::move(buffer)) {}
+
+const std::string Complex128Builder::classname() const {
+  return "Complex128Builder";
+}
+
+const std::string Complex128Builder::to_buffers(BuffersContainer &container,
+                                                int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  void *ptr = container.empty_buffer(form_key.str() + "-data",
+                                     (int64_t)buffer_.length() *
+                                         (int64_t)sizeof(std::complex<double>));
+
+  buffer_.concatenate(reinterpret_cast<std::complex<double> *>(ptr));
+
+  return "{\"class\": \"NumpyArray\", \"primitive\": \"complex128\", "
+         "\"form_key\": \"" +
+         form_key.str() + "\"}";
+}
+
+int64_t Complex128Builder::length() const { return (int64_t)buffer_.length(); }
+
+void Complex128Builder::clear() { buffer_.clear(); }
+
+bool Complex128Builder::active() const { return false; }
+
+const BuilderPtr Complex128Builder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr Complex128Builder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::integer(int64_t x) {
+  buffer_.append(std::complex<double>((double)x, 0));
+  return nullptr;
+}
+
+const BuilderPtr Complex128Builder::real(double x) {
+  buffer_.append(std::complex<double>((double)x, 0));
+  return nullptr;
+}
+
+const BuilderPtr Complex128Builder::complex(std::complex<double> x) {
+  buffer_.append(x);
+  return nullptr;
+}
+
+const BuilderPtr Complex128Builder::datetime(int64_t x,
+                                             const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::timedelta(int64_t x,
+                                              const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::string(const char *x, int64_t length,
+                                           const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr Complex128Builder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Complex128Builder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr Complex128Builder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Complex128Builder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Complex128Builder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void Complex128Builder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Complex128Builder::endrecord() { return shared_from_this(); }
+
+} // namespace awkward

--- a/src/libawkward/builder/Complex128Builder.cpp
+++ b/src/libawkward/builder/Complex128Builder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Complex128Builder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Complex128Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -12,151 +10,172 @@
 #include "awkward/builder/Complex128Builder.h"
 
 namespace awkward {
-const BuilderPtr Complex128Builder::fromempty(const BuilderOptions &options) {
-  return std::make_shared<Complex128Builder>(
-      options, GrowableBuffer<std::complex<double>>::empty(options));
-}
+  const BuilderPtr
+  Complex128Builder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<Complex128Builder>(options,
+                                              GrowableBuffer<std::complex<double>>::empty(options));
+  }
 
-const BuilderPtr
-Complex128Builder::fromint64(const BuilderOptions &options,
-                             const GrowableBuffer<int64_t> &old) {
-  return std::make_shared<Complex128Builder>(
+  const BuilderPtr
+  Complex128Builder::fromint64(const BuilderOptions& options,
+                               const GrowableBuffer<int64_t>& old) {
+    return std::make_shared<Complex128Builder>(
       options,
       std::move(GrowableBuffer<int64_t>::copy_as<std::complex<double>>(old)));
-}
+  }
 
-const BuilderPtr
-Complex128Builder::fromfloat64(const BuilderOptions &options,
-                               const GrowableBuffer<double> &old) {
-  return std::make_shared<Complex128Builder>(
+  const BuilderPtr
+  Complex128Builder::fromfloat64(const BuilderOptions& options,
+                                 const GrowableBuffer<double>& old) {
+    return std::make_shared<Complex128Builder>(
       options,
       std::move(GrowableBuffer<double>::copy_as<std::complex<double>>(old)));
+  }
+
+  Complex128Builder::Complex128Builder(const BuilderOptions& options,
+                                       GrowableBuffer<std::complex<double>> buffer)
+      : options_(options)
+      , buffer_(std::move(buffer)) { }
+
+  const std::string
+  Complex128Builder::classname() const {
+    return "Complex128Builder";
+  }
+
+  const std::string
+  Complex128Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    void* ptr = container.empty_buffer(form_key.str() + "-data",
+      (int64_t)buffer_.length() * (int64_t)sizeof(std::complex<double>));
+
+    buffer_.concatenate(reinterpret_cast<std::complex<double>*>(ptr));
+
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"complex128\", \"form_key\": \""
+           + form_key.str() + "\"}";
+  }
+
+  int64_t
+  Complex128Builder::length() const {
+    return (int64_t)buffer_.length();
+  }
+
+  void
+  Complex128Builder::clear() {
+    buffer_.clear();
+  }
+
+  bool
+  Complex128Builder::active() const {
+    return false;
+  }
+
+  const BuilderPtr
+  Complex128Builder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  }
+
+  const BuilderPtr
+  Complex128Builder::boolean(bool x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  }
+
+  const BuilderPtr
+  Complex128Builder::integer(int64_t x) {
+    buffer_.append(std::complex<double>((double)x, 0));
+    return nullptr;
+  }
+
+  const BuilderPtr
+  Complex128Builder::real(double x) {
+    buffer_.append(std::complex<double>((double)x, 0));
+    return nullptr;
+  }
+
+  const BuilderPtr
+  Complex128Builder::complex(std::complex<double> x) {
+    buffer_.append(x);
+    return nullptr;
+  }
+
+  const BuilderPtr
+  Complex128Builder::datetime(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  Complex128Builder::timedelta(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  Complex128Builder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  }
+
+  const BuilderPtr
+  Complex128Builder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  }
+
+  const BuilderPtr
+  Complex128Builder::endlist() {
+    throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Complex128Builder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  }
+
+  const BuilderPtr
+  Complex128Builder::index(int64_t /* index */) {
+    throw std::invalid_argument(
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Complex128Builder::endtuple() {
+    throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Complex128Builder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  }
+
+  void
+  Complex128Builder::field(const char* /* key */, bool /* check */) {
+    throw std::invalid_argument(
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Complex128Builder::endrecord() {
+    return shared_from_this();
+  }
+
 }
-
-Complex128Builder::Complex128Builder(
-    const BuilderOptions &options, GrowableBuffer<std::complex<double>> buffer)
-    : options_(options), buffer_(std::move(buffer)) {}
-
-const std::string Complex128Builder::classname() const {
-  return "Complex128Builder";
-}
-
-const std::string Complex128Builder::to_buffers(BuffersContainer &container,
-                                                int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  void *ptr = container.empty_buffer(form_key.str() + "-data",
-                                     (int64_t)buffer_.length() *
-                                         (int64_t)sizeof(std::complex<double>));
-
-  buffer_.concatenate(reinterpret_cast<std::complex<double> *>(ptr));
-
-  return "{\"class\": \"NumpyArray\", \"primitive\": \"complex128\", "
-         "\"form_key\": \"" +
-         form_key.str() + "\"}";
-}
-
-int64_t Complex128Builder::length() const { return (int64_t)buffer_.length(); }
-
-void Complex128Builder::clear() { buffer_.clear(); }
-
-bool Complex128Builder::active() const { return false; }
-
-const BuilderPtr Complex128Builder::null() {
-  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-  out.get()->null();
-  return out;
-}
-
-const BuilderPtr Complex128Builder::boolean(bool x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->boolean(x);
-  return out;
-}
-
-const BuilderPtr Complex128Builder::integer(int64_t x) {
-  buffer_.append(std::complex<double>((double)x, 0));
-  return nullptr;
-}
-
-const BuilderPtr Complex128Builder::real(double x) {
-  buffer_.append(std::complex<double>((double)x, 0));
-  return nullptr;
-}
-
-const BuilderPtr Complex128Builder::complex(std::complex<double> x) {
-  buffer_.append(x);
-  return nullptr;
-}
-
-const BuilderPtr Complex128Builder::datetime(int64_t x,
-                                             const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->datetime(x, unit);
-  return out;
-}
-
-const BuilderPtr Complex128Builder::timedelta(int64_t x,
-                                              const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->timedelta(x, unit);
-  return out;
-}
-
-const BuilderPtr Complex128Builder::string(const char *x, int64_t length,
-                                           const char *encoding) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->string(x, length, encoding);
-  return out;
-}
-
-const BuilderPtr Complex128Builder::beginlist() {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginlist();
-  return out;
-}
-
-const BuilderPtr Complex128Builder::endlist() {
-  throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Complex128Builder::begintuple(int64_t numfields) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->begintuple(numfields);
-  return out;
-}
-
-const BuilderPtr Complex128Builder::index(int64_t /* index */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'index' without 'begin_tuple' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Complex128Builder::endtuple() {
-  throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Complex128Builder::beginrecord(const char *name, bool check) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginrecord(name, check);
-  return out;
-}
-
-void Complex128Builder::field(const char * /* key */, bool /* check */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'field' without 'begin_record' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Complex128Builder::endrecord() { return shared_from_this(); }
-
-} // namespace awkward

--- a/src/libawkward/builder/DatetimeBuilder.cpp
+++ b/src/libawkward/builder/DatetimeBuilder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/DatetimeBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/DatetimeBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -10,203 +12,169 @@
 #include "awkward/builder/UnionBuilder.h"
 
 #include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/util.h"
 #include "awkward/datetime_util.h"
+#include "awkward/util.h"
 
 namespace awkward {
-  const BuilderPtr
-  DatetimeBuilder::fromempty(const BuilderOptions& options, const std::string& units) {
-    GrowableBuffer<int64_t> content = GrowableBuffer<int64_t>::empty(options);
-    return std::make_shared<DatetimeBuilder>(options,
-                                             std::move(content),
-                                             units);
-  }
-
-  DatetimeBuilder::DatetimeBuilder(const BuilderOptions& options,
-                                   GrowableBuffer<int64_t> content,
-                                   const std::string& units)
-      : options_(options)
-      , content_(std::move(content))
-      , units_(units) { }
-
-  const std::string
-  DatetimeBuilder::classname() const {
-    return "DatetimeBuilder";
-  };
-
-  const std::string
-  DatetimeBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    content_.concatenate(
-      reinterpret_cast<int64_t*>(
-        container.empty_buffer(form_key.str() + "-data",
-        (int64_t)content_.length() * (int64_t)sizeof(int64_t))));
-
-    std::string primitive(units_);
-
-    if (primitive.find("datetime64") == 0) {
-      return "{\"class\": \"NumpyArray\", \"primitive\": \""
-             + primitive + "\", \"format\": \""
-             + "M8" + primitive.substr(10) + "\", \"form_key\": \""
-             + form_key.str() + "\"}";
-    }
-    else if (primitive.find("timedelta64") == 0) {
-      return "{\"class\": \"NumpyArray\", \"primitive\": \""
-             + primitive + "\", \"format\": \""
-             + "m8" + primitive.substr(11) + "\", \"form_key\": \""
-             + form_key.str() + "\"}";
-    }
-    else {
-      return "{\"class\": \"NumpyArray\", \"primitive\": \""
-             + primitive + "\", \"form_key\": \""
-             + form_key.str() + "\"}";
-    }
-  }
-
-  int64_t
-  DatetimeBuilder::length() const {
-    return (int64_t)content_.length();
-  }
-
-  void
-  DatetimeBuilder::clear() {
-    content_.clear();
-  }
-
-  bool
-  DatetimeBuilder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::datetime(int64_t x, const std::string& unit) {
-    if (unit == units_) {
-      content_.append(x);
-      return nullptr;
-    }
-    else {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->datetime(x, unit);
-      return out;
-    }
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (unit == units_) {
-      content_.append(x);
-      return nullptr;
-    }
-    else {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->timedelta(x, unit);
-      return out;
-    }
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  DatetimeBuilder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const std::string&
-  DatetimeBuilder::units() const {
-    return units_;
-  }
-
+const BuilderPtr DatetimeBuilder::fromempty(const BuilderOptions &options,
+                                            const std::string &units) {
+  GrowableBuffer<int64_t> content = GrowableBuffer<int64_t>::empty(options);
+  return std::make_shared<DatetimeBuilder>(options, std::move(content), units);
 }
+
+DatetimeBuilder::DatetimeBuilder(const BuilderOptions &options,
+                                 GrowableBuffer<int64_t> content,
+                                 const std::string &units)
+    : options_(options), content_(std::move(content)), units_(units) {}
+
+const std::string DatetimeBuilder::classname() const {
+  return "DatetimeBuilder";
+};
+
+const std::string DatetimeBuilder::to_buffers(BuffersContainer &container,
+                                              int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  content_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
+      form_key.str() + "-data",
+      (int64_t)content_.length() * (int64_t)sizeof(int64_t))));
+
+  std::string primitive(units_);
+
+  if (primitive.find("datetime64") == 0) {
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
+           "\", \"format\": \"" + "M8" + primitive.substr(10) +
+           "\", \"form_key\": \"" + form_key.str() + "\"}";
+  } else if (primitive.find("timedelta64") == 0) {
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
+           "\", \"format\": \"" + "m8" + primitive.substr(11) +
+           "\", \"form_key\": \"" + form_key.str() + "\"}";
+  } else {
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
+           "\", \"form_key\": \"" + form_key.str() + "\"}";
+  }
+}
+
+int64_t DatetimeBuilder::length() const { return (int64_t)content_.length(); }
+
+void DatetimeBuilder::clear() { content_.clear(); }
+
+bool DatetimeBuilder::active() const { return false; }
+
+const BuilderPtr DatetimeBuilder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::integer(int64_t x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->integer(x);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::real(double x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::complex(std::complex<double> x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::datetime(int64_t x, const std::string &unit) {
+  if (unit == units_) {
+    content_.append(x);
+    return nullptr;
+  } else {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  }
+}
+
+const BuilderPtr DatetimeBuilder::timedelta(int64_t x,
+                                            const std::string &unit) {
+  if (unit == units_) {
+    content_.append(x);
+    return nullptr;
+  } else {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  }
+}
+
+const BuilderPtr DatetimeBuilder::string(const char *x, int64_t length,
+                                         const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr DatetimeBuilder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr DatetimeBuilder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr DatetimeBuilder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void DatetimeBuilder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr DatetimeBuilder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+const std::string &DatetimeBuilder::units() const { return units_; }
+
+} // namespace awkward

--- a/src/libawkward/builder/DatetimeBuilder.cpp
+++ b/src/libawkward/builder/DatetimeBuilder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/DatetimeBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/DatetimeBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -10,203 +11,169 @@
 #include "awkward/builder/UnionBuilder.h"
 
 #include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/util.h"
 #include "awkward/datetime_util.h"
+#include "awkward/util.h"
 
 namespace awkward {
-  const BuilderPtr
-  DatetimeBuilder::fromempty(const BuilderOptions& options, const std::string& units) {
-    GrowableBuffer<int64_t> content = GrowableBuffer<int64_t>::empty(options);
-    return std::make_shared<DatetimeBuilder>(options,
-                                             std::move(content),
-                                             units);
-  }
-
-  DatetimeBuilder::DatetimeBuilder(const BuilderOptions& options,
-                                   GrowableBuffer<int64_t> content,
-                                   const std::string& units)
-      : options_(options)
-      , content_(std::move(content))
-      , units_(units) { }
-
-  const std::string
-  DatetimeBuilder::classname() const {
-    return "DatetimeBuilder";
-  };
-
-  const std::string
-  DatetimeBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    content_.concatenate(
-      reinterpret_cast<int64_t*>(
-        container.empty_buffer(form_key.str() + "-data",
-        (int64_t)content_.length() * (int64_t)sizeof(int64_t))));
-
-    std::string primitive(units_);
-
-    if (primitive.find("datetime64") == 0) {
-      return "{\"class\": \"NumpyArray\", \"primitive\": \""
-             + primitive + "\", \"format\": \""
-             + "M8" + primitive.substr(10) + "\", \"form_key\": \""
-             + form_key.str() + "\"}";
-    }
-    else if (primitive.find("timedelta64") == 0) {
-      return "{\"class\": \"NumpyArray\", \"primitive\": \""
-             + primitive + "\", \"format\": \""
-             + "m8" + primitive.substr(11) + "\", \"form_key\": \""
-             + form_key.str() + "\"}";
-    }
-    else {
-      return "{\"class\": \"NumpyArray\", \"primitive\": \""
-             + primitive + "\", \"form_key\": \""
-             + form_key.str() + "\"}";
-    }
-  }
-
-  int64_t
-  DatetimeBuilder::length() const {
-    return (int64_t)content_.length();
-  }
-
-  void
-  DatetimeBuilder::clear() {
-    content_.clear();
-  }
-
-  bool
-  DatetimeBuilder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::datetime(int64_t x, const std::string& unit) {
-    if (unit == units_) {
-      content_.append(x);
-      return nullptr;
-    }
-    else {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->datetime(x, unit);
-      return out;
-    }
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (unit == units_) {
-      content_.append(x);
-      return nullptr;
-    }
-    else {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->timedelta(x, unit);
-      return out;
-    }
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  DatetimeBuilder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  DatetimeBuilder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const std::string&
-  DatetimeBuilder::units() const {
-    return units_;
-  }
-
+const BuilderPtr DatetimeBuilder::fromempty(const BuilderOptions &options,
+                                            const std::string    &units) {
+  GrowableBuffer<int64_t> content = GrowableBuffer<int64_t>::empty(options);
+  return std::make_shared<DatetimeBuilder>(options, std::move(content), units);
 }
+
+DatetimeBuilder::DatetimeBuilder(const BuilderOptions   &options,
+                                 GrowableBuffer<int64_t> content,
+                                 const std::string      &units)
+    : options_(options), content_(std::move(content)), units_(units) {}
+
+const std::string DatetimeBuilder::classname() const {
+  return "DatetimeBuilder";
+};
+
+const std::string DatetimeBuilder::to_buffers(BuffersContainer &container,
+                                              int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  content_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
+      form_key.str() + "-data",
+      (int64_t)content_.length() * (int64_t)sizeof(int64_t))));
+
+  std::string primitive(units_);
+
+  if (primitive.find("datetime64") == 0) {
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
+           "\", \"format\": \"" + "M8" + primitive.substr(10) +
+           "\", \"form_key\": \"" + form_key.str() + "\"}";
+  } else if (primitive.find("timedelta64") == 0) {
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
+           "\", \"format\": \"" + "m8" + primitive.substr(11) +
+           "\", \"form_key\": \"" + form_key.str() + "\"}";
+  } else {
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
+           "\", \"form_key\": \"" + form_key.str() + "\"}";
+  }
+}
+
+int64_t DatetimeBuilder::length() const { return (int64_t)content_.length(); }
+
+void DatetimeBuilder::clear() { content_.clear(); }
+
+bool DatetimeBuilder::active() const { return false; }
+
+const BuilderPtr DatetimeBuilder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::integer(int64_t x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->integer(x);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::real(double x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::complex(std::complex<double> x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::datetime(int64_t x, const std::string &unit) {
+  if (unit == units_) {
+    content_.append(x);
+    return nullptr;
+  } else {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  }
+}
+
+const BuilderPtr DatetimeBuilder::timedelta(int64_t            x,
+                                            const std::string &unit) {
+  if (unit == units_) {
+    content_.append(x);
+    return nullptr;
+  } else {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  }
+}
+
+const BuilderPtr DatetimeBuilder::string(const char *x, int64_t length,
+                                         const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr DatetimeBuilder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr DatetimeBuilder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr DatetimeBuilder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr DatetimeBuilder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void DatetimeBuilder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr DatetimeBuilder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+const std::string &DatetimeBuilder::units() const { return units_; }
+
+} // namespace awkward

--- a/src/libawkward/builder/DatetimeBuilder.cpp
+++ b/src/libawkward/builder/DatetimeBuilder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/DatetimeBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/DatetimeBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -12,169 +10,203 @@
 #include "awkward/builder/UnionBuilder.h"
 
 #include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/datetime_util.h"
 #include "awkward/util.h"
+#include "awkward/datetime_util.h"
 
 namespace awkward {
-const BuilderPtr DatetimeBuilder::fromempty(const BuilderOptions &options,
-                                            const std::string &units) {
-  GrowableBuffer<int64_t> content = GrowableBuffer<int64_t>::empty(options);
-  return std::make_shared<DatetimeBuilder>(options, std::move(content), units);
-}
-
-DatetimeBuilder::DatetimeBuilder(const BuilderOptions &options,
-                                 GrowableBuffer<int64_t> content,
-                                 const std::string &units)
-    : options_(options), content_(std::move(content)), units_(units) {}
-
-const std::string DatetimeBuilder::classname() const {
-  return "DatetimeBuilder";
-};
-
-const std::string DatetimeBuilder::to_buffers(BuffersContainer &container,
-                                              int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  content_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
-      form_key.str() + "-data",
-      (int64_t)content_.length() * (int64_t)sizeof(int64_t))));
-
-  std::string primitive(units_);
-
-  if (primitive.find("datetime64") == 0) {
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
-           "\", \"format\": \"" + "M8" + primitive.substr(10) +
-           "\", \"form_key\": \"" + form_key.str() + "\"}";
-  } else if (primitive.find("timedelta64") == 0) {
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
-           "\", \"format\": \"" + "m8" + primitive.substr(11) +
-           "\", \"form_key\": \"" + form_key.str() + "\"}";
-  } else {
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"" + primitive +
-           "\", \"form_key\": \"" + form_key.str() + "\"}";
+  const BuilderPtr
+  DatetimeBuilder::fromempty(const BuilderOptions& options, const std::string& units) {
+    GrowableBuffer<int64_t> content = GrowableBuffer<int64_t>::empty(options);
+    return std::make_shared<DatetimeBuilder>(options,
+                                             std::move(content),
+                                             units);
   }
-}
 
-int64_t DatetimeBuilder::length() const { return (int64_t)content_.length(); }
+  DatetimeBuilder::DatetimeBuilder(const BuilderOptions& options,
+                                   GrowableBuffer<int64_t> content,
+                                   const std::string& units)
+      : options_(options)
+      , content_(std::move(content))
+      , units_(units) { }
 
-void DatetimeBuilder::clear() { content_.clear(); }
+  const std::string
+  DatetimeBuilder::classname() const {
+    return "DatetimeBuilder";
+  };
 
-bool DatetimeBuilder::active() const { return false; }
+  const std::string
+  DatetimeBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
 
-const BuilderPtr DatetimeBuilder::null() {
-  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-  out.get()->null();
-  return out;
-}
+    content_.concatenate(
+      reinterpret_cast<int64_t*>(
+        container.empty_buffer(form_key.str() + "-data",
+        (int64_t)content_.length() * (int64_t)sizeof(int64_t))));
 
-const BuilderPtr DatetimeBuilder::boolean(bool x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->boolean(x);
-  return out;
-}
+    std::string primitive(units_);
 
-const BuilderPtr DatetimeBuilder::integer(int64_t x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->integer(x);
-  return out;
-}
+    if (primitive.find("datetime64") == 0) {
+      return "{\"class\": \"NumpyArray\", \"primitive\": \""
+             + primitive + "\", \"format\": \""
+             + "M8" + primitive.substr(10) + "\", \"form_key\": \""
+             + form_key.str() + "\"}";
+    }
+    else if (primitive.find("timedelta64") == 0) {
+      return "{\"class\": \"NumpyArray\", \"primitive\": \""
+             + primitive + "\", \"format\": \""
+             + "m8" + primitive.substr(11) + "\", \"form_key\": \""
+             + form_key.str() + "\"}";
+    }
+    else {
+      return "{\"class\": \"NumpyArray\", \"primitive\": \""
+             + primitive + "\", \"form_key\": \""
+             + form_key.str() + "\"}";
+    }
+  }
 
-const BuilderPtr DatetimeBuilder::real(double x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->real(x);
-  return out;
-}
+  int64_t
+  DatetimeBuilder::length() const {
+    return (int64_t)content_.length();
+  }
 
-const BuilderPtr DatetimeBuilder::complex(std::complex<double> x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->complex(x);
-  return out;
-}
+  void
+  DatetimeBuilder::clear() {
+    content_.clear();
+  }
 
-const BuilderPtr DatetimeBuilder::datetime(int64_t x, const std::string &unit) {
-  if (unit == units_) {
-    content_.append(x);
-    return nullptr;
-  } else {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
+  bool
+  DatetimeBuilder::active() const {
+    return false;
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
     return out;
   }
-}
 
-const BuilderPtr DatetimeBuilder::timedelta(int64_t x,
-                                            const std::string &unit) {
-  if (unit == units_) {
-    content_.append(x);
-    return nullptr;
-  } else {
+  const BuilderPtr
+  DatetimeBuilder::boolean(bool x) {
     BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
+    out.get()->boolean(x);
     return out;
   }
+
+  const BuilderPtr
+  DatetimeBuilder::integer(int64_t x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::real(double x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::complex(std::complex<double> x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::datetime(int64_t x, const std::string& unit) {
+    if (unit == units_) {
+      content_.append(x);
+      return nullptr;
+    }
+    else {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->datetime(x, unit);
+      return out;
+    }
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::timedelta(int64_t x, const std::string& unit) {
+    if (unit == units_) {
+      content_.append(x);
+      return nullptr;
+    }
+    else {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->timedelta(x, unit);
+      return out;
+    }
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::endlist() {
+    throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::index(int64_t /* index */) {
+    throw std::invalid_argument(
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::endtuple() {
+    throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  }
+
+  void
+  DatetimeBuilder::field(const char* /* key */, bool /* check */) {
+    throw std::invalid_argument(
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  DatetimeBuilder::endrecord() {
+    throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const std::string&
+  DatetimeBuilder::units() const {
+    return units_;
+  }
+
 }
-
-const BuilderPtr DatetimeBuilder::string(const char *x, int64_t length,
-                                         const char *encoding) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->string(x, length, encoding);
-  return out;
-}
-
-const BuilderPtr DatetimeBuilder::beginlist() {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginlist();
-  return out;
-}
-
-const BuilderPtr DatetimeBuilder::endlist() {
-  throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr DatetimeBuilder::begintuple(int64_t numfields) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->begintuple(numfields);
-  return out;
-}
-
-const BuilderPtr DatetimeBuilder::index(int64_t /* index */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'index' without 'begin_tuple' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr DatetimeBuilder::endtuple() {
-  throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr DatetimeBuilder::beginrecord(const char *name, bool check) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginrecord(name, check);
-  return out;
-}
-
-void DatetimeBuilder::field(const char * /* key */, bool /* check */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'field' without 'begin_record' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr DatetimeBuilder::endrecord() {
-  throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same "
-                  "level before it") +
-      FILENAME(__LINE__));
-}
-
-const std::string &DatetimeBuilder::units() const { return units_; }
-
-} // namespace awkward

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Float64Builder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Float64Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -11,173 +12,146 @@
 #include "awkward/builder/Float64Builder.h"
 
 namespace awkward {
-  const BuilderPtr
-  Float64Builder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<Float64Builder>(options,
-                                            GrowableBuffer<double>::empty(options));
-  }
-
-  const BuilderPtr
-  Float64Builder::fromint64(const BuilderOptions& options,
-                            const GrowableBuffer<int64_t>& old) {
-    return std::make_shared<Float64Builder>(
-      options,
-      std::move(GrowableBuffer<int64_t>::copy_as<double>(old)));
-  }
-
-  Float64Builder::Float64Builder(const BuilderOptions& options,
-                                 GrowableBuffer<double> buffer)
-      : options_(options)
-      , buffer_(std::move(buffer)) { }
-
-  GrowableBuffer<double>
-  Float64Builder::buffer() {
-    // FIXME: swap with an empty buffer
-    return std::move(buffer_);
-  }
-
-  const std::string
-  Float64Builder::classname() const {
-    return "Float64Builder";
-  }
-
-  const std::string
-  Float64Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    buffer_.concatenate(
-      reinterpret_cast<double*>(
-        container.empty_buffer(form_key.str() + "-data",
-        (int64_t)buffer_.length() * (int64_t)sizeof(double))));
-
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"float64\", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
-
-  int64_t
-  Float64Builder::length() const {
-    return (int64_t)buffer_.length();
-  }
-
-  void
-  Float64Builder::clear() {
-    buffer_.clear();
-  }
-
-  bool
-  Float64Builder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  Float64Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::integer(int64_t x) {
-    buffer_.append((double)x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Float64Builder::real(double x) {
-    buffer_.append(x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Float64Builder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromfloat64(options_, std::move(buffer_));
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Float64Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Float64Builder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Float64Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  Float64Builder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Float64Builder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr Float64Builder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<Float64Builder>(
+      options, GrowableBuffer<double>::empty(options));
 }
+
+const BuilderPtr Float64Builder::fromint64(const BuilderOptions &options,
+                                           const GrowableBuffer<int64_t> &old) {
+  return std::make_shared<Float64Builder>(
+      options, std::move(GrowableBuffer<int64_t>::copy_as<double>(old)));
+}
+
+Float64Builder::Float64Builder(const BuilderOptions  &options,
+                               GrowableBuffer<double> buffer)
+    : options_(options), buffer_(std::move(buffer)) {}
+
+GrowableBuffer<double> Float64Builder::buffer() {
+  // FIXME: swap with an empty buffer
+  return std::move(buffer_);
+}
+
+const std::string Float64Builder::classname() const { return "Float64Builder"; }
+
+const std::string Float64Builder::to_buffers(BuffersContainer &container,
+                                             int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  buffer_.concatenate(reinterpret_cast<double *>(container.empty_buffer(
+      form_key.str() + "-data",
+      (int64_t)buffer_.length() * (int64_t)sizeof(double))));
+
+  return "{\"class\": \"NumpyArray\", \"primitive\": \"float64\", "
+         "\"form_key\": \"" +
+         form_key.str() + "\"}";
+}
+
+int64_t Float64Builder::length() const { return (int64_t)buffer_.length(); }
+
+void Float64Builder::clear() { buffer_.clear(); }
+
+bool Float64Builder::active() const { return false; }
+
+const BuilderPtr Float64Builder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr Float64Builder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr Float64Builder::integer(int64_t x) {
+  buffer_.append((double)x);
+  return nullptr;
+}
+
+const BuilderPtr Float64Builder::real(double x) {
+  buffer_.append(x);
+  return nullptr;
+}
+
+const BuilderPtr Float64Builder::complex(std::complex<double> x) {
+  BuilderPtr out = Complex128Builder::fromfloat64(options_, std::move(buffer_));
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr Float64Builder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr Float64Builder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr Float64Builder::string(const char *x, int64_t length,
+                                        const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr Float64Builder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr Float64Builder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Float64Builder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr Float64Builder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Float64Builder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Float64Builder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void Float64Builder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Float64Builder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Float64Builder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Float64Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -13,146 +11,173 @@
 #include "awkward/builder/Float64Builder.h"
 
 namespace awkward {
-const BuilderPtr Float64Builder::fromempty(const BuilderOptions &options) {
-  return std::make_shared<Float64Builder>(
-      options, GrowableBuffer<double>::empty(options));
+  const BuilderPtr
+  Float64Builder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<Float64Builder>(options,
+                                            GrowableBuffer<double>::empty(options));
+  }
+
+  const BuilderPtr
+  Float64Builder::fromint64(const BuilderOptions& options,
+                            const GrowableBuffer<int64_t>& old) {
+    return std::make_shared<Float64Builder>(
+      options,
+      std::move(GrowableBuffer<int64_t>::copy_as<double>(old)));
+  }
+
+  Float64Builder::Float64Builder(const BuilderOptions& options,
+                                 GrowableBuffer<double> buffer)
+      : options_(options)
+      , buffer_(std::move(buffer)) { }
+
+  GrowableBuffer<double>
+  Float64Builder::buffer() {
+    // FIXME: swap with an empty buffer
+    return std::move(buffer_);
+  }
+
+  const std::string
+  Float64Builder::classname() const {
+    return "Float64Builder";
+  }
+
+  const std::string
+  Float64Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    buffer_.concatenate(
+      reinterpret_cast<double*>(
+        container.empty_buffer(form_key.str() + "-data",
+        (int64_t)buffer_.length() * (int64_t)sizeof(double))));
+
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"float64\", \"form_key\": \""
+           + form_key.str() + "\"}";
+  }
+
+  int64_t
+  Float64Builder::length() const {
+    return (int64_t)buffer_.length();
+  }
+
+  void
+  Float64Builder::clear() {
+    buffer_.clear();
+  }
+
+  bool
+  Float64Builder::active() const {
+    return false;
+  }
+
+  const BuilderPtr
+  Float64Builder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  }
+
+  const BuilderPtr
+  Float64Builder::boolean(bool x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  }
+
+  const BuilderPtr
+  Float64Builder::integer(int64_t x) {
+    buffer_.append((double)x);
+    return nullptr;
+  }
+
+  const BuilderPtr
+  Float64Builder::real(double x) {
+    buffer_.append(x);
+    return nullptr;
+  }
+
+  const BuilderPtr
+  Float64Builder::complex(std::complex<double> x) {
+    BuilderPtr out = Complex128Builder::fromfloat64(options_, std::move(buffer_));
+    out.get()->complex(x);
+    return out;
+  }
+
+  const BuilderPtr
+  Float64Builder::datetime(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  Float64Builder::timedelta(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  Float64Builder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  }
+
+  const BuilderPtr
+  Float64Builder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  }
+
+  const BuilderPtr
+  Float64Builder::endlist() {
+    throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Float64Builder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  }
+
+  const BuilderPtr
+  Float64Builder::index(int64_t /* index */) {
+    throw std::invalid_argument(
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Float64Builder::endtuple() {
+    throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Float64Builder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  }
+
+  void
+  Float64Builder::field(const char* /* key */, bool /* check */) {
+    throw std::invalid_argument(
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Float64Builder::endrecord() {
+    throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
 }
-
-const BuilderPtr Float64Builder::fromint64(const BuilderOptions &options,
-                                           const GrowableBuffer<int64_t> &old) {
-  return std::make_shared<Float64Builder>(
-      options, std::move(GrowableBuffer<int64_t>::copy_as<double>(old)));
-}
-
-Float64Builder::Float64Builder(const BuilderOptions &options,
-                               GrowableBuffer<double> buffer)
-    : options_(options), buffer_(std::move(buffer)) {}
-
-GrowableBuffer<double> Float64Builder::buffer() {
-  // FIXME: swap with an empty buffer
-  return std::move(buffer_);
-}
-
-const std::string Float64Builder::classname() const { return "Float64Builder"; }
-
-const std::string Float64Builder::to_buffers(BuffersContainer &container,
-                                             int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  buffer_.concatenate(reinterpret_cast<double *>(container.empty_buffer(
-      form_key.str() + "-data",
-      (int64_t)buffer_.length() * (int64_t)sizeof(double))));
-
-  return "{\"class\": \"NumpyArray\", \"primitive\": \"float64\", "
-         "\"form_key\": \"" +
-         form_key.str() + "\"}";
-}
-
-int64_t Float64Builder::length() const { return (int64_t)buffer_.length(); }
-
-void Float64Builder::clear() { buffer_.clear(); }
-
-bool Float64Builder::active() const { return false; }
-
-const BuilderPtr Float64Builder::null() {
-  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-  out.get()->null();
-  return out;
-}
-
-const BuilderPtr Float64Builder::boolean(bool x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->boolean(x);
-  return out;
-}
-
-const BuilderPtr Float64Builder::integer(int64_t x) {
-  buffer_.append((double)x);
-  return nullptr;
-}
-
-const BuilderPtr Float64Builder::real(double x) {
-  buffer_.append(x);
-  return nullptr;
-}
-
-const BuilderPtr Float64Builder::complex(std::complex<double> x) {
-  BuilderPtr out = Complex128Builder::fromfloat64(options_, std::move(buffer_));
-  out.get()->complex(x);
-  return out;
-}
-
-const BuilderPtr Float64Builder::datetime(int64_t x, const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->datetime(x, unit);
-  return out;
-}
-
-const BuilderPtr Float64Builder::timedelta(int64_t x, const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->timedelta(x, unit);
-  return out;
-}
-
-const BuilderPtr Float64Builder::string(const char *x, int64_t length,
-                                        const char *encoding) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->string(x, length, encoding);
-  return out;
-}
-
-const BuilderPtr Float64Builder::beginlist() {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginlist();
-  return out;
-}
-
-const BuilderPtr Float64Builder::endlist() {
-  throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Float64Builder::begintuple(int64_t numfields) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->begintuple(numfields);
-  return out;
-}
-
-const BuilderPtr Float64Builder::index(int64_t /* index */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'index' without 'begin_tuple' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Float64Builder::endtuple() {
-  throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Float64Builder::beginrecord(const char *name, bool check) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginrecord(name, check);
-  return out;
-}
-
-void Float64Builder::field(const char * /* key */, bool /* check */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'field' without 'begin_record' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Float64Builder::endrecord() {
-  throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same "
-                  "level before it") +
-      FILENAME(__LINE__));
-}
-
-} // namespace awkward

--- a/src/libawkward/builder/Float64Builder.cpp
+++ b/src/libawkward/builder/Float64Builder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Float64Builder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Float64Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -11,173 +13,146 @@
 #include "awkward/builder/Float64Builder.h"
 
 namespace awkward {
-  const BuilderPtr
-  Float64Builder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<Float64Builder>(options,
-                                            GrowableBuffer<double>::empty(options));
-  }
-
-  const BuilderPtr
-  Float64Builder::fromint64(const BuilderOptions& options,
-                            const GrowableBuffer<int64_t>& old) {
-    return std::make_shared<Float64Builder>(
-      options,
-      std::move(GrowableBuffer<int64_t>::copy_as<double>(old)));
-  }
-
-  Float64Builder::Float64Builder(const BuilderOptions& options,
-                                 GrowableBuffer<double> buffer)
-      : options_(options)
-      , buffer_(std::move(buffer)) { }
-
-  GrowableBuffer<double>
-  Float64Builder::buffer() {
-    // FIXME: swap with an empty buffer
-    return std::move(buffer_);
-  }
-
-  const std::string
-  Float64Builder::classname() const {
-    return "Float64Builder";
-  }
-
-  const std::string
-  Float64Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    buffer_.concatenate(
-      reinterpret_cast<double*>(
-        container.empty_buffer(form_key.str() + "-data",
-        (int64_t)buffer_.length() * (int64_t)sizeof(double))));
-
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"float64\", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
-
-  int64_t
-  Float64Builder::length() const {
-    return (int64_t)buffer_.length();
-  }
-
-  void
-  Float64Builder::clear() {
-    buffer_.clear();
-  }
-
-  bool
-  Float64Builder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  Float64Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::integer(int64_t x) {
-    buffer_.append((double)x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Float64Builder::real(double x) {
-    buffer_.append(x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Float64Builder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromfloat64(options_, std::move(buffer_));
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Float64Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  Float64Builder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Float64Builder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Float64Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  Float64Builder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Float64Builder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr Float64Builder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<Float64Builder>(
+      options, GrowableBuffer<double>::empty(options));
 }
+
+const BuilderPtr Float64Builder::fromint64(const BuilderOptions &options,
+                                           const GrowableBuffer<int64_t> &old) {
+  return std::make_shared<Float64Builder>(
+      options, std::move(GrowableBuffer<int64_t>::copy_as<double>(old)));
+}
+
+Float64Builder::Float64Builder(const BuilderOptions &options,
+                               GrowableBuffer<double> buffer)
+    : options_(options), buffer_(std::move(buffer)) {}
+
+GrowableBuffer<double> Float64Builder::buffer() {
+  // FIXME: swap with an empty buffer
+  return std::move(buffer_);
+}
+
+const std::string Float64Builder::classname() const { return "Float64Builder"; }
+
+const std::string Float64Builder::to_buffers(BuffersContainer &container,
+                                             int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  buffer_.concatenate(reinterpret_cast<double *>(container.empty_buffer(
+      form_key.str() + "-data",
+      (int64_t)buffer_.length() * (int64_t)sizeof(double))));
+
+  return "{\"class\": \"NumpyArray\", \"primitive\": \"float64\", "
+         "\"form_key\": \"" +
+         form_key.str() + "\"}";
+}
+
+int64_t Float64Builder::length() const { return (int64_t)buffer_.length(); }
+
+void Float64Builder::clear() { buffer_.clear(); }
+
+bool Float64Builder::active() const { return false; }
+
+const BuilderPtr Float64Builder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr Float64Builder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr Float64Builder::integer(int64_t x) {
+  buffer_.append((double)x);
+  return nullptr;
+}
+
+const BuilderPtr Float64Builder::real(double x) {
+  buffer_.append(x);
+  return nullptr;
+}
+
+const BuilderPtr Float64Builder::complex(std::complex<double> x) {
+  BuilderPtr out = Complex128Builder::fromfloat64(options_, std::move(buffer_));
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr Float64Builder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr Float64Builder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr Float64Builder::string(const char *x, int64_t length,
+                                        const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr Float64Builder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr Float64Builder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Float64Builder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr Float64Builder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Float64Builder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Float64Builder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void Float64Builder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Float64Builder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Int64Builder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Int64Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -12,166 +14,141 @@
 #include "awkward/builder/Int64Builder.h"
 
 namespace awkward {
-  const BuilderPtr
-  Int64Builder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<Int64Builder>(options,
-                                          GrowableBuffer<int64_t>::empty(options));
-  }
-
-  Int64Builder::Int64Builder(const BuilderOptions& options,
-                             GrowableBuffer<int64_t> buffer)
-      : options_(options)
-      , buffer_(std::move(buffer)) { }
-
-  GrowableBuffer<int64_t>
-  Int64Builder::buffer() {
-    // FIXME: swap with an empty buffer!
-    return std::move(buffer_);
-  }
-
-  const std::string
-  Int64Builder::classname() const {
-    return "Int64Builder";
-  };
-
-  const std::string
-  Int64Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    buffer_.concatenate(
-      reinterpret_cast<int64_t*>(
-        container.empty_buffer(form_key.str() + "-data",
-        (int64_t)buffer_.length() * (int64_t)sizeof(int64_t))));
-
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"int64\", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
-
-  int64_t
-  Int64Builder::length() const {
-    return (int64_t)buffer_.length();
-  }
-
-  void
-  Int64Builder::clear() {
-    buffer_.clear();
-  }
-
-  bool
-  Int64Builder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  Int64Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::integer(int64_t x) {
-    buffer_.append(x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Int64Builder::real(double x) {
-    BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromint64(options_, buffer_);
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Int64Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Int64Builder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Int64Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  Int64Builder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Int64Builder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr Int64Builder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<Int64Builder>(
+      options, GrowableBuffer<int64_t>::empty(options));
 }
+
+Int64Builder::Int64Builder(const BuilderOptions &options,
+                           GrowableBuffer<int64_t> buffer)
+    : options_(options), buffer_(std::move(buffer)) {}
+
+GrowableBuffer<int64_t> Int64Builder::buffer() {
+  // FIXME: swap with an empty buffer!
+  return std::move(buffer_);
+}
+
+const std::string Int64Builder::classname() const { return "Int64Builder"; };
+
+const std::string Int64Builder::to_buffers(BuffersContainer &container,
+                                           int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  buffer_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
+      form_key.str() + "-data",
+      (int64_t)buffer_.length() * (int64_t)sizeof(int64_t))));
+
+  return "{\"class\": \"NumpyArray\", \"primitive\": \"int64\", \"form_key\": "
+         "\"" +
+         form_key.str() + "\"}";
+}
+
+int64_t Int64Builder::length() const { return (int64_t)buffer_.length(); }
+
+void Int64Builder::clear() { buffer_.clear(); }
+
+bool Int64Builder::active() const { return false; }
+
+const BuilderPtr Int64Builder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr Int64Builder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr Int64Builder::integer(int64_t x) {
+  buffer_.append(x);
+  return nullptr;
+}
+
+const BuilderPtr Int64Builder::real(double x) {
+  BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr Int64Builder::complex(std::complex<double> x) {
+  BuilderPtr out = Complex128Builder::fromint64(options_, buffer_);
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr Int64Builder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr Int64Builder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr Int64Builder::string(const char *x, int64_t length,
+                                      const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr Int64Builder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr Int64Builder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Int64Builder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr Int64Builder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Int64Builder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Int64Builder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void Int64Builder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Int64Builder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Int64Builder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Int64Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -14,141 +12,166 @@
 #include "awkward/builder/Int64Builder.h"
 
 namespace awkward {
-const BuilderPtr Int64Builder::fromempty(const BuilderOptions &options) {
-  return std::make_shared<Int64Builder>(
-      options, GrowableBuffer<int64_t>::empty(options));
+  const BuilderPtr
+  Int64Builder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<Int64Builder>(options,
+                                          GrowableBuffer<int64_t>::empty(options));
+  }
+
+  Int64Builder::Int64Builder(const BuilderOptions& options,
+                             GrowableBuffer<int64_t> buffer)
+      : options_(options)
+      , buffer_(std::move(buffer)) { }
+
+  GrowableBuffer<int64_t>
+  Int64Builder::buffer() {
+    // FIXME: swap with an empty buffer!
+    return std::move(buffer_);
+  }
+
+  const std::string
+  Int64Builder::classname() const {
+    return "Int64Builder";
+  };
+
+  const std::string
+  Int64Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    buffer_.concatenate(
+      reinterpret_cast<int64_t*>(
+        container.empty_buffer(form_key.str() + "-data",
+        (int64_t)buffer_.length() * (int64_t)sizeof(int64_t))));
+
+    return "{\"class\": \"NumpyArray\", \"primitive\": \"int64\", \"form_key\": \""
+           + form_key.str() + "\"}";
+  }
+
+  int64_t
+  Int64Builder::length() const {
+    return (int64_t)buffer_.length();
+  }
+
+  void
+  Int64Builder::clear() {
+    buffer_.clear();
+  }
+
+  bool
+  Int64Builder::active() const {
+    return false;
+  }
+
+  const BuilderPtr
+  Int64Builder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::boolean(bool x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::integer(int64_t x) {
+    buffer_.append(x);
+    return nullptr;
+  }
+
+  const BuilderPtr
+  Int64Builder::real(double x) {
+    BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
+    out.get()->real(x);
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::complex(std::complex<double> x) {
+    BuilderPtr out = Complex128Builder::fromint64(options_, buffer_);
+    out.get()->complex(x);
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::datetime(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::timedelta(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::endlist() {
+    throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Int64Builder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  }
+
+  const BuilderPtr
+  Int64Builder::index(int64_t /* index */) {
+    throw std::invalid_argument(
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Int64Builder::endtuple() {
+    throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Int64Builder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  }
+
+  void
+  Int64Builder::field(const char* /* key */, bool /* check */) {
+    throw std::invalid_argument(
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  Int64Builder::endrecord() {
+    throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
 }
-
-Int64Builder::Int64Builder(const BuilderOptions &options,
-                           GrowableBuffer<int64_t> buffer)
-    : options_(options), buffer_(std::move(buffer)) {}
-
-GrowableBuffer<int64_t> Int64Builder::buffer() {
-  // FIXME: swap with an empty buffer!
-  return std::move(buffer_);
-}
-
-const std::string Int64Builder::classname() const { return "Int64Builder"; };
-
-const std::string Int64Builder::to_buffers(BuffersContainer &container,
-                                           int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  buffer_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
-      form_key.str() + "-data",
-      (int64_t)buffer_.length() * (int64_t)sizeof(int64_t))));
-
-  return "{\"class\": \"NumpyArray\", \"primitive\": \"int64\", \"form_key\": "
-         "\"" +
-         form_key.str() + "\"}";
-}
-
-int64_t Int64Builder::length() const { return (int64_t)buffer_.length(); }
-
-void Int64Builder::clear() { buffer_.clear(); }
-
-bool Int64Builder::active() const { return false; }
-
-const BuilderPtr Int64Builder::null() {
-  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-  out.get()->null();
-  return out;
-}
-
-const BuilderPtr Int64Builder::boolean(bool x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->boolean(x);
-  return out;
-}
-
-const BuilderPtr Int64Builder::integer(int64_t x) {
-  buffer_.append(x);
-  return nullptr;
-}
-
-const BuilderPtr Int64Builder::real(double x) {
-  BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
-  out.get()->real(x);
-  return out;
-}
-
-const BuilderPtr Int64Builder::complex(std::complex<double> x) {
-  BuilderPtr out = Complex128Builder::fromint64(options_, buffer_);
-  out.get()->complex(x);
-  return out;
-}
-
-const BuilderPtr Int64Builder::datetime(int64_t x, const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->datetime(x, unit);
-  return out;
-}
-
-const BuilderPtr Int64Builder::timedelta(int64_t x, const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->timedelta(x, unit);
-  return out;
-}
-
-const BuilderPtr Int64Builder::string(const char *x, int64_t length,
-                                      const char *encoding) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->string(x, length, encoding);
-  return out;
-}
-
-const BuilderPtr Int64Builder::beginlist() {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginlist();
-  return out;
-}
-
-const BuilderPtr Int64Builder::endlist() {
-  throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Int64Builder::begintuple(int64_t numfields) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->begintuple(numfields);
-  return out;
-}
-
-const BuilderPtr Int64Builder::index(int64_t /* index */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'index' without 'begin_tuple' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Int64Builder::endtuple() {
-  throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Int64Builder::beginrecord(const char *name, bool check) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginrecord(name, check);
-  return out;
-}
-
-void Int64Builder::field(const char * /* key */, bool /* check */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'field' without 'begin_record' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr Int64Builder::endrecord() {
-  throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same "
-                  "level before it") +
-      FILENAME(__LINE__));
-}
-
-} // namespace awkward

--- a/src/libawkward/builder/Int64Builder.cpp
+++ b/src/libawkward/builder/Int64Builder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Int64Builder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/Int64Builder.cpp", line)
 
 #include <stdexcept>
 
@@ -12,166 +13,141 @@
 #include "awkward/builder/Int64Builder.h"
 
 namespace awkward {
-  const BuilderPtr
-  Int64Builder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<Int64Builder>(options,
-                                          GrowableBuffer<int64_t>::empty(options));
-  }
-
-  Int64Builder::Int64Builder(const BuilderOptions& options,
-                             GrowableBuffer<int64_t> buffer)
-      : options_(options)
-      , buffer_(std::move(buffer)) { }
-
-  GrowableBuffer<int64_t>
-  Int64Builder::buffer() {
-    // FIXME: swap with an empty buffer!
-    return std::move(buffer_);
-  }
-
-  const std::string
-  Int64Builder::classname() const {
-    return "Int64Builder";
-  };
-
-  const std::string
-  Int64Builder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    buffer_.concatenate(
-      reinterpret_cast<int64_t*>(
-        container.empty_buffer(form_key.str() + "-data",
-        (int64_t)buffer_.length() * (int64_t)sizeof(int64_t))));
-
-    return "{\"class\": \"NumpyArray\", \"primitive\": \"int64\", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
-
-  int64_t
-  Int64Builder::length() const {
-    return (int64_t)buffer_.length();
-  }
-
-  void
-  Int64Builder::clear() {
-    buffer_.clear();
-  }
-
-  bool
-  Int64Builder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  Int64Builder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::integer(int64_t x) {
-    buffer_.append(x);
-    return nullptr;
-  }
-
-  const BuilderPtr
-  Int64Builder::real(double x) {
-    BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromint64(options_, buffer_);
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Int64Builder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  Int64Builder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Int64Builder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Int64Builder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  Int64Builder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  Int64Builder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr Int64Builder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<Int64Builder>(
+      options, GrowableBuffer<int64_t>::empty(options));
 }
+
+Int64Builder::Int64Builder(const BuilderOptions   &options,
+                           GrowableBuffer<int64_t> buffer)
+    : options_(options), buffer_(std::move(buffer)) {}
+
+GrowableBuffer<int64_t> Int64Builder::buffer() {
+  // FIXME: swap with an empty buffer!
+  return std::move(buffer_);
+}
+
+const std::string Int64Builder::classname() const { return "Int64Builder"; };
+
+const std::string Int64Builder::to_buffers(BuffersContainer &container,
+                                           int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  buffer_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
+      form_key.str() + "-data",
+      (int64_t)buffer_.length() * (int64_t)sizeof(int64_t))));
+
+  return "{\"class\": \"NumpyArray\", \"primitive\": \"int64\", \"form_key\": "
+         "\"" +
+         form_key.str() + "\"}";
+}
+
+int64_t Int64Builder::length() const { return (int64_t)buffer_.length(); }
+
+void Int64Builder::clear() { buffer_.clear(); }
+
+bool Int64Builder::active() const { return false; }
+
+const BuilderPtr Int64Builder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr Int64Builder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr Int64Builder::integer(int64_t x) {
+  buffer_.append(x);
+  return nullptr;
+}
+
+const BuilderPtr Int64Builder::real(double x) {
+  BuilderPtr out = Float64Builder::fromint64(options_, buffer_);
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr Int64Builder::complex(std::complex<double> x) {
+  BuilderPtr out = Complex128Builder::fromint64(options_, buffer_);
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr Int64Builder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr Int64Builder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr Int64Builder::string(const char *x, int64_t length,
+                                      const char *encoding) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr Int64Builder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr Int64Builder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Int64Builder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr Int64Builder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Int64Builder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Int64Builder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void Int64Builder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr Int64Builder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ListBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ListBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -11,275 +13,234 @@
 #include "awkward/builder/ListBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  ListBuilder::fromempty(const BuilderOptions& options) {
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
-    offsets.append(0);
-    return std::make_shared<ListBuilder>(options,
-                                         std::move(offsets),
-                                         UnknownBuilder::fromempty(options),
-                                         false);
-  }
+const BuilderPtr ListBuilder::fromempty(const BuilderOptions &options) {
+  GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
+  offsets.append(0);
+  return std::make_shared<ListBuilder>(
+      options, std::move(offsets), UnknownBuilder::fromempty(options), false);
+}
 
-  ListBuilder::ListBuilder(const BuilderOptions& options,
-                           GrowableBuffer<int64_t> offsets,
-                           const BuilderPtr& content,
-                           bool begun)
-      : options_(options)
-      , offsets_(std::move(offsets))
-      , content_(content)
-      , begun_(begun) { }
+ListBuilder::ListBuilder(const BuilderOptions &options,
+                         GrowableBuffer<int64_t> offsets,
+                         const BuilderPtr &content, bool begun)
+    : options_(options), offsets_(std::move(offsets)), content_(content),
+      begun_(begun) {}
 
-  const std::string
-  ListBuilder::classname() const {
-    return "ListBuilder";
-  };
+const std::string ListBuilder::classname() const { return "ListBuilder"; };
 
-  const std::string
-  ListBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
+const std::string ListBuilder::to_buffers(BuffersContainer &container,
+                                          int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
 
-    void* ptr = container.empty_buffer(form_key.str() + "-offsets",
-      (int64_t)offsets_.length() * (int64_t)sizeof(int64_t));
+  void *ptr = container.empty_buffer(form_key.str() + "-offsets",
+                                     (int64_t)offsets_.length() *
+                                         (int64_t)sizeof(int64_t));
 
-    offsets_.concatenate(reinterpret_cast<int64_t*>(ptr));
+  offsets_.concatenate(reinterpret_cast<int64_t *>(ptr));
 
-    return "{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", \"content\": "
-           + content_.get()->to_buffers(container, form_key_id) + ", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
+  return "{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", "
+         "\"content\": " +
+         content_.get()->to_buffers(container, form_key_id) +
+         ", \"form_key\": \"" + form_key.str() + "\"}";
+}
 
-  int64_t
-  ListBuilder::length() const {
-    return (int64_t)offsets_.length() - 1;
-  }
+int64_t ListBuilder::length() const { return (int64_t)offsets_.length() - 1; }
 
-  void
-  ListBuilder::clear() {
-    offsets_.clear();
-    offsets_.append(0);
-    content_.get()->clear();
-  }
+void ListBuilder::clear() {
+  offsets_.clear();
+  offsets_.append(0);
+  content_.get()->clear();
+}
 
-  bool
-  ListBuilder::active() const {
-    return begun_;
-  }
+bool ListBuilder::active() const { return begun_; }
 
-  const BuilderPtr
-  ListBuilder::null() {
-    if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-      out.get()->null();
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->null());
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::boolean(bool x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->boolean(x);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->boolean(x));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::integer(int64_t x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->integer(x);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->integer(x));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::real(double x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->real(x);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->real(x));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::complex(std::complex<double> x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->complex(x);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->complex(x));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::datetime(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->datetime(x, unit);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->datetime(x, unit));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->timedelta(x, unit);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->timedelta(x, unit));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->string(x, length, encoding);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->string(x, length, encoding));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::beginlist() {
-    if (!begun_) {
-      begun_ = true;
-    }
-    else {
-      maybeupdate(content_.get()->beginlist());
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  ListBuilder::endlist() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (!content_.get()->active()) {
-      offsets_.append(content_.get()->length());
-      begun_ = false;
-    }
-    else {
-      maybeupdate(content_.get()->endlist());
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  ListBuilder::begintuple(int64_t numfields) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->begintuple(numfields);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->begintuple(numfields));
-      return shared_from_this();
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::index(int64_t index) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->index(index);
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::endtuple() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->endtuple();
-      return shared_from_this();
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::beginrecord(const char* name, bool check) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginrecord(name, check);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->beginrecord(name, check));
-      return shared_from_this();
-    }
-  }
-
-  void
-  ListBuilder::field(const char* key, bool check) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->field(key, check);
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::endrecord() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same level "
-                    "before it") + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->endrecord();
-      return shared_from_this();
-    }
-  }
-
-  void
-  ListBuilder::maybeupdate(const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != content_.get()) {
-      content_ = std::move(tmp);
-    }
+const BuilderPtr ListBuilder::null() {
+  if (!begun_) {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  } else {
+    maybeupdate(content_.get()->null());
+    return nullptr;
   }
 }
+
+const BuilderPtr ListBuilder::boolean(bool x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  } else {
+    maybeupdate(content_.get()->boolean(x));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::integer(int64_t x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  } else {
+    maybeupdate(content_.get()->integer(x));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::real(double x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  } else {
+    maybeupdate(content_.get()->real(x));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::complex(std::complex<double> x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  } else {
+    maybeupdate(content_.get()->complex(x));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::datetime(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  } else {
+    maybeupdate(content_.get()->datetime(x, unit));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  } else {
+    maybeupdate(content_.get()->timedelta(x, unit));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::string(const char *x, int64_t length,
+                                     const char *encoding) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  } else {
+    maybeupdate(content_.get()->string(x, length, encoding));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::beginlist() {
+  if (!begun_) {
+    begun_ = true;
+  } else {
+    maybeupdate(content_.get()->beginlist());
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr ListBuilder::endlist() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (!content_.get()->active()) {
+    offsets_.append(content_.get()->length());
+    begun_ = false;
+  } else {
+    maybeupdate(content_.get()->endlist());
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr ListBuilder::begintuple(int64_t numfields) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  } else {
+    maybeupdate(content_.get()->begintuple(numfields));
+    return shared_from_this();
+  }
+}
+
+const BuilderPtr ListBuilder::index(int64_t index) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->index(index);
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::endtuple() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->endtuple();
+    return shared_from_this();
+  }
+}
+
+const BuilderPtr ListBuilder::beginrecord(const char *name, bool check) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  } else {
+    maybeupdate(content_.get()->beginrecord(name, check));
+    return shared_from_this();
+  }
+}
+
+void ListBuilder::field(const char *key, bool check) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->field(key, check);
+  }
+}
+
+const BuilderPtr ListBuilder::endrecord() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string(
+            "called 'end_record' without 'begin_record' at the same level "
+            "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->endrecord();
+    return shared_from_this();
+  }
+}
+
+void ListBuilder::maybeupdate(const BuilderPtr tmp) {
+  if (tmp && tmp.get() != content_.get()) {
+    content_ = std::move(tmp);
+  }
+}
+} // namespace awkward

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ListBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ListBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -13,234 +11,275 @@
 #include "awkward/builder/ListBuilder.h"
 
 namespace awkward {
-const BuilderPtr ListBuilder::fromempty(const BuilderOptions &options) {
-  GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
-  offsets.append(0);
-  return std::make_shared<ListBuilder>(
-      options, std::move(offsets), UnknownBuilder::fromempty(options), false);
-}
-
-ListBuilder::ListBuilder(const BuilderOptions &options,
-                         GrowableBuffer<int64_t> offsets,
-                         const BuilderPtr &content, bool begun)
-    : options_(options), offsets_(std::move(offsets)), content_(content),
-      begun_(begun) {}
-
-const std::string ListBuilder::classname() const { return "ListBuilder"; };
-
-const std::string ListBuilder::to_buffers(BuffersContainer &container,
-                                          int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  void *ptr = container.empty_buffer(form_key.str() + "-offsets",
-                                     (int64_t)offsets_.length() *
-                                         (int64_t)sizeof(int64_t));
-
-  offsets_.concatenate(reinterpret_cast<int64_t *>(ptr));
-
-  return "{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", "
-         "\"content\": " +
-         content_.get()->to_buffers(container, form_key_id) +
-         ", \"form_key\": \"" + form_key.str() + "\"}";
-}
-
-int64_t ListBuilder::length() const { return (int64_t)offsets_.length() - 1; }
-
-void ListBuilder::clear() {
-  offsets_.clear();
-  offsets_.append(0);
-  content_.get()->clear();
-}
-
-bool ListBuilder::active() const { return begun_; }
-
-const BuilderPtr ListBuilder::null() {
-  if (!begun_) {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  } else {
-    maybeupdate(content_.get()->null());
-    return nullptr;
+  const BuilderPtr
+  ListBuilder::fromempty(const BuilderOptions& options) {
+    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
+    offsets.append(0);
+    return std::make_shared<ListBuilder>(options,
+                                         std::move(offsets),
+                                         UnknownBuilder::fromempty(options),
+                                         false);
   }
-}
 
-const BuilderPtr ListBuilder::boolean(bool x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  } else {
-    maybeupdate(content_.get()->boolean(x));
-    return nullptr;
+  ListBuilder::ListBuilder(const BuilderOptions& options,
+                           GrowableBuffer<int64_t> offsets,
+                           const BuilderPtr& content,
+                           bool begun)
+      : options_(options)
+      , offsets_(std::move(offsets))
+      , content_(content)
+      , begun_(begun) { }
+
+  const std::string
+  ListBuilder::classname() const {
+    return "ListBuilder";
+  };
+
+  const std::string
+  ListBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    void* ptr = container.empty_buffer(form_key.str() + "-offsets",
+      (int64_t)offsets_.length() * (int64_t)sizeof(int64_t));
+
+    offsets_.concatenate(reinterpret_cast<int64_t*>(ptr));
+
+    return "{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", \"content\": "
+           + content_.get()->to_buffers(container, form_key_id) + ", \"form_key\": \""
+           + form_key.str() + "\"}";
   }
-}
 
-const BuilderPtr ListBuilder::integer(int64_t x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  } else {
-    maybeupdate(content_.get()->integer(x));
-    return nullptr;
+  int64_t
+  ListBuilder::length() const {
+    return (int64_t)offsets_.length() - 1;
   }
-}
 
-const BuilderPtr ListBuilder::real(double x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  } else {
-    maybeupdate(content_.get()->real(x));
-    return nullptr;
+  void
+  ListBuilder::clear() {
+    offsets_.clear();
+    offsets_.append(0);
+    content_.get()->clear();
   }
-}
 
-const BuilderPtr ListBuilder::complex(std::complex<double> x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  } else {
-    maybeupdate(content_.get()->complex(x));
-    return nullptr;
+  bool
+  ListBuilder::active() const {
+    return begun_;
   }
-}
 
-const BuilderPtr ListBuilder::datetime(int64_t x, const std::string &unit) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  } else {
-    maybeupdate(content_.get()->datetime(x, unit));
-    return nullptr;
+  const BuilderPtr
+  ListBuilder::null() {
+    if (!begun_) {
+      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+      out.get()->null();
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->null());
+      return nullptr;
+    }
   }
-}
 
-const BuilderPtr ListBuilder::timedelta(int64_t x, const std::string &unit) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  } else {
-    maybeupdate(content_.get()->timedelta(x, unit));
-    return nullptr;
+  const BuilderPtr
+  ListBuilder::boolean(bool x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->boolean(x);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->boolean(x));
+      return nullptr;
+    }
   }
-}
 
-const BuilderPtr ListBuilder::string(const char *x, int64_t length,
-                                     const char *encoding) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  } else {
-    maybeupdate(content_.get()->string(x, length, encoding));
-    return nullptr;
+  const BuilderPtr
+  ListBuilder::integer(int64_t x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->integer(x);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->integer(x));
+      return nullptr;
+    }
   }
-}
 
-const BuilderPtr ListBuilder::beginlist() {
-  if (!begun_) {
-    begun_ = true;
-  } else {
-    maybeupdate(content_.get()->beginlist());
+  const BuilderPtr
+  ListBuilder::real(double x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->real(x);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->real(x));
+      return nullptr;
+    }
   }
-  return shared_from_this();
-}
 
-const BuilderPtr ListBuilder::endlist() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else if (!content_.get()->active()) {
-    offsets_.append(content_.get()->length());
-    begun_ = false;
-  } else {
-    maybeupdate(content_.get()->endlist());
+  const BuilderPtr
+  ListBuilder::complex(std::complex<double> x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->complex(x);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->complex(x));
+      return nullptr;
+    }
   }
-  return shared_from_this();
-}
 
-const BuilderPtr ListBuilder::begintuple(int64_t numfields) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  } else {
-    maybeupdate(content_.get()->begintuple(numfields));
+  const BuilderPtr
+  ListBuilder::datetime(int64_t x, const std::string& unit) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->datetime(x, unit);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->datetime(x, unit));
+      return nullptr;
+    }
+  }
+
+  const BuilderPtr
+  ListBuilder::timedelta(int64_t x, const std::string& unit) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->timedelta(x, unit);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->timedelta(x, unit));
+      return nullptr;
+    }
+  }
+
+  const BuilderPtr
+  ListBuilder::string(const char* x, int64_t length, const char* encoding) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->string(x, length, encoding);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->string(x, length, encoding));
+      return nullptr;
+    }
+  }
+
+  const BuilderPtr
+  ListBuilder::beginlist() {
+    if (!begun_) {
+      begun_ = true;
+    }
+    else {
+      maybeupdate(content_.get()->beginlist());
+    }
     return shared_from_this();
   }
-}
 
-const BuilderPtr ListBuilder::index(int64_t index) {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else {
-    content_.get()->index(index);
-    return nullptr;
-  }
-}
-
-const BuilderPtr ListBuilder::endtuple() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same "
-                    "level before it") +
-        FILENAME(__LINE__));
-  } else {
-    content_.get()->endtuple();
+  const BuilderPtr
+  ListBuilder::endlist() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (!content_.get()->active()) {
+      offsets_.append(content_.get()->length());
+      begun_ = false;
+    }
+    else {
+      maybeupdate(content_.get()->endlist());
+    }
     return shared_from_this();
   }
-}
 
-const BuilderPtr ListBuilder::beginrecord(const char *name, bool check) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  } else {
-    maybeupdate(content_.get()->beginrecord(name, check));
-    return shared_from_this();
+  const BuilderPtr
+  ListBuilder::begintuple(int64_t numfields) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->begintuple(numfields);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->begintuple(numfields));
+      return shared_from_this();
+    }
+  }
+
+  const BuilderPtr
+  ListBuilder::index(int64_t index) {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      content_.get()->index(index);
+      return nullptr;
+    }
+  }
+
+  const BuilderPtr
+  ListBuilder::endtuple() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      content_.get()->endtuple();
+      return shared_from_this();
+    }
+  }
+
+  const BuilderPtr
+  ListBuilder::beginrecord(const char* name, bool check) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->beginrecord(name, check);
+      return out;
+    }
+    else {
+      maybeupdate(content_.get()->beginrecord(name, check));
+      return shared_from_this();
+    }
+  }
+
+  void
+  ListBuilder::field(const char* key, bool check) {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      content_.get()->field(key, check);
+    }
+  }
+
+  const BuilderPtr
+  ListBuilder::endrecord() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_record' without 'begin_record' at the same level "
+                    "before it") + FILENAME(__LINE__));
+    }
+    else {
+      content_.get()->endrecord();
+      return shared_from_this();
+    }
+  }
+
+  void
+  ListBuilder::maybeupdate(const BuilderPtr tmp) {
+    if (tmp  &&  tmp.get() != content_.get()) {
+      content_ = std::move(tmp);
+    }
   }
 }
-
-void ListBuilder::field(const char *key, bool check) {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else {
-    content_.get()->field(key, check);
-  }
-}
-
-const BuilderPtr ListBuilder::endrecord() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string(
-            "called 'end_record' without 'begin_record' at the same level "
-            "before it") +
-        FILENAME(__LINE__));
-  } else {
-    content_.get()->endrecord();
-    return shared_from_this();
-  }
-}
-
-void ListBuilder::maybeupdate(const BuilderPtr tmp) {
-  if (tmp && tmp.get() != content_.get()) {
-    content_ = std::move(tmp);
-  }
-}
-} // namespace awkward

--- a/src/libawkward/builder/ListBuilder.cpp
+++ b/src/libawkward/builder/ListBuilder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ListBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/ListBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -11,275 +12,234 @@
 #include "awkward/builder/ListBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  ListBuilder::fromempty(const BuilderOptions& options) {
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
-    offsets.append(0);
-    return std::make_shared<ListBuilder>(options,
-                                         std::move(offsets),
-                                         UnknownBuilder::fromempty(options),
-                                         false);
-  }
+const BuilderPtr ListBuilder::fromempty(const BuilderOptions &options) {
+  GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
+  offsets.append(0);
+  return std::make_shared<ListBuilder>(
+      options, std::move(offsets), UnknownBuilder::fromempty(options), false);
+}
 
-  ListBuilder::ListBuilder(const BuilderOptions& options,
-                           GrowableBuffer<int64_t> offsets,
-                           const BuilderPtr& content,
-                           bool begun)
-      : options_(options)
-      , offsets_(std::move(offsets))
-      , content_(content)
-      , begun_(begun) { }
+ListBuilder::ListBuilder(const BuilderOptions   &options,
+                         GrowableBuffer<int64_t> offsets,
+                         const BuilderPtr &content, bool begun)
+    : options_(options), offsets_(std::move(offsets)), content_(content),
+      begun_(begun) {}
 
-  const std::string
-  ListBuilder::classname() const {
-    return "ListBuilder";
-  };
+const std::string ListBuilder::classname() const { return "ListBuilder"; };
 
-  const std::string
-  ListBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
+const std::string ListBuilder::to_buffers(BuffersContainer &container,
+                                          int64_t          &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
 
-    void* ptr = container.empty_buffer(form_key.str() + "-offsets",
-      (int64_t)offsets_.length() * (int64_t)sizeof(int64_t));
+  void *ptr = container.empty_buffer(form_key.str() + "-offsets",
+                                     (int64_t)offsets_.length() *
+                                         (int64_t)sizeof(int64_t));
 
-    offsets_.concatenate(reinterpret_cast<int64_t*>(ptr));
+  offsets_.concatenate(reinterpret_cast<int64_t *>(ptr));
 
-    return "{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", \"content\": "
-           + content_.get()->to_buffers(container, form_key_id) + ", \"form_key\": \""
-           + form_key.str() + "\"}";
-  }
+  return "{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", "
+         "\"content\": " +
+         content_.get()->to_buffers(container, form_key_id) +
+         ", \"form_key\": \"" + form_key.str() + "\"}";
+}
 
-  int64_t
-  ListBuilder::length() const {
-    return (int64_t)offsets_.length() - 1;
-  }
+int64_t ListBuilder::length() const { return (int64_t)offsets_.length() - 1; }
 
-  void
-  ListBuilder::clear() {
-    offsets_.clear();
-    offsets_.append(0);
-    content_.get()->clear();
-  }
+void ListBuilder::clear() {
+  offsets_.clear();
+  offsets_.append(0);
+  content_.get()->clear();
+}
 
-  bool
-  ListBuilder::active() const {
-    return begun_;
-  }
+bool ListBuilder::active() const { return begun_; }
 
-  const BuilderPtr
-  ListBuilder::null() {
-    if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-      out.get()->null();
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->null());
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::boolean(bool x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->boolean(x);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->boolean(x));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::integer(int64_t x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->integer(x);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->integer(x));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::real(double x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->real(x);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->real(x));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::complex(std::complex<double> x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->complex(x);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->complex(x));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::datetime(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->datetime(x, unit);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->datetime(x, unit));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->timedelta(x, unit);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->timedelta(x, unit));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->string(x, length, encoding);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->string(x, length, encoding));
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::beginlist() {
-    if (!begun_) {
-      begun_ = true;
-    }
-    else {
-      maybeupdate(content_.get()->beginlist());
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  ListBuilder::endlist() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (!content_.get()->active()) {
-      offsets_.append(content_.get()->length());
-      begun_ = false;
-    }
-    else {
-      maybeupdate(content_.get()->endlist());
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  ListBuilder::begintuple(int64_t numfields) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->begintuple(numfields);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->begintuple(numfields));
-      return shared_from_this();
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::index(int64_t index) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->index(index);
-      return nullptr;
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::endtuple() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->endtuple();
-      return shared_from_this();
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::beginrecord(const char* name, bool check) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginrecord(name, check);
-      return out;
-    }
-    else {
-      maybeupdate(content_.get()->beginrecord(name, check));
-      return shared_from_this();
-    }
-  }
-
-  void
-  ListBuilder::field(const char* key, bool check) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->field(key, check);
-    }
-  }
-
-  const BuilderPtr
-  ListBuilder::endrecord() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same level "
-                    "before it") + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->endrecord();
-      return shared_from_this();
-    }
-  }
-
-  void
-  ListBuilder::maybeupdate(const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != content_.get()) {
-      content_ = std::move(tmp);
-    }
+const BuilderPtr ListBuilder::null() {
+  if (!begun_) {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  } else {
+    maybeupdate(content_.get()->null());
+    return nullptr;
   }
 }
+
+const BuilderPtr ListBuilder::boolean(bool x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  } else {
+    maybeupdate(content_.get()->boolean(x));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::integer(int64_t x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  } else {
+    maybeupdate(content_.get()->integer(x));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::real(double x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  } else {
+    maybeupdate(content_.get()->real(x));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::complex(std::complex<double> x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  } else {
+    maybeupdate(content_.get()->complex(x));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::datetime(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  } else {
+    maybeupdate(content_.get()->datetime(x, unit));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  } else {
+    maybeupdate(content_.get()->timedelta(x, unit));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::string(const char *x, int64_t length,
+                                     const char *encoding) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  } else {
+    maybeupdate(content_.get()->string(x, length, encoding));
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::beginlist() {
+  if (!begun_) {
+    begun_ = true;
+  } else {
+    maybeupdate(content_.get()->beginlist());
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr ListBuilder::endlist() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (!content_.get()->active()) {
+    offsets_.append(content_.get()->length());
+    begun_ = false;
+  } else {
+    maybeupdate(content_.get()->endlist());
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr ListBuilder::begintuple(int64_t numfields) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  } else {
+    maybeupdate(content_.get()->begintuple(numfields));
+    return shared_from_this();
+  }
+}
+
+const BuilderPtr ListBuilder::index(int64_t index) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->index(index);
+    return nullptr;
+  }
+}
+
+const BuilderPtr ListBuilder::endtuple() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->endtuple();
+    return shared_from_this();
+  }
+}
+
+const BuilderPtr ListBuilder::beginrecord(const char *name, bool check) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  } else {
+    maybeupdate(content_.get()->beginrecord(name, check));
+    return shared_from_this();
+  }
+}
+
+void ListBuilder::field(const char *key, bool check) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->field(key, check);
+  }
+}
+
+const BuilderPtr ListBuilder::endrecord() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string(
+            "called 'end_record' without 'begin_record' at the same level "
+            "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->endrecord();
+    return shared_from_this();
+  }
+}
+
+void ListBuilder::maybeupdate(const BuilderPtr tmp) {
+  if (tmp && tmp.get() != content_.get()) {
+    content_ = std::move(tmp);
+  }
+}
+} // namespace awkward

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -1,250 +1,290 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/OptionBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/OptionBuilder.cpp", line)
 
 #include <stdexcept>
+
 
 #include "awkward/builder/OptionBuilder.h"
 
 namespace awkward {
-const BuilderPtr OptionBuilder::fromnulls(const BuilderOptions &options,
-                                          int64_t nullcount,
-                                          const BuilderPtr &content) {
-  return std::make_shared<OptionBuilder>(
-      options, GrowableBuffer<int64_t>::full(options, -1, nullcount), content);
-}
-
-const BuilderPtr OptionBuilder::fromvalids(const BuilderOptions &options,
-                                           const BuilderPtr &content) {
-  return std::make_shared<OptionBuilder>(
-      options, GrowableBuffer<int64_t>::arange(options, content->length()),
-      content);
-}
-
-OptionBuilder::OptionBuilder(const BuilderOptions &,
-                             GrowableBuffer<int64_t> index,
-                             const BuilderPtr content)
-    : index_(std::move(index)), content_(content) {}
-
-const std::string OptionBuilder::classname() const { return "OptionBuilder"; };
-
-const std::string OptionBuilder::to_buffers(BuffersContainer &container,
-                                            int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  void *ptr = container.empty_buffer(form_key.str() + "-index",
-                                     (int64_t)index_.length() *
-                                         (int64_t)sizeof(int64_t));
-
-  index_.concatenate(reinterpret_cast<int64_t *>(ptr));
-
-  return "{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", "
-         "\"content\": " +
-         content_.get()->to_buffers(container, form_key_id) +
-         ", \"form_key\": \"" + form_key.str() + "\"}";
-}
-
-int64_t OptionBuilder::length() const { return (int64_t)index_.length(); }
-
-void OptionBuilder::clear() {
-  index_.clear();
-  content_.get()->clear();
-}
-
-bool OptionBuilder::active() const { return content_.get()->active(); }
-
-const BuilderPtr OptionBuilder::null() {
-  if (!content_.get()->active()) {
-    index_.append(-1);
-  } else {
-    content_.get()->null();
+  const BuilderPtr
+  OptionBuilder::fromnulls(const BuilderOptions& options,
+                           int64_t nullcount,
+                           const BuilderPtr& content) {
+    return std::make_shared<OptionBuilder>(
+      options,
+      GrowableBuffer<int64_t>::full(options,
+                                    -1,
+                                    nullcount),
+     content);
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::boolean(bool x) {
-  if (!content_.get()->active()) {
-    int64_t length = content_.get()->length();
-    maybeupdate(content_.get()->boolean(x));
-    index_.append(length);
-  } else {
-    content_.get()->boolean(x);
+  const BuilderPtr
+  OptionBuilder::fromvalids(const BuilderOptions& options,
+                            const BuilderPtr& content) {
+    return std::make_shared<OptionBuilder>(options,
+                                           GrowableBuffer<int64_t>::arange(options, content->length()),
+                                           content);
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::integer(int64_t x) {
-  if (!content_.get()->active()) {
-    int64_t length = content_.get()->length();
-    maybeupdate(content_.get()->integer(x));
-    index_.append(length);
-  } else {
-    content_.get()->integer(x);
+  OptionBuilder::OptionBuilder(const BuilderOptions&,
+                               GrowableBuffer<int64_t> index,
+                               const BuilderPtr content)
+    : index_(std::move(index))
+      , content_(content) { }
+
+  const std::string
+  OptionBuilder::classname() const {
+    return "OptionBuilder";
+  };
+
+  const std::string
+  OptionBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    void* ptr = container.empty_buffer(form_key.str() + "-index",
+      (int64_t)index_.length() * (int64_t)sizeof(int64_t));
+
+    index_.concatenate(reinterpret_cast<int64_t*>(ptr));
+
+    return "{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", \"content\": "
+           + content_.get()->to_buffers(container, form_key_id) + ", \"form_key\": \""
+           + form_key.str() + "\"}";
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::real(double x) {
-  if (!content_.get()->active()) {
-    int64_t length = content_.get()->length();
-    maybeupdate(content_.get()->real(x));
-    index_.append(length);
-  } else {
-    content_.get()->real(x);
+  int64_t
+  OptionBuilder::length() const {
+    return (int64_t)index_.length();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::complex(std::complex<double> x) {
-  if (!content_.get()->active()) {
-    int64_t length = content_.get()->length();
-    maybeupdate(content_.get()->complex(x));
-    index_.append(length);
-  } else {
-    content_.get()->complex(x);
+  void
+  OptionBuilder::clear() {
+    index_.clear();
+    content_.get()->clear();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::datetime(int64_t x, const std::string &unit) {
-  if (!content_.get()->active()) {
-    int64_t length = content_.get()->length();
-    maybeupdate(content_.get()->datetime(x, unit));
-    index_.append(length);
-  } else {
-    content_.get()->datetime(x, unit);
+  bool
+  OptionBuilder::active() const {
+    return content_.get()->active();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::timedelta(int64_t x, const std::string &unit) {
-  if (!content_.get()->active()) {
-    int64_t length = content_.get()->length();
-    maybeupdate(content_.get()->timedelta(x, unit));
-    index_.append(length);
-  } else {
-    content_.get()->timedelta(x, unit);
+  const BuilderPtr
+  OptionBuilder::null() {
+    if (!content_.get()->active()) {
+      index_.append(-1);
+    }
+    else {
+      content_.get()->null();
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::string(const char *x, int64_t length,
-                                       const char *encoding) {
-  if (!content_.get()->active()) {
-    int64_t len = content_.get()->length();
-    maybeupdate(content_.get()->string(x, length, encoding));
-    index_.append(len);
-  } else {
-    content_.get()->string(x, length, encoding);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr OptionBuilder::beginlist() {
-  if (!content_.get()->active()) {
-    maybeupdate(content_.get()->beginlist());
-  } else {
-    content_.get()->beginlist();
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr OptionBuilder::endlist() {
-  if (!content_.get()->active()) {
-    throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else {
-    int64_t length = content_.get()->length();
-    content_.get()->endlist();
-    if (length != content_.get()->length()) {
+  const BuilderPtr
+  OptionBuilder::boolean(bool x) {
+    if (!content_.get()->active()) {
+      int64_t length = content_.get()->length();
+      maybeupdate(content_.get()->boolean(x));
       index_.append(length);
     }
+    else {
+      content_.get()->boolean(x);
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::begintuple(int64_t numfields) {
-  if (!content_.get()->active()) {
-    maybeupdate(content_.get()->begintuple(numfields));
-  } else {
-    content_.get()->begintuple(numfields);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr OptionBuilder::index(int64_t index) {
-  if (!content_.get()->active()) {
-    throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else {
-    content_.get()->index(index);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr OptionBuilder::endtuple() {
-  if (!content_.get()->active()) {
-    throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same "
-                    "level before it") +
-        FILENAME(__LINE__));
-  } else {
-    int64_t length = content_.get()->length();
-    content_.get()->endtuple();
-    if (length != content_.get()->length()) {
+  const BuilderPtr
+  OptionBuilder::integer(int64_t x) {
+    if (!content_.get()->active()) {
+      int64_t length = content_.get()->length();
+      maybeupdate(content_.get()->integer(x));
       index_.append(length);
     }
+    else {
+      content_.get()->integer(x);
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr OptionBuilder::beginrecord(const char *name, bool check) {
-  if (!content_.get()->active()) {
-    maybeupdate(content_.get()->beginrecord(name, check));
-  } else {
-    content_.get()->beginrecord(name, check);
-  }
-  return shared_from_this();
-}
-
-void OptionBuilder::field(const char *key, bool check) {
-  if (!content_.get()->active()) {
-    throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else {
-    content_.get()->field(key, check);
-  }
-}
-
-const BuilderPtr OptionBuilder::endrecord() {
-  if (!content_.get()->active()) {
-    throw std::invalid_argument(
-        std::string(
-            "called 'endrecord' without 'beginrecord' at the same level "
-            "before it") +
-        FILENAME(__LINE__));
-  } else {
-    int64_t length = content_.get()->length();
-    content_.get()->endrecord();
-    if (length != content_.get()->length()) {
+  const BuilderPtr
+  OptionBuilder::real(double x) {
+    if (!content_.get()->active()) {
+      int64_t length = content_.get()->length();
+      maybeupdate(content_.get()->real(x));
       index_.append(length);
     }
+    else {
+      content_.get()->real(x);
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-void OptionBuilder::maybeupdate(const BuilderPtr tmp) {
-  if (tmp && tmp.get() != content_.get()) {
-    content_ = std::move(tmp);
+  const BuilderPtr
+  OptionBuilder::complex(std::complex<double> x) {
+    if (!content_.get()->active()) {
+      int64_t length = content_.get()->length();
+      maybeupdate(content_.get()->complex(x));
+      index_.append(length);
+    }
+    else {
+      content_.get()->complex(x);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::datetime(int64_t x, const std::string& unit) {
+    if (!content_.get()->active()) {
+      int64_t length = content_.get()->length();
+      maybeupdate(content_.get()->datetime(x, unit));
+      index_.append(length);
+    }
+    else {
+      content_.get()->datetime(x, unit);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::timedelta(int64_t x, const std::string& unit) {
+    if (!content_.get()->active()) {
+      int64_t length = content_.get()->length();
+      maybeupdate(content_.get()->timedelta(x, unit));
+      index_.append(length);
+    }
+    else {
+      content_.get()->timedelta(x, unit);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::string(const char* x, int64_t length, const char* encoding) {
+    if (!content_.get()->active()) {
+      int64_t len = content_.get()->length();
+      maybeupdate(content_.get()->string(x, length, encoding));
+      index_.append(len);
+    }
+    else {
+      content_.get()->string(x, length, encoding);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::beginlist() {
+    if (!content_.get()->active()) {
+      maybeupdate(content_.get()->beginlist());
+    }
+    else {
+      content_.get()->beginlist();
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::endlist() {
+    if (!content_.get()->active()) {
+      throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      int64_t length = content_.get()->length();
+      content_.get()->endlist();
+      if (length != content_.get()->length()) {
+        index_.append(length);
+      }
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::begintuple(int64_t numfields) {
+    if (!content_.get()->active()) {
+      maybeupdate(content_.get()->begintuple(numfields));
+    }
+    else {
+      content_.get()->begintuple(numfields);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::index(int64_t index) {
+    if (!content_.get()->active()) {
+      throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      content_.get()->index(index);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::endtuple() {
+    if (!content_.get()->active()) {
+      throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      int64_t length = content_.get()->length();
+      content_.get()->endtuple();
+      if (length != content_.get()->length()) {
+        index_.append(length);
+      }
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  OptionBuilder::beginrecord(const char* name, bool check) {
+    if (!content_.get()->active()) {
+      maybeupdate(content_.get()->beginrecord(name, check));
+    }
+    else {
+      content_.get()->beginrecord(name, check);
+    }
+    return shared_from_this();
+  }
+
+  void
+  OptionBuilder::field(const char* key, bool check) {
+    if (!content_.get()->active()) {
+      throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      content_.get()->field(key, check);
+    }
+  }
+
+  const BuilderPtr
+  OptionBuilder::endrecord() {
+    if (!content_.get()->active()) {
+      throw std::invalid_argument(
+        std::string("called 'endrecord' without 'beginrecord' at the same level "
+                    "before it") + FILENAME(__LINE__));
+    }
+    else {
+      int64_t length = content_.get()->length();
+      content_.get()->endrecord();
+      if (length != content_.get()->length()) {
+        index_.append(length);
+      }
+    }
+    return shared_from_this();
+  }
+
+  void
+  OptionBuilder::maybeupdate(const BuilderPtr tmp) {
+    if (tmp  &&  tmp.get() != content_.get()) {
+      content_ = std::move(tmp);
+    }
   }
 }
-} // namespace awkward

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -1,290 +1,249 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/OptionBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/OptionBuilder.cpp", line)
 
 #include <stdexcept>
-
 
 #include "awkward/builder/OptionBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  OptionBuilder::fromnulls(const BuilderOptions& options,
-                           int64_t nullcount,
-                           const BuilderPtr& content) {
-    return std::make_shared<OptionBuilder>(
-      options,
-      GrowableBuffer<int64_t>::full(options,
-                                    -1,
-                                    nullcount),
-     content);
+const BuilderPtr OptionBuilder::fromnulls(const BuilderOptions &options,
+                                          int64_t               nullcount,
+                                          const BuilderPtr     &content) {
+  return std::make_shared<OptionBuilder>(
+      options, GrowableBuffer<int64_t>::full(options, -1, nullcount), content);
+}
+
+const BuilderPtr OptionBuilder::fromvalids(const BuilderOptions &options,
+                                           const BuilderPtr     &content) {
+  return std::make_shared<OptionBuilder>(
+      options, GrowableBuffer<int64_t>::arange(options, content->length()),
+      content);
+}
+
+OptionBuilder::OptionBuilder(const BuilderOptions &,
+                             GrowableBuffer<int64_t> index,
+                             const BuilderPtr        content)
+    : index_(std::move(index)), content_(content) {}
+
+const std::string OptionBuilder::classname() const { return "OptionBuilder"; };
+
+const std::string OptionBuilder::to_buffers(BuffersContainer &container,
+                                            int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  void *ptr = container.empty_buffer(form_key.str() + "-index",
+                                     (int64_t)index_.length() *
+                                         (int64_t)sizeof(int64_t));
+
+  index_.concatenate(reinterpret_cast<int64_t *>(ptr));
+
+  return "{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", "
+         "\"content\": " +
+         content_.get()->to_buffers(container, form_key_id) +
+         ", \"form_key\": \"" + form_key.str() + "\"}";
+}
+
+int64_t OptionBuilder::length() const { return (int64_t)index_.length(); }
+
+void OptionBuilder::clear() {
+  index_.clear();
+  content_.get()->clear();
+}
+
+bool OptionBuilder::active() const { return content_.get()->active(); }
+
+const BuilderPtr OptionBuilder::null() {
+  if (!content_.get()->active()) {
+    index_.append(-1);
+  } else {
+    content_.get()->null();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::fromvalids(const BuilderOptions& options,
-                            const BuilderPtr& content) {
-    return std::make_shared<OptionBuilder>(options,
-                                           GrowableBuffer<int64_t>::arange(options, content->length()),
-                                           content);
+const BuilderPtr OptionBuilder::boolean(bool x) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->boolean(x));
+    index_.append(length);
+  } else {
+    content_.get()->boolean(x);
   }
+  return shared_from_this();
+}
 
-  OptionBuilder::OptionBuilder(const BuilderOptions&,
-                               GrowableBuffer<int64_t> index,
-                               const BuilderPtr content)
-    : index_(std::move(index))
-      , content_(content) { }
-
-  const std::string
-  OptionBuilder::classname() const {
-    return "OptionBuilder";
-  };
-
-  const std::string
-  OptionBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    void* ptr = container.empty_buffer(form_key.str() + "-index",
-      (int64_t)index_.length() * (int64_t)sizeof(int64_t));
-
-    index_.concatenate(reinterpret_cast<int64_t*>(ptr));
-
-    return "{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", \"content\": "
-           + content_.get()->to_buffers(container, form_key_id) + ", \"form_key\": \""
-           + form_key.str() + "\"}";
+const BuilderPtr OptionBuilder::integer(int64_t x) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->integer(x));
+    index_.append(length);
+  } else {
+    content_.get()->integer(x);
   }
+  return shared_from_this();
+}
 
-  int64_t
-  OptionBuilder::length() const {
-    return (int64_t)index_.length();
+const BuilderPtr OptionBuilder::real(double x) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->real(x));
+    index_.append(length);
+  } else {
+    content_.get()->real(x);
   }
+  return shared_from_this();
+}
 
-  void
-  OptionBuilder::clear() {
-    index_.clear();
-    content_.get()->clear();
+const BuilderPtr OptionBuilder::complex(std::complex<double> x) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->complex(x));
+    index_.append(length);
+  } else {
+    content_.get()->complex(x);
   }
+  return shared_from_this();
+}
 
-  bool
-  OptionBuilder::active() const {
-    return content_.get()->active();
+const BuilderPtr OptionBuilder::datetime(int64_t x, const std::string &unit) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->datetime(x, unit));
+    index_.append(length);
+  } else {
+    content_.get()->datetime(x, unit);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::null() {
-    if (!content_.get()->active()) {
-      index_.append(-1);
-    }
-    else {
-      content_.get()->null();
-    }
-    return shared_from_this();
+const BuilderPtr OptionBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->timedelta(x, unit));
+    index_.append(length);
+  } else {
+    content_.get()->timedelta(x, unit);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::boolean(bool x) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->boolean(x));
+const BuilderPtr OptionBuilder::string(const char *x, int64_t length,
+                                       const char *encoding) {
+  if (!content_.get()->active()) {
+    int64_t len = content_.get()->length();
+    maybeupdate(content_.get()->string(x, length, encoding));
+    index_.append(len);
+  } else {
+    content_.get()->string(x, length, encoding);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr OptionBuilder::beginlist() {
+  if (!content_.get()->active()) {
+    maybeupdate(content_.get()->beginlist());
+  } else {
+    content_.get()->beginlist();
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr OptionBuilder::endlist() {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = content_.get()->length();
+    content_.get()->endlist();
+    if (length != content_.get()->length()) {
       index_.append(length);
     }
-    else {
-      content_.get()->boolean(x);
-    }
-    return shared_from_this();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::integer(int64_t x) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->integer(x));
+const BuilderPtr OptionBuilder::begintuple(int64_t numfields) {
+  if (!content_.get()->active()) {
+    maybeupdate(content_.get()->begintuple(numfields));
+  } else {
+    content_.get()->begintuple(numfields);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr OptionBuilder::index(int64_t index) {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->index(index);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr OptionBuilder::endtuple() {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = content_.get()->length();
+    content_.get()->endtuple();
+    if (length != content_.get()->length()) {
       index_.append(length);
     }
-    else {
-      content_.get()->integer(x);
-    }
-    return shared_from_this();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::real(double x) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->real(x));
-      index_.append(length);
-    }
-    else {
-      content_.get()->real(x);
-    }
-    return shared_from_this();
+const BuilderPtr OptionBuilder::beginrecord(const char *name, bool check) {
+  if (!content_.get()->active()) {
+    maybeupdate(content_.get()->beginrecord(name, check));
+  } else {
+    content_.get()->beginrecord(name, check);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::complex(std::complex<double> x) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->complex(x));
-      index_.append(length);
-    }
-    else {
-      content_.get()->complex(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::datetime(int64_t x, const std::string& unit) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->datetime(x, unit));
-      index_.append(length);
-    }
-    else {
-      content_.get()->datetime(x, unit);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->timedelta(x, unit));
-      index_.append(length);
-    }
-    else {
-      content_.get()->timedelta(x, unit);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (!content_.get()->active()) {
-      int64_t len = content_.get()->length();
-      maybeupdate(content_.get()->string(x, length, encoding));
-      index_.append(len);
-    }
-    else {
-      content_.get()->string(x, length, encoding);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::beginlist() {
-    if (!content_.get()->active()) {
-      maybeupdate(content_.get()->beginlist());
-    }
-    else {
-      content_.get()->beginlist();
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::endlist() {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = content_.get()->length();
-      content_.get()->endlist();
-      if (length != content_.get()->length()) {
-        index_.append(length);
-      }
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::begintuple(int64_t numfields) {
-    if (!content_.get()->active()) {
-      maybeupdate(content_.get()->begintuple(numfields));
-    }
-    else {
-      content_.get()->begintuple(numfields);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::index(int64_t index) {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->index(index);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::endtuple() {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = content_.get()->length();
-      content_.get()->endtuple();
-      if (length != content_.get()->length()) {
-        index_.append(length);
-      }
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::beginrecord(const char* name, bool check) {
-    if (!content_.get()->active()) {
-      maybeupdate(content_.get()->beginrecord(name, check));
-    }
-    else {
-      content_.get()->beginrecord(name, check);
-    }
-    return shared_from_this();
-  }
-
-  void
-  OptionBuilder::field(const char* key, bool check) {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->field(key, check);
-    }
-  }
-
-  const BuilderPtr
-  OptionBuilder::endrecord() {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'endrecord' without 'beginrecord' at the same level "
-                    "before it") + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = content_.get()->length();
-      content_.get()->endrecord();
-      if (length != content_.get()->length()) {
-        index_.append(length);
-      }
-    }
-    return shared_from_this();
-  }
-
-  void
-  OptionBuilder::maybeupdate(const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != content_.get()) {
-      content_ = std::move(tmp);
-    }
+void OptionBuilder::field(const char *key, bool check) {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->field(key, check);
   }
 }
+
+const BuilderPtr OptionBuilder::endrecord() {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string(
+            "called 'endrecord' without 'beginrecord' at the same level "
+            "before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = content_.get()->length();
+    content_.get()->endrecord();
+    if (length != content_.get()->length()) {
+      index_.append(length);
+    }
+  }
+  return shared_from_this();
+}
+
+void OptionBuilder::maybeupdate(const BuilderPtr tmp) {
+  if (tmp && tmp.get() != content_.get()) {
+    content_ = std::move(tmp);
+  }
+}
+} // namespace awkward

--- a/src/libawkward/builder/OptionBuilder.cpp
+++ b/src/libawkward/builder/OptionBuilder.cpp
@@ -1,290 +1,250 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/OptionBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/OptionBuilder.cpp", line)
 
 #include <stdexcept>
-
 
 #include "awkward/builder/OptionBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  OptionBuilder::fromnulls(const BuilderOptions& options,
-                           int64_t nullcount,
-                           const BuilderPtr& content) {
-    return std::make_shared<OptionBuilder>(
-      options,
-      GrowableBuffer<int64_t>::full(options,
-                                    -1,
-                                    nullcount),
-     content);
+const BuilderPtr OptionBuilder::fromnulls(const BuilderOptions &options,
+                                          int64_t nullcount,
+                                          const BuilderPtr &content) {
+  return std::make_shared<OptionBuilder>(
+      options, GrowableBuffer<int64_t>::full(options, -1, nullcount), content);
+}
+
+const BuilderPtr OptionBuilder::fromvalids(const BuilderOptions &options,
+                                           const BuilderPtr &content) {
+  return std::make_shared<OptionBuilder>(
+      options, GrowableBuffer<int64_t>::arange(options, content->length()),
+      content);
+}
+
+OptionBuilder::OptionBuilder(const BuilderOptions &,
+                             GrowableBuffer<int64_t> index,
+                             const BuilderPtr content)
+    : index_(std::move(index)), content_(content) {}
+
+const std::string OptionBuilder::classname() const { return "OptionBuilder"; };
+
+const std::string OptionBuilder::to_buffers(BuffersContainer &container,
+                                            int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  void *ptr = container.empty_buffer(form_key.str() + "-index",
+                                     (int64_t)index_.length() *
+                                         (int64_t)sizeof(int64_t));
+
+  index_.concatenate(reinterpret_cast<int64_t *>(ptr));
+
+  return "{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", "
+         "\"content\": " +
+         content_.get()->to_buffers(container, form_key_id) +
+         ", \"form_key\": \"" + form_key.str() + "\"}";
+}
+
+int64_t OptionBuilder::length() const { return (int64_t)index_.length(); }
+
+void OptionBuilder::clear() {
+  index_.clear();
+  content_.get()->clear();
+}
+
+bool OptionBuilder::active() const { return content_.get()->active(); }
+
+const BuilderPtr OptionBuilder::null() {
+  if (!content_.get()->active()) {
+    index_.append(-1);
+  } else {
+    content_.get()->null();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::fromvalids(const BuilderOptions& options,
-                            const BuilderPtr& content) {
-    return std::make_shared<OptionBuilder>(options,
-                                           GrowableBuffer<int64_t>::arange(options, content->length()),
-                                           content);
+const BuilderPtr OptionBuilder::boolean(bool x) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->boolean(x));
+    index_.append(length);
+  } else {
+    content_.get()->boolean(x);
   }
+  return shared_from_this();
+}
 
-  OptionBuilder::OptionBuilder(const BuilderOptions&,
-                               GrowableBuffer<int64_t> index,
-                               const BuilderPtr content)
-    : index_(std::move(index))
-      , content_(content) { }
-
-  const std::string
-  OptionBuilder::classname() const {
-    return "OptionBuilder";
-  };
-
-  const std::string
-  OptionBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    void* ptr = container.empty_buffer(form_key.str() + "-index",
-      (int64_t)index_.length() * (int64_t)sizeof(int64_t));
-
-    index_.concatenate(reinterpret_cast<int64_t*>(ptr));
-
-    return "{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", \"content\": "
-           + content_.get()->to_buffers(container, form_key_id) + ", \"form_key\": \""
-           + form_key.str() + "\"}";
+const BuilderPtr OptionBuilder::integer(int64_t x) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->integer(x));
+    index_.append(length);
+  } else {
+    content_.get()->integer(x);
   }
+  return shared_from_this();
+}
 
-  int64_t
-  OptionBuilder::length() const {
-    return (int64_t)index_.length();
+const BuilderPtr OptionBuilder::real(double x) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->real(x));
+    index_.append(length);
+  } else {
+    content_.get()->real(x);
   }
+  return shared_from_this();
+}
 
-  void
-  OptionBuilder::clear() {
-    index_.clear();
-    content_.get()->clear();
+const BuilderPtr OptionBuilder::complex(std::complex<double> x) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->complex(x));
+    index_.append(length);
+  } else {
+    content_.get()->complex(x);
   }
+  return shared_from_this();
+}
 
-  bool
-  OptionBuilder::active() const {
-    return content_.get()->active();
+const BuilderPtr OptionBuilder::datetime(int64_t x, const std::string &unit) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->datetime(x, unit));
+    index_.append(length);
+  } else {
+    content_.get()->datetime(x, unit);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::null() {
-    if (!content_.get()->active()) {
-      index_.append(-1);
-    }
-    else {
-      content_.get()->null();
-    }
-    return shared_from_this();
+const BuilderPtr OptionBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (!content_.get()->active()) {
+    int64_t length = content_.get()->length();
+    maybeupdate(content_.get()->timedelta(x, unit));
+    index_.append(length);
+  } else {
+    content_.get()->timedelta(x, unit);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::boolean(bool x) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->boolean(x));
+const BuilderPtr OptionBuilder::string(const char *x, int64_t length,
+                                       const char *encoding) {
+  if (!content_.get()->active()) {
+    int64_t len = content_.get()->length();
+    maybeupdate(content_.get()->string(x, length, encoding));
+    index_.append(len);
+  } else {
+    content_.get()->string(x, length, encoding);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr OptionBuilder::beginlist() {
+  if (!content_.get()->active()) {
+    maybeupdate(content_.get()->beginlist());
+  } else {
+    content_.get()->beginlist();
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr OptionBuilder::endlist() {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = content_.get()->length();
+    content_.get()->endlist();
+    if (length != content_.get()->length()) {
       index_.append(length);
     }
-    else {
-      content_.get()->boolean(x);
-    }
-    return shared_from_this();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::integer(int64_t x) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->integer(x));
+const BuilderPtr OptionBuilder::begintuple(int64_t numfields) {
+  if (!content_.get()->active()) {
+    maybeupdate(content_.get()->begintuple(numfields));
+  } else {
+    content_.get()->begintuple(numfields);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr OptionBuilder::index(int64_t index) {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->index(index);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr OptionBuilder::endtuple() {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = content_.get()->length();
+    content_.get()->endtuple();
+    if (length != content_.get()->length()) {
       index_.append(length);
     }
-    else {
-      content_.get()->integer(x);
-    }
-    return shared_from_this();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::real(double x) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->real(x));
-      index_.append(length);
-    }
-    else {
-      content_.get()->real(x);
-    }
-    return shared_from_this();
+const BuilderPtr OptionBuilder::beginrecord(const char *name, bool check) {
+  if (!content_.get()->active()) {
+    maybeupdate(content_.get()->beginrecord(name, check));
+  } else {
+    content_.get()->beginrecord(name, check);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  OptionBuilder::complex(std::complex<double> x) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->complex(x));
-      index_.append(length);
-    }
-    else {
-      content_.get()->complex(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::datetime(int64_t x, const std::string& unit) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->datetime(x, unit));
-      index_.append(length);
-    }
-    else {
-      content_.get()->datetime(x, unit);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (!content_.get()->active()) {
-      int64_t length = content_.get()->length();
-      maybeupdate(content_.get()->timedelta(x, unit));
-      index_.append(length);
-    }
-    else {
-      content_.get()->timedelta(x, unit);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (!content_.get()->active()) {
-      int64_t len = content_.get()->length();
-      maybeupdate(content_.get()->string(x, length, encoding));
-      index_.append(len);
-    }
-    else {
-      content_.get()->string(x, length, encoding);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::beginlist() {
-    if (!content_.get()->active()) {
-      maybeupdate(content_.get()->beginlist());
-    }
-    else {
-      content_.get()->beginlist();
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::endlist() {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = content_.get()->length();
-      content_.get()->endlist();
-      if (length != content_.get()->length()) {
-        index_.append(length);
-      }
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::begintuple(int64_t numfields) {
-    if (!content_.get()->active()) {
-      maybeupdate(content_.get()->begintuple(numfields));
-    }
-    else {
-      content_.get()->begintuple(numfields);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::index(int64_t index) {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->index(index);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::endtuple() {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = content_.get()->length();
-      content_.get()->endtuple();
-      if (length != content_.get()->length()) {
-        index_.append(length);
-      }
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  OptionBuilder::beginrecord(const char* name, bool check) {
-    if (!content_.get()->active()) {
-      maybeupdate(content_.get()->beginrecord(name, check));
-    }
-    else {
-      content_.get()->beginrecord(name, check);
-    }
-    return shared_from_this();
-  }
-
-  void
-  OptionBuilder::field(const char* key, bool check) {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      content_.get()->field(key, check);
-    }
-  }
-
-  const BuilderPtr
-  OptionBuilder::endrecord() {
-    if (!content_.get()->active()) {
-      throw std::invalid_argument(
-        std::string("called 'endrecord' without 'beginrecord' at the same level "
-                    "before it") + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = content_.get()->length();
-      content_.get()->endrecord();
-      if (length != content_.get()->length()) {
-        index_.append(length);
-      }
-    }
-    return shared_from_this();
-  }
-
-  void
-  OptionBuilder::maybeupdate(const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != content_.get()) {
-      content_ = std::move(tmp);
-    }
+void OptionBuilder::field(const char *key, bool check) {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    content_.get()->field(key, check);
   }
 }
+
+const BuilderPtr OptionBuilder::endrecord() {
+  if (!content_.get()->active()) {
+    throw std::invalid_argument(
+        std::string(
+            "called 'endrecord' without 'beginrecord' at the same level "
+            "before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = content_.get()->length();
+    content_.get()->endrecord();
+    if (length != content_.get()->length()) {
+      index_.append(length);
+    }
+  }
+  return shared_from_this();
+}
+
+void OptionBuilder::maybeupdate(const BuilderPtr tmp) {
+  if (tmp && tmp.get() != content_.get()) {
+    content_ = std::move(tmp);
+  }
+}
+} // namespace awkward

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/RecordBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/RecordBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -14,463 +12,554 @@
 #include "awkward/builder/RecordBuilder.h"
 
 namespace awkward {
-const BuilderPtr RecordBuilder::fromempty(const BuilderOptions &options) {
-  return std::make_shared<RecordBuilder>(
-      options, std::vector<BuilderPtr>(), std::vector<std::string>(),
-      std::vector<const char *>(), "", nullptr, -1, false, -1, -1);
-}
+  const BuilderPtr
+  RecordBuilder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<RecordBuilder>(options,
+                                           std::vector<BuilderPtr>(),
+                                           std::vector<std::string>(),
+                                           std::vector<const char*>(),
+                                           "",
+                                           nullptr,
+                                           -1,
+                                           false,
+                                           -1,
+                                           -1);
+  }
 
-RecordBuilder::RecordBuilder(const BuilderOptions &options,
-                             const std::vector<BuilderPtr> &contents,
-                             const std::vector<std::string> &keys,
-                             const std::vector<const char *> &pointers,
-                             const std::string &name, const char *nameptr,
-                             int64_t length, bool begun, int64_t nextindex,
-                             int64_t nexttotry)
-    : options_(options), contents_(contents), keys_(keys), pointers_(pointers),
-      name_(name), nameptr_(nameptr), length_(length), begun_(begun),
-      nextindex_(nextindex), nexttotry_(nexttotry),
-      keys_size_((int64_t)keys.size()) {}
+  RecordBuilder::RecordBuilder(const BuilderOptions& options,
+                               const std::vector<BuilderPtr>& contents,
+                               const std::vector<std::string>& keys,
+                               const std::vector<const char*>& pointers,
+                               const std::string& name,
+                               const char* nameptr,
+                               int64_t length,
+                               bool begun,
+                               int64_t nextindex,
+                               int64_t nexttotry)
+      : options_(options)
+      , contents_(contents)
+      , keys_(keys)
+      , pointers_(pointers)
+      , name_(name)
+      , nameptr_(nameptr)
+      , length_(length)
+      , begun_(begun)
+      , nextindex_(nextindex)
+      , nexttotry_(nexttotry)
+      , keys_size_((int64_t)keys.size()) { }
 
-const std::string RecordBuilder::name() const { return name_; }
+  const std::string
+  RecordBuilder::name() const {
+    return name_;
+  }
 
-const char *RecordBuilder::nameptr() const { return nameptr_; }
+  const char*
+  RecordBuilder::nameptr() const {
+    return nameptr_;
+  }
 
-const std::string RecordBuilder::classname() const { return "RecordBuilder"; };
+  const std::string
+  RecordBuilder::classname() const {
+    return "RecordBuilder";
+  };
 
-const std::string RecordBuilder::to_buffers(BuffersContainer &container,
-                                            int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
+  const std::string
+  RecordBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
 
-  std::stringstream out;
-  out << "{\"class\": \"RecordArray\", \"contents\": {";
-  for (size_t i = 0; i < contents_.size(); i++) {
-    if (i != 0) {
-      out << ", ";
+    std::stringstream out;
+    out << "{\"class\": \"RecordArray\", \"contents\": {";
+    for (size_t i = 0;  i < contents_.size();  i++) {
+      if (i != 0) {
+        out << ", ";
+      }
+      out << "" + util::quote(keys_[i]) + ": ";
+      out << contents_[i].get()->to_buffers(container, form_key_id);
     }
-    out << "" + util::quote(keys_[i]) + ": ";
-    out << contents_[i].get()->to_buffers(container, form_key_id);
-  }
-  out << "}, ";
-  if (!name_.empty()) {
-    out << "\"parameters\": {\"__record__\": " + util::quote(name_) + "}, ";
-  }
-  out << "\"form_key\": \"" + form_key.str() + "\"}";
-
-  return out.str();
-}
-
-int64_t RecordBuilder::length() const { return length_; }
-
-void RecordBuilder::clear() {
-  for (auto x : contents_) {
-    x.get()->clear();
-  }
-  keys_.clear();
-  pointers_.clear();
-  name_ = "";
-  nameptr_ = nullptr;
-  length_ = -1;
-  begun_ = false;
-  nextindex_ = -1;
-  nexttotry_ = 0;
-  keys_size_ = 0;
-}
-
-bool RecordBuilder::active() const { return begun_; }
-
-const BuilderPtr RecordBuilder::null() {
-  if (!begun_) {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'null' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
-  } else {
-    contents_[(size_t)nextindex_].get()->null();
-  }
-  return nullptr;
-}
-
-const BuilderPtr RecordBuilder::boolean(bool x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'boolean' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
-  } else {
-    contents_[(size_t)nextindex_].get()->boolean(x);
-  }
-  return nullptr;
-}
-
-const BuilderPtr RecordBuilder::integer(int64_t x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'integer' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
-  } else {
-    contents_[(size_t)nextindex_].get()->integer(x);
-  }
-  return nullptr;
-}
-
-const BuilderPtr RecordBuilder::real(double x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'real' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
-  } else {
-    contents_[(size_t)nextindex_].get()->real(x);
-  }
-  return nullptr;
-}
-
-const BuilderPtr RecordBuilder::complex(std::complex<double> x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'complex' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
-  } else {
-    contents_[(size_t)nextindex_].get()->complex(x);
-  }
-  return nullptr;
-}
-
-const BuilderPtr RecordBuilder::datetime(int64_t x, const std::string &unit) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'datetime' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_,
-                contents_[(size_t)nextindex_].get()->datetime(x, unit));
-  } else {
-    contents_[(size_t)nextindex_].get()->datetime(x, unit);
-  }
-  return nullptr;
-}
-
-const BuilderPtr RecordBuilder::timedelta(int64_t x, const std::string &unit) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'timedelta' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_,
-                contents_[(size_t)nextindex_].get()->timedelta(x, unit));
-  } else {
-    contents_[(size_t)nextindex_].get()->timedelta(x, unit);
-  }
-  return nullptr;
-}
-
-const BuilderPtr RecordBuilder::string(const char *x, int64_t length,
-                                       const char *encoding) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'string' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->string(
-                                x, length, encoding));
-  } else {
-    contents_[(size_t)nextindex_].get()->string(x, length, encoding);
-  }
-  return nullptr;
-}
-
-const BuilderPtr RecordBuilder::beginlist() {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'begin_list' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
-  } else {
-    contents_[(size_t)nextindex_].get()->beginlist();
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr RecordBuilder::endlist() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'end_list' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record' and then 'begin_list'") +
-        FILENAME(__LINE__));
-  } else {
-    contents_[(size_t)nextindex_].get()->endlist();
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr RecordBuilder::begintuple(int64_t numfields) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'begin_tuple' immediately after 'begin_record'; "
-                    "needs 'field_fast', 'field_check', or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_,
-                contents_[(size_t)nextindex_].get()->begintuple(numfields));
-  } else {
-    contents_[(size_t)nextindex_].get()->begintuple(numfields);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr RecordBuilder::index(int64_t index) {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'index' immediately after 'begin_record'; "
-                    "needs 'field_fast', 'field_check' or 'end_record' "
-                    "and then 'begin_tuple'") +
-        FILENAME(__LINE__));
-  } else {
-    contents_[(size_t)nextindex_].get()->index(index);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr RecordBuilder::endtuple() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same "
-                    "level before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'end_tuple' immediately after 'begin_record'; "
-                    "needs 'field_fast', 'field_check', or 'end_record' "
-                    "and then 'begin_tuple'") +
-        FILENAME(__LINE__));
-  } else {
-    contents_[(size_t)nextindex_].get()->endtuple();
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr RecordBuilder::beginrecord(const char *name, bool check) {
-  if (length_ == -1) {
-    if (name == nullptr) {
-      name_ = std::string("");
-    } else {
-      name_ = std::string(name);
+    out << "}, ";
+    if (!name_.empty()) {
+      out << "\"parameters\": {\"__record__\": " + util::quote(name_) + "}, ";
     }
-    nameptr_ = name;
-    length_ = 0;
+    out << "\"form_key\": \"" + form_key.str() + "\"}";
+
+    return out.str();
   }
 
-  if (!begun_ && ((check && name_ == name) || (!check && nameptr_ == name))) {
-    begun_ = true;
+  int64_t
+  RecordBuilder::length() const {
+    return length_;
+  }
+
+  void
+  RecordBuilder::clear() {
+    for (auto x : contents_) {
+      x.get()->clear();
+    }
+    keys_.clear();
+    pointers_.clear();
+    name_ = "";
+    nameptr_ = nullptr;
+    length_ = -1;
+    begun_ = false;
     nextindex_ = -1;
     nexttotry_ = 0;
-  } else if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
+    keys_size_ = 0;
+  }
+
+  bool
+  RecordBuilder::active() const {
+    return begun_;
+  }
+
+  const BuilderPtr
+  RecordBuilder::null() {
+    if (!begun_) {
+      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+      out.get()->null();
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'null' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->null();
+    }
+    return nullptr;
+  }
+
+  const BuilderPtr
+  RecordBuilder::boolean(bool x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->boolean(x);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'boolean' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->boolean(x);
+    }
+    return nullptr;
+  }
+
+  const BuilderPtr
+  RecordBuilder::integer(int64_t x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->integer(x);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'integer' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->integer(x);
+    }
+    return nullptr;
+  }
+
+  const BuilderPtr
+  RecordBuilder::real(double x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->real(x);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'real' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->real(x);
+    }
+    return nullptr;
+  }
+
+  const BuilderPtr
+  RecordBuilder::complex(std::complex<double> x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->complex(x);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'complex' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->complex(x);
+    }
+    return nullptr;
+  }
+
+  const BuilderPtr
+  RecordBuilder::datetime(int64_t x, const std::string& unit) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->datetime(x, unit);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'datetime' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->datetime(x, unit));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->datetime(x, unit);
+    }
+    return nullptr;
+  }
+
+  const BuilderPtr
+  RecordBuilder::timedelta(int64_t x, const std::string& unit) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->timedelta(x, unit);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'timedelta' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->timedelta(x, unit));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->timedelta(x, unit);
+    }
+    return nullptr;
+  }
+
+  const BuilderPtr
+  RecordBuilder::string(const char* x, int64_t length, const char* encoding) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->string(x, length, encoding);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'string' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->string(x,
+                                                              length,
+                                                              encoding));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->string(x, length, encoding);
+    }
+    return nullptr;
+  }
+
+  const BuilderPtr
+  RecordBuilder::beginlist() {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->beginlist();
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'begin_list' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->beginlist());
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->beginlist();
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  RecordBuilder::endlist() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'end_list' immediately after 'begin_record'; "
+                    "needs 'index' or 'end_record' and then 'begin_list'")
+        + FILENAME(__LINE__));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->endlist();
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  RecordBuilder::begintuple(int64_t numfields) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->begintuple(numfields);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'begin_tuple' immediately after 'begin_record'; "
+                    "needs 'field_fast', 'field_check', or 'end_record'")
+        + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->begintuple(numfields));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->begintuple(numfields);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  RecordBuilder::index(int64_t index) {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'index' immediately after 'begin_record'; "
+                    "needs 'field_fast', 'field_check' or 'end_record' "
+                    "and then 'begin_tuple'") + FILENAME(__LINE__));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->index(index);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  RecordBuilder::endtuple() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'end_tuple' immediately after 'begin_record'; "
+                    "needs 'field_fast', 'field_check', or 'end_record' "
+                    "and then 'begin_tuple'") + FILENAME(__LINE__));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->endtuple();
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  RecordBuilder::beginrecord(const char* name, bool check) {
+    if (length_ == -1) {
+      if (name == nullptr) {
+        name_ = std::string("");
+      }
+      else {
+        name_ = std::string(name);
+      }
+      nameptr_ = name;
+      length_ = 0;
+    }
+
+    if (!begun_  &&
+        ((check  &&  name_ == name)  ||  (!check  &&  nameptr_ == name))) {
+      begun_ = true;
+      nextindex_ = -1;
+      nexttotry_ = 0;
+    }
+    else if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->beginrecord(name, check);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
         std::string("called 'begin_record' immediately after 'begin_record'; "
-                    "needs 'field_fast', 'field_check', or 'end_record'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_,
-                contents_[(size_t)nextindex_].get()->beginrecord(name, check));
-  } else {
-    contents_[(size_t)nextindex_].get()->beginrecord(name, check);
+                    "needs 'field_fast', 'field_check', or 'end_record'")
+        + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->beginrecord(name,
+                                                                   check));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->beginrecord(name, check);
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-void RecordBuilder::field(const char *key, bool check) {
-  if (check) {
-    field_check(key);
-  } else {
-    field_fast(key);
+  void
+  RecordBuilder::field(const char* key, bool check) {
+    if (check) {
+      field_check(key);
+    }
+    else {
+      field_fast(key);
+    }
   }
-}
 
-void RecordBuilder::field_fast(const char *key) {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1 ||
+  void
+  RecordBuilder::field_fast(const char* key) {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1  ||
              !contents_[(size_t)nextindex_].get()->active()) {
-    int64_t i = nexttotry_;
-    do {
-      if (i >= keys_size_) {
-        i = 0;
-        if (i == nexttotry_) {
-          break;
+      int64_t i = nexttotry_;
+      do {
+        if (i >= keys_size_) {
+          i = 0;
+          if (i == nexttotry_) {
+            break;
+          }
+        }
+        if (pointers_[(size_t)i] == key) {
+          nextindex_ = i;
+          nexttotry_ = i + 1;
+          return;
+        }
+        i++;
+      } while (i != nexttotry_);
+      nextindex_ = keys_size_;
+      nexttotry_ = 0;
+      if (length_ == 0) {
+        contents_.push_back(UnknownBuilder::fromempty(options_));
+      }
+      else {
+        contents_.push_back(
+          OptionBuilder::fromnulls(options_,
+                                   length_,
+                                   UnknownBuilder::fromempty(options_)));
+      }
+      keys_.push_back(std::string(key));
+      pointers_.push_back(key);
+      keys_size_ = (int64_t)keys_.size();
+      return;
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->field(key, false);
+      return;
+    }
+  }
+
+  void
+  RecordBuilder::field_check(const char* key) {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+      int64_t i = nexttotry_;
+      do {
+        if (i >= keys_size_) {
+          i = 0;
+          if (i == nexttotry_) {
+            break;
+          }
+        }
+        if (keys_[(size_t)i].compare(key) == 0) {
+          nextindex_ = i;
+          nexttotry_ = i + 1;
+          return;
+        }
+        i++;
+      } while (i != nexttotry_);
+      nextindex_ = keys_size_;
+      nexttotry_ = 0;
+      if (length_ == 0) {
+        contents_.emplace_back(UnknownBuilder::fromempty(options_));
+      }
+      else {
+        contents_.emplace_back(
+          OptionBuilder::fromnulls(options_,
+                                   length_,
+                                   UnknownBuilder::fromempty(options_)));
+      }
+      keys_.emplace_back(std::string(key));
+      pointers_.emplace_back(nullptr);
+      keys_size_ = (int64_t)keys_.size();
+      return;
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->field(key, true);
+      return;
+    }
+  }
+
+  const BuilderPtr
+  RecordBuilder::endrecord() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_record' without 'begin_record' at the same level "
+                    "before it") + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+      for (size_t i = 0;  i < contents_.size();  i++) {
+        if (contents_[i].get()->length() == length_) {
+          maybeupdate((int64_t)i, contents_[i].get()->null());
+        }
+        if (contents_[i].get()->length() != length_ + 1) {
+          throw std::invalid_argument(
+            std::string("record field ") + util::quote(keys_[i])
+            + std::string(" filled more than once") + FILENAME(__LINE__));
         }
       }
-      if (pointers_[(size_t)i] == key) {
-        nextindex_ = i;
-        nexttotry_ = i + 1;
-        return;
-      }
-      i++;
-    } while (i != nexttotry_);
-    nextindex_ = keys_size_;
-    nexttotry_ = 0;
-    if (length_ == 0) {
-      contents_.push_back(UnknownBuilder::fromempty(options_));
-    } else {
-      contents_.push_back(OptionBuilder::fromnulls(
-          options_, length_, UnknownBuilder::fromempty(options_)));
+      length_++;
+      begun_ = false;
     }
-    keys_.push_back(std::string(key));
-    pointers_.push_back(key);
-    keys_size_ = (int64_t)keys_.size();
-    return;
-  } else {
-    contents_[(size_t)nextindex_].get()->field(key, false);
-    return;
-  }
-}
-
-void RecordBuilder::field_check(const char *key) {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1 ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-    int64_t i = nexttotry_;
-    do {
-      if (i >= keys_size_) {
-        i = 0;
-        if (i == nexttotry_) {
-          break;
-        }
-      }
-      if (keys_[(size_t)i].compare(key) == 0) {
-        nextindex_ = i;
-        nexttotry_ = i + 1;
-        return;
-      }
-      i++;
-    } while (i != nexttotry_);
-    nextindex_ = keys_size_;
-    nexttotry_ = 0;
-    if (length_ == 0) {
-      contents_.emplace_back(UnknownBuilder::fromempty(options_));
-    } else {
-      contents_.emplace_back(OptionBuilder::fromnulls(
-          options_, length_, UnknownBuilder::fromempty(options_)));
+    else {
+      contents_[(size_t)nextindex_].get()->endrecord();
     }
-    keys_.emplace_back(std::string(key));
-    pointers_.emplace_back(nullptr);
-    keys_size_ = (int64_t)keys_.size();
-    return;
-  } else {
-    contents_[(size_t)nextindex_].get()->field(key, true);
-    return;
+    return nullptr;
   }
-}
 
-const BuilderPtr RecordBuilder::endrecord() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string(
-            "called 'end_record' without 'begin_record' at the same level "
-            "before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1 ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-    for (size_t i = 0; i < contents_.size(); i++) {
-      if (contents_[i].get()->length() == length_) {
-        maybeupdate((int64_t)i, contents_[i].get()->null());
-      }
-      if (contents_[i].get()->length() != length_ + 1) {
-        throw std::invalid_argument(
-            std::string("record field ") + util::quote(keys_[i]) +
-            std::string(" filled more than once") + FILENAME(__LINE__));
-      }
+  void
+  RecordBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
+    if (tmp  &&  tmp.get() != contents_[(size_t)i].get()) {
+      contents_[(size_t)i] = std::move(tmp);
     }
-    length_++;
-    begun_ = false;
-  } else {
-    contents_[(size_t)nextindex_].get()->endrecord();
-  }
-  return nullptr;
-}
-
-void RecordBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
-  if (tmp && tmp.get() != contents_[(size_t)i].get()) {
-    contents_[(size_t)i] = std::move(tmp);
   }
 }
-} // namespace awkward

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/RecordBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/RecordBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -12,554 +13,463 @@
 #include "awkward/builder/RecordBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  RecordBuilder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<RecordBuilder>(options,
-                                           std::vector<BuilderPtr>(),
-                                           std::vector<std::string>(),
-                                           std::vector<const char*>(),
-                                           "",
-                                           nullptr,
-                                           -1,
-                                           false,
-                                           -1,
-                                           -1);
-  }
+const BuilderPtr RecordBuilder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<RecordBuilder>(
+      options, std::vector<BuilderPtr>(), std::vector<std::string>(),
+      std::vector<const char *>(), "", nullptr, -1, false, -1, -1);
+}
 
-  RecordBuilder::RecordBuilder(const BuilderOptions& options,
-                               const std::vector<BuilderPtr>& contents,
-                               const std::vector<std::string>& keys,
-                               const std::vector<const char*>& pointers,
-                               const std::string& name,
-                               const char* nameptr,
-                               int64_t length,
-                               bool begun,
-                               int64_t nextindex,
-                               int64_t nexttotry)
-      : options_(options)
-      , contents_(contents)
-      , keys_(keys)
-      , pointers_(pointers)
-      , name_(name)
-      , nameptr_(nameptr)
-      , length_(length)
-      , begun_(begun)
-      , nextindex_(nextindex)
-      , nexttotry_(nexttotry)
-      , keys_size_((int64_t)keys.size()) { }
+RecordBuilder::RecordBuilder(const BuilderOptions            &options,
+                             const std::vector<BuilderPtr>   &contents,
+                             const std::vector<std::string>  &keys,
+                             const std::vector<const char *> &pointers,
+                             const std::string &name, const char *nameptr,
+                             int64_t length, bool begun, int64_t nextindex,
+                             int64_t nexttotry)
+    : options_(options), contents_(contents), keys_(keys), pointers_(pointers),
+      name_(name), nameptr_(nameptr), length_(length), begun_(begun),
+      nextindex_(nextindex), nexttotry_(nexttotry),
+      keys_size_((int64_t)keys.size()) {}
 
-  const std::string
-  RecordBuilder::name() const {
-    return name_;
-  }
+const std::string RecordBuilder::name() const { return name_; }
 
-  const char*
-  RecordBuilder::nameptr() const {
-    return nameptr_;
-  }
+const char *RecordBuilder::nameptr() const { return nameptr_; }
 
-  const std::string
-  RecordBuilder::classname() const {
-    return "RecordBuilder";
-  };
+const std::string RecordBuilder::classname() const { return "RecordBuilder"; };
 
-  const std::string
-  RecordBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
+const std::string RecordBuilder::to_buffers(BuffersContainer &container,
+                                            int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
 
-    std::stringstream out;
-    out << "{\"class\": \"RecordArray\", \"contents\": {";
-    for (size_t i = 0;  i < contents_.size();  i++) {
-      if (i != 0) {
-        out << ", ";
-      }
-      out << "" + util::quote(keys_[i]) + ": ";
-      out << contents_[i].get()->to_buffers(container, form_key_id);
+  std::stringstream out;
+  out << "{\"class\": \"RecordArray\", \"contents\": {";
+  for (size_t i = 0; i < contents_.size(); i++) {
+    if (i != 0) {
+      out << ", ";
     }
-    out << "}, ";
-    if (!name_.empty()) {
-      out << "\"parameters\": {\"__record__\": " + util::quote(name_) + "}, ";
-    }
-    out << "\"form_key\": \"" + form_key.str() + "\"}";
-
-    return out.str();
+    out << "" + util::quote(keys_[i]) + ": ";
+    out << contents_[i].get()->to_buffers(container, form_key_id);
   }
-
-  int64_t
-  RecordBuilder::length() const {
-    return length_;
+  out << "}, ";
+  if (!name_.empty()) {
+    out << "\"parameters\": {\"__record__\": " + util::quote(name_) + "}, ";
   }
+  out << "\"form_key\": \"" + form_key.str() + "\"}";
 
-  void
-  RecordBuilder::clear() {
-    for (auto x : contents_) {
-      x.get()->clear();
-    }
-    keys_.clear();
-    pointers_.clear();
-    name_ = "";
-    nameptr_ = nullptr;
-    length_ = -1;
-    begun_ = false;
-    nextindex_ = -1;
-    nexttotry_ = 0;
-    keys_size_ = 0;
+  return out.str();
+}
+
+int64_t RecordBuilder::length() const { return length_; }
+
+void RecordBuilder::clear() {
+  for (auto x : contents_) {
+    x.get()->clear();
   }
+  keys_.clear();
+  pointers_.clear();
+  name_ = "";
+  nameptr_ = nullptr;
+  length_ = -1;
+  begun_ = false;
+  nextindex_ = -1;
+  nexttotry_ = 0;
+  keys_size_ = 0;
+}
 
-  bool
-  RecordBuilder::active() const {
-    return begun_;
-  }
+bool RecordBuilder::active() const { return begun_; }
 
-  const BuilderPtr
-  RecordBuilder::null() {
-    if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-      out.get()->null();
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::null() {
+  if (!begun_) {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'null' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->null();
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
+  } else {
+    contents_[(size_t)nextindex_].get()->null();
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::boolean(bool x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->boolean(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::boolean(bool x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'boolean' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->boolean(x);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->boolean(x);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::integer(int64_t x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->integer(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::integer(int64_t x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'integer' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->integer(x);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->integer(x);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::real(double x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->real(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::real(double x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'real' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->real(x);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->real(x);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::complex(std::complex<double> x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->complex(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::complex(std::complex<double> x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'complex' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->complex(x);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->complex(x);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::datetime(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->datetime(x, unit);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::datetime(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'datetime' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->datetime(x, unit));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->datetime(x, unit);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->datetime(x, unit));
+  } else {
+    contents_[(size_t)nextindex_].get()->datetime(x, unit);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->timedelta(x, unit);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'timedelta' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->timedelta(x, unit));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->timedelta(x, unit);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->timedelta(x, unit));
+  } else {
+    contents_[(size_t)nextindex_].get()->timedelta(x, unit);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->string(x, length, encoding);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::string(const char *x, int64_t length,
+                                       const char *encoding) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'string' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->string(x,
-                                                              length,
-                                                              encoding));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->string(x, length, encoding);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->string(
+                                x, length, encoding));
+  } else {
+    contents_[(size_t)nextindex_].get()->string(x, length, encoding);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::beginlist() {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginlist();
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::beginlist() {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_list' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginlist());
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->beginlist();
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
+  } else {
+    contents_[(size_t)nextindex_].get()->beginlist();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  RecordBuilder::endlist() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::endlist() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'end_list' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record' and then 'begin_list'")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->endlist();
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_record' and then 'begin_list'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->endlist();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  RecordBuilder::begintuple(int64_t numfields) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->begintuple(numfields);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::begintuple(int64_t numfields) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_tuple' immediately after 'begin_record'; "
-                    "needs 'field_fast', 'field_check', or 'end_record'")
-        + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->begintuple(numfields));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->begintuple(numfields);
-    }
-    return shared_from_this();
+                    "needs 'field_fast', 'field_check', or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->begintuple(numfields));
+  } else {
+    contents_[(size_t)nextindex_].get()->begintuple(numfields);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  RecordBuilder::index(int64_t index) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::index(int64_t index) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'index' immediately after 'begin_record'; "
                     "needs 'field_fast', 'field_check' or 'end_record' "
-                    "and then 'begin_tuple'") + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->index(index);
-    }
-    return shared_from_this();
+                    "and then 'begin_tuple'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->index(index);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  RecordBuilder::endtuple() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::endtuple() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'end_tuple' immediately after 'begin_record'; "
                     "needs 'field_fast', 'field_check', or 'end_record' "
-                    "and then 'begin_tuple'") + FILENAME(__LINE__));
+                    "and then 'begin_tuple'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->endtuple();
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr RecordBuilder::beginrecord(const char *name, bool check) {
+  if (length_ == -1) {
+    if (name == nullptr) {
+      name_ = std::string("");
+    } else {
+      name_ = std::string(name);
     }
-    else {
-      contents_[(size_t)nextindex_].get()->endtuple();
-    }
-    return shared_from_this();
+    nameptr_ = name;
+    length_ = 0;
   }
 
-  const BuilderPtr
-  RecordBuilder::beginrecord(const char* name, bool check) {
-    if (length_ == -1) {
-      if (name == nullptr) {
-        name_ = std::string("");
-      }
-      else {
-        name_ = std::string(name);
-      }
-      nameptr_ = name;
-      length_ = 0;
-    }
-
-    if (!begun_  &&
-        ((check  &&  name_ == name)  ||  (!check  &&  nameptr_ == name))) {
-      begun_ = true;
-      nextindex_ = -1;
-      nexttotry_ = 0;
-    }
-    else if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginrecord(name, check);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+  if (!begun_ && ((check && name_ == name) || (!check && nameptr_ == name))) {
+    begun_ = true;
+    nextindex_ = -1;
+    nexttotry_ = 0;
+  } else if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_record' immediately after 'begin_record'; "
-                    "needs 'field_fast', 'field_check', or 'end_record'")
-        + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginrecord(name,
-                                                                   check));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->beginrecord(name, check);
-    }
-    return shared_from_this();
+                    "needs 'field_fast', 'field_check', or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->beginrecord(name, check));
+  } else {
+    contents_[(size_t)nextindex_].get()->beginrecord(name, check);
   }
+  return shared_from_this();
+}
 
-  void
-  RecordBuilder::field(const char* key, bool check) {
-    if (check) {
-      field_check(key);
-    }
-    else {
-      field_fast(key);
-    }
-  }
-
-  void
-  RecordBuilder::field_fast(const char* key) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-      int64_t i = nexttotry_;
-      do {
-        if (i >= keys_size_) {
-          i = 0;
-          if (i == nexttotry_) {
-            break;
-          }
-        }
-        if (pointers_[(size_t)i] == key) {
-          nextindex_ = i;
-          nexttotry_ = i + 1;
-          return;
-        }
-        i++;
-      } while (i != nexttotry_);
-      nextindex_ = keys_size_;
-      nexttotry_ = 0;
-      if (length_ == 0) {
-        contents_.push_back(UnknownBuilder::fromempty(options_));
-      }
-      else {
-        contents_.push_back(
-          OptionBuilder::fromnulls(options_,
-                                   length_,
-                                   UnknownBuilder::fromempty(options_)));
-      }
-      keys_.push_back(std::string(key));
-      pointers_.push_back(key);
-      keys_size_ = (int64_t)keys_.size();
-      return;
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->field(key, false);
-      return;
-    }
-  }
-
-  void
-  RecordBuilder::field_check(const char* key) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-      int64_t i = nexttotry_;
-      do {
-        if (i >= keys_size_) {
-          i = 0;
-          if (i == nexttotry_) {
-            break;
-          }
-        }
-        if (keys_[(size_t)i].compare(key) == 0) {
-          nextindex_ = i;
-          nexttotry_ = i + 1;
-          return;
-        }
-        i++;
-      } while (i != nexttotry_);
-      nextindex_ = keys_size_;
-      nexttotry_ = 0;
-      if (length_ == 0) {
-        contents_.emplace_back(UnknownBuilder::fromempty(options_));
-      }
-      else {
-        contents_.emplace_back(
-          OptionBuilder::fromnulls(options_,
-                                   length_,
-                                   UnknownBuilder::fromempty(options_)));
-      }
-      keys_.emplace_back(std::string(key));
-      pointers_.emplace_back(nullptr);
-      keys_size_ = (int64_t)keys_.size();
-      return;
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->field(key, true);
-      return;
-    }
-  }
-
-  const BuilderPtr
-  RecordBuilder::endrecord() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same level "
-                    "before it") + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-      for (size_t i = 0;  i < contents_.size();  i++) {
-        if (contents_[i].get()->length() == length_) {
-          maybeupdate((int64_t)i, contents_[i].get()->null());
-        }
-        if (contents_[i].get()->length() != length_ + 1) {
-          throw std::invalid_argument(
-            std::string("record field ") + util::quote(keys_[i])
-            + std::string(" filled more than once") + FILENAME(__LINE__));
-        }
-      }
-      length_++;
-      begun_ = false;
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->endrecord();
-    }
-    return nullptr;
-  }
-
-  void
-  RecordBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != contents_[(size_t)i].get()) {
-      contents_[(size_t)i] = std::move(tmp);
-    }
+void RecordBuilder::field(const char *key, bool check) {
+  if (check) {
+    field_check(key);
+  } else {
+    field_fast(key);
   }
 }
+
+void RecordBuilder::field_fast(const char *key) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+    int64_t i = nexttotry_;
+    do {
+      if (i >= keys_size_) {
+        i = 0;
+        if (i == nexttotry_) {
+          break;
+        }
+      }
+      if (pointers_[(size_t)i] == key) {
+        nextindex_ = i;
+        nexttotry_ = i + 1;
+        return;
+      }
+      i++;
+    } while (i != nexttotry_);
+    nextindex_ = keys_size_;
+    nexttotry_ = 0;
+    if (length_ == 0) {
+      contents_.push_back(UnknownBuilder::fromempty(options_));
+    } else {
+      contents_.push_back(OptionBuilder::fromnulls(
+          options_, length_, UnknownBuilder::fromempty(options_)));
+    }
+    keys_.push_back(std::string(key));
+    pointers_.push_back(key);
+    keys_size_ = (int64_t)keys_.size();
+    return;
+  } else {
+    contents_[(size_t)nextindex_].get()->field(key, false);
+    return;
+  }
+}
+
+void RecordBuilder::field_check(const char *key) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+    int64_t i = nexttotry_;
+    do {
+      if (i >= keys_size_) {
+        i = 0;
+        if (i == nexttotry_) {
+          break;
+        }
+      }
+      if (keys_[(size_t)i].compare(key) == 0) {
+        nextindex_ = i;
+        nexttotry_ = i + 1;
+        return;
+      }
+      i++;
+    } while (i != nexttotry_);
+    nextindex_ = keys_size_;
+    nexttotry_ = 0;
+    if (length_ == 0) {
+      contents_.emplace_back(UnknownBuilder::fromempty(options_));
+    } else {
+      contents_.emplace_back(OptionBuilder::fromnulls(
+          options_, length_, UnknownBuilder::fromempty(options_)));
+    }
+    keys_.emplace_back(std::string(key));
+    pointers_.emplace_back(nullptr);
+    keys_size_ = (int64_t)keys_.size();
+    return;
+  } else {
+    contents_[(size_t)nextindex_].get()->field(key, true);
+    return;
+  }
+}
+
+const BuilderPtr RecordBuilder::endrecord() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string(
+            "called 'end_record' without 'begin_record' at the same level "
+            "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+    for (size_t i = 0; i < contents_.size(); i++) {
+      if (contents_[i].get()->length() == length_) {
+        maybeupdate((int64_t)i, contents_[i].get()->null());
+      }
+      if (contents_[i].get()->length() != length_ + 1) {
+        throw std::invalid_argument(
+            std::string("record field ") + util::quote(keys_[i]) +
+            std::string(" filled more than once") + FILENAME(__LINE__));
+      }
+    }
+    length_++;
+    begun_ = false;
+  } else {
+    contents_[(size_t)nextindex_].get()->endrecord();
+  }
+  return nullptr;
+}
+
+void RecordBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
+  if (tmp && tmp.get() != contents_[(size_t)i].get()) {
+    contents_[(size_t)i] = std::move(tmp);
+  }
+}
+} // namespace awkward

--- a/src/libawkward/builder/RecordBuilder.cpp
+++ b/src/libawkward/builder/RecordBuilder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/RecordBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/RecordBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -12,554 +14,463 @@
 #include "awkward/builder/RecordBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  RecordBuilder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<RecordBuilder>(options,
-                                           std::vector<BuilderPtr>(),
-                                           std::vector<std::string>(),
-                                           std::vector<const char*>(),
-                                           "",
-                                           nullptr,
-                                           -1,
-                                           false,
-                                           -1,
-                                           -1);
-  }
+const BuilderPtr RecordBuilder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<RecordBuilder>(
+      options, std::vector<BuilderPtr>(), std::vector<std::string>(),
+      std::vector<const char *>(), "", nullptr, -1, false, -1, -1);
+}
 
-  RecordBuilder::RecordBuilder(const BuilderOptions& options,
-                               const std::vector<BuilderPtr>& contents,
-                               const std::vector<std::string>& keys,
-                               const std::vector<const char*>& pointers,
-                               const std::string& name,
-                               const char* nameptr,
-                               int64_t length,
-                               bool begun,
-                               int64_t nextindex,
-                               int64_t nexttotry)
-      : options_(options)
-      , contents_(contents)
-      , keys_(keys)
-      , pointers_(pointers)
-      , name_(name)
-      , nameptr_(nameptr)
-      , length_(length)
-      , begun_(begun)
-      , nextindex_(nextindex)
-      , nexttotry_(nexttotry)
-      , keys_size_((int64_t)keys.size()) { }
+RecordBuilder::RecordBuilder(const BuilderOptions &options,
+                             const std::vector<BuilderPtr> &contents,
+                             const std::vector<std::string> &keys,
+                             const std::vector<const char *> &pointers,
+                             const std::string &name, const char *nameptr,
+                             int64_t length, bool begun, int64_t nextindex,
+                             int64_t nexttotry)
+    : options_(options), contents_(contents), keys_(keys), pointers_(pointers),
+      name_(name), nameptr_(nameptr), length_(length), begun_(begun),
+      nextindex_(nextindex), nexttotry_(nexttotry),
+      keys_size_((int64_t)keys.size()) {}
 
-  const std::string
-  RecordBuilder::name() const {
-    return name_;
-  }
+const std::string RecordBuilder::name() const { return name_; }
 
-  const char*
-  RecordBuilder::nameptr() const {
-    return nameptr_;
-  }
+const char *RecordBuilder::nameptr() const { return nameptr_; }
 
-  const std::string
-  RecordBuilder::classname() const {
-    return "RecordBuilder";
-  };
+const std::string RecordBuilder::classname() const { return "RecordBuilder"; };
 
-  const std::string
-  RecordBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
+const std::string RecordBuilder::to_buffers(BuffersContainer &container,
+                                            int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
 
-    std::stringstream out;
-    out << "{\"class\": \"RecordArray\", \"contents\": {";
-    for (size_t i = 0;  i < contents_.size();  i++) {
-      if (i != 0) {
-        out << ", ";
-      }
-      out << "" + util::quote(keys_[i]) + ": ";
-      out << contents_[i].get()->to_buffers(container, form_key_id);
+  std::stringstream out;
+  out << "{\"class\": \"RecordArray\", \"contents\": {";
+  for (size_t i = 0; i < contents_.size(); i++) {
+    if (i != 0) {
+      out << ", ";
     }
-    out << "}, ";
-    if (!name_.empty()) {
-      out << "\"parameters\": {\"__record__\": " + util::quote(name_) + "}, ";
-    }
-    out << "\"form_key\": \"" + form_key.str() + "\"}";
-
-    return out.str();
+    out << "" + util::quote(keys_[i]) + ": ";
+    out << contents_[i].get()->to_buffers(container, form_key_id);
   }
-
-  int64_t
-  RecordBuilder::length() const {
-    return length_;
+  out << "}, ";
+  if (!name_.empty()) {
+    out << "\"parameters\": {\"__record__\": " + util::quote(name_) + "}, ";
   }
+  out << "\"form_key\": \"" + form_key.str() + "\"}";
 
-  void
-  RecordBuilder::clear() {
-    for (auto x : contents_) {
-      x.get()->clear();
-    }
-    keys_.clear();
-    pointers_.clear();
-    name_ = "";
-    nameptr_ = nullptr;
-    length_ = -1;
-    begun_ = false;
-    nextindex_ = -1;
-    nexttotry_ = 0;
-    keys_size_ = 0;
+  return out.str();
+}
+
+int64_t RecordBuilder::length() const { return length_; }
+
+void RecordBuilder::clear() {
+  for (auto x : contents_) {
+    x.get()->clear();
   }
+  keys_.clear();
+  pointers_.clear();
+  name_ = "";
+  nameptr_ = nullptr;
+  length_ = -1;
+  begun_ = false;
+  nextindex_ = -1;
+  nexttotry_ = 0;
+  keys_size_ = 0;
+}
 
-  bool
-  RecordBuilder::active() const {
-    return begun_;
-  }
+bool RecordBuilder::active() const { return begun_; }
 
-  const BuilderPtr
-  RecordBuilder::null() {
-    if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-      out.get()->null();
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::null() {
+  if (!begun_) {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'null' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->null();
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
+  } else {
+    contents_[(size_t)nextindex_].get()->null();
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::boolean(bool x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->boolean(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::boolean(bool x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'boolean' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->boolean(x);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->boolean(x);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::integer(int64_t x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->integer(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::integer(int64_t x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'integer' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->integer(x);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->integer(x);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::real(double x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->real(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::real(double x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'real' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->real(x);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->real(x);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::complex(std::complex<double> x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->complex(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::complex(std::complex<double> x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'complex' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->complex(x);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->complex(x);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::datetime(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->datetime(x, unit);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::datetime(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'datetime' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->datetime(x, unit));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->datetime(x, unit);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->datetime(x, unit));
+  } else {
+    contents_[(size_t)nextindex_].get()->datetime(x, unit);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->timedelta(x, unit);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'timedelta' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->timedelta(x, unit));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->timedelta(x, unit);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->timedelta(x, unit));
+  } else {
+    contents_[(size_t)nextindex_].get()->timedelta(x, unit);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->string(x, length, encoding);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::string(const char *x, int64_t length,
+                                       const char *encoding) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'string' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->string(x,
-                                                              length,
-                                                              encoding));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->string(x, length, encoding);
-    }
-    return nullptr;
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->string(
+                                x, length, encoding));
+  } else {
+    contents_[(size_t)nextindex_].get()->string(x, length, encoding);
   }
+  return nullptr;
+}
 
-  const BuilderPtr
-  RecordBuilder::beginlist() {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginlist();
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::beginlist() {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_list' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginlist());
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->beginlist();
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
+  } else {
+    contents_[(size_t)nextindex_].get()->beginlist();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  RecordBuilder::endlist() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::endlist() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'end_list' immediately after 'begin_record'; "
-                    "needs 'index' or 'end_record' and then 'begin_list'")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->endlist();
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_record' and then 'begin_list'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->endlist();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  RecordBuilder::begintuple(int64_t numfields) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->begintuple(numfields);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::begintuple(int64_t numfields) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_tuple' immediately after 'begin_record'; "
-                    "needs 'field_fast', 'field_check', or 'end_record'")
-        + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->begintuple(numfields));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->begintuple(numfields);
-    }
-    return shared_from_this();
+                    "needs 'field_fast', 'field_check', or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->begintuple(numfields));
+  } else {
+    contents_[(size_t)nextindex_].get()->begintuple(numfields);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  RecordBuilder::index(int64_t index) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::index(int64_t index) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'index' immediately after 'begin_record'; "
                     "needs 'field_fast', 'field_check' or 'end_record' "
-                    "and then 'begin_tuple'") + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->index(index);
-    }
-    return shared_from_this();
+                    "and then 'begin_tuple'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->index(index);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  RecordBuilder::endtuple() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr RecordBuilder::endtuple() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'end_tuple' immediately after 'begin_record'; "
                     "needs 'field_fast', 'field_check', or 'end_record' "
-                    "and then 'begin_tuple'") + FILENAME(__LINE__));
+                    "and then 'begin_tuple'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->endtuple();
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr RecordBuilder::beginrecord(const char *name, bool check) {
+  if (length_ == -1) {
+    if (name == nullptr) {
+      name_ = std::string("");
+    } else {
+      name_ = std::string(name);
     }
-    else {
-      contents_[(size_t)nextindex_].get()->endtuple();
-    }
-    return shared_from_this();
+    nameptr_ = name;
+    length_ = 0;
   }
 
-  const BuilderPtr
-  RecordBuilder::beginrecord(const char* name, bool check) {
-    if (length_ == -1) {
-      if (name == nullptr) {
-        name_ = std::string("");
-      }
-      else {
-        name_ = std::string(name);
-      }
-      nameptr_ = name;
-      length_ = 0;
-    }
-
-    if (!begun_  &&
-        ((check  &&  name_ == name)  ||  (!check  &&  nameptr_ == name))) {
-      begun_ = true;
-      nextindex_ = -1;
-      nexttotry_ = 0;
-    }
-    else if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginrecord(name, check);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+  if (!begun_ && ((check && name_ == name) || (!check && nameptr_ == name))) {
+    begun_ = true;
+    nextindex_ = -1;
+    nexttotry_ = 0;
+  } else if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_record' immediately after 'begin_record'; "
-                    "needs 'field_fast', 'field_check', or 'end_record'")
-        + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginrecord(name,
-                                                                   check));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->beginrecord(name, check);
-    }
-    return shared_from_this();
+                    "needs 'field_fast', 'field_check', or 'end_record'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->beginrecord(name, check));
+  } else {
+    contents_[(size_t)nextindex_].get()->beginrecord(name, check);
   }
+  return shared_from_this();
+}
 
-  void
-  RecordBuilder::field(const char* key, bool check) {
-    if (check) {
-      field_check(key);
-    }
-    else {
-      field_fast(key);
-    }
-  }
-
-  void
-  RecordBuilder::field_fast(const char* key) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-      int64_t i = nexttotry_;
-      do {
-        if (i >= keys_size_) {
-          i = 0;
-          if (i == nexttotry_) {
-            break;
-          }
-        }
-        if (pointers_[(size_t)i] == key) {
-          nextindex_ = i;
-          nexttotry_ = i + 1;
-          return;
-        }
-        i++;
-      } while (i != nexttotry_);
-      nextindex_ = keys_size_;
-      nexttotry_ = 0;
-      if (length_ == 0) {
-        contents_.push_back(UnknownBuilder::fromempty(options_));
-      }
-      else {
-        contents_.push_back(
-          OptionBuilder::fromnulls(options_,
-                                   length_,
-                                   UnknownBuilder::fromempty(options_)));
-      }
-      keys_.push_back(std::string(key));
-      pointers_.push_back(key);
-      keys_size_ = (int64_t)keys_.size();
-      return;
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->field(key, false);
-      return;
-    }
-  }
-
-  void
-  RecordBuilder::field_check(const char* key) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-      int64_t i = nexttotry_;
-      do {
-        if (i >= keys_size_) {
-          i = 0;
-          if (i == nexttotry_) {
-            break;
-          }
-        }
-        if (keys_[(size_t)i].compare(key) == 0) {
-          nextindex_ = i;
-          nexttotry_ = i + 1;
-          return;
-        }
-        i++;
-      } while (i != nexttotry_);
-      nextindex_ = keys_size_;
-      nexttotry_ = 0;
-      if (length_ == 0) {
-        contents_.emplace_back(UnknownBuilder::fromempty(options_));
-      }
-      else {
-        contents_.emplace_back(
-          OptionBuilder::fromnulls(options_,
-                                   length_,
-                                   UnknownBuilder::fromempty(options_)));
-      }
-      keys_.emplace_back(std::string(key));
-      pointers_.emplace_back(nullptr);
-      keys_size_ = (int64_t)keys_.size();
-      return;
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->field(key, true);
-      return;
-    }
-  }
-
-  const BuilderPtr
-  RecordBuilder::endrecord() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same level "
-                    "before it") + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-      for (size_t i = 0;  i < contents_.size();  i++) {
-        if (contents_[i].get()->length() == length_) {
-          maybeupdate((int64_t)i, contents_[i].get()->null());
-        }
-        if (contents_[i].get()->length() != length_ + 1) {
-          throw std::invalid_argument(
-            std::string("record field ") + util::quote(keys_[i])
-            + std::string(" filled more than once") + FILENAME(__LINE__));
-        }
-      }
-      length_++;
-      begun_ = false;
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->endrecord();
-    }
-    return nullptr;
-  }
-
-  void
-  RecordBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != contents_[(size_t)i].get()) {
-      contents_[(size_t)i] = std::move(tmp);
-    }
+void RecordBuilder::field(const char *key, bool check) {
+  if (check) {
+    field_check(key);
+  } else {
+    field_fast(key);
   }
 }
+
+void RecordBuilder::field_fast(const char *key) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+    int64_t i = nexttotry_;
+    do {
+      if (i >= keys_size_) {
+        i = 0;
+        if (i == nexttotry_) {
+          break;
+        }
+      }
+      if (pointers_[(size_t)i] == key) {
+        nextindex_ = i;
+        nexttotry_ = i + 1;
+        return;
+      }
+      i++;
+    } while (i != nexttotry_);
+    nextindex_ = keys_size_;
+    nexttotry_ = 0;
+    if (length_ == 0) {
+      contents_.push_back(UnknownBuilder::fromempty(options_));
+    } else {
+      contents_.push_back(OptionBuilder::fromnulls(
+          options_, length_, UnknownBuilder::fromempty(options_)));
+    }
+    keys_.push_back(std::string(key));
+    pointers_.push_back(key);
+    keys_size_ = (int64_t)keys_.size();
+    return;
+  } else {
+    contents_[(size_t)nextindex_].get()->field(key, false);
+    return;
+  }
+}
+
+void RecordBuilder::field_check(const char *key) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+    int64_t i = nexttotry_;
+    do {
+      if (i >= keys_size_) {
+        i = 0;
+        if (i == nexttotry_) {
+          break;
+        }
+      }
+      if (keys_[(size_t)i].compare(key) == 0) {
+        nextindex_ = i;
+        nexttotry_ = i + 1;
+        return;
+      }
+      i++;
+    } while (i != nexttotry_);
+    nextindex_ = keys_size_;
+    nexttotry_ = 0;
+    if (length_ == 0) {
+      contents_.emplace_back(UnknownBuilder::fromempty(options_));
+    } else {
+      contents_.emplace_back(OptionBuilder::fromnulls(
+          options_, length_, UnknownBuilder::fromempty(options_)));
+    }
+    keys_.emplace_back(std::string(key));
+    pointers_.emplace_back(nullptr);
+    keys_size_ = (int64_t)keys_.size();
+    return;
+  } else {
+    contents_[(size_t)nextindex_].get()->field(key, true);
+    return;
+  }
+}
+
+const BuilderPtr RecordBuilder::endrecord() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string(
+            "called 'end_record' without 'begin_record' at the same level "
+            "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+    for (size_t i = 0; i < contents_.size(); i++) {
+      if (contents_[i].get()->length() == length_) {
+        maybeupdate((int64_t)i, contents_[i].get()->null());
+      }
+      if (contents_[i].get()->length() != length_ + 1) {
+        throw std::invalid_argument(
+            std::string("record field ") + util::quote(keys_[i]) +
+            std::string(" filled more than once") + FILENAME(__LINE__));
+      }
+    }
+    length_++;
+    begun_ = false;
+  } else {
+    contents_[(size_t)nextindex_].get()->endrecord();
+  }
+  return nullptr;
+}
+
+void RecordBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
+  if (tmp && tmp.get() != contents_[(size_t)i].get()) {
+    contents_[(size_t)i] = std::move(tmp);
+  }
+}
+} // namespace awkward

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/StringBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/StringBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -11,212 +13,181 @@
 #include "awkward/builder/StringBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  StringBuilder::fromempty(const BuilderOptions& options,
-                           const char* encoding) {
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
-    offsets.append(0);
-    GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
-    return std::make_shared<StringBuilder>(options,
-                                           std::move(offsets),
-                                           std::move(content),
-                                           encoding);
-  }
-
-  StringBuilder::StringBuilder(const BuilderOptions& options,
-                               GrowableBuffer<int64_t> offsets,
-                               GrowableBuffer<uint8_t> content,
-                               const char* encoding)
-      : options_(options)
-      , offsets_(std::move(offsets))
-      , content_(std::move(content))
-      , encoding_(encoding) { }
-
-  const std::string
-  StringBuilder::classname() const {
-    return "StringBuilder";
-  };
-
-  const char*
-  StringBuilder::encoding() const {
-    return encoding_;
-  }
-
-  const std::string
-  StringBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream outer_form_key;
-    std::stringstream inner_form_key;
-    outer_form_key << "node" << (form_key_id++);
-    inner_form_key << "node" << (form_key_id++);
-
-    offsets_.concatenate(
-      reinterpret_cast<int64_t*>(
-        container.empty_buffer(outer_form_key.str() + "-offsets",
-        (int64_t)offsets_.length() * (int64_t)sizeof(int64_t))));
-
-    content_.concatenate(
-      reinterpret_cast<uint8_t*>(
-        container.empty_buffer(inner_form_key.str() + "-data",
-        (int64_t)content_.length() * (int64_t)sizeof(uint8_t))));
-
-    std::string char_parameter;
-    std::string string_parameter;
-    if (encoding_ == nullptr) {
-      char_parameter = std::string("\"byte\"");
-      string_parameter = std::string("\"bytestring\"");
-    }
-    else if (std::string(encoding_) == std::string("utf-8")) {
-      char_parameter = std::string("\"char\"");
-      string_parameter = std::string("\"string\"");
-    }
-    else {
-      throw std::invalid_argument(
-        std::string("unsupported encoding: ") + util::quote(encoding_));
-    }
-
-    return std::string("{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", \"content\": ")
-           + "{\"class\": \"NumpyArray\", \"primitive\": \"uint8\", \"parameters\": {\"__array__\": "
-           + char_parameter + "}, \"form_key\": \"" + inner_form_key.str() + "\"}"
-           + ", \"parameters\": {\"__array__\": " + string_parameter + "}"
-           + ", \"form_key\": \"" + outer_form_key.str() + "\"}";
-  }
-
-  int64_t
-  StringBuilder::length() const {
-    return (int64_t)offsets_.length() - 1;
-  }
-
-  void
-  StringBuilder::clear() {
-    offsets_.clear();
-    offsets_.append(0);
-    content_.clear();
-  }
-
-  bool
-  StringBuilder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  StringBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::string(const char* x, int64_t length, const char* /* encoding */) {
-    if (length < 0) {
-      for (int64_t i = 0;  x[i] != 0;  i++) {
-        content_.append((uint8_t)x[i]);
-      }
-    }
-    else {
-      for (int64_t i = 0;  i < length;  i++) {
-        content_.append((uint8_t)x[i]);
-      }
-    }
-    offsets_.append((int64_t)content_.length());
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  StringBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  StringBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  StringBuilder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  StringBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  StringBuilder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  StringBuilder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr StringBuilder::fromempty(const BuilderOptions &options,
+                                          const char *encoding) {
+  GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
+  offsets.append(0);
+  GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
+  return std::make_shared<StringBuilder>(options, std::move(offsets),
+                                         std::move(content), encoding);
 }
+
+StringBuilder::StringBuilder(const BuilderOptions &options,
+                             GrowableBuffer<int64_t> offsets,
+                             GrowableBuffer<uint8_t> content,
+                             const char *encoding)
+    : options_(options), offsets_(std::move(offsets)),
+      content_(std::move(content)), encoding_(encoding) {}
+
+const std::string StringBuilder::classname() const { return "StringBuilder"; };
+
+const char *StringBuilder::encoding() const { return encoding_; }
+
+const std::string StringBuilder::to_buffers(BuffersContainer &container,
+                                            int64_t &form_key_id) const {
+  std::stringstream outer_form_key;
+  std::stringstream inner_form_key;
+  outer_form_key << "node" << (form_key_id++);
+  inner_form_key << "node" << (form_key_id++);
+
+  offsets_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
+      outer_form_key.str() + "-offsets",
+      (int64_t)offsets_.length() * (int64_t)sizeof(int64_t))));
+
+  content_.concatenate(reinterpret_cast<uint8_t *>(container.empty_buffer(
+      inner_form_key.str() + "-data",
+      (int64_t)content_.length() * (int64_t)sizeof(uint8_t))));
+
+  std::string char_parameter;
+  std::string string_parameter;
+  if (encoding_ == nullptr) {
+    char_parameter = std::string("\"byte\"");
+    string_parameter = std::string("\"bytestring\"");
+  } else if (std::string(encoding_) == std::string("utf-8")) {
+    char_parameter = std::string("\"char\"");
+    string_parameter = std::string("\"string\"");
+  } else {
+    throw std::invalid_argument(std::string("unsupported encoding: ") +
+                                util::quote(encoding_));
+  }
+
+  return std::string("{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", "
+                     "\"content\": ") +
+         "{\"class\": \"NumpyArray\", \"primitive\": \"uint8\", "
+         "\"parameters\": {\"__array__\": " +
+         char_parameter + "}, \"form_key\": \"" + inner_form_key.str() + "\"}" +
+         ", \"parameters\": {\"__array__\": " + string_parameter + "}" +
+         ", \"form_key\": \"" + outer_form_key.str() + "\"}";
+}
+
+int64_t StringBuilder::length() const { return (int64_t)offsets_.length() - 1; }
+
+void StringBuilder::clear() {
+  offsets_.clear();
+  offsets_.append(0);
+  content_.clear();
+}
+
+bool StringBuilder::active() const { return false; }
+
+const BuilderPtr StringBuilder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr StringBuilder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr StringBuilder::integer(int64_t x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->integer(x);
+  return out;
+}
+
+const BuilderPtr StringBuilder::real(double x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr StringBuilder::complex(std::complex<double> x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr StringBuilder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr StringBuilder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr StringBuilder::string(const char *x, int64_t length,
+                                       const char * /* encoding */) {
+  if (length < 0) {
+    for (int64_t i = 0; x[i] != 0; i++) {
+      content_.append((uint8_t)x[i]);
+    }
+  } else {
+    for (int64_t i = 0; i < length; i++) {
+      content_.append((uint8_t)x[i]);
+    }
+  }
+  offsets_.append((int64_t)content_.length());
+  return shared_from_this();
+}
+
+const BuilderPtr StringBuilder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr StringBuilder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr StringBuilder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr StringBuilder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr StringBuilder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr StringBuilder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void StringBuilder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr StringBuilder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/StringBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/StringBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -13,181 +11,212 @@
 #include "awkward/builder/StringBuilder.h"
 
 namespace awkward {
-const BuilderPtr StringBuilder::fromempty(const BuilderOptions &options,
-                                          const char *encoding) {
-  GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
-  offsets.append(0);
-  GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
-  return std::make_shared<StringBuilder>(options, std::move(offsets),
-                                         std::move(content), encoding);
-}
-
-StringBuilder::StringBuilder(const BuilderOptions &options,
-                             GrowableBuffer<int64_t> offsets,
-                             GrowableBuffer<uint8_t> content,
-                             const char *encoding)
-    : options_(options), offsets_(std::move(offsets)),
-      content_(std::move(content)), encoding_(encoding) {}
-
-const std::string StringBuilder::classname() const { return "StringBuilder"; };
-
-const char *StringBuilder::encoding() const { return encoding_; }
-
-const std::string StringBuilder::to_buffers(BuffersContainer &container,
-                                            int64_t &form_key_id) const {
-  std::stringstream outer_form_key;
-  std::stringstream inner_form_key;
-  outer_form_key << "node" << (form_key_id++);
-  inner_form_key << "node" << (form_key_id++);
-
-  offsets_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
-      outer_form_key.str() + "-offsets",
-      (int64_t)offsets_.length() * (int64_t)sizeof(int64_t))));
-
-  content_.concatenate(reinterpret_cast<uint8_t *>(container.empty_buffer(
-      inner_form_key.str() + "-data",
-      (int64_t)content_.length() * (int64_t)sizeof(uint8_t))));
-
-  std::string char_parameter;
-  std::string string_parameter;
-  if (encoding_ == nullptr) {
-    char_parameter = std::string("\"byte\"");
-    string_parameter = std::string("\"bytestring\"");
-  } else if (std::string(encoding_) == std::string("utf-8")) {
-    char_parameter = std::string("\"char\"");
-    string_parameter = std::string("\"string\"");
-  } else {
-    throw std::invalid_argument(std::string("unsupported encoding: ") +
-                                util::quote(encoding_));
+  const BuilderPtr
+  StringBuilder::fromempty(const BuilderOptions& options,
+                           const char* encoding) {
+    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
+    offsets.append(0);
+    GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
+    return std::make_shared<StringBuilder>(options,
+                                           std::move(offsets),
+                                           std::move(content),
+                                           encoding);
   }
 
-  return std::string("{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", "
-                     "\"content\": ") +
-         "{\"class\": \"NumpyArray\", \"primitive\": \"uint8\", "
-         "\"parameters\": {\"__array__\": " +
-         char_parameter + "}, \"form_key\": \"" + inner_form_key.str() + "\"}" +
-         ", \"parameters\": {\"__array__\": " + string_parameter + "}" +
-         ", \"form_key\": \"" + outer_form_key.str() + "\"}";
-}
+  StringBuilder::StringBuilder(const BuilderOptions& options,
+                               GrowableBuffer<int64_t> offsets,
+                               GrowableBuffer<uint8_t> content,
+                               const char* encoding)
+      : options_(options)
+      , offsets_(std::move(offsets))
+      , content_(std::move(content))
+      , encoding_(encoding) { }
 
-int64_t StringBuilder::length() const { return (int64_t)offsets_.length() - 1; }
+  const std::string
+  StringBuilder::classname() const {
+    return "StringBuilder";
+  };
 
-void StringBuilder::clear() {
-  offsets_.clear();
-  offsets_.append(0);
-  content_.clear();
-}
-
-bool StringBuilder::active() const { return false; }
-
-const BuilderPtr StringBuilder::null() {
-  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-  out.get()->null();
-  return out;
-}
-
-const BuilderPtr StringBuilder::boolean(bool x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->boolean(x);
-  return out;
-}
-
-const BuilderPtr StringBuilder::integer(int64_t x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->integer(x);
-  return out;
-}
-
-const BuilderPtr StringBuilder::real(double x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->real(x);
-  return out;
-}
-
-const BuilderPtr StringBuilder::complex(std::complex<double> x) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->complex(x);
-  return out;
-}
-
-const BuilderPtr StringBuilder::datetime(int64_t x, const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->datetime(x, unit);
-  return out;
-}
-
-const BuilderPtr StringBuilder::timedelta(int64_t x, const std::string &unit) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->timedelta(x, unit);
-  return out;
-}
-
-const BuilderPtr StringBuilder::string(const char *x, int64_t length,
-                                       const char * /* encoding */) {
-  if (length < 0) {
-    for (int64_t i = 0; x[i] != 0; i++) {
-      content_.append((uint8_t)x[i]);
-    }
-  } else {
-    for (int64_t i = 0; i < length; i++) {
-      content_.append((uint8_t)x[i]);
-    }
+  const char*
+  StringBuilder::encoding() const {
+    return encoding_;
   }
-  offsets_.append((int64_t)content_.length());
-  return shared_from_this();
-}
 
-const BuilderPtr StringBuilder::beginlist() {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginlist();
-  return out;
-}
+  const std::string
+  StringBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream outer_form_key;
+    std::stringstream inner_form_key;
+    outer_form_key << "node" << (form_key_id++);
+    inner_form_key << "node" << (form_key_id++);
 
-const BuilderPtr StringBuilder::endlist() {
-  throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
+    offsets_.concatenate(
+      reinterpret_cast<int64_t*>(
+        container.empty_buffer(outer_form_key.str() + "-offsets",
+        (int64_t)offsets_.length() * (int64_t)sizeof(int64_t))));
 
-const BuilderPtr StringBuilder::begintuple(int64_t numfields) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->begintuple(numfields);
-  return out;
-}
+    content_.concatenate(
+      reinterpret_cast<uint8_t*>(
+        container.empty_buffer(inner_form_key.str() + "-data",
+        (int64_t)content_.length() * (int64_t)sizeof(uint8_t))));
 
-const BuilderPtr StringBuilder::index(int64_t /* index */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'index' without 'begin_tuple' at the same level before it") +
-      FILENAME(__LINE__));
-}
+    std::string char_parameter;
+    std::string string_parameter;
+    if (encoding_ == nullptr) {
+      char_parameter = std::string("\"byte\"");
+      string_parameter = std::string("\"bytestring\"");
+    }
+    else if (std::string(encoding_) == std::string("utf-8")) {
+      char_parameter = std::string("\"char\"");
+      string_parameter = std::string("\"string\"");
+    }
+    else {
+      throw std::invalid_argument(
+        std::string("unsupported encoding: ") + util::quote(encoding_));
+    }
 
-const BuilderPtr StringBuilder::endtuple() {
-  throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
+    return std::string("{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", \"content\": ")
+           + "{\"class\": \"NumpyArray\", \"primitive\": \"uint8\", \"parameters\": {\"__array__\": "
+           + char_parameter + "}, \"form_key\": \"" + inner_form_key.str() + "\"}"
+           + ", \"parameters\": {\"__array__\": " + string_parameter + "}"
+           + ", \"form_key\": \"" + outer_form_key.str() + "\"}";
+  }
 
-const BuilderPtr StringBuilder::beginrecord(const char *name, bool check) {
-  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-  out.get()->beginrecord(name, check);
-  return out;
-}
+  int64_t
+  StringBuilder::length() const {
+    return (int64_t)offsets_.length() - 1;
+  }
 
-void StringBuilder::field(const char * /* key */, bool /* check */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'field' without 'begin_record' at the same level before it") +
-      FILENAME(__LINE__));
-}
+  void
+  StringBuilder::clear() {
+    offsets_.clear();
+    offsets_.append(0);
+    content_.clear();
+  }
 
-const BuilderPtr StringBuilder::endrecord() {
-  throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same "
-                  "level before it") +
-      FILENAME(__LINE__));
-}
+  bool
+  StringBuilder::active() const {
+    return false;
+  }
 
-} // namespace awkward
+  const BuilderPtr
+  StringBuilder::null() {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::boolean(bool x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::integer(int64_t x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::real(double x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::complex(std::complex<double> x) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::datetime(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::timedelta(int64_t x, const std::string& unit) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::string(const char* x, int64_t length, const char* /* encoding */) {
+    if (length < 0) {
+      for (int64_t i = 0;  x[i] != 0;  i++) {
+        content_.append((uint8_t)x[i]);
+      }
+    }
+    else {
+      for (int64_t i = 0;  i < length;  i++) {
+        content_.append((uint8_t)x[i]);
+      }
+    }
+    offsets_.append((int64_t)content_.length());
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  StringBuilder::beginlist() {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::endlist() {
+    throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  StringBuilder::begintuple(int64_t numfields) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  }
+
+  const BuilderPtr
+  StringBuilder::index(int64_t /* index */) {
+    throw std::invalid_argument(
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  StringBuilder::endtuple() {
+    throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  StringBuilder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  }
+
+  void
+  StringBuilder::field(const char* /* key */, bool /* check */) {
+    throw std::invalid_argument(
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  StringBuilder::endrecord() {
+    throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+}

--- a/src/libawkward/builder/StringBuilder.cpp
+++ b/src/libawkward/builder/StringBuilder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/StringBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/StringBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -11,212 +12,181 @@
 #include "awkward/builder/StringBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  StringBuilder::fromempty(const BuilderOptions& options,
-                           const char* encoding) {
-    GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
-    offsets.append(0);
-    GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
-    return std::make_shared<StringBuilder>(options,
-                                           std::move(offsets),
-                                           std::move(content),
-                                           encoding);
-  }
-
-  StringBuilder::StringBuilder(const BuilderOptions& options,
-                               GrowableBuffer<int64_t> offsets,
-                               GrowableBuffer<uint8_t> content,
-                               const char* encoding)
-      : options_(options)
-      , offsets_(std::move(offsets))
-      , content_(std::move(content))
-      , encoding_(encoding) { }
-
-  const std::string
-  StringBuilder::classname() const {
-    return "StringBuilder";
-  };
-
-  const char*
-  StringBuilder::encoding() const {
-    return encoding_;
-  }
-
-  const std::string
-  StringBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream outer_form_key;
-    std::stringstream inner_form_key;
-    outer_form_key << "node" << (form_key_id++);
-    inner_form_key << "node" << (form_key_id++);
-
-    offsets_.concatenate(
-      reinterpret_cast<int64_t*>(
-        container.empty_buffer(outer_form_key.str() + "-offsets",
-        (int64_t)offsets_.length() * (int64_t)sizeof(int64_t))));
-
-    content_.concatenate(
-      reinterpret_cast<uint8_t*>(
-        container.empty_buffer(inner_form_key.str() + "-data",
-        (int64_t)content_.length() * (int64_t)sizeof(uint8_t))));
-
-    std::string char_parameter;
-    std::string string_parameter;
-    if (encoding_ == nullptr) {
-      char_parameter = std::string("\"byte\"");
-      string_parameter = std::string("\"bytestring\"");
-    }
-    else if (std::string(encoding_) == std::string("utf-8")) {
-      char_parameter = std::string("\"char\"");
-      string_parameter = std::string("\"string\"");
-    }
-    else {
-      throw std::invalid_argument(
-        std::string("unsupported encoding: ") + util::quote(encoding_));
-    }
-
-    return std::string("{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", \"content\": ")
-           + "{\"class\": \"NumpyArray\", \"primitive\": \"uint8\", \"parameters\": {\"__array__\": "
-           + char_parameter + "}, \"form_key\": \"" + inner_form_key.str() + "\"}"
-           + ", \"parameters\": {\"__array__\": " + string_parameter + "}"
-           + ", \"form_key\": \"" + outer_form_key.str() + "\"}";
-  }
-
-  int64_t
-  StringBuilder::length() const {
-    return (int64_t)offsets_.length() - 1;
-  }
-
-  void
-  StringBuilder::clear() {
-    offsets_.clear();
-    offsets_.append(0);
-    content_.clear();
-  }
-
-  bool
-  StringBuilder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  StringBuilder::null() {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::boolean(bool x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::integer(int64_t x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::real(double x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::string(const char* x, int64_t length, const char* /* encoding */) {
-    if (length < 0) {
-      for (int64_t i = 0;  x[i] != 0;  i++) {
-        content_.append((uint8_t)x[i]);
-      }
-    }
-    else {
-      for (int64_t i = 0;  i < length;  i++) {
-        content_.append((uint8_t)x[i]);
-      }
-    }
-    offsets_.append((int64_t)content_.length());
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  StringBuilder::beginlist() {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  StringBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  StringBuilder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  StringBuilder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  StringBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  StringBuilder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  StringBuilder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr StringBuilder::fromempty(const BuilderOptions &options,
+                                          const char           *encoding) {
+  GrowableBuffer<int64_t> offsets = GrowableBuffer<int64_t>::empty(options);
+  offsets.append(0);
+  GrowableBuffer<uint8_t> content = GrowableBuffer<uint8_t>::empty(options);
+  return std::make_shared<StringBuilder>(options, std::move(offsets),
+                                         std::move(content), encoding);
 }
+
+StringBuilder::StringBuilder(const BuilderOptions   &options,
+                             GrowableBuffer<int64_t> offsets,
+                             GrowableBuffer<uint8_t> content,
+                             const char             *encoding)
+    : options_(options), offsets_(std::move(offsets)),
+      content_(std::move(content)), encoding_(encoding) {}
+
+const std::string StringBuilder::classname() const { return "StringBuilder"; };
+
+const char *StringBuilder::encoding() const { return encoding_; }
+
+const std::string StringBuilder::to_buffers(BuffersContainer &container,
+                                            int64_t &form_key_id) const {
+  std::stringstream outer_form_key;
+  std::stringstream inner_form_key;
+  outer_form_key << "node" << (form_key_id++);
+  inner_form_key << "node" << (form_key_id++);
+
+  offsets_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
+      outer_form_key.str() + "-offsets",
+      (int64_t)offsets_.length() * (int64_t)sizeof(int64_t))));
+
+  content_.concatenate(reinterpret_cast<uint8_t *>(container.empty_buffer(
+      inner_form_key.str() + "-data",
+      (int64_t)content_.length() * (int64_t)sizeof(uint8_t))));
+
+  std::string char_parameter;
+  std::string string_parameter;
+  if (encoding_ == nullptr) {
+    char_parameter = std::string("\"byte\"");
+    string_parameter = std::string("\"bytestring\"");
+  } else if (std::string(encoding_) == std::string("utf-8")) {
+    char_parameter = std::string("\"char\"");
+    string_parameter = std::string("\"string\"");
+  } else {
+    throw std::invalid_argument(std::string("unsupported encoding: ") +
+                                util::quote(encoding_));
+  }
+
+  return std::string("{\"class\": \"ListOffsetArray\", \"offsets\": \"i64\", "
+                     "\"content\": ") +
+         "{\"class\": \"NumpyArray\", \"primitive\": \"uint8\", "
+         "\"parameters\": {\"__array__\": " +
+         char_parameter + "}, \"form_key\": \"" + inner_form_key.str() + "\"}" +
+         ", \"parameters\": {\"__array__\": " + string_parameter + "}" +
+         ", \"form_key\": \"" + outer_form_key.str() + "\"}";
+}
+
+int64_t StringBuilder::length() const { return (int64_t)offsets_.length() - 1; }
+
+void StringBuilder::clear() {
+  offsets_.clear();
+  offsets_.append(0);
+  content_.clear();
+}
+
+bool StringBuilder::active() const { return false; }
+
+const BuilderPtr StringBuilder::null() {
+  BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+  out.get()->null();
+  return out;
+}
+
+const BuilderPtr StringBuilder::boolean(bool x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr StringBuilder::integer(int64_t x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->integer(x);
+  return out;
+}
+
+const BuilderPtr StringBuilder::real(double x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr StringBuilder::complex(std::complex<double> x) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr StringBuilder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr StringBuilder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr StringBuilder::string(const char *x, int64_t length,
+                                       const char * /* encoding */) {
+  if (length < 0) {
+    for (int64_t i = 0; x[i] != 0; i++) {
+      content_.append((uint8_t)x[i]);
+    }
+  } else {
+    for (int64_t i = 0; i < length; i++) {
+      content_.append((uint8_t)x[i]);
+    }
+  }
+  offsets_.append((int64_t)content_.length());
+  return shared_from_this();
+}
+
+const BuilderPtr StringBuilder::beginlist() {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr StringBuilder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr StringBuilder::begintuple(int64_t numfields) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr StringBuilder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr StringBuilder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr StringBuilder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void StringBuilder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr StringBuilder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -1,6 +1,8 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/TupleBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/TupleBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -11,436 +13,365 @@
 #include "awkward/builder/TupleBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  TupleBuilder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<TupleBuilder>(options,
-                                          std::vector<BuilderPtr>(),
-                                          -1,
-                                          false,
-                                          -1);
-  }
+const BuilderPtr TupleBuilder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<TupleBuilder>(options, std::vector<BuilderPtr>(), -1,
+                                        false, -1);
+}
 
-  TupleBuilder::TupleBuilder(const BuilderOptions& options,
-                             const std::vector<BuilderPtr>& contents,
-                             int64_t length,
-                             bool begun,
-                             size_t nextindex)
-      : options_(options)
-      , contents_(contents)
-      , length_(length)
-      , begun_(begun)
-      , nextindex_((int64_t)nextindex) { }
+TupleBuilder::TupleBuilder(const BuilderOptions &options,
+                           const std::vector<BuilderPtr> &contents,
+                           int64_t length, bool begun, size_t nextindex)
+    : options_(options), contents_(contents), length_(length), begun_(begun),
+      nextindex_((int64_t)nextindex) {}
 
-  int64_t
-  TupleBuilder::numfields() const {
-    return (int64_t)contents_.size();
-  }
+int64_t TupleBuilder::numfields() const { return (int64_t)contents_.size(); }
 
-  const std::string
-  TupleBuilder::classname() const {
-    return "TupleBuilder";
-  };
+const std::string TupleBuilder::classname() const { return "TupleBuilder"; };
 
-  const std::string
-  TupleBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
+const std::string TupleBuilder::to_buffers(BuffersContainer &container,
+                                           int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
 
-    std::stringstream out;
-    out << "{\"class\": \"RecordArray\", \"contents\": [";
-    for (size_t i = 0;  i < contents_.size();  i++) {
-      if (i != 0) {
-        out << ", ";
-      }
-      out << contents_[i].get()->to_buffers(container, form_key_id);
+  std::stringstream out;
+  out << "{\"class\": \"RecordArray\", \"contents\": [";
+  for (size_t i = 0; i < contents_.size(); i++) {
+    if (i != 0) {
+      out << ", ";
     }
-    out << "], " << "\"form_key\": \"" + form_key.str() + "\"}";
-    return out.str();
+    out << contents_[i].get()->to_buffers(container, form_key_id);
   }
+  out << "], "
+      << "\"form_key\": \"" + form_key.str() + "\"}";
+  return out.str();
+}
 
-  int64_t
-  TupleBuilder::length() const {
-    return length_;
+int64_t TupleBuilder::length() const { return length_; }
+
+void TupleBuilder::clear() {
+  for (auto x : contents_) {
+    x.get()->clear();
   }
+  length_ = -1;
+  begun_ = false;
+  nextindex_ = -1;
+}
 
-  void
-  TupleBuilder::clear() {
-    for (auto x : contents_) {
-      x.get()->clear();
-    }
-    length_ = -1;
-    begun_ = false;
-    nextindex_ = -1;
-  }
+bool TupleBuilder::active() const { return begun_; }
 
-  bool
-  TupleBuilder::active() const {
-    return begun_;
-  }
-
-  const BuilderPtr
-  TupleBuilder::null() {
-    if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-      out.get()->null();
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::null() {
+  if (!begun_) {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'null' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->null();
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
+  } else {
+    contents_[(size_t)nextindex_].get()->null();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::boolean(bool x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->boolean(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::boolean(bool x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'boolean' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->boolean(x);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->boolean(x);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::integer(int64_t x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->integer(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::integer(int64_t x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'integer' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->integer(x);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->integer(x);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::real(double x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->real(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::real(double x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'real' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->real(x);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->real(x);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::complex(std::complex<double> x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->complex(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::complex(std::complex<double> x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'complex' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->complex(x);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->complex(x);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::datetime(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->datetime(x, unit);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::datetime(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'datetime' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->datetime(x, unit));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->datetime(x, unit);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->datetime(x, unit));
+  } else {
+    contents_[(size_t)nextindex_].get()->datetime(x, unit);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->timedelta(x, unit);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'timedelta' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->timedelta(x, unit));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->timedelta(x, unit);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->timedelta(x, unit));
+  } else {
+    contents_[(size_t)nextindex_].get()->timedelta(x, unit);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->string(x, length, encoding);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::string(const char *x, int64_t length,
+                                      const char *encoding) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'string' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->string(x,
-                                                              length,
-                                                              encoding));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->string(x, length, encoding);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->string(
+                                x, length, encoding));
+  } else {
+    contents_[(size_t)nextindex_].get()->string(x, length, encoding);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::beginlist() {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginlist();
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::beginlist() {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_list' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginlist());
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->beginlist();
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
+  } else {
+    contents_[(size_t)nextindex_].get()->beginlist();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::endlist() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::endlist() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'end_list' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_list'")
-        + FILENAME(__LINE__));
+                    "needs 'index' or 'end_tuple' and then 'begin_list'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->endlist();
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr TupleBuilder::begintuple(int64_t numfields) {
+  if (length_ == -1) {
+    for (int64_t i = 0; i < numfields; i++) {
+      contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
     }
-    else {
-      contents_[(size_t)nextindex_].get()->endlist();
-    }
-    return shared_from_this();
+    length_ = 0;
   }
 
-  const BuilderPtr
-  TupleBuilder::begintuple(int64_t numfields) {
-    if (length_ == -1) {
-      for (int64_t i = 0;  i < numfields;  i++) {
-        contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
-      }
-      length_ = 0;
-    }
-
-    if (!begun_  &&  numfields == (int64_t)contents_.size()) {
-      begun_ = true;
-      nextindex_ = -1;
-    }
-    else if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->begintuple(numfields);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+  if (!begun_ && numfields == (int64_t)contents_.size()) {
+    begun_ = true;
+    nextindex_ = -1;
+  } else if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_tuple' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'")
-        + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->begintuple(numfields));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->begintuple(numfields);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->begintuple(numfields));
+  } else {
+    contents_[(size_t)nextindex_].get()->begintuple(numfields);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::index(int64_t index) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (index >= (int64_t)contents_.size()) {
-      throw std::invalid_argument(
-        std::string("'index' ")
-        + std::to_string(index)
-        + (" is out of bounds for a tuple with number of fields ")
-        + std::to_string(contents_.size())
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
+const BuilderPtr TupleBuilder::index(int64_t index) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (index >= (int64_t)contents_.size()) {
+    throw std::invalid_argument(
+        std::string("'index' ") + std::to_string(index) +
+        (" is out of bounds for a tuple with number of fields ") +
+        std::to_string(contents_.size()) + FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
              !contents_[(size_t)nextindex_].get()->active()) {
-      nextindex_ = index;
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->index(index);
-    }
-    return shared_from_this();
+    nextindex_ = index;
+  } else {
+    contents_[(size_t)nextindex_].get()->index(index);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::endtuple() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
+const BuilderPtr TupleBuilder::endtuple() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
              !contents_[(size_t)nextindex_].get()->active()) {
-      for (size_t i = 0;  i < contents_.size();  i++) {
-        if (contents_[i].get()->length() == length_) {
-          maybeupdate((int64_t)i, contents_[i].get()->null());
-        }
-        if (contents_[i].get()->length() != length_ + 1) {
-          throw std::invalid_argument(
-            std::string("tuple index ") + std::to_string(i)
-            + std::string(" filled more than once") + FILENAME(__LINE__));
-        }
+    for (size_t i = 0; i < contents_.size(); i++) {
+      if (contents_[i].get()->length() == length_) {
+        maybeupdate((int64_t)i, contents_[i].get()->null());
       }
-      length_++;
-      begun_ = false;
+      if (contents_[i].get()->length() != length_ + 1) {
+        throw std::invalid_argument(
+            std::string("tuple index ") + std::to_string(i) +
+            std::string(" filled more than once") + FILENAME(__LINE__));
+      }
     }
-    else {
-      contents_[(size_t)nextindex_].get()->endtuple();
-    }
-    return shared_from_this();
+    length_++;
+    begun_ = false;
+  } else {
+    contents_[(size_t)nextindex_].get()->endtuple();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::beginrecord(const char* name, bool check) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginrecord(name, check);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::beginrecord(const char *name, bool check) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_record' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginrecord(name, check)
-                  );
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->beginrecord(name, check);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->beginrecord(name, check));
+  } else {
+    contents_[(size_t)nextindex_].get()->beginrecord(name, check);
   }
+  return shared_from_this();
+}
 
-  void
-  TupleBuilder::field(const char* key, bool check) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'field_fast' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+void TupleBuilder::field(const char *key, bool check) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'field_fast' without 'begin_record' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'field_fast' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_record'")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->field(key, check);
-    }
-  }
-
-  const BuilderPtr
-  TupleBuilder::endrecord() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_record'")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->endrecord();
-    }
-    return shared_from_this();
-  }
-
-  void
-  TupleBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != contents_[(size_t)i].get()) {
-      contents_[(size_t)i] = std::move(tmp);
-    }
+                    "needs 'index' or 'end_tuple' and then 'begin_record'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->field(key, check);
   }
 }
+
+const BuilderPtr TupleBuilder::endrecord() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_record' without 'begin_record' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'end_record' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple' and then 'begin_record'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->endrecord();
+  }
+  return shared_from_this();
+}
+
+void TupleBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
+  if (tmp && tmp.get() != contents_[(size_t)i].get()) {
+    contents_[(size_t)i] = std::move(tmp);
+  }
+}
+} // namespace awkward

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -1,8 +1,6 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/TupleBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/TupleBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -13,365 +11,436 @@
 #include "awkward/builder/TupleBuilder.h"
 
 namespace awkward {
-const BuilderPtr TupleBuilder::fromempty(const BuilderOptions &options) {
-  return std::make_shared<TupleBuilder>(options, std::vector<BuilderPtr>(), -1,
-                                        false, -1);
-}
-
-TupleBuilder::TupleBuilder(const BuilderOptions &options,
-                           const std::vector<BuilderPtr> &contents,
-                           int64_t length, bool begun, size_t nextindex)
-    : options_(options), contents_(contents), length_(length), begun_(begun),
-      nextindex_((int64_t)nextindex) {}
-
-int64_t TupleBuilder::numfields() const { return (int64_t)contents_.size(); }
-
-const std::string TupleBuilder::classname() const { return "TupleBuilder"; };
-
-const std::string TupleBuilder::to_buffers(BuffersContainer &container,
-                                           int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
-
-  std::stringstream out;
-  out << "{\"class\": \"RecordArray\", \"contents\": [";
-  for (size_t i = 0; i < contents_.size(); i++) {
-    if (i != 0) {
-      out << ", ";
-    }
-    out << contents_[i].get()->to_buffers(container, form_key_id);
-  }
-  out << "], "
-      << "\"form_key\": \"" + form_key.str() + "\"}";
-  return out.str();
-}
-
-int64_t TupleBuilder::length() const { return length_; }
-
-void TupleBuilder::clear() {
-  for (auto x : contents_) {
-    x.get()->clear();
-  }
-  length_ = -1;
-  begun_ = false;
-  nextindex_ = -1;
-}
-
-bool TupleBuilder::active() const { return begun_; }
-
-const BuilderPtr TupleBuilder::null() {
-  if (!begun_) {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'null' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
-  } else {
-    contents_[(size_t)nextindex_].get()->null();
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::boolean(bool x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->boolean(x);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'boolean' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
-  } else {
-    contents_[(size_t)nextindex_].get()->boolean(x);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::integer(int64_t x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->integer(x);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'integer' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
-  } else {
-    contents_[(size_t)nextindex_].get()->integer(x);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::real(double x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->real(x);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'real' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
-  } else {
-    contents_[(size_t)nextindex_].get()->real(x);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::complex(std::complex<double> x) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->complex(x);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'complex' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
-  } else {
-    contents_[(size_t)nextindex_].get()->complex(x);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::datetime(int64_t x, const std::string &unit) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->datetime(x, unit);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'datetime' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_,
-                contents_[(size_t)nextindex_].get()->datetime(x, unit));
-  } else {
-    contents_[(size_t)nextindex_].get()->datetime(x, unit);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::timedelta(int64_t x, const std::string &unit) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->timedelta(x, unit);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'timedelta' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_,
-                contents_[(size_t)nextindex_].get()->timedelta(x, unit));
-  } else {
-    contents_[(size_t)nextindex_].get()->timedelta(x, unit);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::string(const char *x, int64_t length,
-                                      const char *encoding) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->string(x, length, encoding);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'string' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->string(
-                                x, length, encoding));
-  } else {
-    contents_[(size_t)nextindex_].get()->string(x, length, encoding);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::beginlist() {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginlist();
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'begin_list' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
-  } else {
-    contents_[(size_t)nextindex_].get()->beginlist();
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::endlist() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'end_list' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_list'") +
-        FILENAME(__LINE__));
-  } else {
-    contents_[(size_t)nextindex_].get()->endlist();
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr TupleBuilder::begintuple(int64_t numfields) {
-  if (length_ == -1) {
-    for (int64_t i = 0; i < numfields; i++) {
-      contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
-    }
-    length_ = 0;
+  const BuilderPtr
+  TupleBuilder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<TupleBuilder>(options,
+                                          std::vector<BuilderPtr>(),
+                                          -1,
+                                          false,
+                                          -1);
   }
 
-  if (!begun_ && numfields == (int64_t)contents_.size()) {
-    begun_ = true;
-    nextindex_ = -1;
-  } else if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->begintuple(numfields);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'begin_tuple' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_,
-                contents_[(size_t)nextindex_].get()->begintuple(numfields));
-  } else {
-    contents_[(size_t)nextindex_].get()->begintuple(numfields);
-  }
-  return shared_from_this();
-}
+  TupleBuilder::TupleBuilder(const BuilderOptions& options,
+                             const std::vector<BuilderPtr>& contents,
+                             int64_t length,
+                             bool begun,
+                             size_t nextindex)
+      : options_(options)
+      , contents_(contents)
+      , length_(length)
+      , begun_(begun)
+      , nextindex_((int64_t)nextindex) { }
 
-const BuilderPtr TupleBuilder::index(int64_t index) {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else if (index >= (int64_t)contents_.size()) {
-    throw std::invalid_argument(
-        std::string("'index' ") + std::to_string(index) +
-        (" is out of bounds for a tuple with number of fields ") +
-        std::to_string(contents_.size()) + FILENAME(__LINE__));
-  } else if (nextindex_ == -1 ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-    nextindex_ = index;
-  } else {
-    contents_[(size_t)nextindex_].get()->index(index);
+  int64_t
+  TupleBuilder::numfields() const {
+    return (int64_t)contents_.size();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr TupleBuilder::endtuple() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same "
-                    "level before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1 ||
-             !contents_[(size_t)nextindex_].get()->active()) {
-    for (size_t i = 0; i < contents_.size(); i++) {
-      if (contents_[i].get()->length() == length_) {
-        maybeupdate((int64_t)i, contents_[i].get()->null());
+  const std::string
+  TupleBuilder::classname() const {
+    return "TupleBuilder";
+  };
+
+  const std::string
+  TupleBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    std::stringstream out;
+    out << "{\"class\": \"RecordArray\", \"contents\": [";
+    for (size_t i = 0;  i < contents_.size();  i++) {
+      if (i != 0) {
+        out << ", ";
       }
-      if (contents_[i].get()->length() != length_ + 1) {
-        throw std::invalid_argument(
-            std::string("tuple index ") + std::to_string(i) +
-            std::string(" filled more than once") + FILENAME(__LINE__));
-      }
+      out << contents_[i].get()->to_buffers(container, form_key_id);
     }
-    length_++;
+    out << "], " << "\"form_key\": \"" + form_key.str() + "\"}";
+    return out.str();
+  }
+
+  int64_t
+  TupleBuilder::length() const {
+    return length_;
+  }
+
+  void
+  TupleBuilder::clear() {
+    for (auto x : contents_) {
+      x.get()->clear();
+    }
+    length_ = -1;
     begun_ = false;
-  } else {
-    contents_[(size_t)nextindex_].get()->endtuple();
+    nextindex_ = -1;
   }
-  return shared_from_this();
-}
 
-const BuilderPtr TupleBuilder::beginrecord(const char *name, bool check) {
-  if (!begun_) {
-    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-    out.get()->beginrecord(name, check);
-    return out;
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
+  bool
+  TupleBuilder::active() const {
+    return begun_;
+  }
+
+  const BuilderPtr
+  TupleBuilder::null() {
+    if (!begun_) {
+      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+      out.get()->null();
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'null' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->null();
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::boolean(bool x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->boolean(x);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'boolean' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->boolean(x);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::integer(int64_t x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->integer(x);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'integer' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->integer(x);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::real(double x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->real(x);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'real' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->real(x);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::complex(std::complex<double> x) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->complex(x);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'complex' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->complex(x);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::datetime(int64_t x, const std::string& unit) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->datetime(x, unit);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'datetime' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->datetime(x, unit));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->datetime(x, unit);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::timedelta(int64_t x, const std::string& unit) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->timedelta(x, unit);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'timedelta' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->timedelta(x, unit));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->timedelta(x, unit);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::string(const char* x, int64_t length, const char* encoding) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->string(x, length, encoding);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'string' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->string(x,
+                                                              length,
+                                                              encoding));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->string(x, length, encoding);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::beginlist() {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->beginlist();
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'begin_list' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->beginlist());
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->beginlist();
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::endlist() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'end_list' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple' and then 'begin_list'")
+        + FILENAME(__LINE__));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->endlist();
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::begintuple(int64_t numfields) {
+    if (length_ == -1) {
+      for (int64_t i = 0;  i < numfields;  i++) {
+        contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
+      }
+      length_ = 0;
+    }
+
+    if (!begun_  &&  numfields == (int64_t)contents_.size()) {
+      begun_ = true;
+      nextindex_ = -1;
+    }
+    else if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->begintuple(numfields);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'begin_tuple' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple'")
+        + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->begintuple(numfields));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->begintuple(numfields);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::index(int64_t index) {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (index >= (int64_t)contents_.size()) {
+      throw std::invalid_argument(
+        std::string("'index' ")
+        + std::to_string(index)
+        + (" is out of bounds for a tuple with number of fields ")
+        + std::to_string(contents_.size())
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+      nextindex_ = index;
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->index(index);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::endtuple() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1  ||
+             !contents_[(size_t)nextindex_].get()->active()) {
+      for (size_t i = 0;  i < contents_.size();  i++) {
+        if (contents_[i].get()->length() == length_) {
+          maybeupdate((int64_t)i, contents_[i].get()->null());
+        }
+        if (contents_[i].get()->length() != length_ + 1) {
+          throw std::invalid_argument(
+            std::string("tuple index ") + std::to_string(i)
+            + std::string(" filled more than once") + FILENAME(__LINE__));
+        }
+      }
+      length_++;
+      begun_ = false;
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->endtuple();
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  TupleBuilder::beginrecord(const char* name, bool check) {
+    if (!begun_) {
+      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+      out.get()->beginrecord(name, check);
+      return out;
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
         std::string("called 'begin_record' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") +
-        FILENAME(__LINE__));
-  } else if (!contents_[(size_t)nextindex_].get()->active()) {
-    maybeupdate(nextindex_,
-                contents_[(size_t)nextindex_].get()->beginrecord(name, check));
-  } else {
-    contents_[(size_t)nextindex_].get()->beginrecord(name, check);
+                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
+    }
+    else if (!contents_[(size_t)nextindex_].get()->active()) {
+      maybeupdate(nextindex_,
+                  contents_[(size_t)nextindex_].get()->beginrecord(name, check)
+                  );
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->beginrecord(name, check);
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-void TupleBuilder::field(const char *key, bool check) {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'field_fast' without 'begin_record' at the same "
-                    "level before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
+  void
+  TupleBuilder::field(const char* key, bool check) {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'field_fast' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
         std::string("called 'field_fast' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_record'") +
-        FILENAME(__LINE__));
-  } else {
-    contents_[(size_t)nextindex_].get()->field(key, check);
+                    "needs 'index' or 'end_tuple' and then 'begin_record'")
+        + FILENAME(__LINE__));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->field(key, check);
+    }
   }
-}
 
-const BuilderPtr TupleBuilder::endrecord() {
-  if (!begun_) {
-    throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same "
-                    "level before it") +
-        FILENAME(__LINE__));
-  } else if (nextindex_ == -1) {
-    throw std::invalid_argument(
+  const BuilderPtr
+  TupleBuilder::endrecord() {
+    if (!begun_) {
+      throw std::invalid_argument(
+        std::string("called 'end_record' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else if (nextindex_ == -1) {
+      throw std::invalid_argument(
         std::string("called 'end_record' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_record'") +
-        FILENAME(__LINE__));
-  } else {
-    contents_[(size_t)nextindex_].get()->endrecord();
+                    "needs 'index' or 'end_tuple' and then 'begin_record'")
+        + FILENAME(__LINE__));
+    }
+    else {
+      contents_[(size_t)nextindex_].get()->endrecord();
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-void TupleBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
-  if (tmp && tmp.get() != contents_[(size_t)i].get()) {
-    contents_[(size_t)i] = std::move(tmp);
+  void
+  TupleBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
+    if (tmp  &&  tmp.get() != contents_[(size_t)i].get()) {
+      contents_[(size_t)i] = std::move(tmp);
+    }
   }
 }
-} // namespace awkward

--- a/src/libawkward/builder/TupleBuilder.cpp
+++ b/src/libawkward/builder/TupleBuilder.cpp
@@ -1,6 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/TupleBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/TupleBuilder.cpp", line)
 
 #include <stdexcept>
 
@@ -11,436 +12,365 @@
 #include "awkward/builder/TupleBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  TupleBuilder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<TupleBuilder>(options,
-                                          std::vector<BuilderPtr>(),
-                                          -1,
-                                          false,
-                                          -1);
-  }
+const BuilderPtr TupleBuilder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<TupleBuilder>(options, std::vector<BuilderPtr>(), -1,
+                                        false, -1);
+}
 
-  TupleBuilder::TupleBuilder(const BuilderOptions& options,
-                             const std::vector<BuilderPtr>& contents,
-                             int64_t length,
-                             bool begun,
-                             size_t nextindex)
-      : options_(options)
-      , contents_(contents)
-      , length_(length)
-      , begun_(begun)
-      , nextindex_((int64_t)nextindex) { }
+TupleBuilder::TupleBuilder(const BuilderOptions          &options,
+                           const std::vector<BuilderPtr> &contents,
+                           int64_t length, bool begun, size_t nextindex)
+    : options_(options), contents_(contents), length_(length), begun_(begun),
+      nextindex_((int64_t)nextindex) {}
 
-  int64_t
-  TupleBuilder::numfields() const {
-    return (int64_t)contents_.size();
-  }
+int64_t TupleBuilder::numfields() const { return (int64_t)contents_.size(); }
 
-  const std::string
-  TupleBuilder::classname() const {
-    return "TupleBuilder";
-  };
+const std::string TupleBuilder::classname() const { return "TupleBuilder"; };
 
-  const std::string
-  TupleBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
+const std::string TupleBuilder::to_buffers(BuffersContainer &container,
+                                           int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
 
-    std::stringstream out;
-    out << "{\"class\": \"RecordArray\", \"contents\": [";
-    for (size_t i = 0;  i < contents_.size();  i++) {
-      if (i != 0) {
-        out << ", ";
-      }
-      out << contents_[i].get()->to_buffers(container, form_key_id);
+  std::stringstream out;
+  out << "{\"class\": \"RecordArray\", \"contents\": [";
+  for (size_t i = 0; i < contents_.size(); i++) {
+    if (i != 0) {
+      out << ", ";
     }
-    out << "], " << "\"form_key\": \"" + form_key.str() + "\"}";
-    return out.str();
+    out << contents_[i].get()->to_buffers(container, form_key_id);
   }
+  out << "], "
+      << "\"form_key\": \"" + form_key.str() + "\"}";
+  return out.str();
+}
 
-  int64_t
-  TupleBuilder::length() const {
-    return length_;
+int64_t TupleBuilder::length() const { return length_; }
+
+void TupleBuilder::clear() {
+  for (auto x : contents_) {
+    x.get()->clear();
   }
+  length_ = -1;
+  begun_ = false;
+  nextindex_ = -1;
+}
 
-  void
-  TupleBuilder::clear() {
-    for (auto x : contents_) {
-      x.get()->clear();
-    }
-    length_ = -1;
-    begun_ = false;
-    nextindex_ = -1;
-  }
+bool TupleBuilder::active() const { return begun_; }
 
-  bool
-  TupleBuilder::active() const {
-    return begun_;
-  }
-
-  const BuilderPtr
-  TupleBuilder::null() {
-    if (!begun_) {
-      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-      out.get()->null();
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::null() {
+  if (!begun_) {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'null' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->null();
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->null());
+  } else {
+    contents_[(size_t)nextindex_].get()->null();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::boolean(bool x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->boolean(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::boolean(bool x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->boolean(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'boolean' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->boolean(x);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->boolean(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->boolean(x);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::integer(int64_t x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->integer(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::integer(int64_t x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->integer(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'integer' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->integer(x);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->integer(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->integer(x);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::real(double x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->real(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::real(double x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->real(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'real' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->real(x);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->real(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->real(x);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::complex(std::complex<double> x) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->complex(x);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::complex(std::complex<double> x) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->complex(x);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'complex' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->complex(x);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->complex(x));
+  } else {
+    contents_[(size_t)nextindex_].get()->complex(x);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::datetime(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->datetime(x, unit);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::datetime(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->datetime(x, unit);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'datetime' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->datetime(x, unit));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->datetime(x, unit);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->datetime(x, unit));
+  } else {
+    contents_[(size_t)nextindex_].get()->datetime(x, unit);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->timedelta(x, unit);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->timedelta(x, unit);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'timedelta' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->timedelta(x, unit));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->timedelta(x, unit);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->timedelta(x, unit));
+  } else {
+    contents_[(size_t)nextindex_].get()->timedelta(x, unit);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->string(x, length, encoding);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::string(const char *x, int64_t length,
+                                      const char *encoding) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->string(x, length, encoding);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'string' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->string(x,
-                                                              length,
-                                                              encoding));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->string(x, length, encoding);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->string(
+                                x, length, encoding));
+  } else {
+    contents_[(size_t)nextindex_].get()->string(x, length, encoding);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::beginlist() {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginlist();
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::beginlist() {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginlist();
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_list' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginlist());
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->beginlist();
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_, contents_[(size_t)nextindex_].get()->beginlist());
+  } else {
+    contents_[(size_t)nextindex_].get()->beginlist();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::endlist() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::endlist() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'end_list' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_list'")
-        + FILENAME(__LINE__));
+                    "needs 'index' or 'end_tuple' and then 'begin_list'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->endlist();
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr TupleBuilder::begintuple(int64_t numfields) {
+  if (length_ == -1) {
+    for (int64_t i = 0; i < numfields; i++) {
+      contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
     }
-    else {
-      contents_[(size_t)nextindex_].get()->endlist();
-    }
-    return shared_from_this();
+    length_ = 0;
   }
 
-  const BuilderPtr
-  TupleBuilder::begintuple(int64_t numfields) {
-    if (length_ == -1) {
-      for (int64_t i = 0;  i < numfields;  i++) {
-        contents_.push_back(BuilderPtr(UnknownBuilder::fromempty(options_)));
-      }
-      length_ = 0;
-    }
-
-    if (!begun_  &&  numfields == (int64_t)contents_.size()) {
-      begun_ = true;
-      nextindex_ = -1;
-    }
-    else if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->begintuple(numfields);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+  if (!begun_ && numfields == (int64_t)contents_.size()) {
+    begun_ = true;
+    nextindex_ = -1;
+  } else if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->begintuple(numfields);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_tuple' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'")
-        + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->begintuple(numfields));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->begintuple(numfields);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->begintuple(numfields));
+  } else {
+    contents_[(size_t)nextindex_].get()->begintuple(numfields);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::index(int64_t index) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (index >= (int64_t)contents_.size()) {
-      throw std::invalid_argument(
-        std::string("'index' ")
-        + std::to_string(index)
-        + (" is out of bounds for a tuple with number of fields ")
-        + std::to_string(contents_.size())
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
+const BuilderPtr TupleBuilder::index(int64_t index) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else if (index >= (int64_t)contents_.size()) {
+    throw std::invalid_argument(
+        std::string("'index' ") + std::to_string(index) +
+        (" is out of bounds for a tuple with number of fields ") +
+        std::to_string(contents_.size()) + FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
              !contents_[(size_t)nextindex_].get()->active()) {
-      nextindex_ = index;
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->index(index);
-    }
-    return shared_from_this();
+    nextindex_ = index;
+  } else {
+    contents_[(size_t)nextindex_].get()->index(index);
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::endtuple() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1  ||
+const BuilderPtr TupleBuilder::endtuple() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1 ||
              !contents_[(size_t)nextindex_].get()->active()) {
-      for (size_t i = 0;  i < contents_.size();  i++) {
-        if (contents_[i].get()->length() == length_) {
-          maybeupdate((int64_t)i, contents_[i].get()->null());
-        }
-        if (contents_[i].get()->length() != length_ + 1) {
-          throw std::invalid_argument(
-            std::string("tuple index ") + std::to_string(i)
-            + std::string(" filled more than once") + FILENAME(__LINE__));
-        }
+    for (size_t i = 0; i < contents_.size(); i++) {
+      if (contents_[i].get()->length() == length_) {
+        maybeupdate((int64_t)i, contents_[i].get()->null());
       }
-      length_++;
-      begun_ = false;
+      if (contents_[i].get()->length() != length_ + 1) {
+        throw std::invalid_argument(
+            std::string("tuple index ") + std::to_string(i) +
+            std::string(" filled more than once") + FILENAME(__LINE__));
+      }
     }
-    else {
-      contents_[(size_t)nextindex_].get()->endtuple();
-    }
-    return shared_from_this();
+    length_++;
+    begun_ = false;
+  } else {
+    contents_[(size_t)nextindex_].get()->endtuple();
   }
+  return shared_from_this();
+}
 
-  const BuilderPtr
-  TupleBuilder::beginrecord(const char* name, bool check) {
-    if (!begun_) {
-      BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
-      out.get()->beginrecord(name, check);
-      return out;
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+const BuilderPtr TupleBuilder::beginrecord(const char *name, bool check) {
+  if (!begun_) {
+    BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());
+    out.get()->beginrecord(name, check);
+    return out;
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'begin_record' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple'") + FILENAME(__LINE__));
-    }
-    else if (!contents_[(size_t)nextindex_].get()->active()) {
-      maybeupdate(nextindex_,
-                  contents_[(size_t)nextindex_].get()->beginrecord(name, check)
-                  );
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->beginrecord(name, check);
-    }
-    return shared_from_this();
+                    "needs 'index' or 'end_tuple'") +
+        FILENAME(__LINE__));
+  } else if (!contents_[(size_t)nextindex_].get()->active()) {
+    maybeupdate(nextindex_,
+                contents_[(size_t)nextindex_].get()->beginrecord(name, check));
+  } else {
+    contents_[(size_t)nextindex_].get()->beginrecord(name, check);
   }
+  return shared_from_this();
+}
 
-  void
-  TupleBuilder::field(const char* key, bool check) {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'field_fast' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
+void TupleBuilder::field(const char *key, bool check) {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'field_fast' without 'begin_record' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
         std::string("called 'field_fast' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_record'")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->field(key, check);
-    }
-  }
-
-  const BuilderPtr
-  TupleBuilder::endrecord() {
-    if (!begun_) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else if (nextindex_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' immediately after 'begin_tuple'; "
-                    "needs 'index' or 'end_tuple' and then 'begin_record'")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)nextindex_].get()->endrecord();
-    }
-    return shared_from_this();
-  }
-
-  void
-  TupleBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
-    if (tmp  &&  tmp.get() != contents_[(size_t)i].get()) {
-      contents_[(size_t)i] = std::move(tmp);
-    }
+                    "needs 'index' or 'end_tuple' and then 'begin_record'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->field(key, check);
   }
 }
+
+const BuilderPtr TupleBuilder::endrecord() {
+  if (!begun_) {
+    throw std::invalid_argument(
+        std::string("called 'end_record' without 'begin_record' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else if (nextindex_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'end_record' immediately after 'begin_tuple'; "
+                    "needs 'index' or 'end_tuple' and then 'begin_record'") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)nextindex_].get()->endrecord();
+  }
+  return shared_from_this();
+}
+
+void TupleBuilder::maybeupdate(int64_t i, const BuilderPtr tmp) {
+  if (tmp && tmp.get() != contents_[(size_t)i].get()) {
+    contents_[(size_t)i] = std::move(tmp);
+  }
+}
+} // namespace awkward

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -1,435 +1,409 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnionBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnionBuilder.cpp", line)
 
 #include <stdexcept>
 
-#include "awkward/builder/OptionBuilder.h"
 #include "awkward/builder/BoolBuilder.h"
-#include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/builder/Int64Builder.h"
-#include "awkward/builder/Float64Builder.h"
-#include "awkward/builder/StringBuilder.h"
-#include "awkward/builder/ListBuilder.h"
-#include "awkward/builder/TupleBuilder.h"
-#include "awkward/builder/RecordBuilder.h"
 #include "awkward/builder/Complex128Builder.h"
+#include "awkward/builder/DatetimeBuilder.h"
+#include "awkward/builder/Float64Builder.h"
+#include "awkward/builder/Int64Builder.h"
+#include "awkward/builder/ListBuilder.h"
+#include "awkward/builder/OptionBuilder.h"
+#include "awkward/builder/RecordBuilder.h"
+#include "awkward/builder/StringBuilder.h"
+#include "awkward/builder/TupleBuilder.h"
 
 #include "awkward/builder/UnionBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  UnionBuilder::fromsingle(const BuilderOptions& options,
-                           const BuilderPtr& firstcontent) {
-    std::vector<BuilderPtr> contents({ firstcontent });
-    return std::make_shared<UnionBuilder>(options,
-                                          GrowableBuffer<int8_t>::full(options, 0, firstcontent->length()),
-                                          GrowableBuffer<int64_t>::arange(options, firstcontent->length()),
-                                          contents);
-  }
-
-  UnionBuilder::UnionBuilder(const BuilderOptions& options,
-                             GrowableBuffer<int8_t> tags,
-                             GrowableBuffer<int64_t> index,
-                             std::vector<BuilderPtr>& contents)
-      : options_(options)
-      , tags_(std::move(tags))
-      , index_(std::move(index))
-      , contents_(contents)
-      , current_(-1) { }
-
-  const std::string
-  UnionBuilder::classname() const {
-    return "UnionBuilder";
-  };
-
-  const std::string
-  UnionBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    tags_.concatenate(
-      reinterpret_cast<int8_t*>(
-        container.empty_buffer(form_key.str() + "-tags",
-        (int64_t)tags_.length() * (int64_t)sizeof(int8_t))));
-
-    index_.concatenate(
-      reinterpret_cast<int64_t*>(
-        container.empty_buffer(form_key.str() + "-index",
-        (int64_t)index_.length() * (int64_t)sizeof(int64_t))));
-
-    std::stringstream out;
-    out << "{\"class\": \"UnionArray\", \"tags\": \"i8\", \"index\": \"i64\", \"contents\": [";
-    for (size_t i = 0;  i < contents_.size();  i++) {
-      if (i != 0) {
-        out << ", ";
-      }
-      out << contents_[i].get()->to_buffers(container, form_key_id);
-    }
-    out << "], \"form_key\": \"" << form_key.str() + "\"}";
-    return out.str();
-  }
-
-  int64_t
-  UnionBuilder::length() const {
-    return (int64_t)tags_.length();
-  }
-
-  void
-  UnionBuilder::clear() {
-    tags_.clear();
-    index_.clear();
-    for (auto x : contents_) {
-      x.get()->clear();
-    }
-  }
-
-  bool
-  UnionBuilder::active() const {
-    return current_ != -1;
-  }
-
-  const BuilderPtr
-  UnionBuilder::null() {
-    if (current_ == -1) {
-      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-      out.get()->null();
-      return out;
-    }
-    else {
-      contents_[(size_t)current_].get()->null();
-      return shared_from_this();
-    }
-  }
-
-  const BuilderPtr
-  UnionBuilder::boolean(bool x) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<BoolBuilder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(BoolBuilder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t length = tofill->get()->length();
-      tofill->get()->boolean(x);
-      tags_.append(i);
-      index_.append(length);
-    }
-    else {
-      contents_[(size_t)current_].get()->boolean(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::integer(int64_t x) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<Int64Builder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(Int64Builder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t len = tofill->get()->length();
-      tofill->get()->integer(x);
-      tags_.append(i);
-      index_.append(len);
-    }
-    else {
-      contents_[(size_t)current_].get()->integer(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::real(double x) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<Float64Builder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-          return dynamic_cast<Int64Builder*>(p.get());
-        });
-        if (tofill != contents_.end()) {
-          *tofill = Float64Builder::fromint64(
-              options_,
-              std::move(static_cast<Int64Builder*>(tofill->get())->buffer()));
-        }
-        else {
-          contents_.emplace_back(Float64Builder::fromempty(options_));
-          tofill = --contents_.end();
-        }
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t length = tofill->get()->length();
-      tofill->get()->real(x);
-      tags_.append(i);
-      index_.append(length);
-    }
-    else {
-      contents_[(size_t)current_].get()->real(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::complex(std::complex<double> x) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<Complex128Builder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-          return dynamic_cast<Float64Builder*>(p.get());
-        });
-        if (tofill != contents_.end()) {
-          *tofill = std::move(Complex128Builder::fromfloat64(
-              options_,
-              std::move(static_cast<Float64Builder*>(tofill->get())->buffer())));
-        }
-      }
-      if (tofill == contents_.end()) {
-        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-          return dynamic_cast<Int64Builder*>(p.get());
-        });
-        if (tofill != contents_.end()) {
-          *tofill = std::move(Complex128Builder::fromint64(
-              options_,
-              std::move(static_cast<Int64Builder*>(tofill->get())->buffer())));
-        }
-        else {
-          contents_.emplace_back(Complex128Builder::fromempty(options_));
-          tofill = --contents_.end();
-        }
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t length = tofill->get()->length();
-      tofill->get()->complex(x);
-      tags_.append(i);
-      index_.append(length);
-    }
-    else {
-      contents_[(size_t)current_].get()->complex(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::datetime(int64_t x, const std::string& unit) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<DatetimeBuilder*>(p.get());
-        return raw != 0 && raw->units() == unit;
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t len = tofill->get()->length();
-      tofill->get()->datetime(x, unit);
-      tags_.append(i);
-      index_.append(len);
-    }
-    else {
-      contents_[(size_t)current_].get()->datetime(x, unit);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<DatetimeBuilder*>(p.get());
-        return raw != 0 && raw->units() == unit;
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t len = tofill->get()->length();
-      tofill->get()->timedelta(x, unit);
-      tags_.append(i);
-      index_.append(len);
-    }
-    else {
-      contents_[(size_t)current_].get()->timedelta(x, unit);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<StringBuilder*>(p.get());
-        return raw != 0 && raw->encoding() == encoding;
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(StringBuilder::fromempty(options_, encoding));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t len = tofill->get()->length();
-      tofill->get()->string(x, length, encoding);
-      tags_.append(i);
-      index_.append(len);
-    }
-    else {
-      contents_[(size_t)current_].get()->string(x, length, encoding);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::beginlist() {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<ListBuilder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(ListBuilder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      tofill->get()->beginlist();
-      current_ = (int8_t)std::distance(contents_.begin(), tofill);
-    }
-    else {
-      contents_[(size_t)current_].get()->beginlist();
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::endlist() {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = contents_[(size_t)current_].get()->length();
-      contents_[(size_t)current_].get()->endlist();
-      if (length != contents_[(size_t)current_].get()->length()) {
-        tags_.append(current_);
-        index_.append(length);
-        current_ = -1;
-      }
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::begintuple(int64_t numfields) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<TupleBuilder*>(p.get());
-        return raw != nullptr  &&  (raw->length() == -1  ||  raw->numfields() == numfields);
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(TupleBuilder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      tofill->get()->begintuple(numfields);
-      current_ = (int8_t)std::distance(contents_.begin(), tofill);
-    }
-    else {
-      contents_[(size_t)current_].get()->begintuple(numfields);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::index(int64_t index) {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)current_].get()->index(index);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::endtuple() {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = contents_[(size_t)current_].get()->length();
-      contents_[(size_t)current_].get()->endtuple();
-      if (length != contents_[(size_t)current_].get()->length()) {
-        tags_.append(current_);
-        index_.append(length);
-        current_ = -1;
-      }
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::beginrecord(const char* name, bool check) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<RecordBuilder*>(p.get());
-        return raw != nullptr  &&  (raw->length() == -1  ||
-                ((check  &&  raw->name() == name)  ||
-                 (!check  &&  raw->nameptr() == name)));
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(RecordBuilder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      tofill->get()->beginrecord(name, check);
-      current_ = (int8_t)std::distance(contents_.begin(), tofill);
-    }
-    else {
-      contents_[(size_t)current_].get()->beginrecord(name, check);
-    }
-    return shared_from_this();
-  }
-
-  void
-  UnionBuilder::field(const char* key, bool check) {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)current_].get()->field(key, check);
-    }
-  }
-
-  const BuilderPtr
-  UnionBuilder::endrecord() {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same level "
-                    "before it") + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = contents_[(size_t)current_].get()->length();
-      contents_[(size_t)current_].get()->endrecord();
-      if (length != contents_[(size_t)current_].get()->length()) {
-        tags_.append(current_);
-        index_.append(length);
-        current_ = -1;
-      }
-    }
-    return shared_from_this();
-  }
-
+const BuilderPtr UnionBuilder::fromsingle(const BuilderOptions &options,
+                                          const BuilderPtr &firstcontent) {
+  std::vector<BuilderPtr> contents({firstcontent});
+  return std::make_shared<UnionBuilder>(
+      options, GrowableBuffer<int8_t>::full(options, 0, firstcontent->length()),
+      GrowableBuffer<int64_t>::arange(options, firstcontent->length()),
+      contents);
 }
+
+UnionBuilder::UnionBuilder(const BuilderOptions &options,
+                           GrowableBuffer<int8_t> tags,
+                           GrowableBuffer<int64_t> index,
+                           std::vector<BuilderPtr> &contents)
+    : options_(options), tags_(std::move(tags)), index_(std::move(index)),
+      contents_(contents), current_(-1) {}
+
+const std::string UnionBuilder::classname() const { return "UnionBuilder"; };
+
+const std::string UnionBuilder::to_buffers(BuffersContainer &container,
+                                           int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  tags_.concatenate(reinterpret_cast<int8_t *>(container.empty_buffer(
+      form_key.str() + "-tags",
+      (int64_t)tags_.length() * (int64_t)sizeof(int8_t))));
+
+  index_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
+      form_key.str() + "-index",
+      (int64_t)index_.length() * (int64_t)sizeof(int64_t))));
+
+  std::stringstream out;
+  out << "{\"class\": \"UnionArray\", \"tags\": \"i8\", \"index\": \"i64\", "
+         "\"contents\": [";
+  for (size_t i = 0; i < contents_.size(); i++) {
+    if (i != 0) {
+      out << ", ";
+    }
+    out << contents_[i].get()->to_buffers(container, form_key_id);
+  }
+  out << "], \"form_key\": \"" << form_key.str() + "\"}";
+  return out.str();
+}
+
+int64_t UnionBuilder::length() const { return (int64_t)tags_.length(); }
+
+void UnionBuilder::clear() {
+  tags_.clear();
+  index_.clear();
+  for (auto x : contents_) {
+    x.get()->clear();
+  }
+}
+
+bool UnionBuilder::active() const { return current_ != -1; }
+
+const BuilderPtr UnionBuilder::null() {
+  if (current_ == -1) {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  } else {
+    contents_[(size_t)current_].get()->null();
+    return shared_from_this();
+  }
+}
+
+const BuilderPtr UnionBuilder::boolean(bool x) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(contents_.begin(), contents_.end(),
+                               [&](BuilderPtr const &p) {
+                                 return dynamic_cast<BoolBuilder *>(p.get());
+                               });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(BoolBuilder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t length = tofill->get()->length();
+    tofill->get()->boolean(x);
+    tags_.append(i);
+    index_.append(length);
+  } else {
+    contents_[(size_t)current_].get()->boolean(x);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::integer(int64_t x) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(contents_.begin(), contents_.end(),
+                               [&](BuilderPtr const &p) {
+                                 return dynamic_cast<Int64Builder *>(p.get());
+                               });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(Int64Builder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t len = tofill->get()->length();
+    tofill->get()->integer(x);
+    tags_.append(i);
+    index_.append(len);
+  } else {
+    contents_[(size_t)current_].get()->integer(x);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::real(double x) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(contents_.begin(), contents_.end(),
+                               [&](BuilderPtr const &p) {
+                                 return dynamic_cast<Float64Builder *>(p.get());
+                               });
+    if (tofill == contents_.end()) {
+      tofill = std::find_if(contents_.begin(), contents_.end(),
+                            [&](BuilderPtr const &p) {
+                              return dynamic_cast<Int64Builder *>(p.get());
+                            });
+      if (tofill != contents_.end()) {
+        *tofill = Float64Builder::fromint64(
+            options_,
+            std::move(static_cast<Int64Builder *>(tofill->get())->buffer()));
+      } else {
+        contents_.emplace_back(Float64Builder::fromempty(options_));
+        tofill = --contents_.end();
+      }
+    }
+    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t length = tofill->get()->length();
+    tofill->get()->real(x);
+    tags_.append(i);
+    index_.append(length);
+  } else {
+    contents_[(size_t)current_].get()->real(x);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::complex(std::complex<double> x) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          return dynamic_cast<Complex128Builder *>(p.get());
+        });
+    if (tofill == contents_.end()) {
+      tofill = std::find_if(contents_.begin(), contents_.end(),
+                            [&](BuilderPtr const &p) {
+                              return dynamic_cast<Float64Builder *>(p.get());
+                            });
+      if (tofill != contents_.end()) {
+        *tofill = std::move(Complex128Builder::fromfloat64(
+            options_,
+            std::move(static_cast<Float64Builder *>(tofill->get())->buffer())));
+      }
+    }
+    if (tofill == contents_.end()) {
+      tofill = std::find_if(contents_.begin(), contents_.end(),
+                            [&](BuilderPtr const &p) {
+                              return dynamic_cast<Int64Builder *>(p.get());
+                            });
+      if (tofill != contents_.end()) {
+        *tofill = std::move(Complex128Builder::fromint64(
+            options_,
+            std::move(static_cast<Int64Builder *>(tofill->get())->buffer())));
+      } else {
+        contents_.emplace_back(Complex128Builder::fromempty(options_));
+        tofill = --contents_.end();
+      }
+    }
+    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t length = tofill->get()->length();
+    tofill->get()->complex(x);
+    tags_.append(i);
+    index_.append(length);
+  } else {
+    contents_[(size_t)current_].get()->complex(x);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::datetime(int64_t x, const std::string &unit) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<DatetimeBuilder *>(p.get());
+          return raw != 0 && raw->units() == unit;
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
+      tofill = --contents_.end();
+    }
+    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t len = tofill->get()->length();
+    tofill->get()->datetime(x, unit);
+    tags_.append(i);
+    index_.append(len);
+  } else {
+    contents_[(size_t)current_].get()->datetime(x, unit);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<DatetimeBuilder *>(p.get());
+          return raw != 0 && raw->units() == unit;
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
+      tofill = --contents_.end();
+    }
+    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t len = tofill->get()->length();
+    tofill->get()->timedelta(x, unit);
+    tags_.append(i);
+    index_.append(len);
+  } else {
+    contents_[(size_t)current_].get()->timedelta(x, unit);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::string(const char *x, int64_t length,
+                                      const char *encoding) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<StringBuilder *>(p.get());
+          return raw != 0 && raw->encoding() == encoding;
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(StringBuilder::fromempty(options_, encoding));
+      tofill = --contents_.end();
+    }
+    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t len = tofill->get()->length();
+    tofill->get()->string(x, length, encoding);
+    tags_.append(i);
+    index_.append(len);
+  } else {
+    contents_[(size_t)current_].get()->string(x, length, encoding);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::beginlist() {
+  if (current_ == -1) {
+    auto tofill = std::find_if(contents_.begin(), contents_.end(),
+                               [&](BuilderPtr const &p) {
+                                 return dynamic_cast<ListBuilder *>(p.get());
+                               });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(ListBuilder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    tofill->get()->beginlist();
+    current_ = (int8_t)std::distance(contents_.begin(), tofill);
+  } else {
+    contents_[(size_t)current_].get()->beginlist();
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::endlist() {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = contents_[(size_t)current_].get()->length();
+    contents_[(size_t)current_].get()->endlist();
+    if (length != contents_[(size_t)current_].get()->length()) {
+      tags_.append(current_);
+      index_.append(length);
+      current_ = -1;
+    }
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::begintuple(int64_t numfields) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<TupleBuilder *>(p.get());
+          return raw != nullptr &&
+                 (raw->length() == -1 || raw->numfields() == numfields);
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(TupleBuilder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    tofill->get()->begintuple(numfields);
+    current_ = (int8_t)std::distance(contents_.begin(), tofill);
+  } else {
+    contents_[(size_t)current_].get()->begintuple(numfields);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::index(int64_t index) {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)current_].get()->index(index);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::endtuple() {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = contents_[(size_t)current_].get()->length();
+    contents_[(size_t)current_].get()->endtuple();
+    if (length != contents_[(size_t)current_].get()->length()) {
+      tags_.append(current_);
+      index_.append(length);
+      current_ = -1;
+    }
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::beginrecord(const char *name, bool check) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<RecordBuilder *>(p.get());
+          return raw != nullptr &&
+                 (raw->length() == -1 || ((check && raw->name() == name) ||
+                                          (!check && raw->nameptr() == name)));
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(RecordBuilder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    tofill->get()->beginrecord(name, check);
+    current_ = (int8_t)std::distance(contents_.begin(), tofill);
+  } else {
+    contents_[(size_t)current_].get()->beginrecord(name, check);
+  }
+  return shared_from_this();
+}
+
+void UnionBuilder::field(const char *key, bool check) {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)current_].get()->field(key, check);
+  }
+}
+
+const BuilderPtr UnionBuilder::endrecord() {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string(
+            "called 'end_record' without 'begin_record' at the same level "
+            "before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = contents_[(size_t)current_].get()->length();
+    contents_[(size_t)current_].get()->endrecord();
+    if (length != contents_[(size_t)current_].get()->length()) {
+      tags_.append(current_);
+      index_.append(length);
+      current_ = -1;
+    }
+  }
+  return shared_from_this();
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -1,409 +1,435 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnionBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnionBuilder.cpp", line)
 
 #include <stdexcept>
 
-#include "awkward/builder/BoolBuilder.h"
-#include "awkward/builder/Complex128Builder.h"
-#include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/builder/Float64Builder.h"
-#include "awkward/builder/Int64Builder.h"
-#include "awkward/builder/ListBuilder.h"
 #include "awkward/builder/OptionBuilder.h"
-#include "awkward/builder/RecordBuilder.h"
+#include "awkward/builder/BoolBuilder.h"
+#include "awkward/builder/DatetimeBuilder.h"
+#include "awkward/builder/Int64Builder.h"
+#include "awkward/builder/Float64Builder.h"
 #include "awkward/builder/StringBuilder.h"
+#include "awkward/builder/ListBuilder.h"
 #include "awkward/builder/TupleBuilder.h"
+#include "awkward/builder/RecordBuilder.h"
+#include "awkward/builder/Complex128Builder.h"
 
 #include "awkward/builder/UnionBuilder.h"
 
 namespace awkward {
-const BuilderPtr UnionBuilder::fromsingle(const BuilderOptions &options,
-                                          const BuilderPtr &firstcontent) {
-  std::vector<BuilderPtr> contents({firstcontent});
-  return std::make_shared<UnionBuilder>(
-      options, GrowableBuffer<int8_t>::full(options, 0, firstcontent->length()),
-      GrowableBuffer<int64_t>::arange(options, firstcontent->length()),
-      contents);
-}
+  const BuilderPtr
+  UnionBuilder::fromsingle(const BuilderOptions& options,
+                           const BuilderPtr& firstcontent) {
+    std::vector<BuilderPtr> contents({ firstcontent });
+    return std::make_shared<UnionBuilder>(options,
+                                          GrowableBuffer<int8_t>::full(options, 0, firstcontent->length()),
+                                          GrowableBuffer<int64_t>::arange(options, firstcontent->length()),
+                                          contents);
+  }
 
-UnionBuilder::UnionBuilder(const BuilderOptions &options,
-                           GrowableBuffer<int8_t> tags,
-                           GrowableBuffer<int64_t> index,
-                           std::vector<BuilderPtr> &contents)
-    : options_(options), tags_(std::move(tags)), index_(std::move(index)),
-      contents_(contents), current_(-1) {}
+  UnionBuilder::UnionBuilder(const BuilderOptions& options,
+                             GrowableBuffer<int8_t> tags,
+                             GrowableBuffer<int64_t> index,
+                             std::vector<BuilderPtr>& contents)
+      : options_(options)
+      , tags_(std::move(tags))
+      , index_(std::move(index))
+      , contents_(contents)
+      , current_(-1) { }
 
-const std::string UnionBuilder::classname() const { return "UnionBuilder"; };
+  const std::string
+  UnionBuilder::classname() const {
+    return "UnionBuilder";
+  };
 
-const std::string UnionBuilder::to_buffers(BuffersContainer &container,
-                                           int64_t &form_key_id) const {
-  std::stringstream form_key;
-  form_key << "node" << (form_key_id++);
+  const std::string
+  UnionBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
 
-  tags_.concatenate(reinterpret_cast<int8_t *>(container.empty_buffer(
-      form_key.str() + "-tags",
-      (int64_t)tags_.length() * (int64_t)sizeof(int8_t))));
+    tags_.concatenate(
+      reinterpret_cast<int8_t*>(
+        container.empty_buffer(form_key.str() + "-tags",
+        (int64_t)tags_.length() * (int64_t)sizeof(int8_t))));
 
-  index_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
-      form_key.str() + "-index",
-      (int64_t)index_.length() * (int64_t)sizeof(int64_t))));
+    index_.concatenate(
+      reinterpret_cast<int64_t*>(
+        container.empty_buffer(form_key.str() + "-index",
+        (int64_t)index_.length() * (int64_t)sizeof(int64_t))));
 
-  std::stringstream out;
-  out << "{\"class\": \"UnionArray\", \"tags\": \"i8\", \"index\": \"i64\", "
-         "\"contents\": [";
-  for (size_t i = 0; i < contents_.size(); i++) {
-    if (i != 0) {
-      out << ", ";
+    std::stringstream out;
+    out << "{\"class\": \"UnionArray\", \"tags\": \"i8\", \"index\": \"i64\", \"contents\": [";
+    for (size_t i = 0;  i < contents_.size();  i++) {
+      if (i != 0) {
+        out << ", ";
+      }
+      out << contents_[i].get()->to_buffers(container, form_key_id);
     }
-    out << contents_[i].get()->to_buffers(container, form_key_id);
+    out << "], \"form_key\": \"" << form_key.str() + "\"}";
+    return out.str();
   }
-  out << "], \"form_key\": \"" << form_key.str() + "\"}";
-  return out.str();
-}
 
-int64_t UnionBuilder::length() const { return (int64_t)tags_.length(); }
-
-void UnionBuilder::clear() {
-  tags_.clear();
-  index_.clear();
-  for (auto x : contents_) {
-    x.get()->clear();
+  int64_t
+  UnionBuilder::length() const {
+    return (int64_t)tags_.length();
   }
-}
 
-bool UnionBuilder::active() const { return current_ != -1; }
+  void
+  UnionBuilder::clear() {
+    tags_.clear();
+    index_.clear();
+    for (auto x : contents_) {
+      x.get()->clear();
+    }
+  }
 
-const BuilderPtr UnionBuilder::null() {
-  if (current_ == -1) {
-    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-    out.get()->null();
-    return out;
-  } else {
-    contents_[(size_t)current_].get()->null();
+  bool
+  UnionBuilder::active() const {
+    return current_ != -1;
+  }
+
+  const BuilderPtr
+  UnionBuilder::null() {
+    if (current_ == -1) {
+      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+      out.get()->null();
+      return out;
+    }
+    else {
+      contents_[(size_t)current_].get()->null();
+      return shared_from_this();
+    }
+  }
+
+  const BuilderPtr
+  UnionBuilder::boolean(bool x) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        return dynamic_cast<BoolBuilder*>(p.get());
+      });
+      if (tofill == contents_.end()) {
+        contents_.emplace_back(BoolBuilder::fromempty(options_));
+        tofill = --contents_.end();
+      }
+      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+      int64_t length = tofill->get()->length();
+      tofill->get()->boolean(x);
+      tags_.append(i);
+      index_.append(length);
+    }
+    else {
+      contents_[(size_t)current_].get()->boolean(x);
+    }
     return shared_from_this();
   }
-}
 
-const BuilderPtr UnionBuilder::boolean(bool x) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(contents_.begin(), contents_.end(),
-                               [&](BuilderPtr const &p) {
-                                 return dynamic_cast<BoolBuilder *>(p.get());
-                               });
-    if (tofill == contents_.end()) {
-      contents_.emplace_back(BoolBuilder::fromempty(options_));
-      tofill = --contents_.end();
-    }
-    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-    int64_t length = tofill->get()->length();
-    tofill->get()->boolean(x);
-    tags_.append(i);
-    index_.append(length);
-  } else {
-    contents_[(size_t)current_].get()->boolean(x);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr UnionBuilder::integer(int64_t x) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(contents_.begin(), contents_.end(),
-                               [&](BuilderPtr const &p) {
-                                 return dynamic_cast<Int64Builder *>(p.get());
-                               });
-    if (tofill == contents_.end()) {
-      contents_.emplace_back(Int64Builder::fromempty(options_));
-      tofill = --contents_.end();
-    }
-    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-    int64_t len = tofill->get()->length();
-    tofill->get()->integer(x);
-    tags_.append(i);
-    index_.append(len);
-  } else {
-    contents_[(size_t)current_].get()->integer(x);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr UnionBuilder::real(double x) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(contents_.begin(), contents_.end(),
-                               [&](BuilderPtr const &p) {
-                                 return dynamic_cast<Float64Builder *>(p.get());
-                               });
-    if (tofill == contents_.end()) {
-      tofill = std::find_if(contents_.begin(), contents_.end(),
-                            [&](BuilderPtr const &p) {
-                              return dynamic_cast<Int64Builder *>(p.get());
-                            });
-      if (tofill != contents_.end()) {
-        *tofill = Float64Builder::fromint64(
-            options_,
-            std::move(static_cast<Int64Builder *>(tofill->get())->buffer()));
-      } else {
-        contents_.emplace_back(Float64Builder::fromempty(options_));
+  const BuilderPtr
+  UnionBuilder::integer(int64_t x) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        return dynamic_cast<Int64Builder*>(p.get());
+      });
+      if (tofill == contents_.end()) {
+        contents_.emplace_back(Int64Builder::fromempty(options_));
         tofill = --contents_.end();
       }
+      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+      int64_t len = tofill->get()->length();
+      tofill->get()->integer(x);
+      tags_.append(i);
+      index_.append(len);
     }
-    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-    int64_t length = tofill->get()->length();
-    tofill->get()->real(x);
-    tags_.append(i);
-    index_.append(length);
-  } else {
-    contents_[(size_t)current_].get()->real(x);
+    else {
+      contents_[(size_t)current_].get()->integer(x);
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr UnionBuilder::complex(std::complex<double> x) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(
-        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
-          return dynamic_cast<Complex128Builder *>(p.get());
+  const BuilderPtr
+  UnionBuilder::real(double x) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        return dynamic_cast<Float64Builder*>(p.get());
+      });
+      if (tofill == contents_.end()) {
+        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+          return dynamic_cast<Int64Builder*>(p.get());
         });
-    if (tofill == contents_.end()) {
-      tofill = std::find_if(contents_.begin(), contents_.end(),
-                            [&](BuilderPtr const &p) {
-                              return dynamic_cast<Float64Builder *>(p.get());
-                            });
-      if (tofill != contents_.end()) {
-        *tofill = std::move(Complex128Builder::fromfloat64(
-            options_,
-            std::move(static_cast<Float64Builder *>(tofill->get())->buffer())));
+        if (tofill != contents_.end()) {
+          *tofill = Float64Builder::fromint64(
+              options_,
+              std::move(static_cast<Int64Builder*>(tofill->get())->buffer()));
+        }
+        else {
+          contents_.emplace_back(Float64Builder::fromempty(options_));
+          tofill = --contents_.end();
+        }
       }
+      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+      int64_t length = tofill->get()->length();
+      tofill->get()->real(x);
+      tags_.append(i);
+      index_.append(length);
     }
-    if (tofill == contents_.end()) {
-      tofill = std::find_if(contents_.begin(), contents_.end(),
-                            [&](BuilderPtr const &p) {
-                              return dynamic_cast<Int64Builder *>(p.get());
-                            });
-      if (tofill != contents_.end()) {
-        *tofill = std::move(Complex128Builder::fromint64(
-            options_,
-            std::move(static_cast<Int64Builder *>(tofill->get())->buffer())));
-      } else {
-        contents_.emplace_back(Complex128Builder::fromempty(options_));
+    else {
+      contents_[(size_t)current_].get()->real(x);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  UnionBuilder::complex(std::complex<double> x) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        return dynamic_cast<Complex128Builder*>(p.get());
+      });
+      if (tofill == contents_.end()) {
+        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+          return dynamic_cast<Float64Builder*>(p.get());
+        });
+        if (tofill != contents_.end()) {
+          *tofill = std::move(Complex128Builder::fromfloat64(
+              options_,
+              std::move(static_cast<Float64Builder*>(tofill->get())->buffer())));
+        }
+      }
+      if (tofill == contents_.end()) {
+        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+          return dynamic_cast<Int64Builder*>(p.get());
+        });
+        if (tofill != contents_.end()) {
+          *tofill = std::move(Complex128Builder::fromint64(
+              options_,
+              std::move(static_cast<Int64Builder*>(tofill->get())->buffer())));
+        }
+        else {
+          contents_.emplace_back(Complex128Builder::fromempty(options_));
+          tofill = --contents_.end();
+        }
+      }
+      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+      int64_t length = tofill->get()->length();
+      tofill->get()->complex(x);
+      tags_.append(i);
+      index_.append(length);
+    }
+    else {
+      contents_[(size_t)current_].get()->complex(x);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  UnionBuilder::datetime(int64_t x, const std::string& unit) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        const auto& raw = dynamic_cast<DatetimeBuilder*>(p.get());
+        return raw != 0 && raw->units() == unit;
+      });
+      if (tofill == contents_.end()) {
+        contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
         tofill = --contents_.end();
       }
+      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+      int64_t len = tofill->get()->length();
+      tofill->get()->datetime(x, unit);
+      tags_.append(i);
+      index_.append(len);
     }
-    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-    int64_t length = tofill->get()->length();
-    tofill->get()->complex(x);
-    tags_.append(i);
-    index_.append(length);
-  } else {
-    contents_[(size_t)current_].get()->complex(x);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr UnionBuilder::datetime(int64_t x, const std::string &unit) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(
-        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
-          const auto &raw = dynamic_cast<DatetimeBuilder *>(p.get());
-          return raw != 0 && raw->units() == unit;
-        });
-    if (tofill == contents_.end()) {
-      contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
-      tofill = --contents_.end();
+    else {
+      contents_[(size_t)current_].get()->datetime(x, unit);
     }
-    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-    int64_t len = tofill->get()->length();
-    tofill->get()->datetime(x, unit);
-    tags_.append(i);
-    index_.append(len);
-  } else {
-    contents_[(size_t)current_].get()->datetime(x, unit);
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr UnionBuilder::timedelta(int64_t x, const std::string &unit) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(
-        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
-          const auto &raw = dynamic_cast<DatetimeBuilder *>(p.get());
-          return raw != 0 && raw->units() == unit;
-        });
-    if (tofill == contents_.end()) {
-      contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
-      tofill = --contents_.end();
+  const BuilderPtr
+  UnionBuilder::timedelta(int64_t x, const std::string& unit) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        const auto& raw = dynamic_cast<DatetimeBuilder*>(p.get());
+        return raw != 0 && raw->units() == unit;
+      });
+      if (tofill == contents_.end()) {
+        contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
+        tofill = --contents_.end();
+      }
+      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+      int64_t len = tofill->get()->length();
+      tofill->get()->timedelta(x, unit);
+      tags_.append(i);
+      index_.append(len);
     }
-    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-    int64_t len = tofill->get()->length();
-    tofill->get()->timedelta(x, unit);
-    tags_.append(i);
-    index_.append(len);
-  } else {
-    contents_[(size_t)current_].get()->timedelta(x, unit);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr UnionBuilder::string(const char *x, int64_t length,
-                                      const char *encoding) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(
-        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
-          const auto &raw = dynamic_cast<StringBuilder *>(p.get());
-          return raw != 0 && raw->encoding() == encoding;
-        });
-    if (tofill == contents_.end()) {
-      contents_.emplace_back(StringBuilder::fromempty(options_, encoding));
-      tofill = --contents_.end();
+    else {
+      contents_[(size_t)current_].get()->timedelta(x, unit);
     }
-    int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-    int64_t len = tofill->get()->length();
-    tofill->get()->string(x, length, encoding);
-    tags_.append(i);
-    index_.append(len);
-  } else {
-    contents_[(size_t)current_].get()->string(x, length, encoding);
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr UnionBuilder::beginlist() {
-  if (current_ == -1) {
-    auto tofill = std::find_if(contents_.begin(), contents_.end(),
-                               [&](BuilderPtr const &p) {
-                                 return dynamic_cast<ListBuilder *>(p.get());
-                               });
-    if (tofill == contents_.end()) {
-      contents_.emplace_back(ListBuilder::fromempty(options_));
-      tofill = --contents_.end();
+  const BuilderPtr
+  UnionBuilder::string(const char* x, int64_t length, const char* encoding) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        const auto& raw = dynamic_cast<StringBuilder*>(p.get());
+        return raw != 0 && raw->encoding() == encoding;
+      });
+      if (tofill == contents_.end()) {
+        contents_.emplace_back(StringBuilder::fromempty(options_, encoding));
+        tofill = --contents_.end();
+      }
+      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
+      int64_t len = tofill->get()->length();
+      tofill->get()->string(x, length, encoding);
+      tags_.append(i);
+      index_.append(len);
     }
-    tofill->get()->beginlist();
-    current_ = (int8_t)std::distance(contents_.begin(), tofill);
-  } else {
-    contents_[(size_t)current_].get()->beginlist();
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr UnionBuilder::endlist() {
-  if (current_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else {
-    int64_t length = contents_[(size_t)current_].get()->length();
-    contents_[(size_t)current_].get()->endlist();
-    if (length != contents_[(size_t)current_].get()->length()) {
-      tags_.append(current_);
-      index_.append(length);
-      current_ = -1;
+    else {
+      contents_[(size_t)current_].get()->string(x, length, encoding);
     }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr UnionBuilder::begintuple(int64_t numfields) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(
-        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
-          const auto &raw = dynamic_cast<TupleBuilder *>(p.get());
-          return raw != nullptr &&
-                 (raw->length() == -1 || raw->numfields() == numfields);
-        });
-    if (tofill == contents_.end()) {
-      contents_.emplace_back(TupleBuilder::fromempty(options_));
-      tofill = --contents_.end();
+  const BuilderPtr
+  UnionBuilder::beginlist() {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        return dynamic_cast<ListBuilder*>(p.get());
+      });
+      if (tofill == contents_.end()) {
+        contents_.emplace_back(ListBuilder::fromempty(options_));
+        tofill = --contents_.end();
+      }
+      tofill->get()->beginlist();
+      current_ = (int8_t)std::distance(contents_.begin(), tofill);
     }
-    tofill->get()->begintuple(numfields);
-    current_ = (int8_t)std::distance(contents_.begin(), tofill);
-  } else {
-    contents_[(size_t)current_].get()->begintuple(numfields);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr UnionBuilder::index(int64_t index) {
-  if (current_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else {
-    contents_[(size_t)current_].get()->index(index);
-  }
-  return shared_from_this();
-}
-
-const BuilderPtr UnionBuilder::endtuple() {
-  if (current_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same "
-                    "level before it") +
-        FILENAME(__LINE__));
-  } else {
-    int64_t length = contents_[(size_t)current_].get()->length();
-    contents_[(size_t)current_].get()->endtuple();
-    if (length != contents_[(size_t)current_].get()->length()) {
-      tags_.append(current_);
-      index_.append(length);
-      current_ = -1;
+    else {
+      contents_[(size_t)current_].get()->beginlist();
     }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-const BuilderPtr UnionBuilder::beginrecord(const char *name, bool check) {
-  if (current_ == -1) {
-    auto tofill = std::find_if(
-        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
-          const auto &raw = dynamic_cast<RecordBuilder *>(p.get());
-          return raw != nullptr &&
-                 (raw->length() == -1 || ((check && raw->name() == name) ||
-                                          (!check && raw->nameptr() == name)));
-        });
-    if (tofill == contents_.end()) {
-      contents_.emplace_back(RecordBuilder::fromempty(options_));
-      tofill = --contents_.end();
+  const BuilderPtr
+  UnionBuilder::endlist() {
+    if (current_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level before it")
+        + FILENAME(__LINE__));
     }
-    tofill->get()->beginrecord(name, check);
-    current_ = (int8_t)std::distance(contents_.begin(), tofill);
-  } else {
-    contents_[(size_t)current_].get()->beginrecord(name, check);
+    else {
+      int64_t length = contents_[(size_t)current_].get()->length();
+      contents_[(size_t)current_].get()->endlist();
+      if (length != contents_[(size_t)current_].get()->length()) {
+        tags_.append(current_);
+        index_.append(length);
+        current_ = -1;
+      }
+    }
+    return shared_from_this();
   }
-  return shared_from_this();
-}
 
-void UnionBuilder::field(const char *key, bool check) {
-  if (current_ == -1) {
-    throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level "
-                    "before it") +
-        FILENAME(__LINE__));
-  } else {
-    contents_[(size_t)current_].get()->field(key, check);
+  const BuilderPtr
+  UnionBuilder::begintuple(int64_t numfields) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        const auto& raw = dynamic_cast<TupleBuilder*>(p.get());
+        return raw != nullptr  &&  (raw->length() == -1  ||  raw->numfields() == numfields);
+      });
+      if (tofill == contents_.end()) {
+        contents_.emplace_back(TupleBuilder::fromempty(options_));
+        tofill = --contents_.end();
+      }
+      tofill->get()->begintuple(numfields);
+      current_ = (int8_t)std::distance(contents_.begin(), tofill);
+    }
+    else {
+      contents_[(size_t)current_].get()->begintuple(numfields);
+    }
+    return shared_from_this();
   }
-}
 
-const BuilderPtr UnionBuilder::endrecord() {
-  if (current_ == -1) {
-    throw std::invalid_argument(
-        std::string(
-            "called 'end_record' without 'begin_record' at the same level "
-            "before it") +
-        FILENAME(__LINE__));
-  } else {
-    int64_t length = contents_[(size_t)current_].get()->length();
-    contents_[(size_t)current_].get()->endrecord();
-    if (length != contents_[(size_t)current_].get()->length()) {
-      tags_.append(current_);
-      index_.append(length);
-      current_ = -1;
+  const BuilderPtr
+  UnionBuilder::index(int64_t index) {
+    if (current_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      contents_[(size_t)current_].get()->index(index);
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  UnionBuilder::endtuple() {
+    if (current_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      int64_t length = contents_[(size_t)current_].get()->length();
+      contents_[(size_t)current_].get()->endtuple();
+      if (length != contents_[(size_t)current_].get()->length()) {
+        tags_.append(current_);
+        index_.append(length);
+        current_ = -1;
+      }
+    }
+    return shared_from_this();
+  }
+
+  const BuilderPtr
+  UnionBuilder::beginrecord(const char* name, bool check) {
+    if (current_ == -1) {
+      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
+        const auto& raw = dynamic_cast<RecordBuilder*>(p.get());
+        return raw != nullptr  &&  (raw->length() == -1  ||
+                ((check  &&  raw->name() == name)  ||
+                 (!check  &&  raw->nameptr() == name)));
+      });
+      if (tofill == contents_.end()) {
+        contents_.emplace_back(RecordBuilder::fromempty(options_));
+        tofill = --contents_.end();
+      }
+      tofill->get()->beginrecord(name, check);
+      current_ = (int8_t)std::distance(contents_.begin(), tofill);
+    }
+    else {
+      contents_[(size_t)current_].get()->beginrecord(name, check);
+    }
+    return shared_from_this();
+  }
+
+  void
+  UnionBuilder::field(const char* key, bool check) {
+    if (current_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level before it")
+        + FILENAME(__LINE__));
+    }
+    else {
+      contents_[(size_t)current_].get()->field(key, check);
     }
   }
-  return shared_from_this();
-}
 
-} // namespace awkward
+  const BuilderPtr
+  UnionBuilder::endrecord() {
+    if (current_ == -1) {
+      throw std::invalid_argument(
+        std::string("called 'end_record' without 'begin_record' at the same level "
+                    "before it") + FILENAME(__LINE__));
+    }
+    else {
+      int64_t length = contents_[(size_t)current_].get()->length();
+      contents_[(size_t)current_].get()->endrecord();
+      if (length != contents_[(size_t)current_].get()->length()) {
+        tags_.append(current_);
+        index_.append(length);
+        current_ = -1;
+      }
+    }
+    return shared_from_this();
+  }
+
+}

--- a/src/libawkward/builder/UnionBuilder.cpp
+++ b/src/libawkward/builder/UnionBuilder.cpp
@@ -1,435 +1,408 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnionBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnionBuilder.cpp", line)
 
 #include <stdexcept>
 
-#include "awkward/builder/OptionBuilder.h"
 #include "awkward/builder/BoolBuilder.h"
-#include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/builder/Int64Builder.h"
-#include "awkward/builder/Float64Builder.h"
-#include "awkward/builder/StringBuilder.h"
-#include "awkward/builder/ListBuilder.h"
-#include "awkward/builder/TupleBuilder.h"
-#include "awkward/builder/RecordBuilder.h"
 #include "awkward/builder/Complex128Builder.h"
+#include "awkward/builder/DatetimeBuilder.h"
+#include "awkward/builder/Float64Builder.h"
+#include "awkward/builder/Int64Builder.h"
+#include "awkward/builder/ListBuilder.h"
+#include "awkward/builder/OptionBuilder.h"
+#include "awkward/builder/RecordBuilder.h"
+#include "awkward/builder/StringBuilder.h"
+#include "awkward/builder/TupleBuilder.h"
 
 #include "awkward/builder/UnionBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  UnionBuilder::fromsingle(const BuilderOptions& options,
-                           const BuilderPtr& firstcontent) {
-    std::vector<BuilderPtr> contents({ firstcontent });
-    return std::make_shared<UnionBuilder>(options,
-                                          GrowableBuffer<int8_t>::full(options, 0, firstcontent->length()),
-                                          GrowableBuffer<int64_t>::arange(options, firstcontent->length()),
-                                          contents);
-  }
-
-  UnionBuilder::UnionBuilder(const BuilderOptions& options,
-                             GrowableBuffer<int8_t> tags,
-                             GrowableBuffer<int64_t> index,
-                             std::vector<BuilderPtr>& contents)
-      : options_(options)
-      , tags_(std::move(tags))
-      , index_(std::move(index))
-      , contents_(contents)
-      , current_(-1) { }
-
-  const std::string
-  UnionBuilder::classname() const {
-    return "UnionBuilder";
-  };
-
-  const std::string
-  UnionBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    tags_.concatenate(
-      reinterpret_cast<int8_t*>(
-        container.empty_buffer(form_key.str() + "-tags",
-        (int64_t)tags_.length() * (int64_t)sizeof(int8_t))));
-
-    index_.concatenate(
-      reinterpret_cast<int64_t*>(
-        container.empty_buffer(form_key.str() + "-index",
-        (int64_t)index_.length() * (int64_t)sizeof(int64_t))));
-
-    std::stringstream out;
-    out << "{\"class\": \"UnionArray\", \"tags\": \"i8\", \"index\": \"i64\", \"contents\": [";
-    for (size_t i = 0;  i < contents_.size();  i++) {
-      if (i != 0) {
-        out << ", ";
-      }
-      out << contents_[i].get()->to_buffers(container, form_key_id);
-    }
-    out << "], \"form_key\": \"" << form_key.str() + "\"}";
-    return out.str();
-  }
-
-  int64_t
-  UnionBuilder::length() const {
-    return (int64_t)tags_.length();
-  }
-
-  void
-  UnionBuilder::clear() {
-    tags_.clear();
-    index_.clear();
-    for (auto x : contents_) {
-      x.get()->clear();
-    }
-  }
-
-  bool
-  UnionBuilder::active() const {
-    return current_ != -1;
-  }
-
-  const BuilderPtr
-  UnionBuilder::null() {
-    if (current_ == -1) {
-      BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
-      out.get()->null();
-      return out;
-    }
-    else {
-      contents_[(size_t)current_].get()->null();
-      return shared_from_this();
-    }
-  }
-
-  const BuilderPtr
-  UnionBuilder::boolean(bool x) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<BoolBuilder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(BoolBuilder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t length = tofill->get()->length();
-      tofill->get()->boolean(x);
-      tags_.append(i);
-      index_.append(length);
-    }
-    else {
-      contents_[(size_t)current_].get()->boolean(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::integer(int64_t x) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<Int64Builder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(Int64Builder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t len = tofill->get()->length();
-      tofill->get()->integer(x);
-      tags_.append(i);
-      index_.append(len);
-    }
-    else {
-      contents_[(size_t)current_].get()->integer(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::real(double x) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<Float64Builder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-          return dynamic_cast<Int64Builder*>(p.get());
-        });
-        if (tofill != contents_.end()) {
-          *tofill = Float64Builder::fromint64(
-              options_,
-              std::move(static_cast<Int64Builder*>(tofill->get())->buffer()));
-        }
-        else {
-          contents_.emplace_back(Float64Builder::fromempty(options_));
-          tofill = --contents_.end();
-        }
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t length = tofill->get()->length();
-      tofill->get()->real(x);
-      tags_.append(i);
-      index_.append(length);
-    }
-    else {
-      contents_[(size_t)current_].get()->real(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::complex(std::complex<double> x) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<Complex128Builder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-          return dynamic_cast<Float64Builder*>(p.get());
-        });
-        if (tofill != contents_.end()) {
-          *tofill = std::move(Complex128Builder::fromfloat64(
-              options_,
-              std::move(static_cast<Float64Builder*>(tofill->get())->buffer())));
-        }
-      }
-      if (tofill == contents_.end()) {
-        tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-          return dynamic_cast<Int64Builder*>(p.get());
-        });
-        if (tofill != contents_.end()) {
-          *tofill = std::move(Complex128Builder::fromint64(
-              options_,
-              std::move(static_cast<Int64Builder*>(tofill->get())->buffer())));
-        }
-        else {
-          contents_.emplace_back(Complex128Builder::fromempty(options_));
-          tofill = --contents_.end();
-        }
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t length = tofill->get()->length();
-      tofill->get()->complex(x);
-      tags_.append(i);
-      index_.append(length);
-    }
-    else {
-      contents_[(size_t)current_].get()->complex(x);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::datetime(int64_t x, const std::string& unit) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<DatetimeBuilder*>(p.get());
-        return raw != 0 && raw->units() == unit;
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t len = tofill->get()->length();
-      tofill->get()->datetime(x, unit);
-      tags_.append(i);
-      index_.append(len);
-    }
-    else {
-      contents_[(size_t)current_].get()->datetime(x, unit);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::timedelta(int64_t x, const std::string& unit) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<DatetimeBuilder*>(p.get());
-        return raw != 0 && raw->units() == unit;
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t len = tofill->get()->length();
-      tofill->get()->timedelta(x, unit);
-      tags_.append(i);
-      index_.append(len);
-    }
-    else {
-      contents_[(size_t)current_].get()->timedelta(x, unit);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::string(const char* x, int64_t length, const char* encoding) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<StringBuilder*>(p.get());
-        return raw != 0 && raw->encoding() == encoding;
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(StringBuilder::fromempty(options_, encoding));
-        tofill = --contents_.end();
-      }
-      int8_t i = (int8_t)std::distance(contents_.begin(), tofill);
-      int64_t len = tofill->get()->length();
-      tofill->get()->string(x, length, encoding);
-      tags_.append(i);
-      index_.append(len);
-    }
-    else {
-      contents_[(size_t)current_].get()->string(x, length, encoding);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::beginlist() {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        return dynamic_cast<ListBuilder*>(p.get());
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(ListBuilder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      tofill->get()->beginlist();
-      current_ = (int8_t)std::distance(contents_.begin(), tofill);
-    }
-    else {
-      contents_[(size_t)current_].get()->beginlist();
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::endlist() {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'end_list' without 'begin_list' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = contents_[(size_t)current_].get()->length();
-      contents_[(size_t)current_].get()->endlist();
-      if (length != contents_[(size_t)current_].get()->length()) {
-        tags_.append(current_);
-        index_.append(length);
-        current_ = -1;
-      }
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::begintuple(int64_t numfields) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<TupleBuilder*>(p.get());
-        return raw != nullptr  &&  (raw->length() == -1  ||  raw->numfields() == numfields);
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(TupleBuilder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      tofill->get()->begintuple(numfields);
-      current_ = (int8_t)std::distance(contents_.begin(), tofill);
-    }
-    else {
-      contents_[(size_t)current_].get()->begintuple(numfields);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::index(int64_t index) {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'index' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)current_].get()->index(index);
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::endtuple() {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = contents_[(size_t)current_].get()->length();
-      contents_[(size_t)current_].get()->endtuple();
-      if (length != contents_[(size_t)current_].get()->length()) {
-        tags_.append(current_);
-        index_.append(length);
-        current_ = -1;
-      }
-    }
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnionBuilder::beginrecord(const char* name, bool check) {
-    if (current_ == -1) {
-      auto tofill = std::find_if(contents_.begin(), contents_.end(), [&](BuilderPtr const& p) {
-        const auto& raw = dynamic_cast<RecordBuilder*>(p.get());
-        return raw != nullptr  &&  (raw->length() == -1  ||
-                ((check  &&  raw->name() == name)  ||
-                 (!check  &&  raw->nameptr() == name)));
-      });
-      if (tofill == contents_.end()) {
-        contents_.emplace_back(RecordBuilder::fromempty(options_));
-        tofill = --contents_.end();
-      }
-      tofill->get()->beginrecord(name, check);
-      current_ = (int8_t)std::distance(contents_.begin(), tofill);
-    }
-    else {
-      contents_[(size_t)current_].get()->beginrecord(name, check);
-    }
-    return shared_from_this();
-  }
-
-  void
-  UnionBuilder::field(const char* key, bool check) {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'field' without 'begin_record' at the same level before it")
-        + FILENAME(__LINE__));
-    }
-    else {
-      contents_[(size_t)current_].get()->field(key, check);
-    }
-  }
-
-  const BuilderPtr
-  UnionBuilder::endrecord() {
-    if (current_ == -1) {
-      throw std::invalid_argument(
-        std::string("called 'end_record' without 'begin_record' at the same level "
-                    "before it") + FILENAME(__LINE__));
-    }
-    else {
-      int64_t length = contents_[(size_t)current_].get()->length();
-      contents_[(size_t)current_].get()->endrecord();
-      if (length != contents_[(size_t)current_].get()->length()) {
-        tags_.append(current_);
-        index_.append(length);
-        current_ = -1;
-      }
-    }
-    return shared_from_this();
-  }
-
+const BuilderPtr UnionBuilder::fromsingle(const BuilderOptions &options,
+                                          const BuilderPtr     &firstcontent) {
+  std::vector<BuilderPtr> contents({firstcontent});
+  return std::make_shared<UnionBuilder>(
+      options, GrowableBuffer<int8_t>::full(options, 0, firstcontent->length()),
+      GrowableBuffer<int64_t>::arange(options, firstcontent->length()),
+      contents);
 }
+
+UnionBuilder::UnionBuilder(const BuilderOptions    &options,
+                           GrowableBuffer<int8_t>   tags,
+                           GrowableBuffer<int64_t>  index,
+                           std::vector<BuilderPtr> &contents)
+    : options_(options), tags_(std::move(tags)), index_(std::move(index)),
+      contents_(contents), current_(-1) {}
+
+const std::string UnionBuilder::classname() const { return "UnionBuilder"; };
+
+const std::string UnionBuilder::to_buffers(BuffersContainer &container,
+                                           int64_t &form_key_id) const {
+  std::stringstream form_key;
+  form_key << "node" << (form_key_id++);
+
+  tags_.concatenate(reinterpret_cast<int8_t *>(container.empty_buffer(
+      form_key.str() + "-tags",
+      (int64_t)tags_.length() * (int64_t)sizeof(int8_t))));
+
+  index_.concatenate(reinterpret_cast<int64_t *>(container.empty_buffer(
+      form_key.str() + "-index",
+      (int64_t)index_.length() * (int64_t)sizeof(int64_t))));
+
+  std::stringstream out;
+  out << "{\"class\": \"UnionArray\", \"tags\": \"i8\", \"index\": \"i64\", "
+         "\"contents\": [";
+  for (size_t i = 0; i < contents_.size(); i++) {
+    if (i != 0) {
+      out << ", ";
+    }
+    out << contents_[i].get()->to_buffers(container, form_key_id);
+  }
+  out << "], \"form_key\": \"" << form_key.str() + "\"}";
+  return out.str();
+}
+
+int64_t UnionBuilder::length() const { return (int64_t)tags_.length(); }
+
+void UnionBuilder::clear() {
+  tags_.clear();
+  index_.clear();
+  for (auto x : contents_) {
+    x.get()->clear();
+  }
+}
+
+bool UnionBuilder::active() const { return current_ != -1; }
+
+const BuilderPtr UnionBuilder::null() {
+  if (current_ == -1) {
+    BuilderPtr out = OptionBuilder::fromvalids(options_, shared_from_this());
+    out.get()->null();
+    return out;
+  } else {
+    contents_[(size_t)current_].get()->null();
+    return shared_from_this();
+  }
+}
+
+const BuilderPtr UnionBuilder::boolean(bool x) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(contents_.begin(), contents_.end(),
+                               [&](BuilderPtr const &p) {
+                                 return dynamic_cast<BoolBuilder *>(p.get());
+                               });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(BoolBuilder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    int8_t  i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t length = tofill->get()->length();
+    tofill->get()->boolean(x);
+    tags_.append(i);
+    index_.append(length);
+  } else {
+    contents_[(size_t)current_].get()->boolean(x);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::integer(int64_t x) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(contents_.begin(), contents_.end(),
+                               [&](BuilderPtr const &p) {
+                                 return dynamic_cast<Int64Builder *>(p.get());
+                               });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(Int64Builder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    int8_t  i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t len = tofill->get()->length();
+    tofill->get()->integer(x);
+    tags_.append(i);
+    index_.append(len);
+  } else {
+    contents_[(size_t)current_].get()->integer(x);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::real(double x) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(contents_.begin(), contents_.end(),
+                               [&](BuilderPtr const &p) {
+                                 return dynamic_cast<Float64Builder *>(p.get());
+                               });
+    if (tofill == contents_.end()) {
+      tofill = std::find_if(contents_.begin(), contents_.end(),
+                            [&](BuilderPtr const &p) {
+                              return dynamic_cast<Int64Builder *>(p.get());
+                            });
+      if (tofill != contents_.end()) {
+        *tofill = Float64Builder::fromint64(
+            options_,
+            std::move(static_cast<Int64Builder *>(tofill->get())->buffer()));
+      } else {
+        contents_.emplace_back(Float64Builder::fromempty(options_));
+        tofill = --contents_.end();
+      }
+    }
+    int8_t  i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t length = tofill->get()->length();
+    tofill->get()->real(x);
+    tags_.append(i);
+    index_.append(length);
+  } else {
+    contents_[(size_t)current_].get()->real(x);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::complex(std::complex<double> x) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          return dynamic_cast<Complex128Builder *>(p.get());
+        });
+    if (tofill == contents_.end()) {
+      tofill = std::find_if(contents_.begin(), contents_.end(),
+                            [&](BuilderPtr const &p) {
+                              return dynamic_cast<Float64Builder *>(p.get());
+                            });
+      if (tofill != contents_.end()) {
+        *tofill = std::move(Complex128Builder::fromfloat64(
+            options_,
+            std::move(static_cast<Float64Builder *>(tofill->get())->buffer())));
+      }
+    }
+    if (tofill == contents_.end()) {
+      tofill = std::find_if(contents_.begin(), contents_.end(),
+                            [&](BuilderPtr const &p) {
+                              return dynamic_cast<Int64Builder *>(p.get());
+                            });
+      if (tofill != contents_.end()) {
+        *tofill = std::move(Complex128Builder::fromint64(
+            options_,
+            std::move(static_cast<Int64Builder *>(tofill->get())->buffer())));
+      } else {
+        contents_.emplace_back(Complex128Builder::fromempty(options_));
+        tofill = --contents_.end();
+      }
+    }
+    int8_t  i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t length = tofill->get()->length();
+    tofill->get()->complex(x);
+    tags_.append(i);
+    index_.append(length);
+  } else {
+    contents_[(size_t)current_].get()->complex(x);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::datetime(int64_t x, const std::string &unit) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<DatetimeBuilder *>(p.get());
+          return raw != 0 && raw->units() == unit;
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
+      tofill = --contents_.end();
+    }
+    int8_t  i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t len = tofill->get()->length();
+    tofill->get()->datetime(x, unit);
+    tags_.append(i);
+    index_.append(len);
+  } else {
+    contents_[(size_t)current_].get()->datetime(x, unit);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::timedelta(int64_t x, const std::string &unit) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<DatetimeBuilder *>(p.get());
+          return raw != 0 && raw->units() == unit;
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(DatetimeBuilder::fromempty(options_, unit));
+      tofill = --contents_.end();
+    }
+    int8_t  i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t len = tofill->get()->length();
+    tofill->get()->timedelta(x, unit);
+    tags_.append(i);
+    index_.append(len);
+  } else {
+    contents_[(size_t)current_].get()->timedelta(x, unit);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::string(const char *x, int64_t length,
+                                      const char *encoding) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<StringBuilder *>(p.get());
+          return raw != 0 && raw->encoding() == encoding;
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(StringBuilder::fromempty(options_, encoding));
+      tofill = --contents_.end();
+    }
+    int8_t  i = (int8_t)std::distance(contents_.begin(), tofill);
+    int64_t len = tofill->get()->length();
+    tofill->get()->string(x, length, encoding);
+    tags_.append(i);
+    index_.append(len);
+  } else {
+    contents_[(size_t)current_].get()->string(x, length, encoding);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::beginlist() {
+  if (current_ == -1) {
+    auto tofill = std::find_if(contents_.begin(), contents_.end(),
+                               [&](BuilderPtr const &p) {
+                                 return dynamic_cast<ListBuilder *>(p.get());
+                               });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(ListBuilder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    tofill->get()->beginlist();
+    current_ = (int8_t)std::distance(contents_.begin(), tofill);
+  } else {
+    contents_[(size_t)current_].get()->beginlist();
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::endlist() {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'end_list' without 'begin_list' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = contents_[(size_t)current_].get()->length();
+    contents_[(size_t)current_].get()->endlist();
+    if (length != contents_[(size_t)current_].get()->length()) {
+      tags_.append(current_);
+      index_.append(length);
+      current_ = -1;
+    }
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::begintuple(int64_t numfields) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<TupleBuilder *>(p.get());
+          return raw != nullptr &&
+                 (raw->length() == -1 || raw->numfields() == numfields);
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(TupleBuilder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    tofill->get()->begintuple(numfields);
+    current_ = (int8_t)std::distance(contents_.begin(), tofill);
+  } else {
+    contents_[(size_t)current_].get()->begintuple(numfields);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::index(int64_t index) {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'index' without 'begin_tuple' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)current_].get()->index(index);
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::endtuple() {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'end_tuple' without 'begin_tuple' at the same "
+                    "level before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = contents_[(size_t)current_].get()->length();
+    contents_[(size_t)current_].get()->endtuple();
+    if (length != contents_[(size_t)current_].get()->length()) {
+      tags_.append(current_);
+      index_.append(length);
+      current_ = -1;
+    }
+  }
+  return shared_from_this();
+}
+
+const BuilderPtr UnionBuilder::beginrecord(const char *name, bool check) {
+  if (current_ == -1) {
+    auto tofill = std::find_if(
+        contents_.begin(), contents_.end(), [&](BuilderPtr const &p) {
+          const auto &raw = dynamic_cast<RecordBuilder *>(p.get());
+          return raw != nullptr &&
+                 (raw->length() == -1 || ((check && raw->name() == name) ||
+                                          (!check && raw->nameptr() == name)));
+        });
+    if (tofill == contents_.end()) {
+      contents_.emplace_back(RecordBuilder::fromempty(options_));
+      tofill = --contents_.end();
+    }
+    tofill->get()->beginrecord(name, check);
+    current_ = (int8_t)std::distance(contents_.begin(), tofill);
+  } else {
+    contents_[(size_t)current_].get()->beginrecord(name, check);
+  }
+  return shared_from_this();
+}
+
+void UnionBuilder::field(const char *key, bool check) {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string("called 'field' without 'begin_record' at the same level "
+                    "before it") +
+        FILENAME(__LINE__));
+  } else {
+    contents_[(size_t)current_].get()->field(key, check);
+  }
+}
+
+const BuilderPtr UnionBuilder::endrecord() {
+  if (current_ == -1) {
+    throw std::invalid_argument(
+        std::string(
+            "called 'end_record' without 'begin_record' at the same level "
+            "before it") +
+        FILENAME(__LINE__));
+  } else {
+    int64_t length = contents_[(size_t)current_].get()->length();
+    contents_[(size_t)current_].get()->endrecord();
+    if (length != contents_[(size_t)current_].get()->length()) {
+      tags_.append(current_);
+      index_.append(length);
+      current_ = -1;
+    }
+  }
+  return shared_from_this();
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -1,216 +1,196 @@
-// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see
+// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnknownBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnknownBuilder.cpp", line)
 
 #include <stdexcept>
 
-#include "awkward/builder/OptionBuilder.h"
 #include "awkward/builder/BoolBuilder.h"
-#include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/builder/Int64Builder.h"
-#include "awkward/builder/Float64Builder.h"
 #include "awkward/builder/Complex128Builder.h"
-#include "awkward/builder/StringBuilder.h"
+#include "awkward/builder/DatetimeBuilder.h"
+#include "awkward/builder/Float64Builder.h"
+#include "awkward/builder/Int64Builder.h"
 #include "awkward/builder/ListBuilder.h"
-#include "awkward/builder/TupleBuilder.h"
+#include "awkward/builder/OptionBuilder.h"
 #include "awkward/builder/RecordBuilder.h"
+#include "awkward/builder/StringBuilder.h"
+#include "awkward/builder/TupleBuilder.h"
 
 #include "awkward/builder/UnknownBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  UnknownBuilder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<UnknownBuilder>(options, 0);
-  }
-
-  UnknownBuilder::UnknownBuilder(const BuilderOptions& options,
-                                 int64_t nullcount)
-      : options_(options)
-      , nullcount_(nullcount) { }
-
-  const std::string
-  UnknownBuilder::classname() const {
-    return "UnknownBuilder";
-  };
-
-  const std::string
-  UnknownBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    if (nullcount_ == 0) {
-      std::stringstream form_key;
-      form_key << "node" << (form_key_id++);
-
-      return "{\"class\": \"EmptyArray\", \"form_key\": \""
-             + form_key.str() + "\"}";
-    }
-    else {
-      std::stringstream outer_form_key;
-      std::stringstream inner_form_key;
-      outer_form_key << "node" << (form_key_id++);
-      inner_form_key << "node" << (form_key_id++);
-
-      container.full_buffer(outer_form_key.str() + "-index", nullcount_, -1, "i8");
-
-      return std::string("{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", \"content\": ")
-             + "{\"class\": \"EmptyArray\", \"form_key\": \""
-             + inner_form_key.str() + "\"}, \"form_key\": \""
-             + outer_form_key.str() + "\"}";
-    }
-  }
-
-  int64_t
-  UnknownBuilder::length() const {
-    return nullcount_;
-  }
-
-  void
-  UnknownBuilder::clear() {
-    nullcount_ = 0;
-  }
-
-  bool
-  UnknownBuilder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::null() {
-    nullcount_++;
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnknownBuilder::boolean(bool x) {
-    BuilderPtr out = BoolBuilder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::integer(int64_t x) {
-    BuilderPtr out = Int64Builder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->integer(x);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::real(double x) {
-    BuilderPtr out = Float64Builder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = StringBuilder::fromempty(options_, encoding);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::beginlist() {
-    BuilderPtr out = ListBuilder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  UnknownBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = TupleBuilder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  UnknownBuilder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  UnknownBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = RecordBuilder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  UnknownBuilder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  UnknownBuilder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr UnknownBuilder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<UnknownBuilder>(options, 0);
 }
+
+UnknownBuilder::UnknownBuilder(const BuilderOptions &options, int64_t nullcount)
+    : options_(options), nullcount_(nullcount) {}
+
+const std::string UnknownBuilder::classname() const {
+  return "UnknownBuilder";
+};
+
+const std::string UnknownBuilder::to_buffers(BuffersContainer &container,
+                                             int64_t &form_key_id) const {
+  if (nullcount_ == 0) {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    return "{\"class\": \"EmptyArray\", \"form_key\": \"" + form_key.str() +
+           "\"}";
+  } else {
+    std::stringstream outer_form_key;
+    std::stringstream inner_form_key;
+    outer_form_key << "node" << (form_key_id++);
+    inner_form_key << "node" << (form_key_id++);
+
+    container.full_buffer(outer_form_key.str() + "-index", nullcount_, -1,
+                          "i8");
+
+    return std::string("{\"class\": \"IndexedOptionArray\", \"index\": "
+                       "\"i64\", \"content\": ") +
+           "{\"class\": \"EmptyArray\", \"form_key\": \"" +
+           inner_form_key.str() + "\"}, \"form_key\": \"" +
+           outer_form_key.str() + "\"}";
+  }
+}
+
+int64_t UnknownBuilder::length() const { return nullcount_; }
+
+void UnknownBuilder::clear() { nullcount_ = 0; }
+
+bool UnknownBuilder::active() const { return false; }
+
+const BuilderPtr UnknownBuilder::null() {
+  nullcount_++;
+  return shared_from_this();
+}
+
+const BuilderPtr UnknownBuilder::boolean(bool x) {
+  BuilderPtr out = BoolBuilder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::integer(int64_t x) {
+  BuilderPtr out = Int64Builder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->integer(x);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::real(double x) {
+  BuilderPtr out = Float64Builder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::complex(std::complex<double> x) {
+  BuilderPtr out = Complex128Builder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::string(const char *x, int64_t length,
+                                        const char *encoding) {
+  BuilderPtr out = StringBuilder::fromempty(options_, encoding);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::beginlist() {
+  BuilderPtr out = ListBuilder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr UnknownBuilder::begintuple(int64_t numfields) {
+  BuilderPtr out = TupleBuilder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr UnknownBuilder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr UnknownBuilder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = RecordBuilder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void UnknownBuilder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr UnknownBuilder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -1,196 +1,216 @@
-// BSD 3-Clause License; see
-// https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line)                                                         \
-  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnknownBuilder.cpp", line)
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnknownBuilder.cpp", line)
 
 #include <stdexcept>
 
-#include "awkward/builder/BoolBuilder.h"
-#include "awkward/builder/Complex128Builder.h"
-#include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/builder/Float64Builder.h"
-#include "awkward/builder/Int64Builder.h"
-#include "awkward/builder/ListBuilder.h"
 #include "awkward/builder/OptionBuilder.h"
-#include "awkward/builder/RecordBuilder.h"
+#include "awkward/builder/BoolBuilder.h"
+#include "awkward/builder/DatetimeBuilder.h"
+#include "awkward/builder/Int64Builder.h"
+#include "awkward/builder/Float64Builder.h"
+#include "awkward/builder/Complex128Builder.h"
 #include "awkward/builder/StringBuilder.h"
+#include "awkward/builder/ListBuilder.h"
 #include "awkward/builder/TupleBuilder.h"
+#include "awkward/builder/RecordBuilder.h"
 
 #include "awkward/builder/UnknownBuilder.h"
 
 namespace awkward {
-const BuilderPtr UnknownBuilder::fromempty(const BuilderOptions &options) {
-  return std::make_shared<UnknownBuilder>(options, 0);
-}
-
-UnknownBuilder::UnknownBuilder(const BuilderOptions &options, int64_t nullcount)
-    : options_(options), nullcount_(nullcount) {}
-
-const std::string UnknownBuilder::classname() const {
-  return "UnknownBuilder";
-};
-
-const std::string UnknownBuilder::to_buffers(BuffersContainer &container,
-                                             int64_t &form_key_id) const {
-  if (nullcount_ == 0) {
-    std::stringstream form_key;
-    form_key << "node" << (form_key_id++);
-
-    return "{\"class\": \"EmptyArray\", \"form_key\": \"" + form_key.str() +
-           "\"}";
-  } else {
-    std::stringstream outer_form_key;
-    std::stringstream inner_form_key;
-    outer_form_key << "node" << (form_key_id++);
-    inner_form_key << "node" << (form_key_id++);
-
-    container.full_buffer(outer_form_key.str() + "-index", nullcount_, -1,
-                          "i8");
-
-    return std::string("{\"class\": \"IndexedOptionArray\", \"index\": "
-                       "\"i64\", \"content\": ") +
-           "{\"class\": \"EmptyArray\", \"form_key\": \"" +
-           inner_form_key.str() + "\"}, \"form_key\": \"" +
-           outer_form_key.str() + "\"}";
+  const BuilderPtr
+  UnknownBuilder::fromempty(const BuilderOptions& options) {
+    return std::make_shared<UnknownBuilder>(options, 0);
   }
-}
 
-int64_t UnknownBuilder::length() const { return nullcount_; }
+  UnknownBuilder::UnknownBuilder(const BuilderOptions& options,
+                                 int64_t nullcount)
+      : options_(options)
+      , nullcount_(nullcount) { }
 
-void UnknownBuilder::clear() { nullcount_ = 0; }
+  const std::string
+  UnknownBuilder::classname() const {
+    return "UnknownBuilder";
+  };
 
-bool UnknownBuilder::active() const { return false; }
+  const std::string
+  UnknownBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
+    if (nullcount_ == 0) {
+      std::stringstream form_key;
+      form_key << "node" << (form_key_id++);
 
-const BuilderPtr UnknownBuilder::null() {
-  nullcount_++;
-  return shared_from_this();
-}
+      return "{\"class\": \"EmptyArray\", \"form_key\": \""
+             + form_key.str() + "\"}";
+    }
+    else {
+      std::stringstream outer_form_key;
+      std::stringstream inner_form_key;
+      outer_form_key << "node" << (form_key_id++);
+      inner_form_key << "node" << (form_key_id++);
 
-const BuilderPtr UnknownBuilder::boolean(bool x) {
-  BuilderPtr out = BoolBuilder::fromempty(options_);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+      container.full_buffer(outer_form_key.str() + "-index", nullcount_, -1, "i8");
+
+      return std::string("{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", \"content\": ")
+             + "{\"class\": \"EmptyArray\", \"form_key\": \""
+             + inner_form_key.str() + "\"}, \"form_key\": \""
+             + outer_form_key.str() + "\"}";
+    }
   }
-  out.get()->boolean(x);
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::integer(int64_t x) {
-  BuilderPtr out = Int64Builder::fromempty(options_);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  int64_t
+  UnknownBuilder::length() const {
+    return nullcount_;
   }
-  out.get()->integer(x);
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::real(double x) {
-  BuilderPtr out = Float64Builder::fromempty(options_);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  void
+  UnknownBuilder::clear() {
+    nullcount_ = 0;
   }
-  out.get()->real(x);
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::complex(std::complex<double> x) {
-  BuilderPtr out = Complex128Builder::fromempty(options_);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  bool
+  UnknownBuilder::active() const {
+    return false;
   }
-  out.get()->complex(x);
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::datetime(int64_t x, const std::string &unit) {
-  BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  const BuilderPtr
+  UnknownBuilder::null() {
+    nullcount_++;
+    return shared_from_this();
   }
-  out.get()->datetime(x, unit);
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::timedelta(int64_t x, const std::string &unit) {
-  BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  const BuilderPtr
+  UnknownBuilder::boolean(bool x) {
+    BuilderPtr out = BoolBuilder::fromempty(options_);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->boolean(x);
+    return out;
   }
-  out.get()->timedelta(x, unit);
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::string(const char *x, int64_t length,
-                                        const char *encoding) {
-  BuilderPtr out = StringBuilder::fromempty(options_, encoding);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  const BuilderPtr
+  UnknownBuilder::integer(int64_t x) {
+    BuilderPtr out = Int64Builder::fromempty(options_);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->integer(x);
+    return out;
   }
-  out.get()->string(x, length, encoding);
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::beginlist() {
-  BuilderPtr out = ListBuilder::fromempty(options_);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  const BuilderPtr
+  UnknownBuilder::real(double x) {
+    BuilderPtr out = Float64Builder::fromempty(options_);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->real(x);
+    return out;
   }
-  out.get()->beginlist();
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::endlist() {
-  throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr UnknownBuilder::begintuple(int64_t numfields) {
-  BuilderPtr out = TupleBuilder::fromempty(options_);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  const BuilderPtr
+  UnknownBuilder::complex(std::complex<double> x) {
+    BuilderPtr out = Complex128Builder::fromempty(options_);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->complex(x);
+    return out;
   }
-  out.get()->begintuple(numfields);
-  return out;
-}
 
-const BuilderPtr UnknownBuilder::index(int64_t /* index */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'index' without 'begin_tuple' at the same level before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr UnknownBuilder::endtuple() {
-  throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
-                  "before it") +
-      FILENAME(__LINE__));
-}
-
-const BuilderPtr UnknownBuilder::beginrecord(const char *name, bool check) {
-  BuilderPtr out = RecordBuilder::fromempty(options_);
-  if (nullcount_ != 0) {
-    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  const BuilderPtr
+  UnknownBuilder::datetime(int64_t x, const std::string& unit) {
+    BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->datetime(x, unit);
+    return out;
   }
-  out.get()->beginrecord(name, check);
-  return out;
-}
 
-void UnknownBuilder::field(const char * /* key */, bool /* check */) {
-  throw std::invalid_argument(
-      std::string(
-          "called 'field' without 'begin_record' at the same level before it") +
-      FILENAME(__LINE__));
-}
+  const BuilderPtr
+  UnknownBuilder::timedelta(int64_t x, const std::string& unit) {
+    BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->timedelta(x, unit);
+    return out;
+  }
 
-const BuilderPtr UnknownBuilder::endrecord() {
-  throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same "
-                  "level before it") +
-      FILENAME(__LINE__));
-}
+  const BuilderPtr
+  UnknownBuilder::string(const char* x, int64_t length, const char* encoding) {
+    BuilderPtr out = StringBuilder::fromempty(options_, encoding);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->string(x, length, encoding);
+    return out;
+  }
 
-} // namespace awkward
+  const BuilderPtr
+  UnknownBuilder::beginlist() {
+    BuilderPtr out = ListBuilder::fromempty(options_);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->beginlist();
+    return out;
+  }
+
+  const BuilderPtr
+  UnknownBuilder::endlist() {
+    throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  UnknownBuilder::begintuple(int64_t numfields) {
+    BuilderPtr out = TupleBuilder::fromempty(options_);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->begintuple(numfields);
+    return out;
+  }
+
+  const BuilderPtr
+  UnknownBuilder::index(int64_t /* index */) {
+    throw std::invalid_argument(
+      std::string("called 'index' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  UnknownBuilder::endtuple() {
+    throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  UnknownBuilder::beginrecord(const char* name, bool check) {
+    BuilderPtr out = RecordBuilder::fromempty(options_);
+    if (nullcount_ != 0) {
+      out = OptionBuilder::fromnulls(options_, nullcount_, out);
+    }
+    out.get()->beginrecord(name, check);
+    return out;
+  }
+
+  void
+  UnknownBuilder::field(const char* /* key */, bool /* check */) {
+    throw std::invalid_argument(
+      std::string("called 'field' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+  const BuilderPtr
+  UnknownBuilder::endrecord() {
+    throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same level before it")
+      + FILENAME(__LINE__));
+  }
+
+}

--- a/src/libawkward/builder/UnknownBuilder.cpp
+++ b/src/libawkward/builder/UnknownBuilder.cpp
@@ -1,216 +1,195 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-#define FILENAME(line) FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnknownBuilder.cpp", line)
+#define FILENAME(line)                                                         \
+  FILENAME_FOR_EXCEPTIONS("src/libawkward/builder/UnknownBuilder.cpp", line)
 
 #include <stdexcept>
 
-#include "awkward/builder/OptionBuilder.h"
 #include "awkward/builder/BoolBuilder.h"
-#include "awkward/builder/DatetimeBuilder.h"
-#include "awkward/builder/Int64Builder.h"
-#include "awkward/builder/Float64Builder.h"
 #include "awkward/builder/Complex128Builder.h"
-#include "awkward/builder/StringBuilder.h"
+#include "awkward/builder/DatetimeBuilder.h"
+#include "awkward/builder/Float64Builder.h"
+#include "awkward/builder/Int64Builder.h"
 #include "awkward/builder/ListBuilder.h"
-#include "awkward/builder/TupleBuilder.h"
+#include "awkward/builder/OptionBuilder.h"
 #include "awkward/builder/RecordBuilder.h"
+#include "awkward/builder/StringBuilder.h"
+#include "awkward/builder/TupleBuilder.h"
 
 #include "awkward/builder/UnknownBuilder.h"
 
 namespace awkward {
-  const BuilderPtr
-  UnknownBuilder::fromempty(const BuilderOptions& options) {
-    return std::make_shared<UnknownBuilder>(options, 0);
-  }
-
-  UnknownBuilder::UnknownBuilder(const BuilderOptions& options,
-                                 int64_t nullcount)
-      : options_(options)
-      , nullcount_(nullcount) { }
-
-  const std::string
-  UnknownBuilder::classname() const {
-    return "UnknownBuilder";
-  };
-
-  const std::string
-  UnknownBuilder::to_buffers(BuffersContainer& container, int64_t& form_key_id) const {
-    if (nullcount_ == 0) {
-      std::stringstream form_key;
-      form_key << "node" << (form_key_id++);
-
-      return "{\"class\": \"EmptyArray\", \"form_key\": \""
-             + form_key.str() + "\"}";
-    }
-    else {
-      std::stringstream outer_form_key;
-      std::stringstream inner_form_key;
-      outer_form_key << "node" << (form_key_id++);
-      inner_form_key << "node" << (form_key_id++);
-
-      container.full_buffer(outer_form_key.str() + "-index", nullcount_, -1, "i8");
-
-      return std::string("{\"class\": \"IndexedOptionArray\", \"index\": \"i64\", \"content\": ")
-             + "{\"class\": \"EmptyArray\", \"form_key\": \""
-             + inner_form_key.str() + "\"}, \"form_key\": \""
-             + outer_form_key.str() + "\"}";
-    }
-  }
-
-  int64_t
-  UnknownBuilder::length() const {
-    return nullcount_;
-  }
-
-  void
-  UnknownBuilder::clear() {
-    nullcount_ = 0;
-  }
-
-  bool
-  UnknownBuilder::active() const {
-    return false;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::null() {
-    nullcount_++;
-    return shared_from_this();
-  }
-
-  const BuilderPtr
-  UnknownBuilder::boolean(bool x) {
-    BuilderPtr out = BoolBuilder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->boolean(x);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::integer(int64_t x) {
-    BuilderPtr out = Int64Builder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->integer(x);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::real(double x) {
-    BuilderPtr out = Float64Builder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->real(x);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::complex(std::complex<double> x) {
-    BuilderPtr out = Complex128Builder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->complex(x);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::datetime(int64_t x, const std::string& unit) {
-    BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->datetime(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::timedelta(int64_t x, const std::string& unit) {
-    BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->timedelta(x, unit);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::string(const char* x, int64_t length, const char* encoding) {
-    BuilderPtr out = StringBuilder::fromempty(options_, encoding);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->string(x, length, encoding);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::beginlist() {
-    BuilderPtr out = ListBuilder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->beginlist();
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::endlist() {
-    throw std::invalid_argument(
-      std::string("called 'end_list' without 'begin_list' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  UnknownBuilder::begintuple(int64_t numfields) {
-    BuilderPtr out = TupleBuilder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->begintuple(numfields);
-    return out;
-  }
-
-  const BuilderPtr
-  UnknownBuilder::index(int64_t /* index */) {
-    throw std::invalid_argument(
-      std::string("called 'index' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  UnknownBuilder::endtuple() {
-    throw std::invalid_argument(
-      std::string("called 'end_tuple' without 'begin_tuple' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  UnknownBuilder::beginrecord(const char* name, bool check) {
-    BuilderPtr out = RecordBuilder::fromempty(options_);
-    if (nullcount_ != 0) {
-      out = OptionBuilder::fromnulls(options_, nullcount_, out);
-    }
-    out.get()->beginrecord(name, check);
-    return out;
-  }
-
-  void
-  UnknownBuilder::field(const char* /* key */, bool /* check */) {
-    throw std::invalid_argument(
-      std::string("called 'field' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
-  const BuilderPtr
-  UnknownBuilder::endrecord() {
-    throw std::invalid_argument(
-      std::string("called 'end_record' without 'begin_record' at the same level before it")
-      + FILENAME(__LINE__));
-  }
-
+const BuilderPtr UnknownBuilder::fromempty(const BuilderOptions &options) {
+  return std::make_shared<UnknownBuilder>(options, 0);
 }
+
+UnknownBuilder::UnknownBuilder(const BuilderOptions &options, int64_t nullcount)
+    : options_(options), nullcount_(nullcount) {}
+
+const std::string UnknownBuilder::classname() const {
+  return "UnknownBuilder";
+};
+
+const std::string UnknownBuilder::to_buffers(BuffersContainer &container,
+                                             int64_t &form_key_id) const {
+  if (nullcount_ == 0) {
+    std::stringstream form_key;
+    form_key << "node" << (form_key_id++);
+
+    return "{\"class\": \"EmptyArray\", \"form_key\": \"" + form_key.str() +
+           "\"}";
+  } else {
+    std::stringstream outer_form_key;
+    std::stringstream inner_form_key;
+    outer_form_key << "node" << (form_key_id++);
+    inner_form_key << "node" << (form_key_id++);
+
+    container.full_buffer(outer_form_key.str() + "-index", nullcount_, -1,
+                          "i8");
+
+    return std::string("{\"class\": \"IndexedOptionArray\", \"index\": "
+                       "\"i64\", \"content\": ") +
+           "{\"class\": \"EmptyArray\", \"form_key\": \"" +
+           inner_form_key.str() + "\"}, \"form_key\": \"" +
+           outer_form_key.str() + "\"}";
+  }
+}
+
+int64_t UnknownBuilder::length() const { return nullcount_; }
+
+void UnknownBuilder::clear() { nullcount_ = 0; }
+
+bool UnknownBuilder::active() const { return false; }
+
+const BuilderPtr UnknownBuilder::null() {
+  nullcount_++;
+  return shared_from_this();
+}
+
+const BuilderPtr UnknownBuilder::boolean(bool x) {
+  BuilderPtr out = BoolBuilder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->boolean(x);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::integer(int64_t x) {
+  BuilderPtr out = Int64Builder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->integer(x);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::real(double x) {
+  BuilderPtr out = Float64Builder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->real(x);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::complex(std::complex<double> x) {
+  BuilderPtr out = Complex128Builder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->complex(x);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::datetime(int64_t x, const std::string &unit) {
+  BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->datetime(x, unit);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::timedelta(int64_t x, const std::string &unit) {
+  BuilderPtr out = DatetimeBuilder::fromempty(options_, unit);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->timedelta(x, unit);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::string(const char *x, int64_t length,
+                                        const char *encoding) {
+  BuilderPtr out = StringBuilder::fromempty(options_, encoding);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->string(x, length, encoding);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::beginlist() {
+  BuilderPtr out = ListBuilder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->beginlist();
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::endlist() {
+  throw std::invalid_argument(
+      std::string("called 'end_list' without 'begin_list' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr UnknownBuilder::begintuple(int64_t numfields) {
+  BuilderPtr out = TupleBuilder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->begintuple(numfields);
+  return out;
+}
+
+const BuilderPtr UnknownBuilder::index(int64_t /* index */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'index' without 'begin_tuple' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr UnknownBuilder::endtuple() {
+  throw std::invalid_argument(
+      std::string("called 'end_tuple' without 'begin_tuple' at the same level "
+                  "before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr UnknownBuilder::beginrecord(const char *name, bool check) {
+  BuilderPtr out = RecordBuilder::fromempty(options_);
+  if (nullcount_ != 0) {
+    out = OptionBuilder::fromnulls(options_, nullcount_, out);
+  }
+  out.get()->beginrecord(name, check);
+  return out;
+}
+
+void UnknownBuilder::field(const char * /* key */, bool /* check */) {
+  throw std::invalid_argument(
+      std::string(
+          "called 'field' without 'begin_record' at the same level before it") +
+      FILENAME(__LINE__));
+}
+
+const BuilderPtr UnknownBuilder::endrecord() {
+  throw std::invalid_argument(
+      std::string("called 'end_record' without 'begin_record' at the same "
+                  "level before it") +
+      FILENAME(__LINE__));
+}
+
+} // namespace awkward


### PR DESCRIPTION
@jpivarski suggested to look at a  fastjet/boost-histogram `.clang-format`. Here is a test for discussion. Perhaps we'd like to tune some things?

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/ianna-clang-format-config-test/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->