### PR TITLE
docs: fix broken build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,6 @@ build:
       - pip install requests pyyaml
       # Generate required code / metadata
       - python3 dev/generate-kernel-docs.py
-      - python3 dev/copy-cpp-headers.py
       # Download built artefacts
       - python3 dev/download-github-artefact.py scikit-hep/awkward-1.0 "^jupyter-cache$" -d docs/_build/.jupyter_cache
       - python3 dev/download-github-artefact.py scikit-hep/awkward-1.0 "^awkward-cpp-wasm$" -d docs/lite/pypi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,8 @@ nb_ipywidgets_js = {
         "crossorigin": "anonymous",
     },
 }
+nb_execution_show_tb = True
+    
 # Additional stuff
 master_doc = "index"
 

--- a/docs/environment.yml.cog
+++ b/docs/environment.yml.cog
@@ -5,6 +5,7 @@ dependencies:
   - pip
   - cxx-compiler
   - root
+  - ipykernel!=6.18.0
   - pip:
     # [[[cog
     # import cog

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,6 @@ sphinx-reredirects
 jupyterlite-sphinx
 ipyleaflet
 jupyterlite>=0.1.0b12
-ipykernel!=6.18.0
 
 numpy>=1.13.1
 numba>=0.50.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,6 +12,7 @@ sphinx-reredirects
 jupyterlite-sphinx
 ipyleaflet
 jupyterlite>=0.1.0b12
+ipykernel!=6.18.0
 
 numpy>=1.13.1
 numba>=0.50.0

--- a/docs/user-guide/how-to-use-header-only-layoutbuilder.md
+++ b/docs/user-guide/how-to-use-header-only-layoutbuilder.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.0
 kernelspec:
   display_name: ROOT C++
   language: c++
@@ -18,7 +18,7 @@ How to use the header-only LayoutBuilder in C++
 :tags: [hide-cell]
 
 // Make Awkward headers available in this notebook
-#pragma cling add_include_path("../../src/awkward/_connect/header-only")
+#pragma cling add_include_path("../../header-only")
 ```
 
 What is header-only Layout Builder?


### PR DESCRIPTION
This PR:
- cleans up how we find our headers - they're now available in the project root
- exposes the tracebacks of broken builds (hopefully)
- fixes the broken dependency of ipykernel that's being pulled from conda-forge.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-header-only-docs/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->