### PR TITLE
fix: ensure that behaviors are propagated through `ak.XXX` operations

### DIFF
--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -96,4 +96,4 @@ def _impl(
         out = layout.combinations(
             n, replacement=replacement, axis=axis, fields=fields, parameters=parameters
         )
-        return ak._util.wrap(out, behavior, highlevel)
+        return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -59,4 +59,4 @@ def argsort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavio
 def _impl(array, axis, ascending, stable, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = layout.argsort(axis, ascending, stable)
-    return ak._util.wrap(out, behavior, highlevel)
+    return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -190,7 +190,4 @@ def _impl(arrays, kwargs):
         numpy_to_regular=True,
     )
     assert isinstance(out, tuple)
-    if highlevel:
-        return [ak._util.wrap(x, behavior) for x in out]
-    else:
-        return list(out)
+    return [ak._util.wrap(x, behavior, highlevel) for x in out]

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -35,11 +35,7 @@ def _impl(array, highlevel):
             return None
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    layout.recursively_apply(action)
+    behavior = ak._util.behavior_of(array)
+    layout.recursively_apply(action, behavior=behavior)
 
-    if output[0] is None:
-        return None
-    elif highlevel:
-        return ak._util.wrap(output[0], ak._util.behavior_of(array))
-    else:
-        return output[0]
+    return ak._util.wrap(output[0], behavior, highlevel)

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -184,8 +184,6 @@ def combinations(
 def _impl(
     array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior
 ):
-    behavior = ak._util.behavior_of(array, behavior=behavior)
-
     if parameters is None:
         parameters = {}
     else:
@@ -197,4 +195,4 @@ def _impl(
     out = layout.combinations(
         n, replacement=replacement, axis=axis, fields=fields, parameters=parameters
     )
-    return ak._util.wrap(out, behavior, highlevel)
+    return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -51,6 +51,7 @@ def concatenate(
 def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
     # Simple single-array, axis=0 fast-path
     single_nplike = ak.nplikes.nplike_of(arrays)
+    behavior = ak._util.behavior_of(*arrays, behavior=behavior)
     numpy = ak.nplikes.Numpy.instance()
 
     if (
@@ -278,11 +279,9 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
         out = ak._broadcasting.broadcast_and_apply(
             content_or_others,
             action,
-            behavior=ak._util.behavior_of(*arrays, behavior=behavior),
+            behavior=behavior,
             allow_records=True,
             right_broadcast=False,
         )[0]
 
-    return ak._util.wrap(
-        out, ak._util.behavior_of(*arrays, behavior=behavior), highlevel
-    )
+    return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -59,6 +59,7 @@ def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
 
 def _impl(array, value, axis, highlevel, behavior):
     arraylayout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     nplike = ak.nplikes.nplike_of(arraylayout)
 
     # Convert value type to appropriate layout
@@ -123,4 +124,4 @@ def _impl(array, value, axis, highlevel, behavior):
     depth_context = {"posaxis": axis}
     out = arraylayout.recursively_apply(action, behavior, depth_context=depth_context)
 
-    return ak._util.wrap(out, ak._util.behavior_of(array, behavior=behavior), highlevel)
+    return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -57,4 +57,4 @@ def _impl(array, axis, highlevel, behavior):
             highlevel=False,
         )[toslice]
 
-    return ak._util.wrap(out, behavior, highlevel)
+    return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -157,8 +157,8 @@ def _impl(array, axis, highlevel, behavior):
 
         out = apply(layout)
 
-        return ak._util.wrap(out, behavior, highlevel)
+        return ak._util.wrap(out, behavior, highlevel, like=array)
 
     else:
         out = layout.flatten(axis)
-        return ak._util.wrap(out, behavior, highlevel)
+        return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -3,12 +3,14 @@
 import awkward as ak
 
 
-def from_categorical(array, highlevel=True):
+def from_categorical(array, highlevel=True, behavior=None):
     """
     Args:
         array: Awkward Array from which to remove the 'categorical' parameter.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
 
     This function replaces categorical data with non-categorical data (by
     removing the label that declares it as such).
@@ -22,12 +24,12 @@ def from_categorical(array, highlevel=True):
     """
     with ak._errors.OperationErrorContext(
         "ak.from_categorical",
-        dict(array=array, highlevel=highlevel),
+        dict(array=array, highlevel=highlevel, behavior=behavior),
     ):
-        return _impl(array, highlevel)
+        return _impl(array, highlevel, behavior)
 
 
-def _impl(array, highlevel):
+def _impl(array, highlevel, behavior):
     def action(layout, **kwargs):
         if layout.parameter("__array__") == "categorical":
             out = ak.operations.with_parameter(
@@ -39,8 +41,9 @@ def _impl(array, highlevel):
             return None
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = layout.recursively_apply(action)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
+    out = layout.recursively_apply(action, behavior=behavior)
     if highlevel:
-        return ak._util.wrap(out, ak._util.behavior_of(array))
+        return ak._util.wrap(out, behavior)
     else:
         return out

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -6,7 +6,7 @@ from awkward import _errors, _util, jax
 def from_jax(array, regulararray=False, highlevel=True, behavior=None):
     """
     Args:
-        array (jax.numpy.DeviceArray): The JAX Device Array array to convert into an Awkward Array.
+        array (jax.numpy.DeviceArray): The JAX DeviceArray to convert into an Awkward Array.
         regulararray (bool): If True and the array is multidimensional,
             the dimensions are represented by nested #ak.contents.RegularArray
             nodes; if False and the array is multidimensional, the dimensions

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -42,6 +42,7 @@ def from_regular(array, axis=1, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     posaxis = layout.axis_wrap_if_negative(axis)
 
     if axis is None:

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -97,6 +97,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             fill_value = fill_value.view(np.uint8)
 
     layout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
 
     def action(layout, **kwargs):
         if layout.parameter("__array__") == "bytestring" and fill_value is _ZEROS:

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -81,4 +81,4 @@ def local_index(array, axis=-1, highlevel=True, behavior=None):
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     out = layout.local_index(axis)
-    return ak._util.wrap(out, behavior, highlevel)
+    return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -51,5 +51,6 @@ def _impl(array, highlevel, behavior):
             return None
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     out = layout.recursively_apply(action, behavior)
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -75,6 +75,7 @@ def num(array, axis=1, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     out = layout.num(axis=axis)
     if isinstance(out, (ak.contents.Content, ak.record.Record)):
         return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -65,4 +65,4 @@ def packed(array, highlevel=True, behavior=None):
 def _impl(array, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     out = layout.packed()
-    return ak._util.wrap(out, behavior, highlevel)
+    return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -139,4 +139,4 @@ def _impl(array, target, axis, clip, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = layout.pad_none(target, axis, clip=clip)
 
-    return ak._util.wrap(out, behavior, highlevel)
+    return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -58,4 +58,4 @@ def _impl(array, highlevel, behavior):
 
     result = out[0].mergemany(out[1:])
 
-    return ak._util.wrap(result, behavior, highlevel)
+    return ak._util.wrap(result, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -215,7 +215,7 @@ def _impl(array, highlevel, behavior):
             return None
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
 
     out = layout.recursively_apply(action, behavior)
-
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -70,6 +70,7 @@ def _impl(array, highlevel, behavior):
             return None
 
     layout = ak.operations.to_layout(array)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     out = layout.recursively_apply(action, behavior)
 
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -54,8 +54,9 @@ def softmax(x, axis=None, keepdims=False, mask_identity=False, flatten_records=F
 
 
 def _impl(x, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(x)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False)
+        ak.operations.to_layout(x, allow_record=False, allow_other=False), behavior
     )
 
     with np.errstate(invalid="ignore"):

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -48,4 +48,4 @@ def sort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=N
 def _impl(array, axis, ascending, stable, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = layout.sort(axis, ascending, stable)
-    return ak._util.wrap(out, behavior, highlevel)
+    return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -141,12 +141,14 @@ def nanstd(
 
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(x)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False)
+        ak.operations.to_layout(x, allow_record=False, allow_other=False), behavior
     )
     if weight is not None:
         weight = ak.highlevel.Array(
-            ak.operations.to_layout(weight, allow_record=False, allow_other=False)
+            ak.operations.to_layout(weight, allow_record=False, allow_other=False),
+            behavior,
         )
 
     with np.errstate(invalid="ignore"):

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -70,5 +70,6 @@ def _impl(array, to, highlevel, behavior):
             return None
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     out = layout.recursively_apply(action, behavior)
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -59,7 +59,6 @@ def _impl(array, backend, highlevel, behavior):
         allow_record=True,
         allow_other=True,
     )
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     backend_layout = layout.to_backend(backend)
-    if highlevel:
-        return ak.Array(backend_layout, behavior=behavior)
-    return backend_layout
+    return ak._util.wrap(backend_layout, behavior, highlevel)

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -136,9 +136,6 @@ def _impl(array, highlevel):
             return None
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = layout.recursively_apply(action)
-    if highlevel:
-        out = ak._util.wrap(out, ak._util.behavior_of(array))
-        return out
-    else:
-        return out
+    behavior = ak._util.behavior_of(array)
+    out = layout.recursively_apply(action, behavior)
+    return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -49,6 +49,7 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     posaxis = layout.axis_wrap_if_negative(axis)
 
     if axis is None:

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -78,6 +78,7 @@ def _impl(array, counts, axis, highlevel, behavior):
     nplike = ak.nplikes.nplike_of(array)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
 
     if isinstance(counts, (numbers.Integral, np.integer)):
         current_offsets = None

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -56,18 +56,7 @@ def values_astype(array, to, highlevel=True, behavior=None):
 
 def _impl(array, to, highlevel, behavior):
     to_dtype = np.dtype(to)
-    to_str = ak.types.numpytype._dtype_to_primitive_dict.get(to_dtype)
-
-    if to_str is None:
-        if to_dtype.name.startswith("datetime64"):
-            to_str = to_dtype.name
-        else:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    f"cannot use {to_dtype} to cast the numeric type of an array"
-                )
-            )
-
+    to_str = ak.types.numpytype.dtype_to_primitive(to_dtype)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = layout.numbers_to_type(to_str)
-    return ak._util.wrap(out, behavior, highlevel)
+    return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/tests/test_1415-behaviour-forwarding.py
+++ b/tests/test_1415-behaviour-forwarding.py
@@ -164,6 +164,17 @@ def test_behavior_forwarding_structure(operation_behavior):
         == merged_behavior
     )
 
+    def transformer(layout, **kwargs):
+        if layout.is_NumpyType:
+            return ak.contents.NumpyArray(layout.data * 2)
+
+    assert (
+        ak.operations.transform(
+            transformer, three, behavior=operation_behavior
+        ).behavior
+        == merged_behavior
+    )
+
     assert (
         ak.operations.to_regular(three, behavior=operation_behavior).behavior
         == merged_behavior
@@ -187,7 +198,7 @@ def test_behavior_forwarding_structure(operation_behavior):
 
     # Different `where` implementations
     assert (
-        ak.operations.where(mask2, behavior=operation_behavior).behavior
+        ak.operations.where(mask2, behavior=operation_behavior)[0].behavior
         == merged_behavior
     )
     assert (

--- a/tests/test_1415-behaviour-forwarding.py
+++ b/tests/test_1415-behaviour-forwarding.py
@@ -187,23 +187,21 @@ def test_behavior_forwarding_structure(operation_behavior):
 
     # Different `where` implementations
     assert (
-        ak.operations.where(mask2, behavior=operation_behavior)[0].behavior
+        ak.operations.where(mask2, behavior=operation_behavior).behavior
         == merged_behavior
     )
     assert (
-        ak.operations.where(mask1, ~mask1, mask1, behavior=operation_behavior)[
-            0
-        ].behavior
+        ak.operations.where(mask1, ~mask1, mask1, behavior=operation_behavior).behavior
         == merged_behavior
     )
     assert (
-        ak.operations.with_field(six, seven, where="y", behavior=operation_behavior)[
-            0
-        ].behavior
+        ak.operations.with_field(
+            six, seven, where="y", behavior=operation_behavior
+        ).behavior
         == merged_behavior
     )
     assert (
-        ak.operations.with_name(six, "cloud", behavior=operation_behavior)[0].behavior
+        ak.operations.with_name(six, "cloud", behavior=operation_behavior).behavior
         == merged_behavior
     )
     assert (
@@ -211,7 +209,7 @@ def test_behavior_forwarding_structure(operation_behavior):
             ak.operations.with_parameter(
                 one, "__array__", "cloud", behavior=operation_behavior
             )
-        )[0].behavior
+        ).behavior
         == merged_behavior
     )
 

--- a/tests/test_1415-behaviour-forwarding.py
+++ b/tests/test_1415-behaviour-forwarding.py
@@ -5,101 +5,221 @@ import pytest  # noqa: F401
 
 import awkward as ak  # noqa: F401
 
-one = ak.Array([[0.0, 1.1, 2.2, None], [], [3.3, 4.4]])
-two = ak.Array([[100, 200, 300, 400], [300], [400, 500]])
 
-
-def test_behavior_forwarding_structure():
-    three = ak.operations.from_iter([[0.99999], [6], [2.99999]], highlevel=True)
-    four = ak.operations.from_iter([[1.00001], [6], [3.00001]], highlevel=True)
-    mask1 = ak.highlevel.Array([[True, True, False, False], [True], [True, False]])
-    five = ak.Array(["1.1", "2.2", "    3.3    ", "00004.4", "-5.5"])
-
-    six = ak.Array([{"x": 1}, {"x": 2}, {"x": 3}, {"x": 3}, {"x": 3}], check_valid=True)
-    seven = ak.Array([1.1, 2.2, 3.3, 4.4, 5.5], check_valid=True)
-
-    assert ak.operations.argcartesian([one, two], behavior={})[0].behavior == {}
-    assert ak.operations.argcombinations(one, 2, behavior={})[0].behavior == {}
-    assert ak.operations.argsort(one, behavior={})[0].behavior == {}
-
-    assert (
-        ak.operations.broadcast_arrays(
-            5, ak.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4]], behavior={})
-        )[0].behavior
-        == {}
+@pytest.mark.parametrize("operation_behavior", [None, {"other-type": ak.Record}])
+def test_behavior_forwarding_structure(operation_behavior):
+    """Ensure that explicit behaviors win, or the existing behavior is maintained"""
+    local_behavior = {"some-type": ak.Array}
+    merged_behavior = (
+        local_behavior if operation_behavior is None else operation_behavior
+    )
+    one = ak.Array([[0.0, 1.1, 2.2, None], [], [3.3, 4.4]], behavior=local_behavior)
+    two = ak.Array([[100, 200, 300, 400], [300], [400, 500]], behavior=local_behavior)
+    three = ak.operations.from_iter(
+        [[0.99999], [6], [2.99999]], highlevel=True, behavior=local_behavior
+    )
+    four = ak.operations.from_iter(
+        [[1.00001], [6], [3.00001]], highlevel=True, behavior=local_behavior
+    )
+    mask1 = ak.highlevel.Array(
+        [[True, True, False, False], [True], [True, False]], behavior=local_behavior
+    )
+    mask2 = ak.highlevel.Array(
+        [[True, True], [True, False], [True, False]], behavior=local_behavior
+    )
+    five = ak.Array(
+        ["1.1", "2.2", "    3.3    ", "00004.4", "-5.5"], behavior=local_behavior
     )
 
-    assert ak.operations.cartesian([one], behavior={})[0].behavior == {}
-    assert ak.operations.combinations(one, 2, behavior={})[0].behavior == {}
-    assert ak.operations.concatenate([one, two], behavior={})[0].behavior == {}
-
-    assert ak.operations.fill_none(one, 42, behavior={})[0].behavior == {}
-    assert ak.operations.flatten(one, behavior={}).behavior == {}
-    assert ak.operations.from_regular(one, behavior={})[0].behavior == {}
-    assert ak.operations.full_like(one, 6, behavior={})[0].behavior == {}
-
-    assert ak.operations.is_none(one, behavior={}).behavior == {}
-    assert ak.operations.isclose(three, four, behavior={}).behavior == {}
-
-    assert ak.operations.local_index(one, behavior={})[0].behavior == {}
-
-    assert ak.operations.mask(two, mask1, behavior={})[0].behavior == {}
-
-    assert ak.operations.nan_to_num(one, behavior={})[0].behavior == {}
-    assert ak.operations.num(one, behavior={}).behavior == {}
-
-    assert ak.operations.ones_like(one, behavior={})[0].behavior == {}
-
-    assert ak.operations.packed(one, behavior={})[0].behavior == {}
-    assert ak.operations.pad_none(one, 6, behavior={})[0].behavior == {}
-
-    assert ak.operations.ravel(one, behavior={}).behavior == {}
-    assert ak.operations.run_lengths(one, behavior={})[0].behavior == {}
-
-    assert ak.operations.sort(one, behavior={})[0].behavior == {}
-    assert ak.operations.strings_astype(five, np.float64, behavior={}).behavior == {}
-
-    assert ak.operations.to_regular(three, behavior={})[0].behavior == {}
-
-    assert ak.operations.unflatten(five, 2, behavior={})[0].behavior == {}
-    assert ak.operations.unzip(ak.Array([{"x": 1}], behavior={}))[0].behavior == {}
-
-    assert ak.operations.values_astype(one, "float32", behavior={})[0].behavior == {}
-
-    assert (
-        ak.operations.where(
-            ak.highlevel.Array(
-                [[True, True], [True, False], [True, False]], behavior={}
-            )
-        )[0].behavior
-        == {}
+    six = ak.Array(
+        [{"x": 1}, {"x": 2}, {"x": 3}, {"x": 3}, {"x": 3}],
+        check_valid=True,
+        behavior=local_behavior,
     )
-    assert (
-        ak.operations.with_field(six, seven, where="y", behavior={})[0].behavior == {}
-    )
-    assert ak.operations.with_name(six, "cloud", behavior={})[0].behavior == {}
-    assert (
-        ak.operations.without_parameters(
-            ak.operations.with_parameter(one, "__array__", "cloud", behavior={})
-        )[0].behavior
-        == {}
+    seven = ak.Array(
+        [1.1, 2.2, 3.3, 4.4, 5.5], check_valid=True, behavior=local_behavior
     )
 
-    assert ak.operations.zeros_like(one, behavior={})[0].behavior == {}
-    assert ak.operations.zip([five, seven], behavior={})[0].behavior == {}
+    assert (
+        ak.operations.argcartesian([one, two], behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.argcombinations(one, 2, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.argsort(one, behavior=operation_behavior)[0].behavior
+        == merged_behavior
+    )
 
+    assert (
+        ak.operations.broadcast_arrays(5, one, behavior=operation_behavior)[0].behavior
+        == merged_behavior
+    )
 
-def test_behavior_forwarding_convert():
+    assert (
+        ak.operations.cartesian([one], behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.combinations(one, 2, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.concatenate([one, two], behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.firsts(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.fill_none(one, 42, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.flatten(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.from_regular(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
     assert (
         ak.operations.from_json(
             " [ 1 ,2 ,3.0, 4, 5]  \n  ",
             schema={"type": "array", "items": {"type": "number"}},
-            behavior={},
+            behavior=local_behavior,
         ).behavior
-        == {}
+        == local_behavior
+    )
+    assert (
+        ak.operations.full_like(one, 6, behavior=operation_behavior).behavior
+        == merged_behavior
     )
 
+    assert (
+        ak.operations.is_none(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.isclose(three, four, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
 
-def test_behaviour_singletons_firsts():
-    assert ak.operations.firsts([one, two], behavior={})[0].behavior == {}
-    assert ak.operations.singletons(one, behavior={})[0].behavior == {}
+    assert (
+        ak.operations.local_index(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.mask(two, mask1, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.nan_to_num(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.num(one, behavior=operation_behavior).behavior == merged_behavior
+    )
+
+    assert (
+        ak.operations.ones_like(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.packed(one, behavior=operation_behavior)[0].behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.pad_none(one, 6, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.ravel(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.run_lengths(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.singletons(one, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.sort(one, behavior=operation_behavior).behavior == merged_behavior
+    )
+    assert (
+        ak.operations.strings_astype(
+            five, np.float64, behavior=operation_behavior
+        ).behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.to_regular(three, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.unflatten(five, 2, behavior=operation_behavior).behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.unzip(six, behavior=operation_behavior)[0].behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.values_astype(
+            one, "float32", behavior=operation_behavior
+        ).behavior
+        == merged_behavior
+    )
+
+    # Different `where` implementations
+    assert (
+        ak.operations.where(mask2, behavior=operation_behavior)[0].behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.where(mask1, ~mask1, mask1, behavior=operation_behavior)[
+            0
+        ].behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.with_field(six, seven, where="y", behavior=operation_behavior)[
+            0
+        ].behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.with_name(six, "cloud", behavior=operation_behavior)[0].behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.without_parameters(
+            ak.operations.with_parameter(
+                one, "__array__", "cloud", behavior=operation_behavior
+            )
+        )[0].behavior
+        == merged_behavior
+    )
+
+    assert (
+        ak.operations.zeros_like(one, behavior=operation_behavior)[0].behavior
+        == merged_behavior
+    )
+    assert (
+        ak.operations.zip([five, seven], behavior=operation_behavior)[0].behavior
+        == merged_behavior
+    )


### PR DESCRIPTION
#1866 wasn't the first time we've seen a regression in behavior preservation, so I've gone through and checked all of our other operations. This PR hopefully catches some missed cases, and ensures that we test both explicit `behavior=some_dict` and `behavior=None` argument behaviour.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-propagate-behavior/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->