### PR TITLE
ci: add option to manually release awkward on PyPI

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -170,7 +170,7 @@ jobs:
   upload_all:
     needs: [build_wheels, build_alt_wheels, make_sdist]
     runs-on: ubuntu-latest
-    if: ${{ inputs.publish-pypi }}
+    if: inputs.publish-pypi
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,10 @@ name: Deploy
 
 on:
   workflow_dispatch:
+    inputs:
+        publish-pypi:
+            type: boolean
+            description: Publish to PyPI
   release:
     types:
     - published
@@ -94,7 +98,7 @@ jobs:
   upload:
     needs: [build, check-requirements, check-cpp-on-pypi]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: (github.event_name == 'release' && github.event.action == 'published') || inputs.publish-pypi
     steps:
     - uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
This PR enables manual re-releasing of failed workflows onto PyPI. This addresses problems such as intermittent CI, but we should have a policy when it comes to failures that require repository changes. In this particular instance, only the CI was modified between the GH release and the valid PyPI release (to come), so I think this is acceptable.