### PR TITLE
feat: better mask_identity defaults for reducer-like functions.

### DIFF
--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -11,7 +11,7 @@ def corr(
     weight=None,
     axis=None,
     keepdims=False,
-    mask_identity=True,
+    mask_identity=False,
     flatten_records=False,
 ):
     """
@@ -82,7 +82,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
             ak.operations.to_layout(weight, allow_record=False, allow_other=False)
         )
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):
         xmean = ak.operations.ak_mean._impl(
             x, weight, axis, False, mask_identity, flatten_records
         )

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -11,7 +11,7 @@ def covar(
     weight=None,
     axis=None,
     keepdims=False,
-    mask_identity=True,
+    mask_identity=False,
     flatten_records=False,
 ):
     """
@@ -80,7 +80,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
             ak.operations.to_layout(weight, allow_record=False, allow_other=False)
         )
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):
         xmean = ak.operations.ak_mean._impl(
             x, weight, axis, False, mask_identity, flatten_records
         )

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -11,7 +11,7 @@ def linear_fit(
     weight=None,
     axis=None,
     keepdims=False,
-    mask_identity=True,
+    mask_identity=False,
     flatten_records=False,
 ):
     """
@@ -95,7 +95,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
             ak.operations.to_layout(weight, allow_record=False, allow_other=False)
         )
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):
         nplike = ak.nplikes.nplike_of(x, y, weight)
         if weight is None:
             sumw = ak.operations.ak_count._impl(

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -7,7 +7,12 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 @ak._connect.numpy.implements("mean")
 def mean(
-    x, weight=None, axis=None, keepdims=False, mask_identity=True, flatten_records=False
+    x,
+    weight=None,
+    axis=None,
+    keepdims=False,
+    mask_identity=False,
+    flatten_records=False,
 ):
     """
     Args:
@@ -151,7 +156,7 @@ def _impl(x, weight, axis, keepdims, mask_identity, flatten_records):
             ak.operations.to_layout(weight, allow_record=False, allow_other=False)
         )
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):
         if weight is None:
             sumw = ak.operations.ak_count._impl(
                 x, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -11,7 +11,7 @@ def moment(
     weight=None,
     axis=None,
     keepdims=False,
-    mask_identity=True,
+    mask_identity=False,
     flatten_records=False,
 ):
     """
@@ -81,7 +81,7 @@ def _impl(x, n, weight, axis, keepdims, mask_identity, flatten_records):
             ak.operations.to_layout(weight, allow_record=False, allow_other=False)
         )
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):
         if weight is None:
             sumw = ak.operations.ak_count._impl(
                 x, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -59,7 +59,7 @@ def _impl(x, axis, keepdims, mask_identity, flatten_records):
         ak.operations.to_layout(x, allow_record=False, allow_other=False), behavior
     )
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):
         nplike = ak.nplikes.nplike_of(x)
         expx = nplike.exp(x)
         denom = ak.operations.ak_sum._impl(

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -12,7 +12,7 @@ def std(
     ddof=0,
     axis=None,
     keepdims=False,
-    mask_identity=True,
+    mask_identity=False,
     flatten_records=False,
 ):
     """
@@ -151,7 +151,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
             behavior,
         )
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):
         return ak.nplikes.nplike_of(x, weight).sqrt(
             ak.operations.ak_var._impl(
                 x,

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -12,7 +12,7 @@ def var(
     ddof=0,
     axis=None,
     keepdims=False,
-    mask_identity=True,
+    mask_identity=False,
     flatten_records=False,
 ):
     """
@@ -155,7 +155,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
             ak.operations.to_layout(weight, allow_record=False, allow_other=False)
         )
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):
         xmean = ak.operations.ak_mean._impl(
             x, weight, axis, False, mask_identity, flatten_records
         )

--- a/tests/test_1320-mask_identity-defaults.py
+++ b/tests/test_1320-mask_identity-defaults.py
@@ -7,7 +7,7 @@ import awkward as ak  # noqa: F401
 
 
 def test():
-    array = ak.Array([[1, 2], [], [3]])
+    array = ak.Array([[1, 2], [], [-np.inf]])
 
     # monoidal reducers (have identities)
     assert ak.count(array, axis=1)[1] == 0
@@ -38,6 +38,7 @@ def test():
 
     # defined in terms of reducers, but a map-like operation
     assert ak.softmax(array, axis=1)[1].tolist() == []
+    assert np.isnan(ak.softmax(array, axis=1)[2, 0])
 
     # defined in terms of reducers, computed from ak.min and ak.max
     assert ak.ptp(array, axis=1)[1] is None

--- a/tests/test_1320-mask_identity-defaults.py
+++ b/tests/test_1320-mask_identity-defaults.py
@@ -1,0 +1,43 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak  # noqa: F401
+
+
+def test():
+    array = ak.Array([[1, 2], [], [3]])
+
+    # monoidal reducers (have identities)
+    assert ak.count(array, axis=1)[1] == 0
+    assert ak.count_nonzero(array, axis=1)[1] == 0
+    assert ak.sum(array, axis=1)[1] == 0
+    assert ak.prod(array, axis=1)[1] == 1
+    assert ak.all(array, axis=1)[1]
+    assert not ak.any(array, axis=1)[1]
+
+    # semigroup reducers (no identity; arguable in the case of min/max on floats)
+    assert ak.max(array, axis=1)[1] is None
+    assert ak.min(array, axis=1)[1] is None
+    assert ak.argmax(array, axis=1)[1] is None
+    assert ak.argmin(array, axis=1)[1] is None
+
+    # defined in terms of reducers, with ak.count in the denominator
+    assert np.isnan(ak.moment(array, 1, axis=1)[1])
+    assert np.isnan(ak.mean(array, axis=1)[1])
+    assert np.isnan(ak.var(array, axis=1)[1])
+    assert np.isnan(ak.std(array, axis=1)[1])
+    assert np.isnan(ak.corr(array, array, axis=1)[1])
+    assert np.isnan(ak.covar(array, array, axis=1)[1])
+
+    assert np.isnan(ak.linear_fit(array, array, axis=1)["intercept", 1])
+    assert np.isnan(ak.linear_fit(array, array, axis=1)["slope", 1])
+    assert np.isnan(ak.linear_fit(array, array, axis=1)["intercept_error", 1])
+    assert np.isnan(ak.linear_fit(array, array, axis=1)["slope_error", 1])
+
+    # defined in terms of reducers, but a map-like operation
+    assert ak.softmax(array, axis=1)[1].tolist() == []
+
+    # defined in terms of reducers, computed from ak.min and ak.max
+    assert ak.ptp(array, axis=1)[1] is None


### PR DESCRIPTION
Motivated by a difference with respect to NumPy: #1320.

The new defaults have been more carefully thought through.

  * monoidal reducers like "sum" (which have identities) have `mask_identity=False`
  * semigroup reducers like "argmax" (no identity) have `mask_identity=True`
  * functions defined in terms of reducers with "count" in the denominator have `mask_identity=False` so that the `np.nan` appears for empty lists (just as it does for NumPy)
  * functions defined in terms of reducers, but are on the whole map-like, rather than reducer-like: `mask_identity=False`
  * functions defined in terms of reducers, computed from "min" and "max": `mask_identity=True`

I also ensured that we're using `np.errstate` consistently. We want to ignore `np.nan` operations and divisions by zero.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-mask_identity-defaults/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->