### PR TITLE
ci: simplify hash computation [skip ci]

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         import os, subprocess
         result = subprocess.run(
-          ["git", "log", "-1", '--format=%ad', '--date=unix', '--', 'pyproject.toml'],
+          ["git", "log", "-1", '--format=%at', '--', 'pyproject.toml'],
           cwd="awkward-cpp", capture_output=True, text=True, check=True
         )
         with open(os.environ["GITHUB_ENV"], "a") as env_file:
@@ -84,7 +84,7 @@ jobs:
       run: |
         import os, subprocess
         result = subprocess.run(
-          ["git", "log", "-1", '--format=%ad', '--date=unix', '--', 'pyproject.toml'],
+          ["git", "log", "-1", '--format=%at', '--', 'pyproject.toml'],
           cwd="awkward-cpp", capture_output=True, text=True, check=True
         )
         with open(os.environ["GITHUB_ENV"], "a") as env_file:
@@ -134,7 +134,7 @@ jobs:
       run: |
         import os, subprocess
         result = subprocess.run(
-          ["git", "log", "-1", '--format=%ad', '--date=unix', '--', 'pyproject.toml'],
+          ["git", "log", "-1", '--format=%at', '--', 'pyproject.toml'],
           cwd="awkward-cpp", capture_output=True, text=True, check=True
         )
         with open(os.environ["GITHUB_ENV"], "a") as env_file:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,9 +30,15 @@ jobs:
           submodules: true
 
       - name: Compute SOURCE_DATE_EPOCH
+        shell: python
         run: |
-          SOURCE_DATE_EPOCH="$(git log -1 --format="%ad" --date=unix -- awkward-cpp/pyproject.toml)"
-          echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" >> $GITHUB_ENV
+          import os, subprocess
+          result = subprocess.run(
+            ["git", "log", "-1", '--format=%at', '--', 'pyproject.toml'],
+            cwd="awkward-cpp", capture_output=True, text=True, check=True
+          )
+          with open(os.environ["GITHUB_ENV"], "a") as env_file:
+            env_file.write(f"SOURCE_DATE_EPOCH={result.stdout.strip()}")
 
       - name: Prepare build files
         run: pipx run nox -s prepare


### PR DESCRIPTION
The release workflow failed in https://github.com/scikit-hep/awkward/actions/runs/3501131090, https://github.com/scikit-hep/awkward/actions/runs/3501173113, because the endpoint URL that is used to look up the PyPI package was not properly formed; when the relative package URL was joined with the endpoint, the `pypi` component was lost. 

This PR fixes the default URL, and adds a check to make this impossible in future. It also simplifies the SOURCE_DATE_EPOCH computation.