### PR TITLE
feat: made 'very optional' arguments keyword-only

### DIFF
--- a/docs/user-guide/how-to-create-arraybuilder.md
+++ b/docs/user-guide/how-to-create-arraybuilder.md
@@ -376,7 +376,7 @@ new_array
 new_array.layout
 ```
 
-Above, we see that `new_array` is just making references ({class}`ak.layout.IndexedArray`) of an {classY}`ak.layout.RecordArray` with `x = [1, 2, 3]` and `y = [1.1, 2.2, 3.3]`.
+Above, we see that `new_array` is just making references ({class}`ak.layout.IndexedArray`) of an {class}`ak.layout.RecordArray` with `x = [1, 2, 3]` and `y = [1.1, 2.2, 3.3]`.
 
 +++
 

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -412,7 +412,7 @@ def behavior_of(*arrays, **kwargs):
     highs = (
         ak.highlevel.Array,
         ak.highlevel.Record,
-        #        ak.highlevel.ArrayBuilder,
+        # ak.highlevel.ArrayBuilder,
     )
     for x in arrays[::-1]:
         if isinstance(x, highs) and x.behavior is not None:
@@ -429,7 +429,6 @@ def behavior_of(*arrays, **kwargs):
     return behavior
 
 
-# maybe_wrap and maybe_wrap_like go here
 def wrap(content, behavior=None, highlevel=True, like=None):
     assert content is None or isinstance(
         content, (ak.contents.Content, ak.record.Record)

--- a/src/awkward/behaviors/mixins.py
+++ b/src/awkward/behaviors/mixins.py
@@ -63,7 +63,7 @@ def mixin_class(registry, name=None):
     return register
 
 
-def mixin_class_method(ufunc, rhs=None, transpose=True):
+def mixin_class_method(ufunc, rhs=None, *, transpose=True):
     """
     Args:
         ufunc (numpy.ufunc): A universal function (or NEP18 callable) that is

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1364,7 +1364,9 @@ class ListArray(Content):
         )
 
     def _to_numpy(self, allow_missing):
-        return ak.operations.to_numpy(self.toRegularArray(), allow_missing)
+        return ak.operations.to_numpy(
+            self.toRegularArray(), allow_missing=allow_missing
+        )
 
     def _completely_flatten(self, nplike, options):
         if (

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1963,7 +1963,9 @@ class ListOffsetArray(Content):
         if array_param in {"bytestring", "string"}:
             return self._nplike.array(self.to_list())
 
-        return ak.operations.to_numpy(self.toRegularArray(), allow_missing)
+        return ak.operations.to_numpy(
+            self.toRegularArray(), allow_missing=allow_missing
+        )
 
     def _completely_flatten(self, nplike, options):
         if (

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -100,7 +100,7 @@ class BitMaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -84,7 +84,7 @@ class ByteMaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -21,7 +21,7 @@ class EmptyForm(Form):
     def _type(self, typestrs):
         return ak.types.UnknownType(
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -69,7 +69,7 @@ class IndexedOptionForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -80,7 +80,7 @@ class ListForm(Form):
         return ak.types.ListType(
             self._content._type(typestrs),
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -50,7 +50,7 @@ class ListOffsetForm(Form):
         return ak.types.ListType(
             self._content._type(typestrs),
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -101,7 +101,7 @@ class NumpyForm(Form):
         out = ak.types.NumpyType(
             self._primitive,
             None,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         )
         for x in self._inner_shape[::-1]:
             out = ak.types.RegularType(out, x)

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -150,7 +150,7 @@ class RecordForm(Form):
             [x._type(typestrs) for x in self._contents],
             self._fields,
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -57,7 +57,7 @@ class RegularForm(Form):
             self._content._type(typestrs),
             self._size,
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -97,7 +97,7 @@ class UnionForm(Form):
         return ak.types.UnionType(
             [x._type(typestrs) for x in self._contents],
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -46,7 +46,7 @@ class UnmaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             self._parameters,
-            ak._util.gettypestr(self._parameters, typestrs),
+            typestr=ak._util.gettypestr(self._parameters, typestrs),
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -184,6 +184,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     def __init__(
         self,
         data,
+        *,
         behavior=None,
         with_name=None,
         check_valid=False,
@@ -1475,6 +1476,7 @@ class Record(NDArrayOperatorsMixin):
     def __init__(
         self,
         data,
+        *,
         behavior=None,
         with_name=None,
         check_valid=False,
@@ -2168,7 +2170,7 @@ class ArrayBuilder(Sized):
     be considered the "least effort" approach.
     """
 
-    def __init__(self, behavior=None, initial=1024, resize=1.5):
+    def __init__(self, *, behavior=None, initial=1024, resize=1.5):
         self._layout = _ext.ArrayBuilder(initial=initial, resize=resize)
         self.behavior = behavior
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -352,7 +352,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             with ak._errors.OperationErrorContext(
                 "ak.Array.mask", {0: self._array, 1: where}
             ):
-                return ak.operations.mask(self._array, where, True)
+                return ak.operations.mask(self._array, where, valid_when=True)
 
     @property
     def mask(self):

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -18,7 +18,7 @@ _dtype_to_form = {
 class Index:
     _expected_dtype = None
 
-    def __init__(self, data, metadata=None, nplike=None):
+    def __init__(self, data, *, metadata=None, nplike=None):
         if nplike is None:
             nplike = ak.nplikes.nplike_of(data)
         self._nplike = nplike
@@ -111,7 +111,7 @@ class Index:
             data = self._data
         else:
             data = self.raw(tt)
-        return type(self)(data.forget_length(), self._metadata, tt)
+        return type(self)(data.forget_length(), metadata=self._metadata, nplike=tt)
 
     def raw(self, nplike):
         return self.nplike.index_nplike.raw(self.data, nplike.index_nplike)
@@ -186,8 +186,8 @@ class Index:
     def __deepcopy__(self, memo):
         return type(self)(
             copy.deepcopy(self._data, memo),
-            copy.deepcopy(self._metadata, memo),
-            self._nplike,
+            metadata=copy.deepcopy(self._metadata, memo),
+            nplike=self._nplike,
         )
 
     def _nbytes_part(self):

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -6,7 +6,9 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("all")
-def all(array, axis=None, keepdims=False, mask_identity=False, flatten_records=False):
+def all(
+    array, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -6,7 +6,9 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("any")
-def any(array, axis=None, keepdims=False, mask_identity=False, flatten_records=False):
+def any(
+    array, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -8,6 +8,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 def argcartesian(
     arrays,
     axis=1,
+    *,
     nested=None,
     parameters=None,
     with_name=None,

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -8,6 +8,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 def argcombinations(
     array,
     n,
+    *,
     replacement=False,
     axis=1,
     fields=None,

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -6,7 +6,9 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argmax")
-def argmax(array, axis=None, keepdims=False, mask_identity=True, flatten_records=False):
+def argmax(
+    array, axis=None, *, keepdims=False, mask_identity=True, flatten_records=False
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -59,7 +61,7 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True, flatten_records
 
 @ak._connect.numpy.implements("nanargmax")
 def nanargmax(
-    array, axis=None, keepdims=False, mask_identity=True, flatten_records=False
+    array, axis=None, *, keepdims=False, mask_identity=True, flatten_records=False
 ):
     """
     Args:

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -6,7 +6,9 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argmin")
-def argmin(array, axis=None, keepdims=False, mask_identity=True, flatten_records=False):
+def argmin(
+    array, axis=None, *, keepdims=False, mask_identity=True, flatten_records=False
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -59,7 +61,7 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True, flatten_records
 
 @ak._connect.numpy.implements("nanargmin")
 def nanargmin(
-    array, axis=None, keepdims=False, mask_identity=True, flatten_records=False
+    array, axis=None, *, keepdims=False, mask_identity=True, flatten_records=False
 ):
     """
     Args:

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -6,7 +6,9 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argsort")
-def argsort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=None):
+def argsort(
+    array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
+):
     """
     Args:
         array: Data for which to get a sorting index, possibly within nested

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -8,6 +8,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 def cartesian(
     arrays,
     axis=1,
+    *,
     nested=None,
     parameters=None,
     with_name=None,
@@ -320,7 +321,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
             ak.index.Index64(x.reshape(-1), nplike=nplike)
             for x in nplike.index_nplike.meshgrid(
                 *[nplike.index_nplike.arange(len(x), dtype=np.int64) for x in layouts],
-                indexing="ij"
+                indexing="ij",
             )
         ]
         outs = [

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -8,6 +8,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 def combinations(
     array,
     n,
+    *,
     replacement=False,
     axis=1,
     fields=None,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -8,7 +8,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 @ak._connect.numpy.implements("concatenate")
 def concatenate(
-    arrays, axis=0, merge=True, mergebool=True, highlevel=True, behavior=None
+    arrays, axis=0, *, merge=True, mergebool=True, highlevel=True, behavior=None
 ):
     """
     Args:

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -10,6 +10,7 @@ def corr(
     y,
     weight=None,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=False,
     flatten_records=False,
@@ -71,15 +72,19 @@ def corr(
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False)
+        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     y = ak.highlevel.Array(
-        ak.operations.to_layout(y, allow_record=False, allow_other=False)
+        ak.operations.to_layout(y, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     if weight is not None:
         weight = ak.highlevel.Array(
-            ak.operations.to_layout(weight, allow_record=False, allow_other=False)
+            ak.operations.to_layout(weight, allow_record=False, allow_other=False),
+            behavior=behavior,
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -5,7 +5,9 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def count(array, axis=None, keepdims=False, mask_identity=False, flatten_records=False):
+def count(
+    array, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -7,7 +7,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 @ak._connect.numpy.implements("count_nonzero")
 def count_nonzero(
-    array, axis=None, keepdims=False, mask_identity=False, flatten_records=False
+    array, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
 ):
     """
     Args:

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -10,6 +10,7 @@ def covar(
     y,
     weight=None,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=False,
     flatten_records=False,
@@ -69,15 +70,19 @@ def covar(
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False)
+        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     y = ak.highlevel.Array(
-        ak.operations.to_layout(y, allow_record=False, allow_other=False)
+        ak.operations.to_layout(y, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     if weight is not None:
         weight = ak.highlevel.Array(
-            ak.operations.to_layout(weight, allow_record=False, allow_other=False)
+            ak.operations.to_layout(weight, allow_record=False, allow_other=False),
+            behavior=behavior,
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def fill_none(array, value, axis=-1, highlevel=True, behavior=None):
+def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data in which to replace None with a given value.

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def firsts(array, axis=1, highlevel=True, behavior=None):
+def firsts(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data from which to select the first elements from nested lists.

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def flatten(array, axis=1, highlevel=True, behavior=None):
+def flatten(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data containing nested lists to flatten.

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def from_arrow(array, generate_bitmasks=False, highlevel=True, behavior=None):
+def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None):
     """
     Args:
         array (`pyarrow.Array`, `pyarrow.ChunkedArray`, `pyarrow.RecordBatch`,

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -9,13 +9,13 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_avro_file(
-    file, debug_forth=False, limit_entries=None, highlevel=True, behavior=None
+    file, limit_entries=None, *, debug_forth=False, highlevel=True, behavior=None
 ):
     """
     Args:
         file (string or fileobject): Avro file to be read as Awkward Array.
-        debug_forth (bool): If True, prints the generated Forth code for debugging.
         limit_entries (int): The number of rows of the Avro file to be read into the Awkward Array.
+        debug_forth (bool): If True, prints the generated Forth code for debugging.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
@@ -33,8 +33,8 @@ def from_avro_file(
             file=file,
             highlevel=highlevel,
             behavior=behavior,
-            debug_forth=debug_forth,
             limit_entries=limit_entries,
+            debug_forth=debug_forth,
         ),
     ):
 

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -13,6 +13,7 @@ def from_buffers(
     length,
     container,
     buffer_key="{form_key}-{attribute}",
+    *,
     nplike=numpy,
     highlevel=True,
     behavior=None,

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -3,7 +3,7 @@
 import awkward as ak
 
 
-def from_categorical(array, highlevel=True, behavior=None):
+def from_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:
         array: Awkward Array from which to remove the 'categorical' parameter.

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -3,7 +3,7 @@
 import awkward as ak
 
 
-def from_cupy(array, regulararray=False, highlevel=True, behavior=None):
+def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:
         array (cp.ndarray): The CuPy array to convert into an Awkward Array.

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -8,18 +8,24 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 def from_iter(
-    iterable, highlevel=True, behavior=None, allow_record=True, initial=1024, resize=1.5
+    iterable,
+    *,
+    allow_record=True,
+    highlevel=True,
+    behavior=None,
+    initial=1024,
+    resize=1.5
 ):
     """
     Args:
         iterable (Python iterable): Data to convert into an Awkward Array.
+        allow_record (bool): If True, the outermost element may be a record
+            (returning #ak.Record or #ak.record.Record type, depending on
+            `highlevel`); if False, the outermost element must be an array.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
-        allow_record (bool): If True, the outermost element may be a record
-            (returning #ak.Record or #ak.record.Record type, depending on
-            `highlevel`); if False, the outermost element must be an array.
         initial (int): Initial size (in bytes) of buffers used by the
             [ak::ArrayBuilder](_static/classawkward_1_1ArrayBuilder.html).
         resize (float): Resize multiplier for buffers used by the
@@ -56,9 +62,9 @@ def from_iter(
         "ak.from_iter",
         dict(
             iterable=iterable,
+            allow_record=allow_record,
             highlevel=highlevel,
             behavior=behavior,
-            allow_record=allow_record,
             initial=initial,
             resize=resize,
         ),

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -3,7 +3,7 @@
 from awkward import _errors, _util, jax
 
 
-def from_jax(array, regulararray=False, highlevel=True, behavior=None):
+def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:
         array (jax.numpy.DeviceArray): The JAX DeviceArray to convert into an Awkward Array.

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -15,6 +15,7 @@ numpy = ak.nplikes.Numpy.instance()
 
 def from_json(
     source,
+    *,
     line_delimited=False,
     schema=None,
     nan_string=None,

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -4,7 +4,7 @@ import awkward as ak
 
 
 def from_numpy(
-    array, regulararray=False, recordarray=True, highlevel=True, behavior=None
+    array, *, regulararray=False, recordarray=True, highlevel=True, behavior=None
 ):
     """
     Args:

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -5,6 +5,7 @@ import awkward as ak
 
 def from_parquet(
     path,
+    *,
     columns=None,
     row_groups=None,
     storage_options=None,

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def from_regular(array, axis=1, highlevel=True, behavior=None):
+def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -7,17 +7,17 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("full_like")
-def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
+def full_like(array, fill_value, *, dtype=None, highlevel=True, behavior=None):
     """
     Args:
         array: Array to use as a model for a replacement that contains only
             `fill_value`.
         fill_value: Value to fill new new array with.
+        dtype (None or NumPy dtype)): Overrides the data type of the result.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
-        dtype (None or NumPy dtype)): Overrides the data type of the result.
 
     This is the equivalent of NumPy's `np.full_like` for Awkward Arrays.
 
@@ -75,9 +75,9 @@ def full_like(array, fill_value, highlevel=True, behavior=None, dtype=None):
         dict(
             array=array,
             fill_value=fill_value,
+            dtype=dtype,
             highlevel=highlevel,
             behavior=behavior,
-            dtype=dtype,
         ),
     ):
         return _impl(array, fill_value, highlevel, behavior, dtype)
@@ -192,7 +192,12 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
 
     out = layout.recursively_apply(action, behavior)
     if dtype is not None:
-        out = ak.operations.strings_astype(out, dtype, highlevel, behavior)
-        out = ak.operations.values_astype(out, dtype, highlevel, behavior)
+        out = ak.operations.strings_astype(
+            out, dtype, highlevel=highlevel, behavior=behavior
+        )
+        out = ak.operations.values_astype(
+            out, dtype, highlevel=highlevel, behavior=behavior
+        )
         return out
-    return ak._util.wrap(out, behavior, highlevel)
+    else:
+        return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def is_none(array, axis=0, highlevel=True, behavior=None):
+def is_none(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data to check for missing values (None).

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -3,7 +3,7 @@
 import awkward as ak
 
 
-def is_valid(array, exception=False):
+def is_valid(array, *, exception=False):
     """
     Args:
         array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -5,12 +5,9 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-### FIXME: ak._connect.numpy.implements needs to exist!
-
-
 @ak._connect.numpy.implements("isclose")
 def isclose(
-    a, b, rtol=1e-05, atol=1e-08, equal_nan=False, highlevel=True, behavior=None
+    a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
 ):
     """
     Args:

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -10,6 +10,7 @@ def linear_fit(
     y,
     weight=None,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=False,
     flatten_records=False,
@@ -84,15 +85,19 @@ def linear_fit(
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False)
+        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     y = ak.highlevel.Array(
-        ak.operations.to_layout(y, allow_record=False, allow_other=False)
+        ak.operations.to_layout(y, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     if weight is not None:
         weight = ak.highlevel.Array(
-            ak.operations.to_layout(weight, allow_record=False, allow_other=False)
+            ak.operations.to_layout(weight, allow_record=False, allow_other=False),
+            behavior=behavior,
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def local_index(array, axis=-1, highlevel=True, behavior=None):
+def local_index(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array to index.

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def mask(array, mask, valid_when=True, highlevel=True, behavior=None):
+def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     """
     Args:
         array: Data to mask, rather than filter.

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -9,6 +9,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 def max(
     array,
     axis=None,
+    *,
     keepdims=False,
     initial=None,
     mask_identity=True,
@@ -69,6 +70,7 @@ def max(
 def nanmax(
     array,
     axis=None,
+    *,
     keepdims=False,
     initial=None,
     mask_identity=True,

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -10,6 +10,7 @@ def mean(
     x,
     weight=None,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=False,
     flatten_records=False,
@@ -94,7 +95,13 @@ def mean(
 
 @ak._connect.numpy.implements("nanmean")
 def nanmean(
-    x, weight=None, axis=None, keepdims=False, mask_identity=True, flatten_records=False
+    x,
+    weight=None,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    flatten_records=False,
 ):
     """
     Args:
@@ -148,12 +155,15 @@ def nanmean(
 
 
 def _impl(x, weight, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False)
+        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     if weight is not None:
         weight = ak.highlevel.Array(
-            ak.operations.to_layout(weight, allow_record=False, allow_other=False)
+            ak.operations.to_layout(weight, allow_record=False, allow_other=False),
+            behavior=behavior,
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -14,7 +14,12 @@ ParquetMetadata = collections.namedtuple(
 
 
 def metadata_from_parquet(
-    path, storage_options=None, row_groups=None, ignore_metadata=False, scan_files=True
+    path,
+    *,
+    storage_options=None,
+    row_groups=None,
+    ignore_metadata=False,
+    scan_files=True
 ):
     """
     This function differs from ak.from_parquet._metadata as follows:

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -9,6 +9,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 def min(
     array,
     axis=None,
+    *,
     keepdims=False,
     initial=None,
     mask_identity=True,
@@ -69,6 +70,7 @@ def min(
 def nanmin(
     array,
     axis=None,
+    *,
     keepdims=False,
     initial=None,
     mask_identity=True,

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -10,6 +10,7 @@ def moment(
     n,
     weight=None,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=False,
     flatten_records=False,
@@ -73,12 +74,15 @@ def moment(
 
 
 def _impl(x, n, weight, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False)
+        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     if weight is not None:
         weight = ak.highlevel.Array(
-            ak.operations.to_layout(weight, allow_record=False, allow_other=False)
+            ak.operations.to_layout(weight, allow_record=False, allow_other=False),
+            behavior=behavior,
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def nan_to_none(array, highlevel=True, behavior=None):
+def nan_to_none(array, *, highlevel=True, behavior=None):
 
     """
     Args:

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -7,7 +7,14 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 @ak._connect.numpy.implements("nan_to_num")
 def nan_to_num(
-    array, copy=True, nan=0.0, posinf=None, neginf=None, highlevel=True, behavior=None
+    array,
+    copy=True,
+    nan=0.0,
+    posinf=None,
+    neginf=None,
+    *,
+    highlevel=True,
+    behavior=None
 ):
 
     """

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def num(array, axis=1, highlevel=True, behavior=None):
+def num(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data containing nested lists to count.

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -6,15 +6,15 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ones_like")
-def ones_like(array, highlevel=True, behavior=None, dtype=None):
+def ones_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     Args:
         array: Array to use as a model for a replacement that contains only `1`.
+        dtype (None or NumPy dtype): Overrides the data type of the result.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
-        dtype (None or NumPy dtype): Overrides the data type of the result.
 
     This is the equivalent of NumPy's `np.ones_like` for Awkward Arrays.
 
@@ -25,7 +25,7 @@ def ones_like(array, highlevel=True, behavior=None, dtype=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.ones_like",
-        dict(array=array, highlevel=highlevel, behavior=behavior, dtype=dtype),
+        dict(array=array, dtype=dtype, highlevel=highlevel, behavior=behavior),
     ):
         return _impl(array, highlevel, behavior, dtype)
 

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def packed(array, highlevel=True, behavior=None):
+def packed(array, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array whose internal structure will be packed.

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def pad_none(array, target, axis=1, clip=False, highlevel=True, behavior=None):
+def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
     """
     Args:
         array: Data containing nested lists to pad to a target length.

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -6,7 +6,9 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("prod")
-def prod(array, axis=None, keepdims=False, mask_identity=False, flatten_records=False):
+def prod(
+    array, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -52,7 +54,7 @@ def prod(array, axis=None, keepdims=False, mask_identity=False, flatten_records=
 
 @ak._connect.numpy.implements("nanprod")
 def nanprod(
-    array, axis=None, keepdims=False, mask_identity=False, flatten_records=False
+    array, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
 ):
     """
     Args:

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -6,7 +6,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ptp")
-def ptp(array, axis=None, keepdims=False, mask_identity=True, flatten_records=False):
+def ptp(array, axis=None, *, keepdims=False, mask_identity=True, flatten_records=False):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -69,8 +69,10 @@ def ptp(array, axis=None, keepdims=False, mask_identity=True, flatten_records=Fa
 
 
 def _impl(array, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(array)
     array = ak.highlevel.Array(
-        ak.operations.to_layout(array, allow_record=False, allow_other=False)
+        ak.operations.to_layout(array, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -6,7 +6,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ravel")
-def ravel(array, highlevel=True, behavior=None):
+def ravel(array, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data containing nested lists to flatten

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def run_lengths(array, highlevel=True, behavior=None):
+def run_lengths(array, *, highlevel=True, behavior=None):
 
     """
     Args:

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def singletons(array, highlevel=True, behavior=None):
+def singletons(array, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data to wrap in lists of length 1 if present and length 0

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -5,7 +5,9 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def softmax(x, axis=None, keepdims=False, mask_identity=False, flatten_records=False):
+def softmax(
+    x, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
+):
     """
     Args:
         x: The data on which to compute the softmax (anything #ak.to_layout recognizes).
@@ -56,7 +58,8 @@ def softmax(x, axis=None, keepdims=False, mask_identity=False, flatten_records=F
 def _impl(x, axis, keepdims, mask_identity, flatten_records):
     behavior = ak._util.behavior_of(x)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False), behavior
+        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -6,7 +6,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("sort")
-def sort(array, axis=-1, ascending=True, stable=True, highlevel=True, behavior=None):
+def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None):
     """
     Args:
         array: Data to sort, possibly within nested lists.

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -11,6 +11,7 @@ def std(
     weight=None,
     ddof=0,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=False,
     flatten_records=False,
@@ -81,6 +82,7 @@ def nanstd(
     weight=None,
     ddof=0,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=True,
     flatten_records=False,
@@ -141,14 +143,15 @@ def nanstd(
 
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
-    behavior = ak._util.behavior_of(x)
+    behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False), behavior
+        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     if weight is not None:
         weight = ak.highlevel.Array(
             ak.operations.to_layout(weight, allow_record=False, allow_other=False),
-            behavior,
+            behavior=behavior,
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def strings_astype(array, to, highlevel=True, behavior=None):
+def strings_astype(array, to, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array whose strings should be converted to a new numeric type.

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -6,7 +6,9 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("sum")
-def sum(array, axis=None, keepdims=False, mask_identity=False, flatten_records=False):
+def sum(
+    array, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -196,7 +198,7 @@ def sum(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
 
 @ak._connect.numpy.implements("nansum")
 def nansum(
-    array, axis=None, keepdims=False, mask_identity=False, flatten_records=False
+    array, axis=None, *, keepdims=False, mask_identity=False, flatten_records=False
 ):
     """
     Args:

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -7,6 +7,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 def to_arrow(
     array,
+    *,
     list_to32=False,
     string_to32=False,
     bytestring_to32=False,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -9,6 +9,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 def to_arrow_table(
     array,
+    *,
     list_to32=False,
     string_to32=False,
     bytestring_to32=False,

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def to_backend(array, backend, highlevel=True, behavior=None):
+def to_backend(array, backend, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data to convert to a specified `backend` set.

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -11,6 +11,7 @@ def to_buffers(
     container=None,
     buffer_key="{form_key}-{attribute}",
     form_key="node{id}",
+    *,
     id_start=0,
     nplike=numpy,
 ):

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -5,12 +5,14 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def to_categorical(array, highlevel=True):
+def to_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data convertible to an Awkward Array
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
 
     Creates a categorical dataset, which has the following properties:
 
@@ -73,12 +75,12 @@ def to_categorical(array, highlevel=True):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_categorical",
-        dict(array=array, highlevel=highlevel),
+        dict(array=array, highlevel=highlevel, behavior=behavior),
     ):
-        return _impl(array, highlevel)
+        return _impl(array, highlevel, behavior)
 
 
-def _impl(array, highlevel):
+def _impl(array, highlevel, behavior):
     def action(layout, **kwargs):
         if layout.purelist_depth == 1:
             if layout.is_option:
@@ -136,6 +138,6 @@ def _impl(array, highlevel):
             return None
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    behavior = ak._util.behavior_of(array)
+    behavior = ak._util.behavior_of(array, behavior=behavior)
     out = layout.recursively_apply(action, behavior)
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -8,7 +8,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 
 
 def to_dataframe(
-    array, how="inner", levelname=lambda i: "sub" * i + "entry", anonymous="values"
+    array, *, how="inner", levelname=lambda i: "sub" * i + "entry", anonymous="values"
 ):
     """
     Args:

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -16,6 +16,7 @@ numpy = ak.nplikes.Numpy.instance()
 def to_json(
     array,
     file=None,
+    *,
     line_delimited=False,
     num_indent_spaces=None,
     num_readability_spaces=0,

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -13,6 +13,7 @@ numpy = ak.nplikes.Numpy.instance()
 
 def to_layout(
     array,
+    *,
     allow_record=True,
     allow_other=False,
     numpytype=(np.number, np.bool_, np.str_, np.bytes_, np.datetime64, np.timedelta64),

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -5,7 +5,7 @@ import numpy
 import awkward as ak
 
 
-def to_numpy(array, allow_missing=True):
+def to_numpy(array, *, allow_missing=True):
     """
     Converts `array` (many types supported, including all Awkward Arrays and
     Records) into a NumPy array, if possible.

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -10,6 +10,7 @@ import awkward as ak
 def to_parquet(
     data,
     destination,
+    *,
     list_to32=False,
     string_to32=True,
     bytestring_to32=True,

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 import awkward as ak
 
 
-def to_rdataframe(arrays, flatlist_as_rvec=True):
+def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     Args:
         arrays (dict of str \u2192 arrays): A dictionary of Array-like data (anything

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def to_regular(array, axis=1, highlevel=True, behavior=None):
+def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -7,7 +7,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
+def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data to create an array with an additional level from.

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def unzip(array, highlevel=True, behavior=None):
+def unzip(array, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array to unzip into individual fields.

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -3,7 +3,7 @@
 import awkward as ak
 
 
-def validity_error(array, exception=False):
+def validity_error(array, *, exception=False):
     """
     Args:
         array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def values_astype(array, to, highlevel=True, behavior=None):
+def values_astype(array, to, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array whose numbers should be converted to a new numeric type.

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -11,6 +11,7 @@ def var(
     weight=None,
     ddof=0,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=False,
     flatten_records=False,
@@ -87,6 +88,7 @@ def nanvar(
     weight=None,
     ddof=0,
     axis=None,
+    *,
     keepdims=False,
     mask_identity=True,
     flatten_records=False,
@@ -147,12 +149,15 @@ def nanvar(
 
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
+    behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False)
+        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        behavior=behavior,
     )
     if weight is not None:
         weight = ak.highlevel.Array(
-            ak.operations.to_layout(weight, allow_record=False, allow_other=False)
+            ak.operations.to_layout(weight, allow_record=False, allow_other=False),
+            behavior=behavior,
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -8,7 +8,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def with_field(base, what, where=None, highlevel=True, behavior=None):
+def with_field(base, what, where=None, *, highlevel=True, behavior=None):
     """
     Args:
         base: Data containing records or tuples.

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def with_name(array, name, highlevel=True, behavior=None):
+def with_name(array, name, *, highlevel=True, behavior=None):
     """
     Args:
         base: Data containing records or tuples.

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def with_parameter(array, parameter, value, highlevel=True, behavior=None):
+def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data convertible into an Awkward Array.

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -5,7 +5,7 @@ import awkward as ak
 np = ak.nplikes.NumpyMetadata.instance()
 
 
-def without_parameters(array, highlevel=True, behavior=None):
+def without_parameters(array, *, highlevel=True, behavior=None):
     """
     Args:
         array: Data convertible into an Awkward Array.

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -9,15 +9,15 @@ _ZEROS = object()
 
 
 @ak._connect.numpy.implements("zeros_like")
-def zeros_like(array, highlevel=True, behavior=None, dtype=None):
+def zeros_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     Args:
         array: Array to use as a model for a replacement that contains only `0`.
+        dtype (None or NumPy dtype)): Overrides the data type of the result.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
-        dtype (None or NumPy dtype)): Overrides the data type of the result.
 
     This is the equivalent of NumPy's `np.zeros_like` for Awkward Arrays.
 
@@ -28,7 +28,7 @@ def zeros_like(array, highlevel=True, behavior=None, dtype=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.zeros_like",
-        dict(array=array, highlevel=highlevel, behavior=behavior, dtype=dtype),
+        dict(array=array, dtype=dtype, highlevel=highlevel, behavior=behavior),
     ):
         return _impl(array, highlevel, behavior, dtype)
 

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -8,6 +8,7 @@ np = ak.nplikes.NumpyMetadata.instance()
 def zip(
     arrays,
     depth_limit=None,
+    *,
     parameters=None,
     with_name=None,
     highlevel=True,

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -6,7 +6,7 @@ from awkward.types.type import Type
 
 
 class ListType(Type):
-    def __init__(self, content, parameters=None, typestr=None):
+    def __init__(self, content, parameters=None, *, typestr=None):
         if not isinstance(content, Type):
             raise ak._errors.wrap_error(
                 TypeError(

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -93,7 +93,7 @@ for primitive, dtype in _primitive_to_dtype_dict.items():
 
 
 class NumpyType(Type):
-    def __init__(self, primitive, parameters=None, typestr=None):
+    def __init__(self, primitive, parameters=None, *, typestr=None):
         primitive = dtype_to_primitive(primitive_to_dtype(primitive))
         if parameters is not None and not isinstance(parameters, dict):
             raise ak._errors.wrap_error(

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -9,7 +9,7 @@ from awkward.types.uniontype import UnionType
 
 
 class OptionType(Type):
-    def __init__(self, content, parameters=None, typestr=None):
+    def __init__(self, content, parameters=None, *, typestr=None):
         if not isinstance(content, Type):
             raise ak._errors.wrap_error(
                 TypeError(
@@ -97,24 +97,27 @@ class OptionType(Type):
             contents = []
             for content in self._content.contents:
                 if isinstance(content, OptionType):
+                    typestr = (
+                        content._typestr if self._typestr is None else self._typestr
+                    )
                     contents.append(
                         OptionType(
                             content.content,
                             ak._util.merge_parameters(
                                 self._parameters, content._parameters
                             ),
-                            content._typestr
-                            if self._typestr is None
-                            else self._typestr,
+                            typestr=typestr,
                         )
                     )
 
                 else:
                     contents.append(
-                        OptionType(content, self._parameters, self._typestr)
+                        OptionType(content, self._parameters, typestr=self._typestr)
                     )
 
-            return UnionType(contents, self._content.parameters, self._content.typestr)
+            return UnionType(
+                contents, self._content.parameters, typestr=self._content.typestr
+            )
 
         else:
             return self

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -10,7 +10,7 @@ from awkward.types.type import Type
 
 
 class RecordType(Type):
-    def __init__(self, contents, fields, parameters=None, typestr=None):
+    def __init__(self, contents, fields, parameters=None, *, typestr=None):
         if not isinstance(contents, Iterable):
             raise ak._errors.wrap_error(
                 TypeError(

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -6,7 +6,7 @@ from awkward.types.type import Type
 
 
 class RegularType(Type):
-    def __init__(self, content, size, parameters=None, typestr=None):
+    def __init__(self, content, size, parameters=None, *, typestr=None):
         if not isinstance(content, Type):
             raise ak._errors.wrap_error(
                 TypeError(

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -8,7 +8,7 @@ from awkward.types.type import Type
 
 
 class UnionType(Type):
-    def __init__(self, contents, parameters=None, typestr=None):
+    def __init__(self, contents, parameters=None, *, typestr=None):
         if not isinstance(contents, Iterable):
             raise ak._errors.wrap_error(
                 TypeError(

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -6,7 +6,7 @@ from awkward.types.type import Type
 
 
 class UnknownType(Type):
-    def __init__(self, parameters=None, typestr=None):
+    def __init__(self, parameters=None, *, typestr=None):
         if parameters is not None and not isinstance(parameters, dict):
             raise ak._errors.wrap_error(
                 TypeError(

--- a/src/awkward/typing.py
+++ b/src/awkward/typing.py
@@ -1,3 +1,5 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
 import typing
 
 if typing.TYPE_CHECKING:

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -425,7 +425,7 @@ def test_ByteMaskedArray():
         [0, 1, 2, 3],
     ]
 
-    assert to_list(ak.operations.sort(array, 1, False, False)) == [
+    assert to_list(ak.operations.sort(array, 1, ascending=False, stable=False)) == [
         [2.2, 1.1, 0.0],
         [],
         None,

--- a/tests/test_0914-types-and-forms.py
+++ b/tests/test_0914-types-and-forms.py
@@ -12,8 +12,11 @@ def test_UnknownType():
         str(ak.types.unknowntype.UnknownType({"x": 123}))
         == 'unknown[parameters={"x": 123}]'
     )
-    assert str(ak.types.unknowntype.UnknownType(None, "override")) == "override"
-    assert str(ak.types.unknowntype.UnknownType({"x": 123}, "override")) == "override"
+    assert str(ak.types.unknowntype.UnknownType(None, typestr="override")) == "override"
+    assert (
+        str(ak.types.unknowntype.UnknownType({"x": 123}, typestr="override"))
+        == "override"
+    )
     assert (
         str(ak.types.unknowntype.UnknownType({"__categorical__": True}))
         == "categorical[type=unknown]"
@@ -23,7 +26,11 @@ def test_UnknownType():
         == 'categorical[type=unknown[parameters={"x": 123}]]'
     )
     assert (
-        str(ak.types.unknowntype.UnknownType({"__categorical__": True}, "override"))
+        str(
+            ak.types.unknowntype.UnknownType(
+                {"__categorical__": True}, typestr="override"
+            )
+        )
         == "categorical[type=override]"
     )
 
@@ -66,9 +73,13 @@ def test_NumpyType():
         str(ak.types.numpytype.NumpyType("bool", {"x": 123}))
         == 'bool[parameters={"x": 123}]'
     )
-    assert str(ak.types.numpytype.NumpyType("bool", None, "override")) == "override"
     assert (
-        str(ak.types.numpytype.NumpyType("bool", {"x": 123}, "override")) == "override"
+        str(ak.types.numpytype.NumpyType("bool", None, typestr="override"))
+        == "override"
+    )
+    assert (
+        str(ak.types.numpytype.NumpyType("bool", {"x": 123}, typestr="override"))
+        == "override"
     )
     assert (
         str(ak.types.numpytype.NumpyType("bool", {"__categorical__": True}))
@@ -79,7 +90,11 @@ def test_NumpyType():
         == 'categorical[type=bool[parameters={"x": 123}]]'
     )
     assert (
-        str(ak.types.numpytype.NumpyType("bool", {"__categorical__": True}, "override"))
+        str(
+            ak.types.numpytype.NumpyType(
+                "bool", {"__categorical__": True}, typestr="override"
+            )
+        )
         == "categorical[type=override]"
     )
     assert str(ak.types.numpytype.NumpyType("datetime64")) == "datetime64"
@@ -281,7 +296,7 @@ def test_RegularType():
     assert (
         str(
             ak.types.regulartype.RegularType(
-                ak.types.unknowntype.UnknownType(), 10, None, "override"
+                ak.types.unknowntype.UnknownType(), 10, None, typestr="override"
             )
         )
         == "override"
@@ -289,7 +304,7 @@ def test_RegularType():
     assert (
         str(
             ak.types.regulartype.RegularType(
-                ak.types.unknowntype.UnknownType(), 10, {"x": 123}, "override"
+                ak.types.unknowntype.UnknownType(), 10, {"x": 123}, typestr="override"
             )
         )
         == "override"
@@ -318,7 +333,7 @@ def test_RegularType():
                 ak.types.unknowntype.UnknownType(),
                 10,
                 {"__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -401,7 +416,7 @@ def test_ListType():
     assert (
         str(
             ak.types.listtype.ListType(
-                ak.types.unknowntype.UnknownType(), None, "override"
+                ak.types.unknowntype.UnknownType(), None, typestr="override"
             )
         )
         == "override"
@@ -409,7 +424,7 @@ def test_ListType():
     assert (
         str(
             ak.types.listtype.ListType(
-                ak.types.unknowntype.UnknownType(), {"x": 123}, "override"
+                ak.types.unknowntype.UnknownType(), {"x": 123}, typestr="override"
             )
         )
         == "override"
@@ -436,7 +451,7 @@ def test_ListType():
             ak.types.listtype.ListType(
                 ak.types.unknowntype.UnknownType(),
                 {"__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -558,7 +573,7 @@ def test_RecordType():
                 ],
                 None,
                 None,
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -572,7 +587,7 @@ def test_RecordType():
                 ],
                 ["x", "y"],
                 None,
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -586,7 +601,7 @@ def test_RecordType():
                 ],
                 None,
                 {"__record__": "Name"},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -600,7 +615,7 @@ def test_RecordType():
                 ],
                 ["x", "y"],
                 {"__record__": "Name"},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -666,7 +681,7 @@ def test_RecordType():
                 ],
                 None,
                 {"x": 123},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -680,7 +695,7 @@ def test_RecordType():
                 ],
                 ["x", "y"],
                 {"x": 123},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -694,7 +709,7 @@ def test_RecordType():
                 ],
                 None,
                 {"__record__": "Name", "x": 123},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -708,7 +723,7 @@ def test_RecordType():
                 ],
                 ["x", "y"],
                 {"__record__": "Name", "x": 123},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -774,7 +789,7 @@ def test_RecordType():
                 ],
                 None,
                 {"__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -788,7 +803,7 @@ def test_RecordType():
                 ],
                 ["x", "y"],
                 {"__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -802,7 +817,7 @@ def test_RecordType():
                 ],
                 None,
                 {"__record__": "Name", "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -816,7 +831,7 @@ def test_RecordType():
                 ],
                 ["x", "y"],
                 {"__record__": "Name", "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -882,7 +897,7 @@ def test_RecordType():
                 ],
                 None,
                 {"x": 123, "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -896,7 +911,7 @@ def test_RecordType():
                 ],
                 ["x", "y"],
                 {"x": 123, "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -910,7 +925,7 @@ def test_RecordType():
                 ],
                 None,
                 {"__record__": "Name", "x": 123, "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -924,7 +939,7 @@ def test_RecordType():
                 ],
                 ["x", "y"],
                 {"__record__": "Name", "x": 123, "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1049,7 +1064,7 @@ def test_OptionType():
     assert (
         str(
             ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(), None, "override"
+                ak.types.unknowntype.UnknownType(), None, typestr="override"
             )
         )
         == "override"
@@ -1059,7 +1074,7 @@ def test_OptionType():
             ak.types.optiontype.OptionType(
                 ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
                 None,
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -1071,7 +1086,7 @@ def test_OptionType():
                     ak.types.unknowntype.UnknownType(), 10
                 ),
                 None,
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -1079,7 +1094,7 @@ def test_OptionType():
     assert (
         str(
             ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(), {"x": 123}, "override"
+                ak.types.unknowntype.UnknownType(), {"x": 123}, typestr="override"
             )
         )
         == "override"
@@ -1089,7 +1104,7 @@ def test_OptionType():
             ak.types.optiontype.OptionType(
                 ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
                 {"x": 123},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -1101,7 +1116,7 @@ def test_OptionType():
                     ak.types.unknowntype.UnknownType(), 10
                 ),
                 {"x": 123},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -1168,7 +1183,7 @@ def test_OptionType():
             ak.types.optiontype.OptionType(
                 ak.types.unknowntype.UnknownType(),
                 {"__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1178,7 +1193,7 @@ def test_OptionType():
             ak.types.optiontype.OptionType(
                 ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
                 {"__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1190,7 +1205,7 @@ def test_OptionType():
                     ak.types.unknowntype.UnknownType(), 10
                 ),
                 {"__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1200,7 +1215,7 @@ def test_OptionType():
             ak.types.optiontype.OptionType(
                 ak.types.unknowntype.UnknownType(),
                 {"x": 123, "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1210,7 +1225,7 @@ def test_OptionType():
             ak.types.optiontype.OptionType(
                 ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
                 {"x": 123, "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1222,7 +1237,7 @@ def test_OptionType():
                     ak.types.unknowntype.UnknownType(), 10
                 ),
                 {"x": 123, "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1286,7 +1301,7 @@ def test_UnionType():
                     ak.types.numpytype.NumpyType("bool"),
                 ],
                 None,
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -1299,7 +1314,7 @@ def test_UnionType():
                     ak.types.numpytype.NumpyType("bool"),
                 ],
                 {"x": 123},
-                "override",
+                typestr="override",
             )
         )
         == "override"
@@ -1336,7 +1351,7 @@ def test_UnionType():
                     ak.types.numpytype.NumpyType("bool"),
                 ],
                 {"__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1349,7 +1364,7 @@ def test_UnionType():
                     ak.types.numpytype.NumpyType("bool"),
                 ],
                 {"x": 123, "__categorical__": True},
-                "override",
+                typestr="override",
             )
         )
         == "categorical[type=override]"
@@ -1398,7 +1413,7 @@ def test_ArrayType():
         ak.types.arraytype.ArrayType(ak.types.unknowntype.UnknownType(), 10, {"x": 123})
     with pytest.raises(TypeError):
         ak.types.arraytype.ArrayType(
-            ak.types.unknowntype.UnknownType(), 10, None, "override"
+            ak.types.unknowntype.UnknownType(), 10, None, typestr="override"
         )
 
     assert (

--- a/tests/test_1072-sort.py
+++ b/tests/test_1072-sort.py
@@ -561,7 +561,7 @@ def test_bytemaskedarray_sort_2():
         [0, 1, 2, 3],
     ]
 
-    assert to_list(ak.operations.sort(array, 1, False, False)) == [
+    assert to_list(ak.operations.sort(array, 1, ascending=False, stable=False)) == [
         [2.2, 1.1, 0.0],
         [],
         None,


### PR DESCRIPTION
Also, the functions that are defined in terms of reducers (`ak.ptp`, `ak.moment`, `ak.mean`, `ak.var`, `ak.std`, `ak.covar`, `ak.corr`, `ak.linear_fit`, `ak.softmax`) now pass behavior consistently. (Previously, only `ak.std` made a half-hearted attempt.)

`ak.to_categorical` had a `behavior` argument added (somehow overlooked before).

The `ak.*_like` functions had their arguments reordered so that `dtype` is earlier than `highlevel` or `behavior` (which is the freedom to fix things that this PR is intended to make permanent).

In general, any `ak.*` function arguments that are "very optional"—configuring unusual situations—are now keyword-only, especially if they're booleans. It's very easy to mix up the order of boolean arguments. But `axis` arguments were left positional, since there are instances of positional `axis` in the wild.

The `Content` and `Form` subclasses, however, were left as they are. They're part of the low-level public API, and have only two arguments that are at all optional: `parameters` and `nplike` or `form_key`. These are all different types and unlikely to get misordered, and very unlikely to change order in the future. So there's not a strong need to make these arguments keyword-only.

The `Type` and `Index` subclasses are also low-level public API. `Type`'s `typestr` argument and `Index`'s `metadata` and `nplike` deserve to be keyword-only because they are rarely used and could be confusing. Any downstream developers who _do_ use them should have a good understanding of what they are and do, at least at the level of spelling out their names.

That's everything that's going on in this PR!

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-made-very-optional-arguments-keyword-only/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->