### PR TITLE
chore: add README.md to awkward-cpp

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -101,6 +101,15 @@ jobs:
         config-file: cibuildwheel.toml
         package-dir: awkward-cpp
 
+    - name: Check metadata
+      shell: python
+      run: |
+        import subprocess, glob
+        subprocess.run(
+          ["pipx", "run", "twine", "check", *glob.glob("wheelhouse/*.whl")],
+          check=True
+        )
+
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
@@ -143,6 +152,15 @@ jobs:
       with:
         config-file: cibuildwheel.toml
         package-dir: awkward-cpp
+
+    - name: Check metadata
+      shell: python
+      run: |
+        import subprocess, glob
+        subprocess.run(
+          ["pipx", "run", "twine", "check", *glob.glob("wheelhouse/*.whl")],
+          check=True
+        )
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/awkward-cpp/README.md
+++ b/awkward-cpp/README.md
@@ -1,0 +1,3 @@
+# `awkward-cpp`
+
+`awkward-cpp` provides the `awkward` package with a suite of high-performance (compiled) kernels which facilitate computations on ragged arrays. It also implements performance-sensitive features, such as the `ak.ArrayBuilder()` class.

--- a/awkward-cpp/README.md
+++ b/awkward-cpp/README.md
@@ -1,3 +1,3 @@
 # `awkward-cpp`
 
-`awkward-cpp` provides the `awkward` package with a suite of high-performance (compiled) kernels which facilitate computations on ragged arrays. It also implements performance-sensitive features, such as the `ak.ArrayBuilder()` class.
+`awkward-cpp` provides precompiled routines for the `awkward` package. It is not useful on its own, only as a dependency for `awkward `.

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -11,6 +11,7 @@ version = "1"
 dependencies = [
     "numpy>=1.13.1"
 ]
+readme = "README.md"
 description = "CPU kernels and compiled extensions for Awkward Array"
 authors = [
     {name = "Jim Pivarski", email = "pivarski@princeton.edu"},


### PR DESCRIPTION
This definitely fixes the wheel (locally), but I also added tests to ensure that we check the metadata of the wheels before upload. This just ensures that if we do practice runs, we'll catch metadata issues a bit earlier.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-chore-fix-cpp-readme/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->