### PR TITLE
ci: set tokens & disable release for C++ [skip ci]

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -2,9 +2,6 @@ name: Deploy C++
 
 on:
   workflow_dispatch:
-  release:
-    types:
-    - published
 
 
 jobs:
@@ -161,4 +158,4 @@ jobs:
 
     - uses: pypa/gh-action-pypi-publish@v1.5.1
       with:
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.PYPI_PASSWORD_CPP }}

--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -2,7 +2,10 @@ name: Deploy C++
 
 on:
   workflow_dispatch:
-
+    inputs:
+        publish-pypi:
+            type: boolean
+            description: Publish to PyPI
 
 jobs:
 
@@ -149,7 +152,7 @@ jobs:
   upload_all:
     needs: [build_wheels, build_alt_wheels, make_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: ${{ inputs.publish-pypi }}
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,4 +97,4 @@ jobs:
 
     - uses: pypa/gh-action-pypi-publish@v1.5.1
       with:
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This PR adds an input form to enable publishing the C++ distributions to PyPI, and sets the API token.
