### PR TITLE
fix: install missing PyPI dependency

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,18 +5,15 @@ on:
     branches:
       - main
     paths-ignore:
-      - README*.md
-      - VERSION_INFO
-      - .ci/*
+      - README.md
+      - CONTRIBUTING.md
+      - CITATION.cff
+      - LICENSE
       - .readthedocs.yml
-      - include/*
-      - src/*
-      - docs-src/*
-      - docs-img/*
-      - docs-jupyter/*
-      - docs-doxygen/*
-      - docs/*
-      - studies/*
+      - docs-img/**
+      - docs/**
+      - awkward-cpp/docs/**
+      - studies/**
 
   workflow_dispatch:
 
@@ -56,13 +53,15 @@ jobs:
 
       - name: Build awkward-cpp wheel
         if: steps.cache-awkward-cpp-wheel.outputs.cache-hit != 'true'
-        run: python3 -m build -w ./awkward-cpp
+        run: |
+          python -m pip install build
+          python -m build -w ./awkward-cpp
 
       - name: Install awkward-cpp
-        run: python3 -m pip install -v ./awkward-cpp/dist/*.whl
+        run: python -m pip install -v ./awkward-cpp/dist/*.whl
 
       - name: Build & install awkward
-        run: python3 -m pip install -v .
+        run: python -m pip install -v .
 
       - name: Print versions
         run: python -m pip list


### PR DESCRIPTION
The codecov workflow had drifted from build-test. This ensures that we first install the needed `build` dependency.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-coverage-workflow/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->