### PR TITLE
ci: set constant `$SOURCE_DATE_EPOCH`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ env:
   # Leverage reproducible builds by setting a constant SOURCE_DATE_EPOCH
   # This will ensure that the hash of the awkward-cpp directory remains
   # constant for unchanged files, meaning that it can be used for caching
-  SOURCE_DATE_EPOCH: "1667773939"
+  SOURCE_DATE_EPOCH: "1668811211"
 
 jobs:
   Windows:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,12 @@ concurrency:
   group: 'coverage-${{ github.head_ref || github.run_id }}'
   cancel-in-progress: true
 
+env:
+  # Leverage reproducible builds by setting a constant SOURCE_DATE_EPOCH
+  # This will ensure that the hash of the awkward-cpp directory remains
+  # constant for unchanged files, meaning that it can be used for caching
+  SOURCE_DATE_EPOCH: "1668811211"
+
 jobs:
   coverage:
     runs-on: ubuntu-20.04
@@ -28,7 +34,6 @@ jobs:
     env:
       PIP_ONLY_BINARY: cmake
       PYTHON_VERSION: "3.9"
-      SOURCE_DATE_EPOCH: "1668811211"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,8 +28,7 @@ jobs:
     env:
       PIP_ONLY_BINARY: cmake
       PYTHON_VERSION: "3.9"
-      # Ensure predictable hash
-      SOURCE_DATE_EPOCH: "1667773939"
+      SOURCE_DATE_EPOCH: "1668811211"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -7,14 +7,33 @@ on:
             type: boolean
             description: Publish to PyPI
 
-env:
-  SOURCE_DATE_EPOCH: "1668811211"
-
 jobs:
