### PR TITLE
fix: ignore .nox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+.nox/
 .tox/
 .coverage
 .coverage.*


### PR DESCRIPTION
I think, it should be ignored

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/ianna-git-ignore-nox/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->