### PR TITLE
chore: fix NumPy bound & noxfile installs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,7 @@ def tests(session):
     """
     Run the unit and regular tests.
     """
-    session.install("-r", "requirements-test.txt", "./awkward-cpp", "./awkward")
+    session.install("-r", "requirements-test.txt", "./awkward-cpp", ".")
     session.run("pytest", *session.posargs if session.posargs else ["tests"])
 
 
@@ -51,7 +51,7 @@ def coverage(session):
     """
     Run the unit and regular tests.
     """
-    session.install("-r", "requirements-test.txt", "./awkward-cpp", "./awkward")
+    session.install("-r", "requirements-test.txt", "./awkward-cpp", ".")
     session.run(
         "pytest", "tests", "--cov=awkward", "--cov-report=xml", *session.posargs
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==1",
     "importlib_resources;python_version < \"3.9\"",
-    "numpy>=1.13.1",
+    "numpy>=1.14.5",
     "packaging",
 ]
 dynamic = [


### PR DESCRIPTION
The NumPy lower bound for Awkward increased when we moved to `python_version>=3.7`. We made this fix in the CI, but not in the packaging metadata.

We also didn't test the `tests` or `coverage` Nox sessions, as they don't work with `scikit-build-core` out of the box. I'll follow up with @henryiii, but in the mean time we can at least ensure that they try to install the right package :facepalm: 

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-pytest/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->