+  determine-source-date-epoch:
+    name: "Determine SOURCE_DATE_EPOCH"
+    runs-on: ubuntu-latest
+    outputs:
+      source-date-epoch: ${{ steps.log.outputs.source-date-epoch }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - id: log
+        name: Compute SOURCE_DATE_EPOCH
+        run: |
+          # Find latest unix timestamp in awkward-cpp, and the kernel generation files
+          epoch=$( git log -1 --format=%at -- awkward-cpp kernel-specification.yml kernel-test-data.json )
+          echo "source-date-epoch=$epoch" >> $GITHUB_OUTPUT
 
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
+    needs: [determine-source-date-epoch]
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -34,8 +53,11 @@ jobs:
         path: awkward-cpp/dist/*.tar.gz
 
   build_wheels:
+    needs: [determine-source-date-epoch]
     name: "Wheel: ${{ matrix.type }} ${{ matrix.arch }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -93,8 +115,11 @@ jobs:
 
 
   build_alt_wheels:
+    needs: [determine-source-date-epoch]
     name: "Wheel: ${{ matrix.python }} on ${{ matrix.arch }}"
     runs-on: ubuntu-latest
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     strategy:
       matrix:
         python: [37, 38, 39, 310, 311]

--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -7,6 +7,9 @@ on:
             type: boolean
             description: Publish to PyPI
 
+env:
+  SOURCE_DATE_EPOCH: "1668811211"
+
 jobs:
 
   make_sdist:
@@ -16,22 +19,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-
-    - name: Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-
-    - name: Compute SOURCE_DATE_EPOCH
-      shell: python
-      run: |
-        import os, subprocess
-        result = subprocess.run(
-          ["git", "log", "-1", '--format=%at', '--', 'pyproject.toml'],
-          cwd="awkward-cpp", capture_output=True, text=True, check=True
-        )
-        with open(os.environ["GITHUB_ENV"], "a") as env_file:
-          env_file.write(f"SOURCE_DATE_EPOCH={result.stdout.strip()}")
 
     - name: Prepare build files
       run: pipx run nox -s prepare
@@ -79,17 +66,6 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Compute SOURCE_DATE_EPOCH
-      shell: python
-      run: |
-        import os, subprocess
-        result = subprocess.run(
-          ["git", "log", "-1", '--format=%at', '--', 'pyproject.toml'],
-          cwd="awkward-cpp", capture_output=True, text=True, check=True
-        )
-        with open(os.environ["GITHUB_ENV"], "a") as env_file:
-          env_file.write(f"SOURCE_DATE_EPOCH={result.stdout.strip()}")
-
     - name: Prepare build files
       run: pipx run nox -s prepare
 
@@ -129,16 +105,10 @@ jobs:
       with:
         submodules: true
 
-    - name: Compute SOURCE_DATE_EPOCH
-      shell: python
-      run: |
-        import os, subprocess
-        result = subprocess.run(
-          ["git", "log", "-1", '--format=%at', '--', 'pyproject.toml'],
-          cwd="awkward-cpp", capture_output=True, text=True, check=True
-        )
-        with open(os.environ["GITHUB_ENV"], "a") as env_file:
-          env_file.write(f"SOURCE_DATE_EPOCH={result.stdout.strip()}")
+    - name: Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
 
     - name: Prepare build files
       run: pipx run nox -s prepare

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
     types:
     - published
 
+env:
+  SOURCE_DATE_EPOCH: "1668811211"
 
 jobs:
   check-requirements:
@@ -33,17 +35,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Compute SOURCE_DATE_EPOCH
-        shell: python
-        run: |
-          import os, subprocess
-          result = subprocess.run(
-            ["git", "log", "-1", '--format=%at', '--', 'pyproject.toml'],
-            cwd="awkward-cpp", capture_output=True, text=True, check=True
-          )
-          with open(os.environ["GITHUB_ENV"], "a") as env_file:
-            env_file.write(f"SOURCE_DATE_EPOCH={result.stdout.strip()}")
-
       - name: Prepare build files
         run: pipx run nox -s prepare
 
@@ -60,12 +51,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-
-    - name: Compute SOURCE_DATE_EPOCH
-      run: |
-        # Set SOURCE_DATE_EPOCH to datetime of last change to pyproject.toml
-        SOURCE_DATE_EPOCH="$(git log -1 --format="%ad" --date=unix -- pyproject.toml)"
-        echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" >> $GITHUB_ENV
 
     - name: Prepare build files
       run: pipx run nox -s prepare

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,26 @@ on:
     types:
     - published
 
-env:
-  SOURCE_DATE_EPOCH: "1668811211"
-
 jobs:
+  determine-source-date-epoch:
+    name: "Determine SOURCE_DATE_EPOCH"
+    runs-on: ubuntu-latest
+    outputs:
+      source-date-epoch: ${{ steps.log.outputs.source-date-epoch }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - id: log
+        name: Compute SOURCE_DATE_EPOCH
+        run: |
+          # Find latest unix timestamp in awkward-cpp, and the kernel generation files
+          epoch=$( git log -1 --format=%at -- awkward-cpp kernel-specification.yml kernel-test-data.json )
+          echo "source-date-epoch=$epoch" >> $GITHUB_OUTPUT
+
   check-requirements:
     name: "Check awkward requirements"
     runs-on: ubuntu-latest
@@ -29,6 +45,9 @@ jobs:
   check-cpp-on-pypi:
     name: "Check awkward-cpp dependency on PyPI"
     runs-on: ubuntu-latest
+    needs: [determine-source-date-epoch]
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
 
     steps:
       - uses: actions/checkout@v3
@@ -47,6 +66,9 @@ jobs:
   build:
     name: "Build wheel & sdist"
     runs-on: ubuntu-latest
+    needs: [determine-source-date-epoch]
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,8 +14,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.10.6"
-  # Ensure predictable hash
-  SOURCE_DATE_EPOCH: "1667773939"
+  SOURCE_DATE_EPOCH: "1668811211"
 
 jobs:
   awkward-cpp-wasm:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ concurrency:
   group: wheels-${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  SOURCE_DATE_EPOCH: "1668811211"
 
 jobs:
   pylint:


### PR DESCRIPTION
The CI currently tries to figure out the last modification time of the source code for reproducibility. We use this value in the following ways:
- setting a timestamp for the generated test files
- setting the PAX headers for the built sdist

We really need this figure to be exact; when we check whether awkward-cpp has been released, we do this as safely as possible by building an sdist and comparing the SHA256. Of course, if any generated timestamps are different, the checksums will not agree. 

There is no single notion of what the "last modified" time of the source should be; really, the generated C++ tests should use the modification time of the kernel specification/data, whereas the awkward-cpp package should use the last commit of anything inside the subdirectory. Needless to say, to properly support all of this, we would 
1. need to add a new env var / config option for the test generation and download more comprehensive git history in the CI workflows.
2. exclusively use `SOURCE_DATE_EPOCH`, and set it to a constant value. 

This PR started with option (2) to make `SOURCE_DATE_EPOCH` constant in every workflow. However, (1) is feasible, and the fix is to just download the entire repository history in a single job. We do not need to do this for the `build-test` workflow, which doesn't need an accurate value for `SOURCE_DATE_EPOCH`; the build cache just needs a stable timestamp.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-ci-simplify-source-date-epoch/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->